### PR TITLE
Installation next steps

### DIFF
--- a/docs/install-include.rst
+++ b/docs/install-include.rst
@@ -90,6 +90,8 @@ Select your preferences and run the install command.
 
            .. container:: cpu
 
+              The following MXNet package requires a Python 3.7 environment.
+
               .. code-block:: bash
 
                  pip install https://autogluon.s3.amazonaws.com/dist/mxnet-1.6.0b20191125-cp37-cp37m-macosx_10_13_x86_64.whl
@@ -105,6 +107,8 @@ Select your preferences and run the install command.
 
            .. container:: cpu
 
+              The following MXNet package requires a Python 3.7 environment.
+
               .. code-block:: bash
 
                  pip install https://autogluon.s3.amazonaws.com/dist/mxnet-1.6.0b20191125-cp37-cp37m-macosx_10_13_x86_64.whl
@@ -118,4 +122,3 @@ Select your preferences and run the install command.
                  # Please build mxnet from source manually
                  git clone https://github.com/awslabs/autogluon
                  cd autogluon && python setup.py install --user
-

--- a/docs/install-include.rst
+++ b/docs/install-include.rst
@@ -90,8 +90,6 @@ Select your preferences and run the install command.
 
            .. container:: cpu
 
-              The following MXNet package requires a Python 3.7 environment.
-
               .. code-block:: bash
 
                  pip install https://autogluon.s3.amazonaws.com/dist/mxnet-1.6.0b20191125-cp37-cp37m-macosx_10_13_x86_64.whl
@@ -107,8 +105,6 @@ Select your preferences and run the install command.
 
            .. container:: cpu
 
-              The following MXNet package requires a Python 3.7 environment.
-
               .. code-block:: bash
 
                  pip install https://autogluon.s3.amazonaws.com/dist/mxnet-1.6.0b20191125-cp37-cp37m-macosx_10_13_x86_64.whl
@@ -122,3 +118,4 @@ Select your preferences and run the install command.
                  # Please build mxnet from source manually
                  git clone https://github.com/awslabs/autogluon
                  cd autogluon && python setup.py install --user
+

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,12 +12,13 @@ Installation
 Next steps
 ~~~~~~~~~~
 
-- Checkout `beta.mxnet.io <http://beta.mxnet.io/install/index.html>`_ for more options such as ARM devices and docker images.
-- `Verify your MXNet installation <https://beta.mxnet.io/install/validate-mxnet.html>`_
+- `AutoGluon tutorials </tutorials/index.html>`_
+- `AutoGluon API </api/index.html>`_
+- Checkout the `MXNet website <https://mxnet.apache.org/get_started>`_ for more installation options such as ARM devices and docker images.
+- `Verify your MXNet installation <https://mxnet.apache.org/get_started/validate_mxnet>`_
 - `Configure MXNet environment variables <https://mxnet.incubator.apache.org/versions/master/faq/env_var.html>`_
-- For new users: `60-minute Gluon crash course <https://beta.mxnet.io/guide/getting-started/crash-course/index.html>`_
-- For experienced users: `MXNet Guides. <https://beta.mxnet.io/guide/getting-started/crash-course/index.html>`_
-- For advanced users: `MXNet API <https://beta.mxnet.io/api/index.html>`_ and `GluonCV API <../api/index.html>`_.
+- For new Gluon users: `60-minute Gluon crash course <https://mxnet.apache.org/api/python/docs/tutorials/getting-started/crash-course/index.html>`_
+- For advanced users: `MXNet API <https://mxnet.apache.org/api/python/docs/api/index.html>`_ and the `MXNet ecosystem <https://mxnet.apache.org/ecosystem>`_.
 
 .. raw:: html
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,11 +14,7 @@ Next steps
 
 - `AutoGluon tutorials </tutorials/index.html>`_
 - `AutoGluon API </api/index.html>`_
-- Checkout the `MXNet website <https://mxnet.apache.org/get_started>`_ for more installation options such as ARM devices and docker images.
-- `Verify your MXNet installation <https://mxnet.apache.org/get_started/validate_mxnet>`_
 - `Configure MXNet environment variables <https://mxnet.incubator.apache.org/versions/master/faq/env_var.html>`_
-- For new Gluon users: `60-minute Gluon crash course <https://mxnet.apache.org/api/python/docs/tutorials/getting-started/crash-course/index.html>`_
-- For advanced users: `MXNet API <https://mxnet.apache.org/api/python/docs/api/index.html>`_ and the `MXNet ecosystem <https://mxnet.apache.org/ecosystem>`_.
 
 .. raw:: html
 


### PR DESCRIPTION
## Changes
- Removed reference to the old beta website
- Updated link to the real getting started page for MXNet, not the old one
- Updated link to the real validate MXNet page, not the old one
- Updated link to the real getting started crash course page, not the old one.
- Updated link to the real MXNet API pages, not the old one.

## Additions
- Added relevant next steps. (Currently it is sending you to MXNet's website for more options and API and the crash course.) It is a good user experience to have a Call To Action at the end of the page, and have the CTA be the most relevant thing a new user might do.