### PR TITLE
FIX: training will not hang if in task an error occurs

### DIFF
--- a/autogluon/core/task.py
+++ b/autogluon/core/task.py
@@ -42,7 +42,7 @@ class Task:
 
     @classmethod
     def set_id(cls, taskid):
-        logger.info(f'Seting TASK ID: {taskid}')
+        logger.info(f'Setting TASK ID: {taskid}')
         cls.TASK_ID.value = taskid
 
     def __repr__(self):

--- a/autogluon/core/task.py
+++ b/autogluon/core/task.py
@@ -1,20 +1,21 @@
+import argparse
 import copy
 import logging
-import argparse
 import multiprocessing as mp
 
 logger = logging.getLogger(__name__)
 
 __all__ = ['Task']
 
-class Task(object):
-    """Individual training task, containing the lauch function, default arguments and
+
+class Task:
+    """Individual training task, containing the launch function, default arguments and
     required resources.
 
     Args:
-        fn (callable): Lauch function for the training task.
+        fn (callable): Launch function for the training task.
         args (argparse.ArgumentParser): Default function arguments.
-        resources (autogluon.scheduler.Resources): Required resources for lauching the task.
+        resources (autogluon.scheduler.Resources): Required resources for launching the task.
 
     Example:
         >>> def my_task():
@@ -24,6 +25,7 @@ class Task(object):
     """
     TASK_ID = mp.Value('i', 0)
     LOCK = mp.Lock()
+
     def __init__(self, fn, args, resources):
         self.fn = fn
         self.args = copy.deepcopy(args)
@@ -40,17 +42,20 @@ class Task(object):
 
     @classmethod
     def set_id(cls, taskid):
-        logger.info('Seting TASK ID: {}'.format(taskid))
+        logger.info(f'Seting TASK ID: {taskid}')
         cls.TASK_ID.value = taskid
 
     def __repr__(self):
-        reprstr = self.__class__.__name__ +  \
-            ' (' + 'task_id: ' + str(self.task_id) + \
-            ',\n\tfn: ' + str(self.fn) + \
-            ',\n\targs: {'
+        reprstr = (
+            f'{self.__class__.__name__} ('
+            f'task_id: {self.task_id},'
+            f'\n\tfn: {self.fn},'
+            f'\n\targs: {{'
+        )
+
         for k, v in self.args.items():
             data = str(v)
             info = (data[:100] + '..') if len(data) > 100 else data
-            reprstr +=  '{}'.format(k) + ': ' + info + ', '
-        reprstr +=  '},\n\tresource: ' + str(self.resources) + ')\n'
+            reprstr += f'{k}: {info}, '
+        reprstr += f'}},\n\tresource: {self.resources})\n'
         return reprstr

--- a/autogluon/scheduler/fifo.py
+++ b/autogluon/scheduler/fifo.py
@@ -239,6 +239,7 @@ class FIFOScheduler(TaskScheduler):
         rp.start()
         task_dict = self._dict_from_task(task)
         task_dict.update({'Task': task, 'Job': job, 'ReporterThread': rp})
+
         # checkpoint thread
         if self._checkpoint is not None:
             def _save_checkpoint_callback(fut):
@@ -257,6 +258,9 @@ class FIFOScheduler(TaskScheduler):
         last_result = None
         while not task_job.done():
             reported_result = reporter.fetch()
+            if reported_result is None:
+                continue
+
             if reported_result.get('done', False):
                 reporter.move_on()
                 break
@@ -264,6 +268,7 @@ class FIFOScheduler(TaskScheduler):
                 task.task_id, reported_result, config=task.args['config'])
             reporter.move_on()
             last_result = reported_result
+
         if last_result is not None:
             last_result['done'] = True
             searcher.update(

--- a/autogluon/scheduler/hyperband.py
+++ b/autogluon/scheduler/hyperband.py
@@ -1,14 +1,13 @@
-import pickle
 import logging
+import pickle
 import threading
+
 import numpy as np
-import multiprocessing as mp
 
 from .fifo import FIFOScheduler
-from .hyperband_stopping import HyperbandStopping_Manager
 from .hyperband_promotion import HyperbandPromotion_Manager
-from .reporter import DistStatusReporter, DistSemaphore
-from ..utils import DeprecationHelper
+from .hyperband_stopping import HyperbandStopping_Manager
+from .reporter import DistStatusReporter
 
 __all__ = ['HyperbandScheduler', 'HyperbandStopping_Manager', 'HyperbandPromotion_Manager']
 
@@ -219,6 +218,9 @@ class HyperbandScheduler(FIFOScheduler):
         last_updated = None
         while not task_job.done():
             reported_result = reporter.fetch()
+            if reported_result is None:
+                continue
+
             if reported_result.get('done', False):
                 reporter.move_on()
                 terminator.on_task_complete(task, last_result)

--- a/autogluon/scheduler/reporter.py
+++ b/autogluon/scheduler/reporter.py
@@ -64,6 +64,9 @@ class DistStatusReporter(object):
             raise AutoGluonEarlyStop('Stopping!')
 
     def fetch(self, block=True):
+        if not self._queue.qsize():
+            return None
+
         try:
             kwargs = self._queue.get()
         except CommClosedError:

--- a/autogluon/scheduler/rl_scheduler.py
+++ b/autogluon/scheduler/rl_scheduler.py
@@ -183,6 +183,9 @@ class RLScheduler(FIFOScheduler):
                 config = task.args['config']
                 while task_thread.is_alive():
                     reported_result = reporter.fetch()
+                    if reported_result is None:
+                        continue
+
                     if 'done' in reported_result and reported_result['done'] is True:
                         reporter.move_on()
                         task_thread.join()
@@ -237,6 +240,8 @@ class RLScheduler(FIFOScheduler):
             config = task.args['config']
             while not task_job.done():
                 reported_result = reporter.fetch()
+                if reported_result is None:
+                    continue
                 #print('reported_result', reported_result)
                 if 'done' in reported_result and reported_result['done'] is True:
                     reporter.move_on()


### PR DESCRIPTION
*Issue #266, if available:*

*Description of changes:*
Checking queue size before calling fetch. When we call fetch and the process which is inside the queue fails, then we have deadlock: process is raising exception, put the thread which opened this process is not raising an exception.
Basic PEP8 corrections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
