### PR TITLE
Tabular: Feature Importance

### DIFF
--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -452,6 +452,23 @@ class AbstractLearner:
                 print(leaderboard)
         return leaderboard
 
+    # TODO: Should this return a dictionary or pandas Series? Current it returns a Series
+    # TODO: enable_fit_continuation must be set to True to be able to pass X and y as None in this function, otherwise it will error.
+    # Warning: This can take a very, very long time to compute if the data is large and the model is complex.
+    # TODO: Warning: This is not memory safe, large datasets may result in OOM errors during feature importance calculation.
+    # A value of 0.01 means that the objective metric error would be expected to increase by 0.01 if the feature were removed.
+    # Negative values mean the feature is likely harmful.
+    def get_feature_importance(self, model, X=None, y=None) -> Series:
+        if X is not None:
+            if y is None:
+                X, y = self.extract_label(X)
+            X = self.transform_features(X)
+            y = self.label_cleaner.transform(y)
+        else:
+            y = None
+        trainer = self.load_trainer()
+        return trainer.get_feature_importance(X=X, y=y, model=model)
+
     # TODO: Add data info gathering at beginning of .fit() that is used by all learners to add to get_info output
     # TODO: Add feature inference / feature engineering info to get_info output
     def get_info(self, include_model_info=False):

--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -141,7 +141,11 @@ class AbstractModel:
     # TODO: Add preprocess_stateful() to enable stateful preprocessing for models such as KNN
     def preprocess(self, X):
         if self.features is not None:
-            return X[self.features]
+            # TODO: In online-inference this becomes expensive, add option to remove it (only safe in controlled environment where it is already known features are present
+            if list(X.columns) != self.features:
+                return X[self.features]
+        else:
+            self.features = list(X.columns)  # TODO: add fit and transform versions of preprocess instead of doing this
         return X
 
     def fit(self, X_train, Y_train, **kwargs):
@@ -216,7 +220,8 @@ class AbstractModel:
             obj.set_contexts(path)
             return obj
 
-    def compute_feature_importance(self, X, y, features_to_use=None):
+    # TODO: Consider disabling feature pruning when num_features is high (>1000 for example), or using a faster feature importance calculation method
+    def compute_feature_importance(self, X, y, features_to_use=None, preprocess=True):
         sample_size = 10000
         if len(X) > sample_size:
             X = X.sample(sample_size, random_state=0)
@@ -228,16 +233,40 @@ class AbstractModel:
         X.reset_index(drop=True, inplace=True)
         y.reset_index(drop=True, inplace=True)
 
-        X = self.preprocess(X)
+        if preprocess:
+            X = self.preprocess(X)
 
         if not features_to_use:
             features = X.columns.values
         else:
             features = features_to_use
+
+        feature_importance_quick_dict = self.get_model_feature_importance()
+        # TODO: Also consider banning features with close to 0 importance
+        # TODO: Consider adding 'golden' features if the importance is high enough to avoid unnecessary computation when doing feature selection
+        banned_features = [feature for feature, importance in feature_importance_quick_dict.items() if importance == 0 and feature in features]
+        features = [feature for feature in features if feature not in banned_features]
+
+        permutation_importance_dict = self.compute_permutation_importance(X=X, y=y, features=features, preprocess=False)
+
+        feature_importances = pd.Series(permutation_importance_dict)
+        results_banned = pd.Series(data=[0 for _ in range(len(banned_features))], index=banned_features)
+        feature_importances = pd.concat([feature_importances, results_banned])
+        feature_importances = feature_importances.sort_values(ascending=False)
+
+        return feature_importances
+
+    # TODO: Optimize this
+    # TODO: Check memory usage to avoid OOM
+    # Compute feature importance via permutation importance
+    # Note: Expensive to compute
+    #  Time to compute is O(predict_time*num_features)
+    def compute_permutation_importance(self, X, y, features: list, preprocess=True) -> dict:
+        if preprocess:
+            X = self.preprocess(X)
+
         feature_count = len(features)
-
         model_score_base = self.score(X=X, y=y)
-
         model_score_diff = []
 
         row_count = X.shape[0]
@@ -252,7 +281,6 @@ class AbstractModel:
             if indice + compute_count > feature_count:
                 compute_count = feature_count - indice
 
-            logger.debug(indice)
             x = [X.copy() for _ in range(compute_count)]  # TODO Make this much faster, only make this and concat it once. Then just update values and reset the values edited each iteration
             for j, val in enumerate(x):
                 feature = features[indice + j]
@@ -272,10 +300,12 @@ class AbstractModel:
                 score = self.objective_func(y, Y_pred_cur)
                 model_score_diff.append(model_score_base - score)
 
-        results = pd.Series(data=model_score_diff, index=features)
-        results = results.sort_values(ascending=False)
+        permutation_importance_dict = {feature: score_diff for feature, score_diff in zip(features, model_score_diff)}
+        return permutation_importance_dict
 
-        return results
+    # Custom feature importance values for a model (such as those calculated from training)
+    def get_model_feature_importance(self) -> dict:
+        return dict()
 
     def _get_default_searchspace(self, problem_type):
         return NotImplementedError

