### PR TITLE
FIX: tabular training hang due to error in model training

### DIFF
--- a/autogluon/utils/tabular/ml/models/abstract/model_trial.py
+++ b/autogluon/utils/tabular/ml/models/abstract/model_trial.py
@@ -8,6 +8,7 @@ from autogluon.core import args
 
 logger = logging.getLogger(__name__)  # TODO: Currently unused
 
+
 @args()
 def model_trial(args, reporter):
     """ Training script for hyperparameter evaluation of an arbitrary model that subclasses AbstractModel.
@@ -19,27 +20,33 @@ def model_trial(args, reporter):
                 'num_threads', 'num_gpus' to set specific resources in model.fit()
             - model.save() must have return_filename, file_prefix, directory options
     """
-    trial_id = args.pop('task_id')  # Note may not start at 0 if HPO has been run for other models with same scheduler
-    directory = args.pop('directory')  # TODO: Separate model parameters vs HPO
-    file_prefix = f"trial_{trial_id}_"  # append to all file names created during this trial. Do NOT change!
-    model = args.pop('model')  # the model object must be passed into model_trial() here
+    try:
+        trial_id = args.pop('task_id')  # Note may not start at 0 if HPO has been run for other models with same scheduler
+        directory = args.pop('directory')  # TODO: Separate model parameters vs HPO
+        file_prefix = f"trial_{trial_id}_"  # append to all file names created during this trial. Do NOT change!
+        model = args.pop('model')  # the model object must be passed into model_trial() here
 
-    dataset_train_filename = args.pop('dataset_train_filename')
-    X_train, Y_train = pickle.load(open(directory + dataset_train_filename, 'rb'))
-    dataset_val_filename = args.pop('dataset_val_filename', None)
-    if dataset_val_filename is None:
-        raise NotImplementedError("must provide validation data for model_trial()")
-    X_val, Y_val = pickle.load(open(directory + dataset_val_filename, 'rb'))
-    model.params = model.params.copy()  # all hyperparameters must be stored in this dict
-    model.params.update(args)
-    if 'seed_value' in model.params:
-        random.seed(model.params['seed_value'])
-        np.random.seed(model.params['seed_value'])
+        dataset_train_filename = args.pop('dataset_train_filename')
+        X_train, Y_train = pickle.load(open(directory + dataset_train_filename, 'rb'))
+        dataset_val_filename = args.pop('dataset_val_filename', None)
+        if dataset_val_filename is None:
+            raise NotImplementedError("must provide validation data for model_trial()")
+        X_val, Y_val = pickle.load(open(directory + dataset_val_filename, 'rb'))
+        model.params = model.params.copy()  # all hyperparameters must be stored in this dict
+        model.params.update(args)
+        if 'seed_value' in model.params:
+            random.seed(model.params['seed_value'])
+            np.random.seed(model.params['seed_value'])
 
-        model.params.pop('seed_value')  # TODO: Should we be popping this?
+            model.params.pop('seed_value')  # TODO: Should we be popping this?
 
-    model.fit(X_train, Y_train, X_val, Y_val)
-    val_perf = model.score(X_val, Y_val)
-    trial_model_file = model.save(file_prefix=file_prefix, directory=directory, return_filename=True)
-    reporter(epoch=0, validation_performance=val_perf, directory=directory, file_prefix=file_prefix, 
-             trial_model_file=trial_model_file)  #  auxiliary_info = ?)
+        model.fit(X_train, Y_train, X_val, Y_val)
+        val_perf = model.score(X_val, Y_val)
+        trial_model_file = model.save(file_prefix=file_prefix, directory=directory, return_filename=True)
+
+    except Exception as e:
+        logger.exception(e, exc_info=True)
+        reporter.terminate()
+    else:
+        reporter(epoch=0, validation_performance=val_perf, directory=directory, file_prefix=file_prefix,
+                 trial_model_file=trial_model_file)  # auxiliary_info = ?)

