### PR TITLE
fix for balanced accuracy computation

### DIFF
--- a/autogluon/utils/tabular/metrics/classification_metrics.py
+++ b/autogluon/utils/tabular/metrics/classification_metrics.py
@@ -17,15 +17,19 @@ def balanced_accuracy(solution, prediction):
         pass
 
     elif y_type == 'multiclass':
-        # Need to create a multiclass solution and a multiclass predictions
-        max_class = int(np.max((np.max(solution), np.max(prediction))))
-        solution_binary = np.zeros((len(solution), max_class + 1))
-        prediction_binary = np.zeros((len(prediction), max_class + 1))
-        for i in range(len(solution)):
-            solution_binary[i, int(solution[i])] = 1
-            prediction_binary[i, int(prediction[i])] = 1
-        solution = solution_binary
-        prediction = prediction_binary
+        n = len(solution)
+        unique_sol, encoded_sol = np.unique(solution, return_inverse=True)
+        unique_pred, encoded_pred = np.unique(prediction, return_inverse=True)
+        classes = np.unique(np.concatenate((unique_sol, unique_pred)))
+        map_sol = np.array([np.where(classes==c)[0][0] for c in unique_sol])
+        map_pred = np.array([np.where(classes==c)[0][0] for c in unique_pred])
+        # one hot encoding
+        sol_ohe = np.zeros((n, len(classes)))
+        pred_ohe = np.zeros((n, len(classes)))
+        sol_ohe[np.arange(n), map_sol[encoded_sol]] = 1
+        pred_ohe[np.arange(n), map_pred[encoded_pred]] = 1
+        solution = sol_ohe
+        prediction = pred_ohe
 
     elif y_type == 'multilabel-indicator':
         solution = solution.toarray()


### PR DESCRIPTION
closes #378

Before:

```python
>>> ag.utils.tabular.metrics.balanced_accuracy(y_test, y_pred)
[error]
```

After

```python
>>> ag.utils.tabular.metrics.balanced_accuracy(y_test, y_pred)
0.1826867855754422
```

Sklearn:

```python
>>> sklearn.metrics.balanced_accuracy_score(y_test, y_pred)
0.1826867855754422
```

## MWE

```python
import autogluon as ag
import pandas as pd
d = {'solution': ['a','b','c','a','b','c'], 'prediction': ['b','b','c','d','b','c']}
df = pd.DataFrame(data=d)
ag.utils.tabular.metrics.balanced_accuracy(df['solution'], df['prediction'])
```

with this PR, it returns `0.75`, without, you get an error. 

### Notes

* There may be more efficient ways to do the OHE.
* We could also just wrap around `sklearn.metrics.balanced_accuracy_score`, note however that it fails on the MWE above because that score expects the classes to match (afaict); for non-pathological cases where all classes are present in both vectors, the results are the same:

```python
import autogluon as ag
import pandas as pd
import sklearn as sk
d = {'solution': ['a','b','c','a','b','c','d','d'], 'prediction': ['b','b','c','d','b','c','a','d']}
df = pd.DataFrame(data=d)
ag.utils.tabular.metrics.balanced_accuracy(df['solution'], df['prediction']) # 0.625
sk.metrics.balanced_accuracy_score(df['solution'], df['prediction']) # 0.625
```