--- a/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
+++ b/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
@@ -201,3 +201,10 @@ class CatboostModel(AbstractModel):
                 self.model.shrink(ntree_start=0, ntree_end=best_iteration+1)
 
         self.params_trained['iterations'] = self.model.tree_count_
+
+    def get_model_feature_importance(self):
+        importance_df = self.model.get_feature_importance(prettified=True)
+        importance_df['Importances'] = importance_df['Importances'] / 100
+        importance_series = importance_df.set_index('Feature Id')['Importances']
+        importance_dict = importance_series.to_dict()
+        return importance_dict

--- a/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
@@ -99,6 +99,8 @@ class BaggedEnsembleModel(AbstractModel):
             stratified = True
 
         model_base = self._get_model_base()
+        if self.features is not None:
+            model_base.features = self.features
         model_base.feature_types_metadata = self.feature_types_metadata  # TODO: Don't pass this here
 
         if k_fold == 1:
@@ -135,7 +137,6 @@ class BaggedEnsembleModel(AbstractModel):
         oof_pred_model_repeats = np.zeros(shape=len(X))
 
         models = []
-        time_limit_fold = None
         folds_to_fit = fold_end - fold_start
         for j in range(n_repeat_start, n_repeats):  # For each n_repeat
             cur_repeat_count = j - n_repeat_start
@@ -161,6 +162,8 @@ class BaggedEnsembleModel(AbstractModel):
                             raise TimeLimitExceeded
                     if time_left <= 0:
                         raise TimeLimitExceeded
+                else:
+                    time_limit_fold = None
 
                 time_start_fold = time.time()
                 train_index, test_index = fold
@@ -237,6 +240,46 @@ class BaggedEnsembleModel(AbstractModel):
         y_pred_proba = self.oof_pred_proba[valid_indices]
 
         return self.score_with_y_pred_proba(y=y, y_pred_proba=y_pred_proba)
+
+    # TODO: Augment to generate OOF after shuffling each column in X (Batching), this is the fastest way.
+    # Generates OOF predictions from pre-trained bagged models, assuming X and y are in the same row order as used in .fit(X, y)
+    def compute_feature_importance(self, X, y, features_to_use=None, preprocess=True):
+        if self.problem_type == REGRESSION:
+            stratified = False
+        else:
+            stratified = True
+
+        feature_importance_fold_list = []
+        fold_weights = []
+        # TODO: Preprocess data here instead of repeatedly
+        model_index = 0
+        for n_repeat, k in enumerate(self._k_per_n_repeat):
+            kfolds = generate_kfold(X=X, y=y, n_splits=k, stratified=stratified, random_state=self._random_state, n_repeats=n_repeat + 1)
+            cur_kfolds = kfolds[n_repeat * k:(n_repeat+1) * k]
+            for i, fold in enumerate(cur_kfolds):
+                train_index, test_index = fold
+                model = self.load_child(self.models[model_index + i])
+                feature_importance_fold = model.compute_feature_importance(X=X.iloc[test_index, :], y=y.iloc[test_index], features_to_use=features_to_use, preprocess=preprocess)
+                feature_importance_fold_list.append(feature_importance_fold)
+                fold_weights.append(len(test_index))
+            model_index += k
+
+        weight_total = sum(fold_weights)
+        fold_weights = [weight/weight_total for weight in fold_weights]
+
+        for i, result in enumerate(feature_importance_fold_list):
+            feature_importance_fold_list[i] = feature_importance_fold_list[i] * fold_weights[i]
+
+        feature_importance = pd.concat(feature_importance_fold_list, axis=1, sort=True).sum(1).sort_values(ascending=False)
+
+        # TODO: Consider utilizing z scores and stddev to make threshold decisions
+        # stddev = pd.concat(feature_importance_fold_list, axis=1, sort=True).std(1).sort_values(ascending=False)
+        # feature_importance_df = pd.DataFrame(index=feature_importance.index)
+        # feature_importance_df['importance'] = feature_importance
+        # feature_importance_df['stddev'] = stddev
+        # feature_importance_df['z'] = feature_importance_df['importance'] / feature_importance_df['stddev']
+
+        return feature_importance
 
     def load_child(self, model, verbose=False) -> AbstractModel:
         if isinstance(model, str):

--- a/autogluon/utils/tabular/ml/models/ensemble/greedy_weighted_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/greedy_weighted_ensemble_model.py
@@ -25,6 +25,7 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
+    # TODO: Consider moving convert_pred_probas_df_to_list into inner model to ensure X remains a dataframe after preprocess is called
     def preprocess(self, X):
         X = self.convert_pred_probas_df_to_list(X)
         return X

--- a/autogluon/utils/tabular/ml/models/knn/knn_model.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_model.py
@@ -24,7 +24,8 @@ class KNNModel(SKLearnModel):
 
     def preprocess(self, X):
         cat_columns = X.select_dtypes(['category']).columns