--- a/autogluon/utils/tabular/ml/models/lgb/hyperparameters/lgb_trial.py
+++ b/autogluon/utils/tabular/ml/models/lgb/hyperparameters/lgb_trial.py
@@ -12,76 +12,81 @@ logger = logging.getLogger(__name__)  # TODO: Currently unused
 @args()
 def lgb_trial(args, reporter):
     """ Training script for hyperparameter evaluation of Gradient Boosting model """
-    try_import_lightgbm()
-    import lightgbm as lgb
-    # list of args which are not model hyperparameters:
-    nonparam_args = set(['directory', 'task_id', 'lgb_model', 'dataset_train_filename', 'dataset_val_filename'])
-    trial_id = args.task_id # Note may not start at 0 if HPO has been run for other models with same scheduler
-    directory = args.directory
-    file_prefix = "trial_"+str(trial_id)+"_" # append to all file names created during this trial. Do NOT change!
-    lgb_model = args.lgb_model
-    lgb_model.params = lgb_model.params.copy() # ensure no remaining pointers across trials
-    for key in args:
-        if key not in nonparam_args:
-            lgb_model.params[key] = args[key] # use these hyperparam values in this trial
-    dataset_train = lgb.Dataset(directory+args.dataset_train_filename)
-    dataset_val_filename = args.get('dataset_val_filename', None)
-    if dataset_val_filename is not None:
-        dataset_val = lgb.Dataset(directory+dataset_val_filename)
-    eval_metric = lgb_model.get_eval_metric()
-    if lgb_model.problem_type == BINARY:
-        train_loss_name = 'binary_logloss'
-    elif lgb_model.problem_type == MULTICLASS:
-        train_loss_name = 'multi_logloss'
-    elif lgb_model.problem_type == REGRESSION:
-        train_loss_name = 'l2'
+    try:
+        try_import_lightgbm()
+        import lightgbm as lgb
+        # list of args which are not model hyperparameters:
+        nonparam_args = set(['directory', 'task_id', 'lgb_model', 'dataset_train_filename', 'dataset_val_filename'])
+        trial_id = args.task_id # Note may not start at 0 if HPO has been run for other models with same scheduler
+        directory = args.directory
+        file_prefix = "trial_"+str(trial_id)+"_" # append to all file names created during this trial. Do NOT change!
+        lgb_model = args.lgb_model
+        lgb_model.params = lgb_model.params.copy() # ensure no remaining pointers across trials
+        for key in args:
+            if key not in nonparam_args:
+                lgb_model.params[key] = args[key] # use these hyperparam values in this trial
+        dataset_train = lgb.Dataset(directory+args.dataset_train_filename)
+        dataset_val_filename = args.get('dataset_val_filename', None)
+        if dataset_val_filename is not None:
+            dataset_val = lgb.Dataset(directory+dataset_val_filename)
+        eval_metric = lgb_model.get_eval_metric()
+        if lgb_model.problem_type == BINARY:
+            train_loss_name = 'binary_logloss'
+        elif lgb_model.problem_type == MULTICLASS:
+            train_loss_name = 'multi_logloss'
+        elif lgb_model.problem_type == REGRESSION:
+            train_loss_name = 'l2'
+        else:
+            raise ValueError("unknown problem_type for LGBModel: %s" % lgb_model.problem_type)
+        lgb_model.eval_results = {}
+        callbacks = []
+        valid_names = ['train_set']
+        valid_sets = [dataset_train]
+        if dataset_val is not None:
+            callbacks += [
+                hpo_callback(reporter=reporter, stopping_rounds=150, metrics_to_use=[('valid_set', lgb_model.eval_metric_name)],
+                    max_diff=None, ignore_dart_warning=True, verbose=False, train_loss_name=train_loss_name, eval_results=lgb_model.eval_results)
+            ]
+            valid_names = ['valid_set'] + valid_names
+            valid_sets = [dataset_val] + valid_sets
+        else:
+            raise NotImplementedError("cannot call gbm hyperparameter_tune without validation dataset")
+
+        num_boost_round = lgb_model.params.pop('num_boost_round', 1000)
+        seed_value = lgb_model.params.pop('seed_value', None)
+        train_params = {
+            'params': lgb_model.params.copy(),
+            'train_set': dataset_train,
+            'num_boost_round': num_boost_round,
+            'valid_sets': valid_sets,
+            'valid_names': valid_names,
+            'evals_result': lgb_model.eval_results,
+            'callbacks': callbacks,
+            'verbose_eval': -1,
+        }
+        if type(eval_metric) != str:
+            train_params['feval'] = eval_metric
+        if seed_value is not None:
+            train_params['seed'] = seed_value
+            random.seed(seed_value)
+            np.random.seed(seed_value)
+
+        lgb_model.model = lgb.train(**train_params)
+        lgb_model.params['num_boost_round'] = num_boost_round # re-set this value after training
+        if seed_value is not None:
+            lgb_model.params['seed_value'] = seed_value
+        lgb_model.best_iteration = lgb_model.model.best_iteration
+        # TODO: difficult to ensure these iters always match
+        # if lgb_model.eval_results['best_iter'] != lgb_model.best_iteration:
+        #     raise ValueError('eval_results[best_iter]=%s does not match lgb_model.best_iteration=%s' % (lgb_model.eval_results['best_iter'], lgb_model.best_iteration) )
+        # print('eval_results[best_iter]=%s does not match lgb_model.best_iteration=%s' % (lgb_model.eval_results['best_iter'], lgb_model.best_iteration) )
+        trial_model_file = lgb_model.save(file_prefix=file_prefix, directory=directory, return_filename=True)
+    except Exception as e:
+        logger.exception(e, exc_info=True)
+        reporter.terminate()
     else:
