### PR TITLE
Tabular: Fixed CatBoost iterations value after training

### DIFF
--- a/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
+++ b/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
@@ -23,7 +23,6 @@ class CatboostModel(AbstractModel):
         try_import_catboost()
         from catboost import CatBoostClassifier, CatBoostRegressor
         self.model_type = CatBoostClassifier if problem_type in PROBLEM_TYPES_CLASSIFICATION else CatBoostRegressor
-        self.best_iteration = 0
         if isinstance(self.params['eval_metric'], str):
             self.metric_name = self.params['eval_metric']
         else:
@@ -201,5 +200,4 @@ class CatboostModel(AbstractModel):
 
                 self.model.shrink(ntree_start=0, ntree_end=best_iteration+1)
 
-        self.best_iteration = self.model.tree_count_ - 1
-        self.params_trained['iterations'] = self.model.tree_count_ - 1
+        self.params_trained['iterations'] = self.model.tree_count_


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed CatBoost iterations value after training, previously was 1 too few. Caused _FULL models to train for 1 fewer iterations than expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
