### PR TITLE
Tabular: Added improved inference time estimates + networkx dependency

### DIFF
--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -180,7 +180,7 @@ class TabularPredictor(BasePredictor):
     def leaderboard(self, dataset=None, silent=False):
         """
             Output summary of information about models produced during fit() as a pandas DataFrame.
-            Includes information on test and validation scores for all models, model training times and stack levels.
+            Includes information on test and validation scores for all models, model training times, inference times, and stack levels.
 
             Parameters
             ----------

--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -181,13 +181,29 @@ class TabularPredictor(BasePredictor):
         """
             Output summary of information about models produced during fit() as a pandas DataFrame.
             Includes information on test and validation scores for all models, model training times, inference times, and stack levels.
+            Output DataFrame columns include:
+                'model': The name of the model.
+                'score_val': The validation score of the model on the 'eval_metric'.
+                'pred_time_val': The inference time required to compute predictions on the validation data end-to-end.
+                    Equivalent to the sum of all 'pred_time_val_marginal' values for the model and all of its base models.
+                'fit_time': The fit time required to train the model end-to-end (Including base models if the model is a stack ensemble).
+                    Equivalent to the sum of all 'fit_time_marginal' values for the model and all of its base models.
+                'pred_time_val_marginal': The inference time required to compute predictions on the validation data (Ignoring inference times for base models).
+                    Note that this ignores the time required to load the model into memory when bagging is disabled.
+                'fit_time_marginal': The fit time required to train the model (Ignoring base models).
+                'stack_level': The stack level of the model.
+                    A model with stack level N can take any set of models with stack level less than N as input, with stack level 0 models having no model inputs.
 
             Parameters
             ----------
             dataset : str or :class:`TabularDataset` or `pandas.DataFrame` (optional)
                 This Dataset must also contain the label-column with the same column-name as specified during fit().
-                If specified, then the leaderboard returned will contain an additional column 'score_test'
-                'score_test' is the score of the model on the validation_metric for the dataset provided
+                If specified, then the leaderboard returned will contain additional columns 'score_test', 'pred_time_test', and 'pred_time_test_marginal'.
+                    'score_test': The score of the model on the 'eval_metric' for the dataset provided.
+                    'pred_time_test': The true end-to-end wall-clock inference time of the model for the dataset provided.
+                        Equivalent to the sum of all 'pred_time_test_marginal' values for the model and all of its base models.
+                    'pred_time_test_marginal': The inference time of the model for the dataset provided, minus the inference time for the model's base models, if it has any.
+                        Note that this ignores the time required to load the model into memory when bagging is disabled.
                 If str is passed, `dataset` will be loaded using the str value as the file path.
             silent: bool (optional)
                 Should leaderboard DataFrame be printed?