-        raise ValueError("unknown problem_type for LGBModel: %s" % lgb_model.problem_type)
-    lgb_model.eval_results = {}
-    callbacks = []
-    valid_names = ['train_set']
-    valid_sets = [dataset_train]
-    if dataset_val is not None:
-        callbacks += [
-            hpo_callback(reporter=reporter, stopping_rounds=150, metrics_to_use=[('valid_set', lgb_model.eval_metric_name)], 
-                max_diff=None, ignore_dart_warning=True, verbose=False, train_loss_name=train_loss_name, eval_results=lgb_model.eval_results)
-        ]
-        valid_names = ['valid_set'] + valid_names
-        valid_sets = [dataset_val] + valid_sets
-    else:
-        raise NotImplementedError("cannot call gbm hyperparameter_tune without validation dataset")
-    
-    num_boost_round = lgb_model.params.pop('num_boost_round', 1000)
-    seed_value = lgb_model.params.pop('seed_value', None)
-    train_params = {
-        'params': lgb_model.params.copy(),
-        'train_set': dataset_train,
-        'num_boost_round': num_boost_round, 
-        'valid_sets': valid_sets,
-        'valid_names': valid_names,
-        'evals_result': lgb_model.eval_results,
-        'callbacks': callbacks,
-        'verbose_eval': -1,
-    }
-    if type(eval_metric) != str:
-        train_params['feval'] = eval_metric
-    if seed_value is not None:
-        train_params['seed'] = seed_value
-        random.seed(seed_value)
-        np.random.seed(seed_value)
-    
-    lgb_model.model = lgb.train(**train_params)
-    lgb_model.params['num_boost_round'] = num_boost_round # re-set this value after training
-    if seed_value is not None:
-        lgb_model.params['seed_value'] = seed_value
-    lgb_model.best_iteration = lgb_model.model.best_iteration
-    # TODO: difficult to ensure these iters always match
-    # if lgb_model.eval_results['best_iter'] != lgb_model.best_iteration:
-    #     raise ValueError('eval_results[best_iter]=%s does not match lgb_model.best_iteration=%s' % (lgb_model.eval_results['best_iter'], lgb_model.best_iteration) )
-    # print('eval_results[best_iter]=%s does not match lgb_model.best_iteration=%s' % (lgb_model.eval_results['best_iter'], lgb_model.best_iteration) )
-    trial_model_file = lgb_model.save(file_prefix=file_prefix, directory=directory, return_filename=True)
-    reporter(epoch=num_boost_round+1, validation_performance=lgb_model.eval_results['best_valperf'],
-             train_loss=lgb_model.eval_results['best_trainloss'],
-             best_iteration=lgb_model.eval_results['best_iter'],
-             directory=directory, file_prefix=file_prefix, trial_model_file=trial_model_file)
-    # TODO: add to reporter: time_of_trial without load/save time (isn't this just function of early-stopping point?), memory/inference ??
+        reporter(epoch=num_boost_round+1, validation_performance=lgb_model.eval_results['best_valperf'],
+                 train_loss=lgb_model.eval_results['best_trainloss'],
+                 best_iteration=lgb_model.eval_results['best_iter'],
+                 directory=directory, file_prefix=file_prefix, trial_model_file=trial_model_file)
+        # TODO: add to reporter: time_of_trial without load/save time (isn't this just function of early-stopping point?), memory/inference ??

