### PR TITLE
FIX: random searcher for negative reward

### DIFF
--- a/autogluon/searcher/searcher.py
+++ b/autogluon/searcher/searcher.py
@@ -26,6 +26,11 @@ class BaseSearcher(object):
         self._results = OrderedDict()
         self._best_state_path = None
 
+    @staticmethod
+    def _reward_while_pending():
+        """Defines the reward value which is assigned to config, while it is pending."""
+        return float("-inf")
+
     def get_config(self, **kwargs):
         """Function to sample a new configuration
 
@@ -82,7 +87,7 @@ class BaseSearcher(object):
         with self.LOCK:
             if self._results:
                 return max(self._results.values())
-        return float("-inf")
+        return self._reward_while_pending()
 
     def get_reward(self, config):
         """Calculates the reward (i.e. validation performance) produced by training with the given configuration.
@@ -110,7 +115,7 @@ class BaseSearcher(object):
                 config_pkl = max(self._results, key=self._results.get)
                 return pickle.loads(config_pkl), self._results[config_pkl]
             else:
-                return dict(), float("-inf")
+                return dict(), self._reward_while_pending()
 
     def __repr__(self):
         config, reward = self.get_best_config_reward()
@@ -167,7 +172,7 @@ class RandomSearcher(BaseSearcher):
                     f"Cannot find new config in BaseSearcher, even after {self.MAX_RETRIES} trials"
                 new_config = self.configspace.sample_configuration().get_dictionary()
                 num_tries += 1
-            self._results[pickle.dumps(new_config)] = float("-inf")
+            self._results[pickle.dumps(new_config)] = self._reward_while_pending()
         return new_config
 
 

--- a/autogluon/searcher/searcher.py
+++ b/autogluon/searcher/searcher.py
@@ -82,7 +82,7 @@ class BaseSearcher(object):
         with self.LOCK:
             if self._results:
                 return max(self._results.values())
-        return 0.0
+        return float("-inf")
 
     def get_reward(self, config):
         """Calculates the reward (i.e. validation performance) produced by training with the given configuration.
@@ -110,7 +110,7 @@ class BaseSearcher(object):
                 config_pkl = max(self._results, key=self._results.get)
                 return pickle.loads(config_pkl), self._results[config_pkl]
             else:
-                return dict(), 0.0
+                return dict(), float("-inf")
 
     def __repr__(self):
         config, reward = self.get_best_config_reward()
@@ -170,5 +170,5 @@ class RandomSearcher(BaseSearcher):
             self._results[pickle.dumps(new_config)] = float("-inf")
         return new_config
 
-   
+
 RandomSampling = DeprecationHelper(RandomSearcher, 'RandomSampling')

--- a/autogluon/searcher/skopt_searcher.py
+++ b/autogluon/searcher/skopt_searcher.py
@@ -114,7 +114,7 @@ class SKoptSearcher(BaseSearcher):
                 new_config_cs.is_valid_configuration()
                 new_config = new_config_cs.get_dictionary()
                 if (pickle.dumps(new_config) not in self._results.keys()): # have not encountered this config
-                    self._results[pickle.dumps(new_config)] = 0
+                    self._results[pickle.dumps(new_config)] = self._reward_while_pending()
                     return new_config
             except self.errors_tohandle:
                 pass
@@ -126,7 +126,7 @@ class SKoptSearcher(BaseSearcher):
                     new_config_cs.is_valid_configuration()
                     new_config = new_config_cs.get_dictionary()
                     if (pickle.dumps(new_config) not in self._results.keys()): # have not encountered this config
-                        self._results[pickle.dumps(new_config)] = 0
+                        self._results[pickle.dumps(new_config)] = self._reward_while_pending()
                         return new_config
                 except self.errors_tohandle:
                     pass
@@ -145,7 +145,7 @@ class SKoptSearcher(BaseSearcher):
         """
         new_config_cs = self.configspace.get_default_configuration()
         new_config = new_config_cs.get_dictionary()
-        self._results[pickle.dumps(new_config)] = 0
+        self._results[pickle.dumps(new_config)] = self._reward_while_pending()
         return new_config
         
     def random_config(self):
@@ -155,7 +155,7 @@ class SKoptSearcher(BaseSearcher):
         new_config = self.configspace.sample_configuration().get_dictionary()
         while pickle.dumps(new_config) in self._results.keys():
             new_config = self.configspace.sample_configuration().get_dictionary()
-        self._results[pickle.dumps(new_config)] = 0
+        self._results[pickle.dumps(new_config)] = self._reward_while_pending()
         return new_config
 
     def update(self, config, reward, **kwargs):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Basic PEP8 corrections and optimisations. 
- Fixing random searcher, when reward is negative value (for example r2).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
