### PR TITLE
Tabular Metric Documentation Improvement + Bugfix

### DIFF
--- a/autogluon/task/tabular_prediction/tabular_prediction.py
+++ b/autogluon/task/tabular_prediction/tabular_prediction.py
@@ -97,7 +97,10 @@ class TabularPrediction(BaseTask):
             AutoGluon tunes factors such as hyperparameters, early-stopping, ensemble-weights, etc. in order to improve this metric on validation data. 
             
             If `eval_metric = None`, it is automatically chosen based on `problem_type`. 
-            Otherwise, options for classification: ['accuracy', 'balanced_accuracy', 'f1', 'roc_auc', 'average_precision', 'precision', 'recall', 'log_loss', 'pac_score']. 
+            Otherwise, options for classification: [
+                'accuracy', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_weighted',
+                'roc_auc', 'average_precision', 'precision', 'precision_macro', 'precision_micro', 'precision_weighted',
+                'recall', 'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score'].
             Options for regression: ['r2', 'mean_squared_error', 'root_mean_squared_error' 'mean_absolute_error', 'median_absolute_error']. 
             For more information on these options, see `sklearn.metrics`: https://scikit-learn.org/stable/modules/classes.html#sklearn-metrics-metrics   
             

--- a/autogluon/task/tabular_prediction/tabular_prediction.py
+++ b/autogluon/task/tabular_prediction/tabular_prediction.py
@@ -96,12 +96,13 @@ class TabularPrediction(BaseTask):
             Metric by which predictions will be ultimately evaluated on test data.
             AutoGluon tunes factors such as hyperparameters, early-stopping, ensemble-weights, etc. in order to improve this metric on validation data. 
             
-            If `eval_metric = None`, it is automatically chosen based on `problem_type`. 
+            If `eval_metric = None`, it is automatically chosen based on `problem_type`.
+            Defaults to 'accuracy' for binary and multiclass classification and 'root_mean_squared_error' for regression.
             Otherwise, options for classification: [
                 'accuracy', 'balanced_accuracy', 'f1', 'f1_macro', 'f1_micro', 'f1_weighted',
                 'roc_auc', 'average_precision', 'precision', 'precision_macro', 'precision_micro', 'precision_weighted',
                 'recall', 'recall_macro', 'recall_micro', 'recall_weighted', 'log_loss', 'pac_score'].
-            Options for regression: ['r2', 'mean_squared_error', 'root_mean_squared_error' 'mean_absolute_error', 'median_absolute_error']. 
+            Options for regression: ['root_mean_squared_error', 'mean_squared_error', 'mean_absolute_error', 'median_absolute_error', 'r2'].
             For more information on these options, see `sklearn.metrics`: https://scikit-learn.org/stable/modules/classes.html#sklearn-metrics-metrics   
             
             You can also pass your own evaluation function here as long as it follows formatting of the functions defined in `autogluon/utils/tabular/metrics/`.

--- a/autogluon/utils/tabular/ml/learner/default_learner.py
+++ b/autogluon/utils/tabular/ml/learner/default_learner.py
@@ -8,7 +8,6 @@ from ...data.cleaner import Cleaner
 from ...data.label_cleaner import LabelCleaner
 from ..trainer.auto_trainer import AutoTrainer
 from ..constants import BINARY, MULTICLASS, REGRESSION
-from ...metrics import log_loss
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +110,7 @@ class DefaultLearner(AbstractLearner):
 
         self.threshold, holdout_frac, num_bagging_folds = self.adjust_threshold_if_necessary(X[self.label], threshold=self.threshold, holdout_frac=holdout_frac, num_bagging_folds=num_bagging_folds)
 
-        if self.objective_func == log_loss:
+        if (self.objective_func.name == 'log_loss') and (self.problem_type == MULTICLASS):
             X = self.augment_rare_classes(X)
 
         # Gets labels prior to removal of infrequent classes
@@ -223,8 +222,6 @@ class DefaultLearner(AbstractLearner):
             for which no classes may be filtered out.
             This method will augment dataset with additional examples of rare classes.
         """
-        if self.problem_type != MULTICLASS:
-            raise ValueError("log_loss eval_metric cannot be specified for non-multiclass problem.")
         class_counts = X[self.label].value_counts()
         class_counts_invalid = class_counts[class_counts < self.threshold]
         if len(class_counts_invalid) == 0:

--- a/autogluon/utils/tabular/ml/learner/default_learner.py
+++ b/autogluon/utils/tabular/ml/learner/default_learner.py
@@ -110,7 +110,7 @@ class DefaultLearner(AbstractLearner):
 
         self.threshold, holdout_frac, num_bagging_folds = self.adjust_threshold_if_necessary(X[self.label], threshold=self.threshold, holdout_frac=holdout_frac, num_bagging_folds=num_bagging_folds)
 
-        if (self.objective_func.name == 'log_loss') and (self.problem_type == MULTICLASS):
+        if (self.objective_func is not None) and (self.objective_func.name == 'log_loss') and (self.problem_type == MULTICLASS):
             X = self.augment_rare_classes(X)
 
         # Gets labels prior to removal of infrequent classes

--- a/autogluon/utils/tabular/ml/models/catboost/catboost_utils.py
+++ b/autogluon/utils/tabular/ml/models/catboost/catboost_utils.py
@@ -86,5 +86,13 @@ def construct_custom_catboost_metric(metric, is_higher_better, needs_pred_proba,
         return 'Accuracy'
     if (metric.name == 'log_loss') and (problem_type == BINARY) and needs_pred_proba:
         return 'Logloss'
+    if (metric.name == 'f1') and (problem_type == BINARY) and not needs_pred_proba:
+        return 'F1'
+    if (metric.name == 'balanced_accuracy') and (problem_type == BINARY) and not needs_pred_proba:
+        return 'BalancedAccuracy'
+    if (metric.name == 'recall') and (problem_type == BINARY) and not needs_pred_proba:
+        return 'Recall'
+    if (metric.name == 'precision') and (problem_type == BINARY) and not needs_pred_proba:
+        return 'Precision'
     metric_class = metric_classes_dict[problem_type]
     return metric_class(metric=metric, is_higher_better=is_higher_better, needs_pred_proba=needs_pred_proba)


### PR DESCRIPTION
*Issue #, if available:*

#205 

*Description of changes:*

- Improved documentation of metric options in Tabular
- Improved CatBoost support for binary metrics
- Fixed defect prevent log_loss metric usage in binary classification

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