--- a/autogluon/utils/plots.py
+++ b/autogluon/utils/plots.py
@@ -90,11 +90,11 @@ def plot_tabular_models(results, output_directory=None, save_file="SummaryOfMode
     hpo_used = results['hyperparameter_tune']
     if not hpo_used:  # currently, times are only stored without HPO
         leaderboard = results['leaderboard'].copy()
-        leaderboard['fit_time'] = leaderboard['fit_time'].fillna(0)
-        leaderboard['pred_time_val'] = leaderboard['pred_time_val'].fillna(0)
+        leaderboard['fit_time_full'] = leaderboard['fit_time_full'].fillna(0)
+        leaderboard['pred_time_val_full'] = leaderboard['pred_time_val_full'].fillna(0)
 
-        datadict['inference_latency'] = [leaderboard['pred_time_val'][leaderboard['model'] == m].values[0] for m in model_names]
-        datadict['training_time'] = [leaderboard['fit_time'][leaderboard['model'] == m].values[0] for m in model_names]
+        datadict['inference_latency'] = [leaderboard['pred_time_val_full'][leaderboard['model'] == m].values[0] for m in model_names]
+        datadict['training_time'] = [leaderboard['fit_time_full'][leaderboard['model'] == m].values[0] for m in model_names]
         mousover_plot(datadict, attr_x='inference_latency', attr_y='performance', attr_color='model_type', 
                       save_file=save_path, plot_title=plot_title, hidden_keys=hidden_keys)
     else:

--- a/autogluon/utils/plots.py
+++ b/autogluon/utils/plots.py
@@ -90,11 +90,11 @@ def plot_tabular_models(results, output_directory=None, save_file="SummaryOfMode
     hpo_used = results['hyperparameter_tune']
     if not hpo_used:  # currently, times are only stored without HPO
         leaderboard = results['leaderboard'].copy()
-        leaderboard['fit_time_full'] = leaderboard['fit_time_full'].fillna(0)
-        leaderboard['pred_time_val_full'] = leaderboard['pred_time_val_full'].fillna(0)
+        leaderboard['fit_time'] = leaderboard['fit_time'].fillna(0)
+        leaderboard['pred_time_val'] = leaderboard['pred_time_val'].fillna(0)
 
-        datadict['inference_latency'] = [leaderboard['pred_time_val_full'][leaderboard['model'] == m].values[0] for m in model_names]
-        datadict['training_time'] = [leaderboard['fit_time_full'][leaderboard['model'] == m].values[0] for m in model_names]
+        datadict['inference_latency'] = [leaderboard['pred_time_val'][leaderboard['model'] == m].values[0] for m in model_names]
+        datadict['training_time'] = [leaderboard['fit_time'][leaderboard['model'] == m].values[0] for m in model_names]
         mousover_plot(datadict, attr_x='inference_latency', attr_y='performance', attr_color='model_type', 
                       save_file=save_path, plot_title=plot_title, hidden_keys=hidden_keys)
     else:

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -278,12 +278,10 @@ class AbstractTrainer:
                 if score is None:
                     model.predict_time = None
                 else:
-                    # TODO: Correct weighted ensembles + compressed models to have either None pred time or 0 pred time
                     model.predict_time = pred_end_time - fit_end_time
             if model.val_score is None:
                 model.val_score = score
             # TODO: Add recursive=True to avoid repeatedly loading models each time this is called for bagged ensembles (especially during repeated bagging)
-            # model.save_info()  # TODO: Potentially add parameter to avoid doing this if specified
             self.save_model(model=model)
         except TimeLimitExceeded:
             logger.log(20, '\tTime limit exceeded... Skipping %s.' % model.name)

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -951,6 +951,8 @@ class AbstractTrainer:
             return self.model_graph.nodes[base_model_set[0]][attribute]
         attribute_full = 0
         for base_model in base_model_set:
+            if self.model_graph.nodes[base_model][attribute] is None:
+                return None
             attribute_full += self.model_graph.nodes[base_model][attribute]
         return attribute_full
 
@@ -964,28 +966,28 @@ class AbstractTrainer:
     def leaderboard(self):
         model_names = self.get_model_names_all()
         score_val = []
+        fit_time_marginal = []
+        pred_time_val_marginal = []
+        stack_level = []
         fit_time = []
         pred_time_val = []
-        stack_level = []
-        fit_time_full = []
-        pred_time_val_full = []
         for model_name in model_names:
             score_val.append(self.model_performance.get(model_name))
-            fit_time.append(self.model_fit_times.get(model_name))
-            fit_time_full.append(self.get_model_attribute_full(model=model_name, attribute='fit_time'))
-            pred_time_val.append(self.model_pred_times.get(model_name))
-            pred_time_val_full.append(self.get_model_attribute_full(model=model_name, attribute='predict_time'))
+            fit_time_marginal.append(self.model_fit_times.get(model_name))
+            fit_time.append(self.get_model_attribute_full(model=model_name, attribute='fit_time'))
+            pred_time_val_marginal.append(self.model_pred_times.get(model_name))
+            pred_time_val.append(self.get_model_attribute_full(model=model_name, attribute='predict_time'))
             stack_level.append(self.get_model_level(model_name))
         df = pd.DataFrame(data={
             'model': model_names,
             'score_val': score_val,
-            'fit_time_full': fit_time_full,
-            'pred_time_val_full': pred_time_val_full,
-            'fit_time': fit_time,
             'pred_time_val': pred_time_val,
+            'fit_time': fit_time,
+            'pred_time_val_marginal': pred_time_val_marginal,
+            'fit_time_marginal': fit_time_marginal,
             'stack_level': stack_level,
         })
-        df_sorted = df.sort_values(by=['score_val', 'pred_time_val_full', 'model'], ascending=[False, True, False]).reset_index(drop=True)
+        df_sorted = df.sort_values(by=['score_val', 'pred_time_val', 'model'], ascending=[False, True, False]).reset_index(drop=True)
         return df_sorted
 
     def get_info(self, include_model_info=False):

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ requirements = [
     'pandas>=0.24.0,<1.0',
     'psutil>=5.0.0',
     'scikit-learn>=0.20.0',
-    'networkx',
+    'networkx>=2.3,<3.0',
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ requirements = [
     'pandas>=0.24.0,<1.0',
     'psutil>=5.0.0',
     'scikit-learn>=0.20.0',
+    'networkx',
 ]
 
 test_requirements = [


### PR DESCRIPTION
*Issue #, if available:*

#175 

*Description of changes:*

Major Changes:
- Added networkx dependency
- Added Directed Acyclic Graph model dependency representation in Tabular Trainer
- Added pred_time_val_full to .leaderboard() -> pred_time_val of model + pred_time_val of all required base models
- Added fit_time_full to .leaderboard() -> fit_time of model + fit_time of all required base models
- Improved pred_time_test_full on .leaderboard() -> It is now accurate for weighted ensembles, previously it overestimated the time.
- Improved model sorting in leaderboard, if two models have the same score, put the one with lower inference time in front.
- All improvements also added to .fit_summary()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
