### PR TITLE
Tabular: HPO Fix + Various Cleanup

### DIFF
--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -297,14 +297,12 @@ class AbstractModel:
         trained_params.update(self.params_trained)
         return trained_params
 
-    # TODO: currently inplace and destructive. This won't work well for in-memory models.
-    #  Problem with not inplace -> 2x memory usage, try to avoid somehow
-    # After calling this function, model should be able to be fit as if it was new, as well as deep-copied.
+    # After calling this function, returned model should be able to be fit as if it was new, as well as deep-copied.
     def convert_to_template(self):
         model = self.model
         self.model = None
         template = copy.deepcopy(self)
-        template.params_trained = dict()
+        template.reset_metrics()
         self.model = model
         return template
 
@@ -412,6 +410,13 @@ class AbstractModel:
         features_to_keep = feature_pruner.features_in_iter[feature_pruner.best_iteration]
         logger.debug(str(features_to_keep))
         self.features = features_to_keep
+
+    # Resets metrics for the model
+    def reset_metrics(self):
+        self.fit_time = None
+        self.predict_time = None
+        self.val_score = None
+        self.params_trained = dict()
 
     def get_info(self):
         info = dict(

--- a/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
@@ -251,16 +251,6 @@ class BaggedEnsembleModel(AbstractModel):
         child.save(verbose=verbose)
 
     # TODO: Multiply epochs/n_iterations by some value (such as 1.1) to account for having more training data than bagged models
-    # Trains a single model on all of the data, averaging the hyperparameters of all the bagged models (such as epochs trained)
-    # Generally expected to have lower accuracy but faster inference time
-    def compress(self, X, y):
-        model_compressed = self.convert_to_compressed_template()
-        model_compressed.fit(X_train=X, Y_train=y)  # TODO: This only works for stacker, not for bagged
-        return model_compressed
-
-    def convert_to_compressed_template(self):
-        raise NotImplementedError
-
     def convert_to_refitfull_template(self):
         compressed_params = self._get_compressed_params()
         model_compressed = copy.deepcopy(self._get_model_base())

--- a/autogluon/utils/tabular/ml/models/knn/knn_model.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_model.py
@@ -58,8 +58,8 @@ class KNNModel(SKLearnModel):
 
     def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options=None, **kwargs):
         fit_model_args = dict(X_train=X_train, Y_train=Y_train, **kwargs)
-        score_model_args = dict(X=X_test, y=Y_test)
-        model_trial.fit_and_save_model(model=self, params=dict(), fit_model_args=fit_model_args, score_model_args=score_model_args, time_start=time.time(), time_limit=None)
+        predict_proba_args = dict(X=X_test)
+        model_trial.fit_and_save_model(model=self, params=dict(), fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_test=Y_test, time_start=time.time(), time_limit=None)
         hpo_results = {'total_time': self.fit_time}
         hpo_model_performances = {self.name: self.val_score}
         hpo_models = {self.name: self.path}

--- a/autogluon/utils/tabular/ml/models/knn/knn_model.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_model.py
@@ -5,6 +5,7 @@ import psutil
 import sys
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
+from ..abstract import model_trial
 from ...constants import REGRESSION
 from ..sklearn.sklearn_model import SKLearnModel
 from ....utils.exceptions import NotEnoughMemoryError
@@ -56,12 +57,10 @@ class KNNModel(SKLearnModel):
         self.model = model.fit(X_train, Y_train)
 
     def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options=None, **kwargs):
-        time_start = time.time()
-        self.fit(X_train=X_train, Y_train=Y_train, **kwargs)
-        time_end = time.time()
-        hpo_model_performances = {self.name: self.score(X_test, Y_test)}
-        hpo_results = {'total_time': time_end - time_start}
-        self.save()
+        fit_model_args = dict(X_train=X_train, Y_train=Y_train, **kwargs)
+        score_model_args = dict(X=X_test, y=Y_test)
+        model_trial.fit_and_save_model(model=self, params=dict(), fit_model_args=fit_model_args, score_model_args=score_model_args, time_start=time.time(), time_limit=None)
+        hpo_results = {'total_time': self.fit_time}
+        hpo_model_performances = {self.name: self.val_score}
         hpo_models = {self.name: self.path}
-
         return hpo_models, hpo_model_performances, hpo_results

--- a/autogluon/utils/tabular/ml/models/lgb/hyperparameters/lgb_trial.py
+++ b/autogluon/utils/tabular/ml/models/lgb/hyperparameters/lgb_trial.py
@@ -26,8 +26,8 @@ def lgb_trial(args, reporter):
         X_val, y_val = load_pkl.load(util_args.directory + util_args.dataset_val_pkl_filename)
 
         fit_model_args = dict(dataset_train=dataset_train, dataset_val=dataset_val)
