### PR TITLE
FIX: fixing training hanging

### DIFF
--- a/autogluon/scheduler/fifo.py
+++ b/autogluon/scheduler/fifo.py
@@ -257,6 +257,10 @@ class FIFOScheduler(TaskScheduler):
         last_result = None
         while not task_job.done():
             reported_result = reporter.fetch()
+            if 'traceback' in reported_result:
+                logger.exception(reported_result['traceback'])
+                break
+
             if reported_result.get('done', False):
                 reporter.move_on()
                 break

--- a/autogluon/scheduler/scheduler.py
+++ b/autogluon/scheduler/scheduler.py
@@ -14,7 +14,7 @@ from .remote import RemoteManager
 from .resource import DistributedResourceManager
 from ..core import Task
 from .reporter import *
-from ..utils import AutoGluonWarning, AutoGluonEarlyStop
+from ..utils import AutoGluonWarning, AutoGluonEarlyStop, CustomProcess
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +142,7 @@ class TaskScheduler(object):
 
         try:
             # start local progress
-            p = mp.Process(target=_worker, args=(return_list,gpu_ids, args))
+            p = CustomProcess(target=_worker, args=(return_list, gpu_ids, args))
             p.start()
             if 'reporter' in args:
                 cp = Communicator.Create(p, local_reporter, dist_reporter)

--- a/autogluon/utils/__init__.py
+++ b/autogluon/utils/__init__.py
@@ -16,4 +16,4 @@ from .file_helper import *
 from .plot_network import plot_network
 from .defaultdict import keydefaultdict
 from .util_decorator import classproperty
-
+from .custom_process import CustomProcess

--- a/autogluon/utils/custom_process.py
+++ b/autogluon/utils/custom_process.py
@@ -1,0 +1,27 @@
+# Adapted from: https://stackoverflow.com/a/33599967/8199034
+import multiprocessing as mp
+import traceback
+
+
+class CustomProcess(mp.Process):
+    """Custom Process implementation which checks has Exception property."""
+
+    def __init__(self, *args, **kwargs):
+        mp.Process.__init__(self, *args, **kwargs)
+        self._pconn, self._cconn = mp.Pipe()
+        self._exception = None
+
+    def run(self):
+        try:
+            mp.Process.run(self)
+            self._cconn.send(None)
+        except Exception as e:
+            tb = traceback.format_exc()
+            self._cconn.send((e, tb))
+            # raise e  # You can still rise this exception if you need to
+
+    @property
+    def exception(self):
+        if self._pconn.poll():
+            self._exception = self._pconn.recv()
+        return self._exception


### PR DESCRIPTION
*Issue #329 , if available:*

*Description of changes:*
- Implementation of `CustomProcess` class, which has property `exception`.
- Using `CustomProcess` class for individual training process.
- Checking individual training fails due to some Exception using `exception` property of `CustomProcess`.
- Before fetching from local reporter queue checking if it has some results, if not continue waiting for results or exception in `while self.process.is_alive()`. 
- If process is not fails,  then reported results are transferred to `dist_reporter` and so on.
- if process fails, terminating `local_reporter` and transferring exception traceback to `dist_reporter`.

The change is implemented only for `FIFO` scheduler, it will be approved, then we can implement also for other schedulers. 

Code sample # 1:
```
import autogluon as ag
import pandas as pd
import sklearn.datasets
from sklearn.ensemble import RandomForestRegressor
from sklearn.metrics import r2_score, mean_absolute_error

initial_data = sklearn.datasets.load_boston(return_X_y=False)
data = pd.DataFrame(initial_data['data'], columns=initial_data['feature_names'])
data['target'] = initial_data['target']


def train_rf(args, reporter):
    train_data = args.train_data
    target_variable = args.target_variable

    rf = RandomForestRegressor(
        n_estimators=args.n_estimators,
        max_depth=args.max_depth,
        min_samples_leaf=args.min_samples_leaf,
        min_samples_split=args.min_samples_split,
        min_weight_fraction_leaf=args.min_weight_fraction_leaf,
        random_state=34
    )

    rf.fit(train_data.drop(columns=target_variable), train_data[target_variable])
    pred = rf.predict(train_data.drop(columns=target_variable))
    mae = abs(mean_absolute_error(train_data[target_variable], pred))
    r2 = r2_score(train_data[target_variable], pred)
    reporter(mae=mae, r2=r2)


@ag.args(
    n_estimators=-10,  # this will raise an exception, since it must be >= 1
    max_depth=ag.space.Int(1, 10),
    min_samples_leaf=ag.space.Int(1, 5),
    min_samples_split=ag.space.Int(2, 5),
    min_weight_fraction_leaf=ag.space.Real(0.0, 1e-1),
    train_data=data,
    target_variable="target"
)
def ag_train_rf(args, reporter):
    return train_rf(args, reporter)


myscheduler = ag.scheduler.FIFOScheduler(
    ag_train_rf,
    resource={'num_cpus': 8, 'num_gpus': 0},
    num_trials=5,
    reward_attr='r2',
    searcher='skopt',  # currently supports "random", "skopt", "gird",
    max_reward=0,
)
print(myscheduler)
myscheduler.run()
myscheduler.join_jobs()
```

Code sample # 2:
```
import autogluon as ag
from autogluon import ImageClassification as task

train_data = task.Dataset(name='fashionmnist')

classifier = task.fit(
    train_data,
    num_trials=1,
    net=ag.Categorical('hello'),  # this will raise an exception
    epochs=5,
    ngpus_per_trial=1,
    verbose=False,
    auto_search=False,
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