-        X = X.drop(cat_columns, axis=1).fillna(0)  # TODO: Test if crash when all columns are categorical
+        X = X.drop(cat_columns, axis=1)  # TODO: Test if crash when all columns are categorical
+        X = super().preprocess(X).fillna(0)
         return X
 
     def _set_default_params(self):

--- a/autogluon/utils/tabular/ml/models/lgb/lgb_model.py
+++ b/autogluon/utils/tabular/ml/models/lgb/lgb_model.py
@@ -277,3 +277,9 @@ class LGBModel(AbstractModel):
         for key in self.nondefault_params: # delete all user-specified hyperparams from the default search space
             _ = def_search_space.pop(key, None)
         self.params.update(def_search_space)
+
+    def get_model_feature_importance(self):
+        feature_names = self.model.feature_name()
+        importances = self.model.feature_importance()
+        importance_dict = {feature_name: importance for (feature_name, importance) in zip(feature_names, importances)}
+        return importance_dict

--- a/autogluon/utils/tabular/ml/models/rf/rf_model.py
+++ b/autogluon/utils/tabular/ml/models/rf/rf_model.py
@@ -124,3 +124,13 @@ class RFModel(SKLearnModel):
         hpo_model_performances = {self.name: self.val_score}
         hpo_models = {self.name: self.path}
         return hpo_models, hpo_model_performances, hpo_results
+
+    def get_model_feature_importance(self):
+        if self.features is None:
+            # TODO: Consider making this raise an exception
+            logger.warning('Warning: get_model_feature_importance called when self.features is None!')
+            return dict()
+        feature_names = self.features
+        importances = self.model.feature_importances_
+        importance_dict = {feature_name: importance for (feature_name, importance) in zip(feature_names, importances)}
+        return importance_dict


### PR DESCRIPTION
*Issue #, if available:*

#304 

*Description of changes:*

Major Update
- Added get_feature_importance() function to learner and trainer.
- Note: This is not surfaced to the user-facing API yet

Code Example:

```
import datetime
import pandas as pd

import sklearn.datasets

from autogluon.utils.tabular.ml.utils import generate_train_test_split
from autogluon import TabularPrediction as task

LABEL = 'target'


if __name__ == '__main__':
    utcnow = datetime.datetime.utcnow()
    timestamp_str_now = utcnow.strftime("%Y%m%d_%H%M%S")
    path_prefix = 'datasets/breast_cancer/'
    path_model_prefix = path_prefix + 'learners/' + timestamp_str_now + '/'

    cancer_data = sklearn.datasets.load_breast_cancer(return_X_y=False)
    X = pd.DataFrame(cancer_data['data'], columns=cancer_data['feature_names'])
    X[LABEL] = cancer_data['target']

    X_train, X_test, y_train, y_test = generate_train_test_split(X=X.drop(LABEL, axis=1), y=X[LABEL], problem_type='binary', test_size=0.2)

    X = X_train
    X[LABEL] = y_train
    X_test[LABEL] = y_test

    X = X.reset_index(drop=True)
    X_test = X_test.reset_index(drop=True)

    predictor = task.fit(
        train_data=X, label=LABEL, output_directory=path_model_prefix,
        hyperparameters={
            'RF': {'n_estimators': 10},
            'GBM': {'num_boost_round': 10},
            'CAT': {'iterations': 10},
        },
        auto_stack=True,
        eval_metric='roc_auc',
        enable_fit_continuation=True,
        verbosity=2,
    )

    print('CatboostClassifier_STACKER_l0')
    feature_importance = predictor._learner.get_feature_importance(model='CatboostClassifier_STACKER_l0')
    print(feature_importance)
    print()
    print('weighted_ensemble_k0_l1')
    feature_importance = predictor._learner.get_feature_importance(model='weighted_ensemble_k0_l1')
    print(feature_importance)


```
Code Output:

```
CatboostClassifier_STACKER_l0
worst concave points       1.300310e-02
worst perimeter            1.238390e-02
worst texture              6.501548e-03
worst radius               5.263158e-03
worst area                 2.786378e-03
mean texture               2.063983e-03
mean area                  1.754386e-03
worst concavity            1.547988e-03
mean concavity             1.341589e-03
mean concave points        1.135191e-03
perimeter error            9.287926e-04
area error                 7.223942e-04
mean radius                5.159959e-04
worst compactness          5.159959e-04
symmetry error             2.063983e-04
concave points error       2.063983e-04
mean smoothness            2.063983e-04
mean compactness           1.031992e-04
concavity error            1.031992e-04
mean fractal dimension     2.221259e-17
texture error              0.000000e+00
mean perimeter             0.000000e+00
worst fractal dimension    0.000000e+00
mean symmetry              0.000000e+00
smoothness error          -1.031992e-04
compactness error         -2.063983e-04
radius error              -3.095975e-04
worst smoothness          -4.127967e-04
worst symmetry            -4.127967e-04
fractal dimension error   -4.127967e-04
dtype: float64

weighted_ensemble_k0_l1
RandomForestClassifierEntr_STACKER_l0    0.800000
LightGBMClassifier_STACKER_l0            0.133333
CatboostClassifier_STACKER_l0            0.066667
dtype: float64
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