-        score_model_args = dict(X=X_val, y=y_val)
-        model_trial.fit_and_save_model(model=model, params=args, fit_model_args=fit_model_args, score_model_args=score_model_args,
+        predict_proba_args = dict(X=X_val)
+        model_trial.fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_test=y_val,
                                        time_start=util_args.time_start, time_limit=util_args.get('time_limit', None), reporter=reporter)
     except Exception as e:
         if not isinstance(e, TimeLimitExceeded):

--- a/autogluon/utils/tabular/ml/models/rf/rf_model.py
+++ b/autogluon/utils/tabular/ml/models/rf/rf_model.py
@@ -118,8 +118,8 @@ class RFModel(SKLearnModel):
 
     def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options=None, **kwargs):
         fit_model_args = dict(X_train=X_train, Y_train=Y_train, **kwargs)
-        score_model_args = dict(X=X_test, y=Y_test)
-        model_trial.fit_and_save_model(model=self, params=dict(), fit_model_args=fit_model_args, score_model_args=score_model_args, time_start=time.time(), time_limit=None)
+        predict_proba_args = dict(X=X_test)
+        model_trial.fit_and_save_model(model=self, params=dict(), fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_test=Y_test, time_start=time.time(), time_limit=None)
         hpo_results = {'total_time': self.fit_time}
         hpo_model_performances = {self.name: self.val_score}
         hpo_models = {self.name: self.path}

--- a/autogluon/utils/tabular/ml/models/rf/rf_model.py
+++ b/autogluon/utils/tabular/ml/models/rf/rf_model.py
@@ -4,6 +4,7 @@ import psutil
 import sys
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor, ExtraTreesClassifier, ExtraTreesRegressor
 
+from ..abstract import model_trial
 from ..sklearn.sklearn_model import SKLearnModel
 from ...constants import MULTICLASS, REGRESSION
 from ....utils.exceptions import NotEnoughMemoryError, TimeLimitExceeded
@@ -116,12 +117,10 @@ class RFModel(SKLearnModel):
         self.params_trained['n_estimators'] = self.model.n_estimators
 
     def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options=None, **kwargs):
-        time_start = time.time()
-        self.fit(X_train=X_train, Y_train=Y_train, **kwargs)
-        time_end = time.time()
-        hpo_model_performances = {self.name: self.score(X_test, Y_test)}
-        hpo_results = {'total_time': time_end - time_start}
-        self.save()
+        fit_model_args = dict(X_train=X_train, Y_train=Y_train, **kwargs)
+        score_model_args = dict(X=X_test, y=Y_test)
+        model_trial.fit_and_save_model(model=self, params=dict(), fit_model_args=fit_model_args, score_model_args=score_model_args, time_start=time.time(), time_limit=None)
+        hpo_results = {'total_time': self.fit_time}
+        hpo_model_performances = {self.name: self.val_score}
         hpo_models = {self.name: self.path}
-
         return hpo_models, hpo_model_performances, hpo_results

--- a/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
@@ -96,13 +96,6 @@ class TabularNeuralNetModel(AbstractModel):
         self.optimizer = None
         self.verbosity = None
 
-    # TODO: Fix model to not have tabNN in params
-    def convert_to_template(self):
-        new_model = TabularNeuralNetModel(path=self.path, name=self.name, problem_type=self.problem_type, objective_func=self.objective_func, stopping_metric=self.stopping_metric, features=self.features, hyperparameters=self.params)
-        new_model.path = self.path
-        new_model.params['tabNN'] = None
-        return new_model
-
     def _set_default_params(self):
         """ Specifies hyperparameter values to use by default """
         default_params = get_default_param(self.problem_type)

--- a/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_trial.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_trial.py
@@ -19,8 +19,8 @@ def tabular_nn_trial(args, reporter):
         y_test = test_dataset.get_labels()
 
         fit_model_args = dict(X_train=train_dataset, Y_train=None, X_test=test_dataset)
-        score_model_args = dict(X=test_dataset, y=y_test)
-        model_trial.fit_and_save_model(model=model, params=args, fit_model_args=fit_model_args, score_model_args=score_model_args,
+        predict_proba_args = dict(X=test_dataset)
+        model_trial.fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_test=y_test,
                                        time_start=util_args.time_start, time_limit=util_args.get('time_limit', None), reporter=reporter)
     except Exception as e:
         if not isinstance(e, TimeLimitExceeded):

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -68,7 +68,7 @@ class AbstractTrainer:
             logger.log(25, "This metric expects predicted probabilities rather than predicted class labels, so you'll need to use predict_proba() instead of predict()")
 
         logger.log(20, "To change this, specify the eval_metric argument of fit()")
