### PR TITLE
Removed redundant skopt logging

### DIFF
--- a/autogluon/searcher/skopt_searcher.py
+++ b/autogluon/searcher/skopt_searcher.py
@@ -167,9 +167,6 @@ class SKoptSearcher(BaseSearcher):
                                       -reward)  # provide negative reward since skopt performs minimization
         except self.errors_tohandle:
             logger.info("surrogate model not updated this trial")
-        logger.info(
-            'Finished Task with config: {} and reward: {}'.format(pickle.dumps(config), reward))
-        logger.info('Finished Task with config: {} and reward: {}'.format(pickle.dumps(config), reward))
 
     def config2skopt(self, config):
         """ Converts autogluon config (dict object) to skopt format (list object).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously:

```
Finished Task with config: {'depth': 7, 'l2_leaf_reg': 2.411136570044195, 'learning_rate': 0.16222294597513923} and reward: 0.8516593362654938
Finished Task with config: b'\x80\x03}q\x00(X\x05\x00\x00\x00depthq\x01K\x07X\x0b\x00\x00\x00l2_leaf_regq\x02G@\x03J\x01\xf8T<FX\r\x00\x00\x00learning_rateq\x03G?\xc4\xc3\xb8\xb3\xcf\xdf)u.' and reward: 0.8516593362654938
Finished Task with config: b'\x80\x03}q\x00(X\x05\x00\x00\x00depthq\x01K\x07X\x0b\x00\x00\x00l2_leaf_regq\x02G@\x03J\x01\xf8T<FX\r\x00\x00\x00learning_rateq\x03G?\xc4\xc3\xb8\xb3\xcf\xdf)u.' and reward: 0.8516593362654938

```

Now:

```
Finished Task with config: {'feature_fraction': 0.9670482733697998, 'learning_rate': 0.005265640081214188, 'min_data_in_leaf': 3, 'num_leaves': 17} and reward: 0.8476609356257497
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
