### PR TITLE
Fixes issue #42; allows for extra keyword args from the scheduler

### DIFF
--- a/autogluon/searcher/searcher.py
+++ b/autogluon/searcher/searcher.py
@@ -142,7 +142,7 @@ class RandomSearcher(BaseSearcher):
         >>> searcher = RandomSearcher(cs)
         >>> searcher.get_config()
     """
-    def get_config(self):
+    def get_config(self, **kwargs):
         """Function to sample a new configuration
         This function is called inside Hyperband to query a new configuration
 


### PR DESCRIPTION
*Issue #42:*

*Description of changes:*

Make function signature of `ag.searcher.RandomSearcher.get_config` consistent with that of its superclass `ag.searcher.BaseSearcher`, i.e. `get_config(self, **kwargs)`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
