### PR TITLE
Tabular: Fixed LightGBM HPO

### DIFF
--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -314,7 +314,7 @@ class AbstractModel:
         template.path = template.create_contexts(self.path + template.name + os.path.sep)
         return template
 
-    def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options=None, **kwargs):
+    def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options, **kwargs):
         # verbosity = kwargs.get('verbosity', 2)
         start_time = time.time()
         logger.log(15, "Starting generic AbstractModel hyperparameter tuning for %s model..." % self.name)

--- a/autogluon/utils/tabular/ml/models/lgb/callbacks.py
+++ b/autogluon/utils/tabular/ml/models/lgb/callbacks.py
@@ -74,6 +74,10 @@ def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_u
        Whether to use only the first metric for early stopping.
     verbose : bool, optional (default=True)
         Whether to print message with early stopping information.
+    train_loss_name : str, optional (default=None):
+        Name of metric that contains training loss value.
+    reporter : optional (default=None):
+        reporter object from AutoGluon scheduler.
 
     Returns
     -------

--- a/autogluon/utils/tabular/ml/models/lgb/callbacks.py
+++ b/autogluon/utils/tabular/ml/models/lgb/callbacks.py
@@ -6,7 +6,7 @@ from .....try_import import try_import_lightgbm
 
 logger = logging.getLogger(__name__)
 
-# callback
+
 def save_model_callback(path, latest_model_checkpoint, interval, offset):
     def _callback(env):
         if ((env.iteration - offset) % interval == 0) & (env.iteration != 0):
@@ -149,7 +149,7 @@ def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_u
         if not enabled[0]:
             return
         if train_loss_name is not None:
-            train_loss_evals = [eval for i, eval in enumerate(env.evaluation_result_list) if eval[0] == 'train_set' and eval[1] == train_loss_name]
+            train_loss_evals = [eval for eval in env.evaluation_result_list if eval[0] == 'train_set' and eval[1] == train_loss_name]
             train_loss_val = train_loss_evals[0][2]
         else:
             train_loss_val = 0.0
@@ -196,7 +196,6 @@ def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_u
         if time_limit:
             time_elapsed = time.time() - start_time
             time_left = time_limit - time_elapsed
