### PR TITLE
Add pynvml to dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ requirements = [
     'lightgbm==2.3.0',
     'pandas>=0.24.0,<1.0',
     'psutil>=5.0.0',
+    'pynvml>=8.0.4',
     'scikit-learn==0.21.2',
 ]
 


### PR DESCRIPTION
I'm installing autogluon from source via the following command on an EC2 Deep Learning base AMI: "Deep Learning Base AMI (Ubuntu 18.04)"

```
pip install -U -e . --user
```

However, it still shows the following error:

```python
In [1]: import autogluon                                                                       
Traceback (most recent call last):

  File "/usr/local/lib/python3.6/dist-packages/IPython/core/interactiveshell.py", line 3296, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  File "<ipython-input-1-22265195b07c>", line 1, in <module>
    import autogluon

  File "/home/ubuntu/autogluon/autogluon/__init__.py", line 10, in <module>
    from . import scheduler, searcher, utils

  File "/home/ubuntu/autogluon/autogluon/scheduler/__init__.py", line 5, in <module>
    from .scheduler import *

  File "/home/ubuntu/autogluon/autogluon/scheduler/scheduler.py", line 26, in <module>
    class TaskScheduler(object):

  File "/home/ubuntu/autogluon/autogluon/scheduler/scheduler.py", line 31, in TaskScheduler
    REMOTE_MANAGER = RemoteManager()

  File "/home/ubuntu/autogluon/autogluon/scheduler/remote/remote_manager.py", line 37, in __new__
    cls.start_local_node()

  File "/home/ubuntu/autogluon/autogluon/scheduler/remote/remote_manager.py", line 48, in start_local_node
    remote = Remote(cls.MASTER_IP, port, local=True)
  File "/home/ubuntu/autogluon/autogluon/scheduler/remote/remote.py", line 67, in __init__
    super(Remote, self).__init__(processes=False)

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/client.py", line 721, in __init__
    self.start(timeout=timeout)

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/client.py", line 886, in start
    sync(self.loop, self._start, **kwargs)

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/utils.py", line 333, in sync
    raise exc.with_traceback(tb)

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/utils.py", line 317, in f
    result[0] = yield future

  File "/usr/local/lib/python3.6/dist-packages/tornado/gen.py", line 735, in run
    value = future.result()

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/client.py", line 952, in _start
    **self._startup_kwargs

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/deploy/spec.py", line 346, in _
    await self._start()

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/deploy/spec.py", line 264, in _start
    **self.scheduler_spec.get("options", {})

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/scheduler.py", line 903, in
 __init__
    from distributed.dashboard import BokehScheduler

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/dashboard/__init__.py", line 1, in <module>
    from .scheduler import BokehScheduler

  File "/home/ubuntu/.local/lib/python3.6/site-packages/distributed/dashboard/scheduler.py", line 402, in <module>
    import pynvml  # noqa: 1708

  File "/usr/local/lib/python3.6/dist-packages/pynvml.py", line 1831
    print c_count.value
                ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(c_count.value)?

```

I find it's related to the incorrect version of pynvml in the AMI. So I think it would be better to also set constraint of the version of pynvml.