### PR TITLE
Fixed defect causing LightGBM to fail on multiclass classification

### DIFF
--- a/autogluon/utils/tabular/ml/models/lgb/lgb_model.py
+++ b/autogluon/utils/tabular/ml/models/lgb/lgb_model.py
@@ -148,7 +148,7 @@ class LGBModel(AbstractModel):
                 return y_pred_proba[:, 1]
 
     def generate_datasets(self, X_train: DataFrame, Y_train: Series, params, X_test=None, Y_test=None, dataset_train=None, dataset_val=None, save=False):
-        lgb_dataset_params_keys = ['two_round', 'num_threads', 'num_classes', 'verbose']  # Keys that are specific to lightGBM Dataset object construction.
+        lgb_dataset_params_keys = ['objective', 'two_round', 'num_threads', 'num_classes', 'verbose']  # Keys that are specific to lightGBM Dataset object construction.
         data_params = {}
         for key in lgb_dataset_params_keys:
             if key in params:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed defect causing LightGBM to fail on multiclass classification

Defect introduced in #344 

This highlights that we should alter tests to fail if **ANY** model failure occurs, rather than if training fails entirely.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