--- a/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_trial.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_trial.py
@@ -12,82 +12,87 @@ EPS = 10e-8 # small number
 @args()
 def tabular_nn_trial(args, reporter):
     """ Training and evaluation function used during a single trial of HPO """
-    tabNN = args.pop('tabNN')
-    tabNN.params = tabNN.params.copy() # duplicate to make sure there are no remaining pointers across trials.
-    tabNN.params.update(args) # Set params dict object == to args to explore in this trial.
-    trial_id = args.task_id # Note may not start at 0 if HPO has been run for other models with same scheduler
-    directory = args.directory
-    file_prefix = "trial_"+str(trial_id)+"_" # append to all file names created during this trial. Do NOT change!
-    trial_temp_file_name = directory + file_prefix + tabNN.temp_file_name # temporary file used throughout this trial
-    # Load datasets:
-    train_fileprefix = args.train_fileprefix
-    test_fileprefix = args.test_fileprefix # cannot be None
-    train_dataset = TabularNNDataset.load(train_fileprefix)
-    test_dataset = TabularNNDataset.load(test_fileprefix)
-    # Define network:
-    net = tabNN.get_net(train_dataset)
-    ctx = tabNN.ctx
-    # Set seed:
-    seed_value = args.seed_value # Set seed
-    if seed_value is not None:
-        random.seed(seed_value)
-        np.random.seed(seed_value)
-        mx.random.seed(seed_value)
-    # Initialize:
-    tabNN.model.collect_params().initialize(ctx=ctx)
-    tabNN.model.hybridize()
-    # TODO: Not used for now, we always setup the trainer:  if setup_trainer:
-    tabNN.setup_trainer()
-    best_val_metric = -np.inf  # we always assume higher = better
-    val_metric = None
-    best_val_epoch = 0
-    best_train_epoch = 0  # epoch with best training loss so far
-    best_train_loss = np.inf  # smaller = better
-    num_epochs = args.num_epochs
-    if test_dataset is not None:
-        y_test = test_dataset.get_labels()
-    
-    loss_scaling_factor = 1.0 # we divide loss by this quantity to stabilize gradients
-    loss_torescale = [key for key in tabNN.rescale_losses if isinstance(tabNN.loss_func, key)]
-    if len(loss_torescale) > 0:
-        loss_torescale = loss_torescale[0]
-        if tabNN.rescale_losses[loss_torescale] == 'std':
-            loss_scaling_factor = np.std(train_dataset.get_labels())/5.0 + EPS # std-dev of labels
-        elif tabNN.rescale_losses[loss_torescale] == 'var':
-            loss_scaling_factor = np.var(train_dataset.get_labels())/5.0 + EPS # variance of labels
-        else:
-            raise ValueError("Unknown loss-rescaling type %s specified for loss_func==%s" % (tabNN.rescale_losses[loss_torescale],tabNN.loss_func))
-    # Training Loop:
-    for e in range(num_epochs):
-        cumulative_loss = 0
-        for batch_idx, data_batch in enumerate(train_dataset.dataloader):
-            data_batch = train_dataset.format_batch_data(data_batch, ctx)
-            with autograd.record():
-                output = tabNN.model(data_batch)
-                labels = data_batch['label']
-                loss = tabNN.loss_func(output, labels) / loss_scaling_factor
-            loss.backward()
-            tabNN.optimizer.step(labels.shape[0])
-            cumulative_loss += loss.sum()
-        train_loss = cumulative_loss/float(train_dataset.num_examples) # training loss this epoch
+    try:
+        tabNN = args.pop('tabNN')
+        tabNN.params = tabNN.params.copy() # duplicate to make sure there are no remaining pointers across trials.
+        tabNN.params.update(args) # Set params dict object == to args to explore in this trial.
+        trial_id = args.task_id # Note may not start at 0 if HPO has been run for other models with same scheduler
+        directory = args.directory
+        file_prefix = "trial_"+str(trial_id)+"_" # append to all file names created during this trial. Do NOT change!
+        trial_temp_file_name = directory + file_prefix + tabNN.temp_file_name # temporary file used throughout this trial
+        # Load datasets:
+        train_fileprefix = args.train_fileprefix
+        test_fileprefix = args.test_fileprefix # cannot be None
+        train_dataset = TabularNNDataset.load(train_fileprefix)
+        test_dataset = TabularNNDataset.load(test_fileprefix)
+        # Define network:
+        net = tabNN.get_net(train_dataset)
+        ctx = tabNN.ctx
+        # Set seed:
+        seed_value = args.seed_value # Set seed
+        if seed_value is not None:
+            random.seed(seed_value)
+            np.random.seed(seed_value)
+            mx.random.seed(seed_value)
+        # Initialize:
+        tabNN.model.collect_params().initialize(ctx=ctx)
+        tabNN.model.hybridize()
+        # TODO: Not used for now, we always setup the trainer:  if setup_trainer:
+        tabNN.setup_trainer()
+        best_val_metric = -np.inf  # we always assume higher = better
+        val_metric = None
+        best_val_epoch = 0
+        best_train_epoch = 0  # epoch with best training loss so far
+        best_train_loss = np.inf  # smaller = better
+        num_epochs = args.num_epochs
         if test_dataset is not None:
