### PR TITLE
Fix OrderedDict not imported

### DIFF
--- a/autogluon/task/image_classification/classifier.py
+++ b/autogluon/task/image_classification/classifier.py
@@ -3,6 +3,7 @@ import math
 import pickle
 import numpy as np
 from PIL import Image
+from collections import OrderedDict
 
 import mxnet as mx
 import matplotlib.pyplot as plt


### PR DESCRIPTION
*Issue #, if available:*
#194 'OrderedDict' is not defined in classifier.py

*Description of changes:*
Imports the `OrderedDict` module in `classifier.py`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
