### PR TITLE
TypeError fix

### DIFF
--- a/autogluon/utils/tabular/ml/learner/default_learner.py
+++ b/autogluon/utils/tabular/ml/learner/default_learner.py
@@ -244,7 +244,7 @@ class DefaultLearner(AbstractLearner):
             new_df = clss_df.copy()
             new_df = new_df[:remainder]
             while duplicate_times > 0:
-                logger.debug("Duplicating data from rare class: " + clss)
+                logger.debug("Duplicating data from rare class: " + str(clss))
                 duplicate_times -= 1
                 new_df = new_df.append(clss_df.copy())
             aug_df = aug_df.append(new_df.copy())


### PR DESCRIPTION
Fixing TypeError in logging statement

```
~/Projects/autogluon/autogluon/utils/tabular/ml/learner/default_learner.py in augment_rare_classes(self, X)
    245             new_df = new_df[:remainder]
    246             while duplicate_times > 0:
--> 247                 logger.debug("Duplicating data from rare class: " + clss)
    248                 duplicate_times -= 1
    249                 new_df = new_df.append(clss_df.copy())

TypeError: must be str, not int
```

(cherry picked from commit 32ba0d4cdeaa6e6c09302dcb639352622d499a84)

*Issue #, if available:*

*Description of changes:*
Added conversion to str, so the line does not fail with exception

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