-            # print('time left:', time_left)
             if time_left <= 0:
                 i = indices_to_check[0]
                 logger.log(20, '\tRan out of time, early stopping on iteration ' + str(env.iteration+1) + '. Best iteration is:\n\t[%d]\t%s' % (

--- a/autogluon/utils/tabular/ml/models/lgb/callbacks.py
+++ b/autogluon/utils/tabular/ml/models/lgb/callbacks.py
@@ -53,7 +53,7 @@ def record_evaluation_custom(path, eval_result, interval, offset=0, early_stoppi
 
 
 # TODO: Add option to stop if current run's metric value is X% lower, such as min 30%, current 40% -> Stop
-def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_use=None, start_time=None, time_limit=None, verbose=True, max_diff=None, ignore_dart_warning=False, manual_stop_file=None):
+def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_use=None, start_time=None, time_limit=None, verbose=True, max_diff=None, ignore_dart_warning=False, manual_stop_file=None, train_loss_name=None, reporter=None):
     """Create a callback that activates early stopping.
 
     Note
@@ -83,6 +83,7 @@ def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_u
     best_score = []
     best_iter = []
     best_score_list = []
+    best_trainloss = []  # stores training losses at corresponding best_iter
     cmp_op = []
     enabled = [True]
     indices_to_check = []
@@ -113,6 +114,7 @@ def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_u
         for eval_ret in env.evaluation_result_list:
             best_iter.append(0)
             best_score_list.append(None)
+            best_trainloss.append(None)
             if eval_ret[3]:
                 best_score.append(float('-inf'))
                 cmp_op.append(gt)
@@ -142,14 +144,27 @@ def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_u
             _init(env)
         if not enabled[0]:
             return
-
+        if train_loss_name is not None:
+            train_loss_evals = [eval for i, eval in enumerate(env.evaluation_result_list) if eval[0] == 'train_set' and eval[1] == train_loss_name]
+            train_loss_val = train_loss_evals[0][2]
+        else:
+            train_loss_val = 0.0
         for i in indices_to_check:
             score = env.evaluation_result_list[i][2]
             if best_score_list[i] is None or cmp_op[i](score, best_score[i]):
                 best_score[i] = score
                 best_iter[i] = env.iteration
                 best_score_list[i] = env.evaluation_result_list
-            elif env.iteration - best_iter[i] >= stopping_rounds:
+                best_trainloss[i] = train_loss_val
+            if reporter is not None:  # Report current best scores for iteration, used in HPO
+                if i == indices_to_check[0]:  # TODO: documentation needs to note that we assume 0th index is the 'official' validation performance metric.
+                    if cmp_op[i] == gt:
+                        validation_perf = score
+                    else:
+                        validation_perf = -score
+                    reporter(epoch=env.iteration, validation_performance=validation_perf, train_loss=best_trainloss[i],
+                             best_iter_sofar=best_iter[i] + 1, best_valperf_sofar=best_score[i])
+            if env.iteration - best_iter[i] >= stopping_rounds:
                 if verbose:
                     logger.log(15, 'Early stopping, best iteration is:\n[%d]\t%s' % (
                         best_iter[i] + 1, '\t'.join([_format_eval_result(x) for x in best_score_list[i]])))
@@ -220,156 +235,5 @@ def early_stopping_custom(stopping_rounds, first_metric_only=False, metrics_to_u
                         best_iter[0] + 1, '\t'.join([_format_eval_result(x) for x in best_score_list[0]])))
                 raise EarlyStopException(best_iter[0], best_score_list[0])
 
-    _callback.order = 30
-    return _callback
-
-
-def hpo_callback(reporter, stopping_rounds, first_metric_only=False, metrics_to_use=None, 
-                 verbose=True, max_diff=None, ignore_dart_warning=False, manual_stop_file=None, 
-                 train_loss_name=None, eval_results={}):
-    """Create a callback that activates early stopping to use in HPO.
-
-    Note
-    ----
-    metrics_to_use must be list of len == 1.  We do NOT support multiple metrics_to_use here!
-    The model will train until the validation score stops improving.
-    Validation score needs to improve at least every ``early_stopping_rounds`` round(s)
-    to continue training.
-    Requires at least one validation data and one metric.
-    If there's more than one, will check all of them. But the training data is ignored anyway.
-    To check only the first metric set ``first_metric_only`` to True.
-
-    Parameters
-    ----------
-    reporter: reporter object from AutoGluon scheduler
-    stopping_rounds : int
-       The possible number of rounds without the trend occurrence.
-    first_metric_only : bool, optional (default=False)
-       Whether to use only the first metric for early stopping.
-    verbose : bool, optional (default=True)
-        Whether to print message with early stopping information
-    train_loss_name (str): Name of metric that contains training loss value
-    eval_results (dict): Where to store stuff
-    
-    Returns
-    -------
-    callback : function
-        The callback that activates early stopping
-    """
-    best_score = []
-    best_iter = []
-    best_score_list = []
-    best_trainloss = [] # stores training losses at corresponding best_iter
-    cmp_op = []
-    indices_to_check = []
-    enabled = [True]
-    timex = [time.time()]
-    if len(metrics_to_use) != 1:
-        raise ValueError("hpo_callback() can only be used when metrics_to_use is list of length == 1")
-
-    def _init(env):
-        if not ignore_dart_warning:
-            enabled[0] = not any((boost_alias in env.params
-                                  and env.params[boost_alias] == 'dart') for boost_alias in ('boosting',
-                                                                                             'boosting_type',
-                                                                                             'boost'))
-        if not enabled[0]:
-            warnings.warn('Early stopping is not available in dart mode')
-            return
-        if not env.evaluation_result_list:
-            raise ValueError('For early stopping, '
-                             'at least one dataset and eval metric is required for evaluation')
-
-        if verbose:
-            # msg = "Training until validation scores don't improve for {} rounds."
-            logger.log(15, "Training GBM model until validation scores don't improve for %s rounds" % stopping_rounds)
-            if manual_stop_file:
-                logger.log(15, 'You can manually stop training by creating a temp file at location: %s' % manual_stop_file)
-        
-        for eval_ret in env.evaluation_result_list:
-            best_iter.append(0)
-            best_score_list.append(None)
-            best_trainloss.append(0.0)
-            if eval_ret[3]:
-                best_score.append(float('-inf'))
-                cmp_op.append(gt)
-            else:
-                best_score.append(float('inf'))
-                cmp_op.append(lt)
-        
-        if metrics_to_use is None:
-            for i in range(len(env.evaluation_result_list)):
-                indices_to_check.append(i)
-                if first_metric_only:
-                    break
-        else:
-            for i, eval in enumerate(env.evaluation_result_list):
-                if (eval[0], eval[1]) in metrics_to_use:
-                    indices_to_check.append(i)
-                    if first_metric_only:
-                        break
-
-    def _callback(env):
-        try_import_lightgbm()
-        from lightgbm.callback import _format_eval_result, EarlyStopException
-        cur_time = time.time()
-        # if verbose:
-        #     print(cur_time - timex[0])
-        timex[0] = cur_time
-        if not cmp_op:
-            _init(env)
-        if not enabled[0]:
-            return
-        if train_loss_name is not None:
-            train_loss_evals = [eval for i, eval in enumerate(env.evaluation_result_list) if eval[0]=='train_set' and eval[1]==train_loss_name]
-            train_loss_val = train_loss_evals[0][2]
-        else:
-            train_loss_val = 0.0
-        for i in indices_to_check:
-            score = env.evaluation_result_list[i][2]
-            if i == indices_to_check[0]: # TODO: documentation needs to note that we assume 0th index is the 'official' validation performance metric.
-                if cmp_op[i] == gt:
-                    validation_perf = score
-                else:
-                    validation_perf = -score
-            if best_score_list[i] is None or cmp_op[i](score, best_score[i]):
-                best_score[i] = score
-                best_iter[i] = env.iteration
-                best_score_list[i] = env.evaluation_result_list
-                if train_loss_name is not None:
-                    best_trainloss[i] = train_loss_val # same for all i
-            elif env.iteration - best_iter[i] >= stopping_rounds:
-                if verbose:
-                    logger.log(15, 'Early stopping, best iteration is:\n[%d]\t%s' % (
-                        best_iter[i] + 1, '\t'.join([_format_eval_result(x) for x in best_score_list[i]])))
-                raise EarlyStopException(best_iter[i], best_score_list[i])
-            elif (max_diff is not None) and (abs(score - best_score[i]) > max_diff):
-                if verbose:
-                    logger.debug('max_diff breached!')
-                    logger.debug(str(abs(score - best_score[i])))
-                    logger.log(15, 'Early stopping, best iteration is:\n[%d]\t%s' % (
-                        best_iter[i] + 1, '\t'.join([_format_eval_result(x) for x in best_score_list[i]])))
-                
-                raise EarlyStopException(best_iter[i], best_score_list[i])
-            if env.iteration == env.end_iteration - 1:
-                if verbose:
-                    logger.log(15, 'Did not meet early stopping criterion. Best iteration is:\n[%d]\t%s' % (
-                        best_iter[i] + 1, '\t'.join([_format_eval_result(x) for x in best_score_list[i]])))
-                raise EarlyStopException(best_iter[i], best_score_list[i])
-            if verbose:
-                logger.debug(str(env.iteration - best_iter[i], env.evaluation_result_list[i]))
-            if manual_stop_file:
-                if os.path.exists(manual_stop_file):
-                    logger.log(20, 'Found manual stop file, early stopping. Best iteration is:\n[%d]\t%s' % (
-                        best_iter[i] + 1, '\t'.join([_format_eval_result(x) for x in best_score_list[i]])))
-                    raise EarlyStopException(best_iter[i], best_score_list[i])
-        # TODO: This should be moved inside for loop at the start, otherwise it won't record the final iteration
-        idx = indices_to_check[0]
-        eval_results['best_iter'] = best_iter[idx] + 1 # add one to index to align with lightgbm best_iteration instance variable.
-        eval_results['best_valperf'] = best_score[idx] # validation performance at round = best_iter
-        eval_results['best_trainloss'] = best_trainloss[idx] # training loss at round = best_iter
-        reporter(epoch=env.iteration, validation_performance=validation_perf, train_loss=train_loss_val, 
-                 best_iter_sofar=eval_results['best_iter'], best_valperf_sofar=eval_results['best_valperf'])
-        # TODO: Add memory checks as in early_stopping_custom
     _callback.order = 30
     return _callback

--- a/autogluon/utils/tabular/ml/models/lgb/hyperparameters/lgb_trial.py
+++ b/autogluon/utils/tabular/ml/models/lgb/hyperparameters/lgb_trial.py
@@ -1,12 +1,12 @@
-import logging, random
-import numpy as np
+import logging
+import os
+import time
 
+from .....utils.exceptions import TimeLimitExceeded
 from .......core import args
-from ..callbacks import hpo_callback
-from ....constants import BINARY, MULTICLASS, REGRESSION
 from ......try_import import try_import_lightgbm
 
-logger = logging.getLogger(__name__)  # TODO: Currently unused
+logger = logging.getLogger(__name__)
 
 
 @args()
@@ -15,80 +15,34 @@ def lgb_trial(args, reporter):
     try:
         try_import_lightgbm()
         import lightgbm as lgb
-        # list of args which are not model hyperparameters:
-        nonparam_args = set(['directory', 'task_id', 'lgb_model', 'dataset_train_filename', 'dataset_val_filename'])
-        trial_id = args.task_id # Note may not start at 0 if HPO has been run for other models with same scheduler
-        directory = args.directory
-        file_prefix = "trial_"+str(trial_id)+"_" # append to all file names created during this trial. Do NOT change!
-        lgb_model = args.lgb_model
-        # FIXME: Refactor this function, use the below 2 lines potentially or get rid of file_prefix altogether
-        # lgb_model.name = lgb_model.name + '_' + file_prefix
-        # lgb_model.set_contexts(path_context=lgb_model.path_root + lgb_model.name + os.path.sep)
-        lgb_model.params = lgb_model.params.copy() # ensure no remaining pointers across trials
+        dataset_train = lgb.Dataset(args.directory + args.dataset_train_filename)
+        dataset_val = lgb.Dataset(args.directory + args.dataset_val_filename)
+
+        nonparam_args = {'directory', 'task_id', 'time_start', 'time_limit', 'model', 'dataset_train_filename', 'dataset_val_filename'}  # list of args which are not model hyperparameters
+        # Note: args.task_id may not start at 0 if HPO has been run for other models with same scheduler
+        file_prefix = "trial_" + str(args.task_id)  # append to all file names created during this trial. Do NOT change!
+        model = args.model
+        model.name = model.name + os.path.sep + file_prefix
+        model.set_contexts(path_context=model.path_root + model.name + os.path.sep)
         for key in args:
             if key not in nonparam_args:
-                lgb_model.params[key] = args[key] # use these hyperparam values in this trial
-        dataset_train = lgb.Dataset(directory+args.dataset_train_filename)
-        dataset_val_filename = args.get('dataset_val_filename', None)
-        if dataset_val_filename is not None:
-            dataset_val = lgb.Dataset(directory+dataset_val_filename)
-        eval_metric = lgb_model.get_eval_metric()
-        if lgb_model.problem_type == BINARY:
-            train_loss_name = 'binary_logloss'
-        elif lgb_model.problem_type == MULTICLASS:
-            train_loss_name = 'multi_logloss'
-        elif lgb_model.problem_type == REGRESSION:
-            train_loss_name = 'l2'
-        else:
-            raise ValueError("unknown problem_type for LGBModel: %s" % lgb_model.problem_type)
-        lgb_model.eval_results = {}
-        callbacks = []
-        valid_names = ['train_set']
-        valid_sets = [dataset_train]
-        if dataset_val is not None:
-            callbacks += [
-                hpo_callback(reporter=reporter, stopping_rounds=150, metrics_to_use=[('valid_set', lgb_model.eval_metric_name)],
-                    max_diff=None, ignore_dart_warning=True, verbose=False, train_loss_name=train_loss_name, eval_results=lgb_model.eval_results)
-            ]
-            valid_names = ['valid_set'] + valid_names
-            valid_sets = [dataset_val] + valid_sets
-        else:
-            raise NotImplementedError("cannot call gbm hyperparameter_tune without validation dataset")
+                model.params[key] = args[key]  # use these hyperparam values in this trial
 
-        num_boost_round = lgb_model.params.pop('num_boost_round', 1000)
-        seed_value = lgb_model.params.pop('seed_value', None)
-        train_params = {
-            'params': lgb_model.params.copy(),
-            'train_set': dataset_train,
-            'num_boost_round': num_boost_round,
-            'valid_sets': valid_sets,
-            'valid_names': valid_names,
-            'evals_result': lgb_model.eval_results,
-            'callbacks': callbacks,
-            'verbose_eval': -1,
-        }
-        if not isinstance(eval_metric, str):
-            train_params['feval'] = eval_metric
-        if seed_value is not None:
-            train_params['seed'] = seed_value
-            random.seed(seed_value)
-            np.random.seed(seed_value)
+        time_current = time.time()
+        time_elapsed = time_current - args.time_start
+        if 'time_limit' in args:
+            time_left = args.time_limit - time_elapsed
+            if time_left <= 0:
+                raise TimeLimitExceeded
+        else:
+            time_left = None
 
-        lgb_model.model = lgb.train(**train_params)
-        lgb_model.params['num_boost_round'] = num_boost_round # re-set this value after training
-        if seed_value is not None:
-            lgb_model.params['seed_value'] = seed_value
-        # TODO: difficult to ensure these iters always match
-        # if lgb_model.eval_results['best_iter'] != lgb_model.best_iteration:
-        #     raise ValueError('eval_results[best_iter]=%s does not match lgb_model.best_iteration=%s' % (lgb_model.eval_results['best_iter'], lgb_model.best_iteration) )
-        # print('eval_results[best_iter]=%s does not match lgb_model.best_iteration=%s' % (lgb_model.eval_results['best_iter'], lgb_model.best_iteration) )
-        trial_model_file = lgb_model.save(file_prefix=file_prefix, directory=directory, return_filename=True)
-    except Exception as e:
-        logger.exception(e, exc_info=True)
-        reporter.terminate()
-    else:
-        reporter(epoch=num_boost_round+1, validation_performance=lgb_model.eval_results['best_valperf'],
-                 train_loss=lgb_model.eval_results['best_trainloss'],
-                 best_iteration=lgb_model.eval_results['best_iter'],
-                 directory=directory, file_prefix=file_prefix, trial_model_file=trial_model_file)
+        model.fit(dataset_train=dataset_train, dataset_val=dataset_val, time_limit=time_left, reporter=reporter)
+        # TODO: Set fit_time variable in model here
+        model.save()
         # TODO: add to reporter: time_of_trial without load/save time (isn't this just function of early-stopping point?), memory/inference ??
+        # TODO: add to reporter: Name/path of model
+    except Exception as e:
+        if not isinstance(e, TimeLimitExceeded):
+            logger.exception(e, exc_info=True)
+        reporter.terminate()

--- a/autogluon/utils/tabular/ml/models/lgb/lgb_model.py
+++ b/autogluon/utils/tabular/ml/models/lgb/lgb_model.py
@@ -28,7 +28,6 @@ class LGBModel(AbstractModel):
 
         self.eval_metric_name = self.stopping_metric.name
         self.is_higher_better = True
-        self.best_iteration = None
 
     def _set_default_params(self):
         default_params = get_param_baseline(problem_type=self.problem_type, num_classes=self.num_classes)
@@ -38,29 +37,13 @@ class LGBModel(AbstractModel):
     def get_eval_metric(self):
         return lgb_utils.func_generator(metric=self.stopping_metric, is_higher_better=True, needs_pred_proba=not self.stopping_metric_needs_y_pred, problem_type=self.problem_type)
 
-    # TODO: Avoid deleting X_train and X_test to not corrupt future runs
     def fit(self, X_train=None, Y_train=None, X_test=None, Y_test=None, dataset_train=None, dataset_val=None, time_limit=None, **kwargs):
         start_time = time.time()
         params = self.params.copy()
 
-        # TODO: Do this for dataset_train and dataset_val instead
-        # TODO: Better solution: Track trend to early stop when score is far worse than best score, or score is trending worse over time
-        if (X_test is not None) and (X_train is not None):
-            num_rows_train = len(X_train)
-            if num_rows_train <= 10000:
-                modifier = 1
-            else:
-                modifier = 10000 / num_rows_train
-            early_stopping_rounds = max(round(modifier * 150), 10)
-        else:
-            early_stopping_rounds = 150
-
         # TODO: kwargs can have num_cpu, num_gpu. Currently these are ignored.
         verbosity = kwargs.get('verbosity', 2)
         params = fixedvals_from_searchspaces(params)
-        if 'min_data_in_leaf' in params:
-            if params['min_data_in_leaf'] > X_train.shape[0]: # TODO: may not be necessary
-                params['min_data_in_leaf'] = max(1, int(X_train.shape[0]/5.0))
 
         if verbosity <= 1:
             verbose_eval = False
@@ -71,37 +54,49 @@ class LGBModel(AbstractModel):
         else:
             verbose_eval = 1
 
+        eval_metric = self.get_eval_metric()
+        dataset_train, dataset_val = self.generate_datasets(X_train=X_train, Y_train=Y_train, params=params, X_test=X_test, Y_test=Y_test, dataset_train=dataset_train, dataset_val=dataset_val)
+        gc.collect()
+
         num_boost_round = params.pop('num_boost_round', 1000)
         logger.log(15, 'Training Gradient Boosting Model for %s rounds...' % num_boost_round)
         logger.log(15, "with the following hyperparameter settings:")
         logger.log(15, params)
-        seed_val = params.pop('seed_value', 0)
 
-        eval_metric = self.get_eval_metric()
-        dataset_train, dataset_val = self.generate_datasets(X_train=X_train, Y_train=Y_train, params=params, X_test=X_test, Y_test=Y_test, dataset_train=dataset_train, dataset_val=dataset_val)
-        gc.collect()
+        num_rows_train = len(dataset_train.data)
+        if 'min_data_in_leaf' in params:
+            if params['min_data_in_leaf'] > num_rows_train:  # TODO: may not be necessary
+                params['min_data_in_leaf'] = max(1, int(num_rows_train/5.0))
+
+        # TODO: Better solution: Track trend to early stop when score is far worse than best score, or score is trending worse over time
+        if (dataset_val is not None) and (dataset_train is not None):
+            if num_rows_train <= 10000:
+                modifier = 1
+            else:
+                modifier = 10000 / num_rows_train
+            early_stopping_rounds = max(round(modifier * 150), 10)
+        else:
+            early_stopping_rounds = 150
 
         callbacks = []
         valid_names = ['train_set']
         valid_sets = [dataset_train]
         if dataset_val is not None:
+            reporter = kwargs.get('reporter', None)
+            if reporter is not None:
+                train_loss_name = self._get_train_loss_name()
+            else:
+                train_loss_name = None
             callbacks += [
                 early_stopping_custom(early_stopping_rounds, metrics_to_use=[('valid_set', self.eval_metric_name)], max_diff=None, start_time=start_time, time_limit=time_limit,
-                                      ignore_dart_warning=True, verbose=False, manual_stop_file=False),
+                                      ignore_dart_warning=True, verbose=False, manual_stop_file=False, reporter=reporter, train_loss_name=train_loss_name),
                 ]
             valid_names = ['valid_set'] + valid_names
             valid_sets = [dataset_val] + valid_sets
 
-        try_import_lightgbm()
-        import lightgbm as lgb
-        callbacks += [
-            # lgb.reset_parameter(learning_rate=lambda iter: alpha * (0.999 ** iter)),
-        ]
-        # lr_over_time = lambda iter: 0.05 * (0.99 ** iter)
-        # alpha = 0.1
-        
+        seed_val = params.pop('seed_value', 0)
         train_params = {
-            'params': params.copy(),
+            'params': params,
             'train_set': dataset_train,
             'num_boost_round': num_boost_round,
             'valid_sets': valid_sets,
@@ -115,9 +110,11 @@ class LGBModel(AbstractModel):
             train_params['params']['seed'] = seed_val
             random.seed(seed_val)
             np.random.seed(seed_val)
-        # Train lgbm model:
+
+        # Train LightGBM model:
+        try_import_lightgbm()
+        import lightgbm as lgb
         self.model = lgb.train(**train_params)
-        self.best_iteration = self.model.best_iteration
         self.params_trained['num_boost_round'] = self.model.best_iteration
 
     def predict_proba(self, X, preprocess=True):
@@ -189,50 +186,42 @@ class LGBModel(AbstractModel):
     # FIXME: Requires major refactor + refactor lgb_trial.py
     #  model names are not aligned with what is communicated to trainer!
     # FIXME: Likely tabular_nn_trial.py and abstract trial also need to be refactored heavily + hyperparameter functions
-    # FIXME: Don't alter self.params, only alter the copy!
-    def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options=None, **kwargs):
-        # verbosity = kwargs.get('verbosity', 2)
-        start_time = time.time()
+    def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options, **kwargs):
+        time_start = time.time()
         logger.log(15, "Beginning hyperparameter tuning for Gradient Boosting Model...")
         self._set_default_searchspace()
-        if isinstance(self.params['min_data_in_leaf'], Int):
-            upper_minleaf = self.params['min_data_in_leaf'].upper
-            if upper_minleaf > X_train.shape[0]: # TODO: this min_data_in_leaf adjustment based on sample size may not be necessary
+        params_copy = self.params.copy()
+        if isinstance(params_copy['min_data_in_leaf'], Int):
+            upper_minleaf = params_copy['min_data_in_leaf'].upper
+            if upper_minleaf > X_train.shape[0]:  # TODO: this min_data_in_leaf adjustment based on sample size may not be necessary
                 upper_minleaf = max(1, int(X_train.shape[0]/5.0))
-                lower_minleaf = self.params['min_data_in_leaf'].lower
+                lower_minleaf = params_copy['min_data_in_leaf'].lower
                 if lower_minleaf > upper_minleaf:
                     lower_minleaf = max(1, int(upper_minleaf/3.0))
-                self.params['min_data_in_leaf'] = Int(lower=lower_minleaf, upper=upper_minleaf)
-        params_copy = self.params.copy()
-        seed_val = self.params.pop('seed_value', None)  # FIXME: DEFECT?
-        num_boost_round = self.params.pop('num_boost_round', 1000)  # FIXME: DEFECT?
+                params_copy['min_data_in_leaf'] = Int(lower=lower_minleaf, upper=upper_minleaf)
 
         directory = self.path # also create model directory if it doesn't exist
         # TODO: This will break on S3! Use tabular/utils/savers for datasets, add new function
         if not os.path.exists(directory):
             os.makedirs(directory)
-        scheduler_func = scheduler_options[0] # Unpack tuple
-        scheduler_options = scheduler_options[1]
+        scheduler_func, scheduler_options = scheduler_options  # Unpack tuple
         if scheduler_func is None or scheduler_options is None:
             raise ValueError("scheduler_func and scheduler_options cannot be None for hyperparameter tuning")
         num_threads = scheduler_options['resource'].get('num_cpus', -1)
-        self.params['num_threads'] = num_threads
+        params_copy['num_threads'] = num_threads
         # num_gpus = scheduler_options['resource']['num_gpus'] # TODO: unused
 
-        dataset_train, dataset_val = self.generate_datasets(X_train=X_train, Y_train=Y_train, params=self.params, X_test=X_test, Y_test=Y_test)
+        dataset_train, dataset_val = self.generate_datasets(X_train=X_train, Y_train=Y_train, params=params_copy, X_test=X_test, Y_test=Y_test)
         dataset_train_filename = "dataset_train.bin"
         train_file = self.path + dataset_train_filename
         if os.path.exists(train_file): # clean up old files first
             os.remove(train_file)
         dataset_train.save_binary(train_file)
-        if dataset_val is not None:
-            dataset_val_filename = "dataset_val.bin" # names without directory info
-            val_file = self.path + dataset_val_filename
-            if os.path.exists(val_file): # clean up old files first
-                os.remove(val_file)
-            dataset_val.save_binary(val_file)
-        else:
-            dataset_val_filename = None
+        dataset_val_filename = "dataset_val.bin"  # names without directory info
+        val_file = self.path + dataset_val_filename
+        if os.path.exists(val_file):  # clean up old files first
+            os.remove(val_file)
+        dataset_val.save_binary(val_file)
 
         if not np.any([isinstance(params_copy[hyperparam], Space) for hyperparam in params_copy]):
             logger.warning("Attempting to do hyperparameter optimization without any search space (all hyperparameters are already fixed values)")
@@ -242,9 +231,7 @@ class LGBModel(AbstractModel):
                 if isinstance(params_copy[hyperparam], Space):
                     logger.log(15, str(hyperparam)+":   " + str(params_copy[hyperparam]))
 
-        lgb_trial.register_args(dataset_train_filename=dataset_train_filename,
-            dataset_val_filename=dataset_val_filename,
-            directory=directory, lgb_model=self, **params_copy)
+        lgb_trial.register_args(dataset_train_filename=dataset_train_filename, dataset_val_filename=dataset_val_filename, directory=directory, model=self, time_start=time_start, time_limit=scheduler_options['time_out'], **params_copy)
         scheduler = scheduler_func(lgb_trial, **scheduler_options)
         if ('dist_ip_addrs' in scheduler_options) and (len(scheduler_options['dist_ip_addrs']) > 0):
             # This is multi-machine setting, so need to copy dataset to workers:
@@ -261,7 +248,7 @@ class LGBModel(AbstractModel):
         best_hp = scheduler.get_best_config() # best_hp only contains searchable stuff
         hpo_results = {'best_reward': scheduler.get_best_reward(),
                        'best_config': best_hp,
-                       'total_time': time.time() - start_time,
+                       'total_time': time.time() - time_start,
                        'metadata': scheduler.metadata,
                        'training_history': scheduler.training_history,
                        'config_history': scheduler.config_history,
@@ -277,23 +264,27 @@ class LGBModel(AbstractModel):
         hpo_model_performances = {}
         for trial in sorted(hpo_results['trial_info'].keys()):
             # TODO: ignore models which were killed early by scheduler (eg. in Hyperband). How to ID these?
-            file_id = "trial_"+str(trial) # unique identifier to files from this trial
-            file_prefix = file_id + "_"
-            trial_model_name = self.name+"_"+file_id
-            trial_model_path = self.path + file_prefix
+            file_id = "trial_" + str(trial)  # unique identifier to files from this trial
+            trial_model_name = self.name + os.path.sep + file_id
+            trial_model_path = self.path_root + trial_model_name + os.path.sep
             hpo_models[trial_model_name] = trial_model_path
             hpo_model_performances[trial_model_name] = hpo_results['trial_info'][trial][scheduler._reward_attr]
 
         logger.log(15, "Time for Gradient Boosting hyperparameter optimization: %s" % str(hpo_results['total_time']))
-        self.params.update(best_hp)
-        # TODO: reload model params from best trial? Do we want to save this under cls.model_file as the "optimal model"
         logger.log(15, "Best hyperparameter configuration for Gradient Boosting Model: ")
         logger.log(15, best_hp)
-        return (hpo_models, hpo_model_performances, hpo_results)
-        # TODO: do final fit here?
-        # args.final_fit = True
-        # final_model = scheduler.run_with_config(best_config)
-        # save(final_model)
+        return hpo_models, hpo_model_performances, hpo_results
+
+    def _get_train_loss_name(self):
+        if self.problem_type == BINARY:
+            train_loss_name = 'binary_logloss'
+        elif self.problem_type == MULTICLASS:
+            train_loss_name = 'multi_logloss'
+        elif self.problem_type == REGRESSION:
+            train_loss_name = 'l2'
+        else:
+            raise ValueError("unknown problem_type for LGBModel: %s" % self.problem_type)
+        return train_loss_name
 
     def _set_default_searchspace(self):
         """ Sets up default search space for HPO. Each hyperparameter which user did not specify is converted from


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Major Changes:
- Significantly simplified lgb_trial.py to call model.fit.
- Corrected HPO model path reporting and names
- Enabled time-based early stopping of HPO trials for LightGBM
- Enabled memory-based early stopping of HPO trials for LightGBM
- Significantly simplified LightGBM callback code, merged two existing callbacks into one
- Corrected LightGBM HPO hyperparameters (Previously was throwing away seed and num_boost_rounds, + altering original model hyperparameters incorrectly)
- Optimized early stopping for LightGBM HPO to use dynamic early stopping rounds

Note: These issues still exist for the other models. Because this is a major change, I will leave the code changes for other models to separate PR's.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
