### PR TITLE
MXNet Neural Network performance improvements (reduced minibatch runtime on large datasets)

### DIFF
--- a/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
@@ -308,7 +308,7 @@ class TabularNeuralNetModel(AbstractModel):
                     # print(str(nd.mean(loss).asscalar()), end="\r") # prints per-batch losses
                 loss.backward()
                 self.optimizer.step(labels.shape[0])
-                cumulative_loss += nd.sum(loss).asscalar()
+                cumulative_loss += loss.sum()
             train_loss = cumulative_loss/float(train_dataset.num_examples) # training loss this epoch
             if test_dataset is not None:
                 # val_metric = self.evaluate_metric(test_dataset) # Evaluate after each epoch
@@ -320,15 +320,15 @@ class TabularNeuralNetModel(AbstractModel):
             if test_dataset is not None:
                 if verbose_eval > 0 and e % verbose_eval == 0:
                     logger.log(15, "Epoch %s.  Train loss: %s, Val %s: %s" %
-                      (e, train_loss, self.eval_metric_name, val_metric))
+                      (e, train_loss.asscalar(), self.eval_metric_name, val_metric))
                 if self.summary_writer is not None:
-                    self.summary_writer.add_scalar(tag='val_'+self.eval_metric_name, 
+                    self.summary_writer.add_scalar(tag='val_'+self.eval_metric_name,
                                                    value=val_metric, global_step=e)
             else:
                 if verbose_eval > 0 and e % verbose_eval == 0:
-                    logger.log(15, "Epoch %s.  Train loss: %s" % (e, train_loss))
+                    logger.log(15, "Epoch %s.  Train loss: %s" % (e, train_loss.asscalar()))
             if self.summary_writer is not None:
-                self.summary_writer.add_scalar(tag='train_loss', value=train_loss, global_step=e)  # TODO: do we want to keep mxboard support?
+                self.summary_writer.add_scalar(tag='train_loss', value=train_loss.asscalar(), global_step=e)  # TODO: do we want to keep mxboard support?
             if e - best_val_epoch > self.params['epochs_wo_improve']:
                 break
             if time_limit:

--- a/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_trial.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_trial.py
@@ -68,7 +68,7 @@ def tabular_nn_trial(args, reporter):
                 loss = tabNN.loss_func(output, labels) / loss_scaling_factor
             loss.backward()
             tabNN.optimizer.step(labels.shape[0])
-            cumulative_loss += nd.sum(loss).asscalar()
+            cumulative_loss += loss.sum()
         train_loss = cumulative_loss/float(train_dataset.num_examples) # training loss this epoch
         if test_dataset is not None:
             # val_metric = tabNN.evaluate_metric(test_dataset) # Evaluate after each epoch
@@ -78,7 +78,7 @@ def tabular_nn_trial(args, reporter):
             best_val_epoch = e
             tabNN.model.save_parameters(trial_temp_file_name)
         # print("Epoch %s.  Train loss: %s, Val %s: %s" % (e, train_loss, tabNN.eval_metric_name, val_metric))
-        reporter(epoch=e, validation_performance=val_metric, train_loss=train_loss) # Higher val_metric = better
+        reporter(epoch=e, validation_performance=val_metric, train_loss=float(train_loss.asscalar())) # Higher val_metric = better
         if e - best_val_epoch > args.epochs_wo_improve:
             break
     tabNN.model.load_parameters(trial_temp_file_name) # Revert back to best model


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`nd.sum(loss).asscalar()` is doing implicit conversion tonumpy(), which is expensive (especially on GPU). Computing everything in NDArray speeds up computation. This problem exists in other parts of the NN training loop (scoring), but not as severe since loss is computed on batch level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