-            # val_metric = tabNN.evaluate_metric(test_dataset) # Evaluate after each epoch
-            val_metric = tabNN.score(X=test_dataset, y=y_test)
-        if test_dataset is None or val_metric >= best_val_metric: # assume model is getting better while validation accuracy remains the same.
-            best_val_metric = val_metric
-            best_val_epoch = e
-            tabNN.model.save_parameters(trial_temp_file_name)
-        # print("Epoch %s.  Train loss: %s, Val %s: %s" % (e, train_loss, tabNN.eval_metric_name, val_metric))
-        reporter(epoch=e, validation_performance=val_metric, train_loss=float(train_loss.asscalar())) # Higher val_metric = better
-        if e - best_val_epoch > args.epochs_wo_improve:
-            break
-    tabNN.model.load_parameters(trial_temp_file_name) # Revert back to best model
-    # final_val_metric = tabNN.evaluate_metric(test_dataset)
-    final_performance = tabNN.score(X=test_dataset, y=y_test)
-    modelobj_file, netparams_file = tabNN.save(file_prefix=file_prefix, directory=directory, return_name=True)
-    # print("Best model found in epoch %d. Val %s: %s" % (best_val_epoch, tabNN.eval_metric_name, final_val_metric))
-    # add fake epoch at the end containg performance of early-stopped model.  Higher val_metric = better
-    reporter(epoch= e+1, validation_performance = final_performance, directory = directory, file_prefix = file_prefix,
-             modelobj_file = modelobj_file, netparams_file = netparams_file) # unused in reporter, only directory+file_prefix required to load model.
-    
-    # TODO: how to keep track of which filename corresponds to which performance?
+            y_test = test_dataset.get_labels()
+
+        loss_scaling_factor = 1.0 # we divide loss by this quantity to stabilize gradients
+        loss_torescale = [key for key in tabNN.rescale_losses if isinstance(tabNN.loss_func, key)]
+        if len(loss_torescale) > 0:
+            loss_torescale = loss_torescale[0]
+            if tabNN.rescale_losses[loss_torescale] == 'std':
+                loss_scaling_factor = np.std(train_dataset.get_labels())/5.0 + EPS # std-dev of labels
+            elif tabNN.rescale_losses[loss_torescale] == 'var':
+                loss_scaling_factor = np.var(train_dataset.get_labels())/5.0 + EPS # variance of labels
+            else:
+                raise ValueError("Unknown loss-rescaling type %s specified for loss_func==%s" % (tabNN.rescale_losses[loss_torescale],tabNN.loss_func))
+        # Training Loop:
+        for e in range(num_epochs):
+            cumulative_loss = 0
+            for batch_idx, data_batch in enumerate(train_dataset.dataloader):
+                data_batch = train_dataset.format_batch_data(data_batch, ctx)
+                with autograd.record():
+                    output = tabNN.model(data_batch)
+                    labels = data_batch['label']
+                    loss = tabNN.loss_func(output, labels) / loss_scaling_factor
+                loss.backward()
+                tabNN.optimizer.step(labels.shape[0])
+                cumulative_loss += loss.sum()
+            train_loss = cumulative_loss/float(train_dataset.num_examples) # training loss this epoch
+            if test_dataset is not None:
+                # val_metric = tabNN.evaluate_metric(test_dataset) # Evaluate after each epoch
+                val_metric = tabNN.score(X=test_dataset, y=y_test)
+            if test_dataset is None or val_metric >= best_val_metric: # assume model is getting better while validation accuracy remains the same.
+                best_val_metric = val_metric
+                best_val_epoch = e
+                tabNN.model.save_parameters(trial_temp_file_name)
+            # print("Epoch %s.  Train loss: %s, Val %s: %s" % (e, train_loss, tabNN.eval_metric_name, val_metric))
+            reporter(epoch=e, validation_performance=val_metric, train_loss=float(train_loss.asscalar())) # Higher val_metric = better
+            if e - best_val_epoch > args.epochs_wo_improve:
+                break
+        tabNN.model.load_parameters(trial_temp_file_name) # Revert back to best model
+        # final_val_metric = tabNN.evaluate_metric(test_dataset)
+        final_performance = tabNN.score(X=test_dataset, y=y_test)
+        modelobj_file, netparams_file = tabNN.save(file_prefix=file_prefix, directory=directory, return_name=True)
+        # print("Best model found in epoch %d. Val %s: %s" % (best_val_epoch, tabNN.eval_metric_name, final_val_metric))
+        # add fake epoch at the end containg performance of early-stopped model.  Higher val_metric = better
+    except Exception as e:
+        logger.exception(e, exc_info=True)
+        reporter.terminate()
+    else:
+        reporter(epoch= e+1, validation_performance = final_performance, directory = directory, file_prefix = file_prefix,
+                 modelobj_file = modelobj_file, netparams_file = netparams_file) # unused in reporter, only directory+file_prefix required to load model.
+
+        # TODO: how to keep track of which filename corresponds to which performance?


