### PR TITLE
fix skopt_searcher exception for big categoricals

### DIFF
--- a/autogluon/searcher/skopt_searcher.py
+++ b/autogluon/searcher/skopt_searcher.py
@@ -66,6 +66,7 @@ class SKoptSearcher(BaseSearcher):
         If all of these have configs have already been scheduled to try (might happen in asynchronous setting), 
         then get_config simply reverts to random search via random_config().
     """
+    errors_tohandle = (ValueError, TypeError, RuntimeError)
     
     def __init__(self, configspace, **kwargs):
         BaseSearcher.__init__(self, configspace)
@@ -117,7 +118,7 @@ class SKoptSearcher(BaseSearcher):
                 if (pickle.dumps(new_config) not in self._results.keys()): # have not encountered this config
                     self._results[pickle.dumps(new_config)] = 0
                     return new_config
-            except ValueError:
+            except self.errors_tohandle:
                 pass
             new_points = self.bayes_optimizer.ask(n_points=max_tries) # ask skopt for many configs since first one was not new
             i = 1 # which new point to return as new_config, we already tried the first point above
@@ -129,10 +130,10 @@ class SKoptSearcher(BaseSearcher):
                     if (pickle.dumps(new_config) not in self._results.keys()): # have not encountered this config
                         self._results[pickle.dumps(new_config)] = 0
                         return new_config
-                except ValueError:
+                except self.errors_tohandle:
                     pass
                 i += 1
-        except ValueError:
+        except self.errors_tohandle:
             pass
         logger.info("used random search instead of skopt to produce new hyperparameter configuration in this trial")
         return self.random_config()
@@ -170,7 +171,7 @@ class SKoptSearcher(BaseSearcher):
         try:
             self.bayes_optimizer.tell(self.config2skopt(config),
                                       -reward)  # provide negative reward since skopt performs minimization
-        except ValueError:
+        except self.errors_tohandle:
             logger.info("surrogate model not updated this trial")
         logger.info(
             'Finished Task with config: {} and reward: {}'.format(pickle.dumps(config), reward))


### PR DESCRIPTION
quick fix to address: https://github.com/awslabs/autogluon/issues/69 
Longer term, we may want to have more involved fix, but not worth investing time if Berlin BayesOpt will mostly subsume skopt anyway

*Issue #, if available:*  https://github.com/awslabs/autogluon/issues/69

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