-        logger.log(25, "AutoGluon will early stop models using evaluation metric: %s" % self.stopping_metric.name)  # TODO: stopping_metric is likely not used during HPO, fix this
+        logger.log(25, "AutoGluon will early stop models using evaluation metric: %s" % self.stopping_metric.name)
         self.num_classes = num_classes
         self.feature_prune = False # will be set to True if feature-pruning is turned on.
         self.low_memory = low_memory
@@ -91,7 +91,6 @@ class AbstractTrainer:
         # self.models_level_all['aux1'][1] # Stacker level 1 aux models, such as weighted_ensemble
         # self.models_level_all['core'][2] # Stacker level 2
         self.models_level = defaultdict(dd_list)
-        self.models_level_hpo = defaultdict(dd_list)  # stores additional models produced during HPO
 
         self.model_best = None
         self.model_best_core = None
@@ -355,14 +354,11 @@ class AbstractTrainer:
             elif k_fold_start != 0:
                 raise ValueError('k_fold_start must be 0 to hyperparameter_tune, value = ' + str(k_fold_start))
             # hpo_models (dict): keys = model_names, values = model_paths
-            try:  # TODO: Make exception handling more robust? Return successful HPO models?
+            try:
                 if isinstance(model, BaggedEnsembleModel):
                     hpo_models, hpo_model_performances, hpo_results = model.hyperparameter_tune(X=X_train, y=y_train, k_fold=kfolds, scheduler_options=(self.scheduler_func, self.scheduler_options), verbosity=self.verbosity)
                 else:
-                    if (X_test is None) or (y_test is None):
-                        X_train, X_test, y_train, y_test = generate_train_test_split(X_train, y_train, problem_type=self.problem_type, test_size=0.2)  # TODO: Adjust test_size, perhaps user specified?
-                    hpo_models, hpo_model_performances, hpo_results = model.hyperparameter_tune(X_train=X_train, X_test=X_test,
-                        Y_train=y_train, Y_test=y_test, scheduler_options=(self.scheduler_func, self.scheduler_options), verbosity=self.verbosity)
+                    hpo_models, hpo_model_performances, hpo_results = model.hyperparameter_tune(X_train=X_train, X_test=X_test, Y_train=y_train, Y_test=y_test, scheduler_options=(self.scheduler_func, self.scheduler_options), verbosity=self.verbosity)
             except Exception as err:
                 if self.verbosity >= 1:
                     traceback.print_tb(err.__traceback__)
@@ -371,26 +367,12 @@ class AbstractTrainer:
                 del model
                 model_names_trained = []
             else:
-                model_names_trained = list(sorted(hpo_models.keys()))
-                self.models_level_hpo[stack_name][level] += model_names_trained
-                self.model_paths.update(hpo_models)
-
                 self.hpo_results[model.name] = hpo_results
-                self.model_types.update({name: type(model) for name in model_names_trained})
-                if isinstance(model, BaggedEnsembleModel):
-                    self.model_types_inner.update({name: model._child_type for name in model_names_trained})
-                else:
-                    self.model_types_inner.update({name: type(model) for name in model_names_trained})
-
-                for model_hpo_name in model_names_trained:
-                    model_hpo = self.load_model(model_hpo_name)
-                    if model_hpo.val_score is not None:
-                        # TODO: Remove this once HPO scheduler results are fixed
-                        hpo_model_performances[model_hpo_name] = model_hpo.val_score
-
-                    # TODO: Uncomment self.add_model() once HPO is fixed
-                    # self.add_model(model=model_hpo, stack_name=stack_name, level=level)
-                self.model_performance.update(hpo_model_performances)
+                model_names_trained = []
+                for model_hpo_name, model_path in hpo_models.items():
+                    model_hpo = self.load_model(model_hpo_name, path=model_path, model_type=type(model))
+                    self.add_model(model=model_hpo, stack_name=stack_name, level=level)
+                    model_names_trained.append(model_hpo.name)
         else:
             model_names_trained = self.train_and_save(X_train, y_train, X_test, y_test, model, stack_name=stack_name, kfolds=kfolds, k_fold_start=k_fold_start, k_fold_end=k_fold_end, n_repeats=n_repeats, n_repeat_start=n_repeat_start, level=level, time_limit=time_limit)
         self.save()
