### PR TITLE
use configspace defaults in first trial of HPO

### DIFF
--- a/autogluon/searcher/searcher.py
+++ b/autogluon/searcher/searcher.py
@@ -154,8 +154,11 @@ class RandomSearcher(BaseSearcher):
         returns: (config, info_dict)
             must return a valid configuration and a (possibly empty) info dict
         """
-        new_config = self.configspace.sample_configuration().get_dictionary()
-        while pickle.dumps(new_config) in self._results.keys():
+        if len(self._results) == 0: # no hyperparams have been tried yet, first try default config
+            new_config = self.configspace.get_default_configuration().get_dictionary()
+        else:
+            new_config = self.configspace.sample_configuration().get_dictionary()
+        while pickle.dumps(new_config) in self._results.keys(): # TODO: may never terminate
             new_config = self.configspace.sample_configuration().get_dictionary()
         self._results[pickle.dumps(new_config)] = 0
         return new_config


### PR DESCRIPTION
Change searcher to always use get_default_configuration() instead of sample_configuration in the first trial.  This is crucial to ensure reasonable anytime performance.

*Issue #, if available:*

*Description of changes:*

Note that this non-halting issue: https://github.com/awslabs/autogluon/issues/10 
still remains in the while loop of the searcher.

Here is one potential fix below, but I am not sure it will be thread/parallel-safe so I didn't put it in yet. 
@zhanghang1989 can you verify whether this would be safe or some kind of lock is needed?

In the base Searcher object, we keep instance variable ```num_possible_configs``` 
and when the search-space is passed to scheduler, we update this space, eg. via:

```
if any of the hyperparameters are Real:
    self.num_possible_configs = np.inf
else:
   self.num_possible_configs = 0
   for each hyperparameter in search space:
           self.num_possible_configs += number of possible values of hyperparameter (assuming Categorical or bounded Integer, may be np.inf as well)
```

Then for each subclassed Searcher, we have:  

```
def get_config():
   if self.num_possible_configs <= 0:
      terminate search process
   ...
   new_config = ...
   self.num_possible_configs -= 1
   return new_config
```

