### PR TITLE
Fixed problem_type detection on Windows

### DIFF
--- a/autogluon/utils/tabular/features/abstract_feature_generator.py
+++ b/autogluon/utils/tabular/features/abstract_feature_generator.py
@@ -386,16 +386,21 @@ class AbstractFeatureGenerator:
     # TODO: add option for user to specify dtypes on load
     @staticmethod
     def get_type_family(type):
-        if type.name in ['int', 'int64', 'int32', 'int16', 'int8', 'int_', 'uint', 'uint8', 'uint16', 'uint32', 'uint64']:
-            return 'int'
-        elif type.name in ['float', 'float_', 'float16', 'float32', 'float64']:
-            return 'float'
-        elif type.name in ['bool', 'bool_']:
+        try:
+            if 'datetime' in type.name:
+                return 'datetime'
+            elif np.issubdtype(type, np.integer):
+                return 'int'
+            elif np.issubdtype(type, np.floating):
+                return 'float'
+        except Exception as err:
+            logger.exception('Warning: dtype %s is not recognized as a valid dtype by numpy! AutoGluon may incorrectly handle this feature...')
+            logger.exception(err)
+
+        if type.name in ['bool', 'bool_']:
             return 'bool'
         elif type.name in ['str', 'string', 'object']:
             return 'object'
-        elif 'datetime' in type.name:
-            return 'datetime'
         else:
             return type.name
 

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -452,7 +452,7 @@ class AbstractLearner:
         if len(unique_vals) == 2:
             problem_type = BINARY
             reason = "only two unique label-values observed"
-        elif unique_vals.dtype == 'float':
+        elif np.issubdtype(unique_vals.dtype, np.floating):
             unique_ratio = len(unique_vals) / float(len(y))
             if (unique_ratio <= REGRESS_THRESHOLD) and (unique_count <= MULTICLASS_LIMIT):
                 try:
@@ -472,7 +472,7 @@ class AbstractLearner:
         elif unique_vals.dtype == 'object':
             problem_type = MULTICLASS
             reason = "dtype of label-column == object"
-        elif unique_vals.dtype == 'int':
+        elif np.issubdtype(unique_vals.dtype, np.integer):
             unique_ratio = len(unique_vals)/float(len(y))
             if (unique_ratio <= REGRESS_THRESHOLD) and (unique_count <= MULTICLASS_LIMIT):
                 problem_type = MULTICLASS  # TODO: Check if integers are from 0 to n-1 for n unique values, if they have a wide spread, it could still be regression


### PR DESCRIPTION
*Issue #, if available:*

#192 

*Description of changes:*

Made type detection generic using np.issubdtype, this enables AutoGluon to handle label dtypes of any kind of integer and float instead of only int64 and float64, which was causing issues on Windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