@@ -435,8 +417,6 @@ class AbstractTrainer:
     def train_multi_initial(self, X_train, y_train, X_test, y_test, models: List[AbstractModel], kfolds, n_repeats, hyperparameter_tune=True, feature_prune=False, stack_name='core', level=0, time_limit=None):
         stack_loc = self.models_level[stack_name]
 
-        model_names_trained = []
-        model_names_trained_hpo = []
         models_valid = models
         if kfolds == 0:
             models_valid = self.train_multi_fold(X_train, y_train, X_test, y_test, models_valid, hyperparameter_tune=hyperparameter_tune, feature_prune=feature_prune, stack_name=stack_name,
@@ -454,13 +434,7 @@ class AbstractTrainer:
             models_valid = self.train_multi_fold(X_train, y_train, X_test, y_test, models_valid, hyperparameter_tune=False, feature_prune=False, stack_name=stack_name,
                                                  kfolds=kfolds, k_fold_start=k_fold_start, k_fold_end=kfolds, n_repeats=n_repeats, n_repeat_start=0, level=level, time_limit=time_limit)
 
-        if hyperparameter_tune:
-            model_names_trained_hpo += models_valid
-        else:
-            model_names_trained += models_valid
-
-        stack_loc[level] += model_names_trained_hpo  # Update model list with (potentially empty) list of new models created during HPO
-        model_names_trained += model_names_trained_hpo
+        model_names_trained = models_valid
         unique_names = []
         for item in stack_loc[level]:
             if item not in unique_names: unique_names.append(item)
@@ -828,11 +802,15 @@ class AbstractTrainer:
                     if isinstance(fold_model, str):
                         model.models[fold] = model.load_child(fold_model)
 
-    def load_model(self, model_name: str) -> AbstractModel:
+    def load_model(self, model_name: str, path: str = None, model_type=None) -> AbstractModel:
         if model_name in self.models.keys():
             return self.models[model_name]
         else:
-            return self.model_types[model_name].load(path=self.model_paths[model_name], reset_paths=self.reset_paths)
+            if path is None:
+                path = self.model_paths[model_name]
+            if model_type is None:
+                model_type = self.model_types[model_name]
+            return model_type.load(path=path, reset_paths=self.reset_paths)
 
     def _get_dummy_stacker(self, level, use_orig_features=True):
         model_names = self.models_level['core'][level-1]

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -282,7 +282,8 @@ class AbstractTrainer:
                     model.predict_time = pred_end_time - fit_end_time
             if model.val_score is None:
                 model.val_score = score
-            model.save_info()  # TODO: Potentially add parameter to avoid doing this if specified
+            # TODO: Add recursive=True to avoid repeatedly loading models each time this is called for bagged ensembles (especially during repeated bagging)
+            # model.save_info()  # TODO: Potentially add parameter to avoid doing this if specified
             self.save_model(model=model)
         except TimeLimitExceeded:
             logger.log(20, '\tTime limit exceeded... Skipping %s.' % model.name)

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -267,7 +267,10 @@ class AbstractTrainer:
                 else:
                     score = None
             else:
-                score = model.score(X=X_test, y=y_test)
+                if X_test is not None and y_test is not None:
+                    score = model.score(X=X_test, y=y_test)
+                else:
+                    score = None
             pred_end_time = time.time()
             if model.fit_time is None:
                 model.fit_time = fit_end_time - fit_start_time
@@ -751,7 +754,6 @@ class AbstractTrainer:
                     X = X.drop(cols_to_drop, axis=1)
         return X
 
-    # TODO: this currently only works for bagged models.
     # You must have previously called fit() with enable_fit_continuation=True, and either num_bagging_folds > 1 or auto_stack=True.
     def refit_single_full(self, X=None, y=None, models=None):
         if X is None:

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -21,7 +21,6 @@ from ..models.ensemble.weighted_ensemble_model import WeightedEnsembleModel
 logger = logging.getLogger(__name__)
 
 
-# TODO: Try to optimize for log loss at level 0 for stacking, only optimize for objective func at later levels or in aux models. Might work better.
 # FIXME: Below is major defect!
 #  Weird interaction for metrics like AUC during bagging.
 #  If kfold = 5, scores are 0.9, 0.85, 0.8, 0.75, and 0.7, the score is not 0.8! It is much lower because probs are combined together and AUC is recalculated


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes:
- Added refitfull support for non-bagged models
- Disabled unnecessary model.save_info() calls during training
- Added fit_time, predict_time to HPO models
- Various HPO cleanup
- Removed outdated code and outdated TODOs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