### PR DESCRIPTION
*Issue #266, if available:*

*Description of changes:*
Terminating reporter if tabular model failed to train due to some reason.

#### The code sample which was not working before the change:
```
import autogluon as ag
from autogluon.task import TabularPrediction as task

import sklearn.datasets
import pandas as pd

cancer_data = sklearn.datasets.load_breast_cancer(return_X_y=False)
data = pd.DataFrame(cancer_data['data'], columns=cancer_data['feature_names'])
data['target'] = cancer_data['target']

hp_tune = True
cat_options = {
    'num_leaves': ag.space.Int(lower=26, upper=66, default=36),
    'depth': ag.space.Int(lower=4, upper=10, default=6),
}
gbm_options = {
    'num_boost_round': 100,
    'num_leaves': ag.space.Int(lower=26, upper=66, default=36),
}

hyperparameters = {
    'CAT': cat_options,
    'GBM': gbm_options,
}

time_limits = 2 * 60
num_trials = 3
output_directory = './agModels--tuningCancerDataset'
data = task.Dataset(data)
label_column = 'target'

# case 1: random search
search_strategy = 'random'
print('\n' * 2)
print('#' * 100)
print(f'Case 1: Running HPO suing search strategy = "{search_strategy}".')
print()
predictor = task.fit(
    train_data=data,
    holdout_frac=0.3,
    label=label_column,
    output_directory=output_directory,
    time_limits=time_limits,
    num_trials=num_trials,
    hyperparameter_tune=hp_tune,
    hyperparameters=hyperparameters,
    search_strategy=search_strategy,
    auto_stack=False,
    stack_ensemble_levels=0
)
```

