### PR TITLE
FIX: removing duplicate method _format_results

### DIFF
--- a/autogluon/task/image_classification/classifier.py
+++ b/autogluon/task/image_classification/classifier.py
@@ -1,24 +1,24 @@
-import os
-import math
 import copy
+import math
+import os
+from collections import OrderedDict, defaultdict
+
 import cloudpickle as pkl
+import matplotlib.pyplot as plt
+import mxnet as mx
 import numpy as np
 from PIL import Image
-from collections import OrderedDict
-
-import mxnet as mx
-import matplotlib.pyplot as plt
 from mxnet.gluon.data.vision import transforms
 
-from ...core import AutoGluonObject
-from .utils import *
-from .nets import get_network
 from .metrics import get_metric_instance
+from .nets import get_network
+from .utils import *
 from ..base.base_predictor import BasePredictor
+from ...core import AutoGluonObject
 from ...utils import save, load, tqdm, collect_params, update_params
-from ...utils.pil_transforms import *
 
 __all__ = ['Classifier']
+
 
 class Classifier(BasePredictor):
     """Trained Image Classifier returned by fit() that can be used to make predictions on new images.
@@ -39,6 +39,7 @@ class Classifier(BasePredictor):
     >>> image = 'data/test/BabyShirt/BabyShirt_323.jpg'
     >>> ind, prob = classifier.predict(image)
     """
+
     def __init__(self, model, results, eval_func, scheduler_checkpoint,
                  args, ensemble=0, format_results=True, **kwargs):
         self.model = model
@@ -136,12 +137,12 @@ class Classifier(BasePredictor):
                 return ind, probai, proba
 
         def avg_prediction(different_dataset, threshold=0.001):
-            result = {}
+            result = defaultdict(list)
             inds, probas, probals_all = [], [], []
             for i in range(len(different_dataset)):
-                items = len(different_dataset[0])
-                for j in range(items):
-                    result.setdefault(j, []).append(different_dataset[i][j])
+                for j in range(len(different_dataset[0])):
+                    result[j].append(different_dataset[i][j])
+
             for c in result.keys():
                 proba_all = sum([*result[c]]) / len(different_dataset)
                 proba_all = mx.nd.array(np.where(proba_all.asnumpy() >= threshold, proba_all.asnumpy(), 0))
@@ -172,8 +173,10 @@ class Classifier(BasePredictor):
                 for i, x in enumerate(X):
                     tbar.update(1)
                     ind, proba, proba_all = predict_img(x[0])
-                    tbar.set_description('The input picture [%d] is classified as [%d], with probability %.2f ' %
-                      (i, ind.asscalar(), proba.asscalar()))
+                    tbar.set_description(
+                        'The input picture [%d] is classified as [%d], with probability %.2f ' %
+                        (i, ind.asscalar(), proba.asscalar())
+                    )
                     inds.append(ind.asscalar())
                     probas.append(proba.asnumpy())
                     probals_all.append(proba_all.asnumpy().flatten())
@@ -192,7 +195,7 @@ class Classifier(BasePredictor):
             X = X.init()
             return predict_imgs(X)
 
-        if isinstance(X, list) and len(X)>1:
+        if isinstance(X, list) and len(X) > 1:
             X_group = []
             for X_item in X:
                 X_item = X_item.init()
@@ -249,30 +252,4 @@ class Classifier(BasePredictor):
         return test_reward
 
     def evaluate_predictions(self, y_true, y_pred):
-        raise NotImplementedError # TODO
-
-    @staticmethod
-    def _format_results(results): # TODO: remove since this has been moved to base_predictor.py
-        def _merge_scheduler_history(training_history, config_history, reward_attr):
-            trial_info = {}
-            for tid, config in config_history.items():
-                trial_info[tid] = {}
-                trial_info[tid]['config'] = config
-                if tid in training_history:
-                    trial_info[tid]['history'] = training_history[tid]
-                    trial_info[tid]['metadata'] = {}
-
-                    if len(training_history[tid]) > 0 and reward_attr in training_history[tid][-1]:
-                        last_history = training_history[tid][-1]
-                        trial_info[tid][reward_attr] = last_history.pop(reward_attr)
-                        trial_info[tid]['metadata'].update(last_history)
-            return trial_info
-
-        training_history = results.pop('training_history')
-        config_history = results.pop('config_history')
-        results['trial_info'] = _merge_scheduler_history(training_history, config_history,
-                                                         results['reward_attr'])
-        results[results['reward_attr']] = results['best_reward']
-        results['search_space'] = results['metadata'].pop('search_space')
-        results['search_strategy'] = results['metadata'].pop('search_strategy')
-        return results
+        raise NotImplementedError  # TODO

--- a/autogluon/task/object_detection/detector.py
+++ b/autogluon/task/object_detection/detector.py
@@ -1,49 +1,26 @@
-import os
-import math
-import pickle
-import mxnet as mx
 import matplotlib.pyplot as plt
