### PR TITLE
Fix mousouver plot after bokeh dropped previewsave

### DIFF
--- a/autogluon/utils/plots.py
+++ b/autogluon/utils/plots.py
@@ -138,7 +138,7 @@ def mousover_plot(datadict, attr_x, attr_y, attr_color=None, attr_size=None, sav
         bokeh_imported = False
     
     if not bokeh_imported:
-        warnings.warn('AutoGluon summary plots cannot be created because bokeh is not installed. To see plots, please do: "pip install bokeh"')
+        warnings.warn('AutoGluon summary plots cannot be created because bokeh is not installed. To see plots, please do: "pip install bokeh==2.0.1"')
         return None
     
     n = len(datadict[attr_x])

--- a/autogluon/utils/plots.py
+++ b/autogluon/utils/plots.py
@@ -182,7 +182,7 @@ def mousover_plot(datadict, attr_x, attr_y, attr_color=None, attr_size=None, sav
         print("Plot summary of models saved to file: %s" % save_file)
     
     source = ColumnDataSource(datadict)
-    TOOLS="crosshair,pan,wheel_zoom,box_zoom,reset,hover,previewsave"
+    TOOLS="crosshair,pan,wheel_zoom,box_zoom,reset,hover,save"
     p = figure(title=plot_title, tools=TOOLS)
     if attr_x_is_string:
         circ = p.circle(attr_x2, attr_y, line_color=default_color, line_alpha = point_transparency,


### PR DESCRIPTION
Update mousoverplot to match bokeh update to v2.0.1 which dropped compatibility with previewsave tool.
