### PR TITLE
Added support for sklearn 0.24+, resolved sklearn deprecation warning

### DIFF
--- a/autogluon/utils/tabular/metrics/classification_metrics.py
+++ b/autogluon/utils/tabular/metrics/classification_metrics.py
@@ -1,7 +1,10 @@
 import logging
 
 import numpy as np
-from sklearn.metrics.classification import _check_targets, type_of_target
+try:
+    from sklearn.metrics._classification import _check_targets, type_of_target
+except:
+    from sklearn.metrics.classification import _check_targets, type_of_target
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In prior version, with the following code:

```
if __name__ == '__main__':
    import autogluon
```

Produces warning output:

```
FutureWarning: The sklearn.metrics.classification module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.metrics. Anything that cannot be imported from sklearn.metrics is now part of the private API.
  warnings.warn(message, FutureWarning)
```

After this change, nothing is logged (No warning). This change should enable AutoGluon to work with sklearn 0.24 when it releases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