-from mxnet.gluon.data.vision import transforms
+import mxnet as mx
+from gluoncv.data.batchify import Tuple, Stack, Pad
+from gluoncv.data.transforms import presets
+from gluoncv.data.transforms.presets.yolo import YOLO3DefaultValTransform
+from mxnet import gluon
 
 from .utils import *
 from ..base.base_predictor import BasePredictor
-from ...utils import save, load, tqdm
-
-import warnings
-import logging
-
-import numpy as np
-from mxnet.gluon import nn
-from mxnet import gluon, init, autograd, nd
-from mxnet.gluon.data.vision import transforms
-import gluoncv as gcv
-from gluoncv.model_zoo import get_model
-from gluoncv import utils as gutils
-
-from gluoncv.data.batchify import Tuple, Stack, Pad
-from gluoncv.data.transforms.presets.yolo import YOLO3DefaultTrainTransform
-from gluoncv.data.transforms.presets.yolo import YOLO3DefaultValTransform
-from gluoncv.data.dataloader import RandomTransformDataLoader
-from gluoncv.utils.metrics.voc_detection import VOC07MApMetric
-from gluoncv.utils.metrics.coco_detection import COCODetectionMetric
-from gluoncv.utils import LRScheduler, LRSequential
-
-from gluoncv.data.transforms import presets
-import gluoncv as gcv
 
 __all__ = ['Detector']
+
 
 class Detector(BasePredictor):
     """
     Trained Object Detector returned by `task.fit()`
     """
-    def __init__(self, model, results, scheduler_checkpoint,
-                 args, **kwargs):
+
+    def __init__(self, model, results, scheduler_checkpoint, args, **kwargs):
         self.model = model
         self.results = self._format_results(results)
         self.scheduler_checkpoint = scheduler_checkpoint
         self.args = args
-
 
     def evaluate(self, dataset, ctx=[mx.cpu()]):
         """Evaluate performance of this object detector's predictions on test data.
@@ -67,7 +44,7 @@ class Detector(BasePredictor):
                 test_dataset.transform(YOLO3DefaultValTransform(width, height)),
                 batch_size, False, batchify_fn=val_batchify_fn, last_batch='keep', num_workers=num_workers)
             return test_loader
-        
+
         def _validate(net, val_data, ctx, eval_metric):
             """Test on validation dataset."""
             eval_metric.reset()
@@ -105,33 +82,7 @@ class Detector(BasePredictor):
         test_dataset, eval_metric = dataset.get_dataset_and_metric()
         test_data = _get_dataloader(net, test_dataset, args.data_shape, args.batch_size, args.num_workers, args)
         return _validate(net, test_data, ctx, eval_metric)
-    
-    @staticmethod
-    def _format_results(results):
-        def _merge_scheduler_history(training_history, config_history, reward_attr):
-            trial_info = {}
-            for tid, config in config_history.items():
-                trial_info[tid] = {}
-                trial_info[tid]['config'] = config
-                if tid in training_history:
-                    trial_info[tid]['history'] = training_history[tid]
-                    trial_info[tid]['metadata'] = {}
 
-                    if len(training_history[tid]) > 0 and reward_attr in training_history[tid][-1]:
-                        last_history = training_history[tid][-1]
-                        trial_info[tid][reward_attr] = last_history.pop(reward_attr)
-                        trial_info[tid]['metadata'].update(last_history)
-            return trial_info
-
-        training_history = results.pop('training_history')
-        config_history = results.pop('config_history')
-        results['trial_info'] = _merge_scheduler_history(training_history, config_history,
-                                                              results['reward_attr'])
-        results[results['reward_attr']] = results.pop('best_reward')
-        results['search_space'] = results['metadata'].pop('search_space')
-        results['search_strategy'] = results['metadata'].pop('search_strategy')
-        return results
-    
     def predict(self, X, input_size=224, thresh=0.15, plot=True):
         """ Use this object detector to make predictions on test data.
         
@@ -152,32 +103,29 @@ class Detector(BasePredictor):
         """
         net = self.model
         net.set_nms(0.45, 200)
-        net.collect_params().reset_ctx(ctx = mx.cpu())
+        net.collect_params().reset_ctx(ctx=mx.cpu())
 
         x, img = presets.yolo.load_test(X, short=512)
         ids, scores, bboxes = [xx[0].asnumpy() for xx in net(x)]
 
         if plot:
-            ax = gcv.utils.viz.plot_bbox(img, bboxes, scores, ids, thresh=thresh,
-                                        class_names=net.classes, ax=None)
+            gcv.utils.viz.plot_bbox(img, bboxes, scores, ids, thresh=thresh,
+                                    class_names=net.classes, ax=None)
             plt.show()
         return ids, scores, bboxes
-        
 
+    @classmethod
     def load(cls, checkpoint):
         raise NotImplemented
-    
+
     def save(self, checkpoint):
         raise NotImplemented
 
-    
     def predict_proba(self, X):
         raise NotImplemented
-    
+
     def _save_model(self, *args, **kwargs):
         raise NotImplemented
 
     def evaluate_predictions(self, y_true, y_pred):
         raise NotImplemented
-        
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Performing basic PEP8 corrections.
Removing `_format_results` method from `Classifier` and `Detector` since it has been moved to mother class. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