After detailed investigation I understood the core issue. So please find the description below. If I am wrong, please correct me. 

-  We call `autogluon.scheduler.scheduler.TaskScheduler._run_dist_job` method and by doing this we create a separate `process` for training our model. 
- For `Tabular Prediction` it calls the function `autogluon.utils.tabular.ml.models.abstract.model_trial.model_trial` https://github.com/awslabs/autogluon/blob/ddb167bdf835182bed4aec7752f21f80ae7dcc75/autogluon/utils/tabular/ml/models/abstract/model_trial.py#L12. 
-  It is passing also `reporter` object to this function.

##### Scenario A:  there is no any exception before calling reporter

- At the end of `model_trial` function we call `autogluon.scheduler.reporter.DistStatusReporter.__call__` https://github.com/awslabs/autogluon/blob/ddb167bdf835182bed4aec7752f21f80ae7dcc75/autogluon/scheduler/reporter.py#L42 or `autogluon.scheduler.reporter.LocalStatusReporter.__call__` https://github.com/awslabs/autogluon/blob/ddb167bdf835182bed4aec7752f21f80ae7dcc75/autogluon/scheduler/reporter.py#L113 which will put data into reporter queue. 
- After that we call `_run_rporter` of scheduler (for example `autogluon.scheduler.fifo.FIFOScheduler._run_reporter`). Which will try to get data from `reporter queue` with `lock`. 
- It will return some results from model training, since `Reporter.__call__` is called.

##### Scenario B:  there is an exception before calling reporter

- `autogluon.scheduler.reporter.DistStatusReporter.__call__` https://github.com/awslabs/autogluon/blob/ddb167bdf835182bed4aec7752f21f80ae7dcc75/autogluon/scheduler/reporter.py#L42 or `autogluon.scheduler.reporter.LocalStatusReporter.__call__` https://github.com/awslabs/autogluon/blob/ddb167bdf835182bed4aec7752f21f80ae7dcc75/autogluon/scheduler/reporter.py#L113 are **NOT** called, so queue is not filled: it will be **always empty**.
- After that we call `_run_rporter` of scheduler (for example `autogluon.scheduler.fifo.FIFOScheduler._run_reporter`). Which will try to get data from `reporter queue` with `lock`.
- It will cause `deadlock`, since `Reporter.__call__` is not called.

So in order to eliminate Scenario B I added `try except` and in case of exception terminated the reporter. 

I believe that this solution is much safer than returning `None`. The latter was also working as expected and as @mseeger noticed today, was not breaking block searcher update, but it was simply transferring it to `while` loop. 

If you are agree with this change, I assume that we should put similar `try except` calls in other training functions, for example : `autogluon.task.image_classification.pipeline.train_image_classification` https://github.com/awslabs/autogluon/blob/ddb167bdf835182bed4aec7752f21f80ae7dcc75/autogluon/task/image_classification/pipeline.py#L19.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
