### PR TITLE
Tabular: Added only_breakpoints parameter to .leaderboard()

### DIFF
--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -178,7 +178,7 @@ class TabularPredictor(BasePredictor):
         return self._learner.evaluate(y_true=y_true, y_pred=y_pred, silent=silent,
                                       auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
-    def leaderboard(self, dataset=None, silent=False):
+    def leaderboard(self, dataset=None, only_breakpoints=False, silent=False):
         """
             Output summary of information about models produced during fit() as a pandas DataFrame.
             Includes information on test and validation scores for all models, model training times, inference times, and stack levels.
@@ -206,7 +206,12 @@ class TabularPredictor(BasePredictor):
                     'pred_time_test_marginal': The inference time of the model for the dataset provided, minus the inference time for the model's base models, if it has any.
                         Note that this ignores the time required to load the model into memory when bagging is disabled.
                 If str is passed, `dataset` will be loaded using the str value as the file path.
-            silent: bool (optional)
+            only_breakpoints : bool (optional)
+                If `True`, only return model information of models which achieve the highest score within their end-to-end inference time.
+                At minimum this will include the model with the highest score and the model with the lowest inference time.
+                This is useful when deciding which model to use during inference if inference time is a consideration.
+                Models filtered out by this process would never be optimal choices for a user that only cares about model inference time and score.
+            silent : bool (optional)
                 Should leaderboard DataFrame be printed?
 
             Returns
@@ -214,7 +219,7 @@ class TabularPredictor(BasePredictor):
             Pandas `pandas.DataFrame` of model performance summary information.
         """
         dataset = self.__get_dataset(dataset) if dataset is not None else dataset
-        return self._learner.leaderboard(X=dataset, silent=silent)
+        return self._learner.leaderboard(X=dataset, only_breakpoints=only_breakpoints, silent=silent)
 
     def fit_summary(self, verbosity=3):
         """

--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -207,7 +207,7 @@ class TabularPredictor(BasePredictor):
                         Note that this ignores the time required to load the model into memory when bagging is disabled.
                 If str is passed, `dataset` will be loaded using the str value as the file path.
             only_pareto_frontier : bool (optional)
-                If `True`, only return model information of models in the Pareto frontier (Models which achieve the highest score within their end-to-end inference time).
+                If `True`, only return model information of models in the Pareto frontier of the accuracy/latency trade-off (models which achieve the highest score within their end-to-end inference time).
                 At minimum this will include the model with the highest score and the model with the lowest inference time.
                 This is useful when deciding which model to use during inference if inference time is a consideration.
                 Models filtered out by this process would never be optimal choices for a user that only cares about model inference time and score.

--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -178,7 +178,7 @@ class TabularPredictor(BasePredictor):
         return self._learner.evaluate(y_true=y_true, y_pred=y_pred, silent=silent,
                                       auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
-    def leaderboard(self, dataset=None, only_breakpoints=False, silent=False):
+    def leaderboard(self, dataset=None, only_pareto_frontier=False, silent=False):
         """
             Output summary of information about models produced during fit() as a pandas DataFrame.
             Includes information on test and validation scores for all models, model training times, inference times, and stack levels.
@@ -206,8 +206,8 @@ class TabularPredictor(BasePredictor):
                     'pred_time_test_marginal': The inference time of the model for the dataset provided, minus the inference time for the model's base models, if it has any.
                         Note that this ignores the time required to load the model into memory when bagging is disabled.
                 If str is passed, `dataset` will be loaded using the str value as the file path.
-            only_breakpoints : bool (optional)
-                If `True`, only return model information of models which achieve the highest score within their end-to-end inference time.
+            only_pareto_frontier : bool (optional)
+                If `True`, only return model information of models in the Pareto frontier (Models which achieve the highest score within their end-to-end inference time).
                 At minimum this will include the model with the highest score and the model with the lowest inference time.
                 This is useful when deciding which model to use during inference if inference time is a consideration.
                 Models filtered out by this process would never be optimal choices for a user that only cares about model inference time and score.
@@ -219,7 +219,7 @@ class TabularPredictor(BasePredictor):
             Pandas `pandas.DataFrame` of model performance summary information.
         """
         dataset = self.__get_dataset(dataset) if dataset is not None else dataset
-        return self._learner.leaderboard(X=dataset, only_breakpoints=only_breakpoints, silent=silent)
+        return self._learner.leaderboard(X=dataset, only_pareto_frontier=only_pareto_frontier, silent=silent)
 
     def fit_summary(self, verbosity=3):
         """

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -16,7 +16,7 @@ from sklearn.metrics import mean_absolute_error, explained_variance_score, r2_sc
 from ..constants import BINARY, MULTICLASS, REGRESSION
 from ..trainer.abstract_trainer import AbstractTrainer
 from ..tuning.ensemble_selection import EnsembleSelection
-from ..utils import get_pred_from_proba, get_leaderboard_breakpoints
+from ..utils import get_pred_from_proba, get_leaderboard_pareto_frontier
 from ...data.label_cleaner import LabelCleaner
 from ...utils.loaders import load_pkl, load_pd
 from ...utils.savers import save_pkl, save_pd, save_json
@@ -469,20 +469,20 @@ class AbstractLearner:
         y_pred_proba = self.predict_proba(X_test=X_test, inverse_transform=False)
         return self.submit_from_preds(X_test=X_test, y_pred_proba=y_pred_proba, save=save, save_proba=save_proba)
 
-    def leaderboard(self, X=None, y=None, only_breakpoints=False, silent=False):
+    def leaderboard(self, X=None, y=None, only_pareto_frontier=False, silent=False):
         if X is not None:
             leaderboard = self.score_debug(X=X, y=y, silent=True)
         else:
             trainer = self.load_trainer()
             leaderboard = trainer.leaderboard()
-        if only_breakpoints:
+        if only_pareto_frontier:
             if 'score_test' in leaderboard.columns and 'pred_time_test' in leaderboard.columns:
                 score_col = 'score_test'
                 inference_time_col = 'pred_time_test'
             else:
                 score_col = 'score_val'
                 inference_time_col = 'pred_time_val'
-            leaderboard = get_leaderboard_breakpoints(leaderboard=leaderboard, score_col=score_col, inference_time_col=inference_time_col)
+            leaderboard = get_leaderboard_pareto_frontier(leaderboard=leaderboard, score_col=score_col, inference_time_col=inference_time_col)
         if not silent:
             with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 1000):
                 print(leaderboard)

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -16,7 +16,7 @@ from sklearn.metrics import mean_absolute_error, explained_variance_score, r2_sc
 from ..constants import BINARY, MULTICLASS, REGRESSION
 from ..trainer.abstract_trainer import AbstractTrainer
 from ..tuning.ensemble_selection import EnsembleSelection
-from ..utils import get_pred_from_proba
+from ..utils import get_pred_from_proba, get_leaderboard_breakpoints
 from ...data.label_cleaner import LabelCleaner
 from ...utils.loaders import load_pkl, load_pd
 from ...utils.savers import save_pkl, save_pd, save_json
@@ -158,8 +158,7 @@ class AbstractLearner:
     # y should be y_train from original fit call, if None then load saved y_train in trainer (if save_data=True)
     # Compresses bagged ensembles to a single model fit on 100% of the data.
     # Results in worse model quality (-), but much faster inference times (+++), reduced memory usage (+++), and reduced space usage (+++).
-    # TODO: this currently only works for bagged models.
-    # You must have previously called fit() with enable_fit_continuation=True, and either num_bagging_folds > 1 or auto_stack=True.
+    # You must have previously called fit() with cache_data=True.
     def refit_single_full(self, models=None):
         X = None
         y = None
@@ -470,12 +469,20 @@ class AbstractLearner:
         y_pred_proba = self.predict_proba(X_test=X_test, inverse_transform=False)
         return self.submit_from_preds(X_test=X_test, y_pred_proba=y_pred_proba, save=save, save_proba=save_proba)
 
-    def leaderboard(self, X=None, y=None, silent=False):
+    def leaderboard(self, X=None, y=None, only_breakpoints=False, silent=False):
         if X is not None:
             leaderboard = self.score_debug(X=X, y=y, silent=True)
         else:
             trainer = self.load_trainer()
             leaderboard = trainer.leaderboard()
+        if only_breakpoints:
+            if 'score_test' in leaderboard.columns and 'pred_time_test' in leaderboard.columns:
+                score_col = 'score_test'
+                inference_time_col = 'pred_time_test'
+            else:
+                score_col = 'score_val'
+                inference_time_col = 'pred_time_val'
+            leaderboard = get_leaderboard_breakpoints(leaderboard=leaderboard, score_col=score_col, inference_time_col=inference_time_col)
         if not silent:
             with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 1000):
                 print(leaderboard)

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -732,7 +732,7 @@ class AbstractTrainer:
                     X = X.drop(cols_to_drop, axis=1)
         return X
 
-    # You must have previously called fit() with enable_fit_continuation=True, and either num_bagging_folds > 1 or auto_stack=True.
+    # You must have previously called fit() with cache_data=True
     def refit_single_full(self, X=None, y=None, models=None):
         if X is None:
             X = self.load_X_train()

--- a/autogluon/utils/tabular/ml/utils.py
+++ b/autogluon/utils/tabular/ml/utils.py
@@ -120,6 +120,34 @@ def dd_list():
     return defaultdict(list)
 
 
+def get_leaderboard_breakpoints(leaderboard: DataFrame, score_col='score_val', inference_time_col='pred_time_val_full') -> DataFrame:
+    """
+    Given a set of models, returns in ranked order from best score to worst score models which satisfy the criteria:
+    1. No other model in the set has both a lower inference time and a better or equal score.
+
+    :param leaderboard: Leaderboard DataFrame of model info containing score_col and inference_time_col
+    :param score_col: Column name in leaderboard of model score values
+    :param inference_time_col: Column name in leaderboard of model inference times
+    :return: Subset of the original leaderboard DataFrame containing only models that are a valid optimal choice at different valuations of score and inference time.
+    """
+    leaderboard = leaderboard.sort_values(by=[score_col, inference_time_col], ascending=[False, True]).reset_index(drop=True)
+    leaderboard_unique = leaderboard.drop_duplicates(subset=[score_col])
+
+    breakpoints = []
+    inference_time_min = None
+    for index, row in leaderboard_unique.iterrows():
+        if row[inference_time_col] is None or row[score_col] is None:
+            pass
+        elif inference_time_min is None:
+            inference_time_min = row[inference_time_col]
+            breakpoints.append(index)
+        elif row[inference_time_col] < inference_time_min:
+            inference_time_min = row[inference_time_col]
+            breakpoints.append(index)
+    leaderboard_breakpoints = leaderboard_unique.loc[breakpoints].reset_index(drop=True)
+    return leaderboard_breakpoints
+
+
 def combine_pred_and_true(y_predprob, y_true, upweight_factor=0.25):
     """ Used in distillation, combines true (integer) classes with 2D array of predicted probabilities.
         Returns new 2D array of predicted probabilities where true classes are upweighted by upweight_factor (and then probabilities are renormalized)

--- a/autogluon/utils/tabular/ml/utils.py
+++ b/autogluon/utils/tabular/ml/utils.py
@@ -120,7 +120,7 @@ def dd_list():
     return defaultdict(list)
 
 
-def get_leaderboard_breakpoints(leaderboard: DataFrame, score_col='score_val', inference_time_col='pred_time_val_full') -> DataFrame:
+def get_leaderboard_pareto_frontier(leaderboard: DataFrame, score_col='score_val', inference_time_col='pred_time_val_full') -> DataFrame:
     """
     Given a set of models, returns in ranked order from best score to worst score models which satisfy the criteria:
     1. No other model in the set has both a lower inference time and a better or equal score.
@@ -133,19 +133,16 @@ def get_leaderboard_breakpoints(leaderboard: DataFrame, score_col='score_val', i
     leaderboard = leaderboard.sort_values(by=[score_col, inference_time_col], ascending=[False, True]).reset_index(drop=True)
     leaderboard_unique = leaderboard.drop_duplicates(subset=[score_col])
 
-    breakpoints = []
+    pareto_frontier = []
     inference_time_min = None
     for index, row in leaderboard_unique.iterrows():
         if row[inference_time_col] is None or row[score_col] is None:
             pass
-        elif inference_time_min is None:
+        elif (inference_time_min is None) or (row[inference_time_col] < inference_time_min):
             inference_time_min = row[inference_time_col]
-            breakpoints.append(index)
-        elif row[inference_time_col] < inference_time_min:
-            inference_time_min = row[inference_time_col]
-            breakpoints.append(index)
-    leaderboard_breakpoints = leaderboard_unique.loc[breakpoints].reset_index(drop=True)
-    return leaderboard_breakpoints
+            pareto_frontier.append(index)
+    leaderboard_pareto_frontier = leaderboard_unique.loc[pareto_frontier].reset_index(drop=True)
+    return leaderboard_pareto_frontier
 
 
 def combine_pred_and_true(y_predprob, y_true, upweight_factor=0.25):


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Enables user to filter leaderboard to the relevant models when choosing between inference speed and accuracy.

Example Code:

```
import pandas as pd
import sklearn.datasets

from autogluon.utils.tabular.ml.utils import generate_train_test_split
from autogluon import TabularPrediction as task

LABEL = 'target'


if __name__ == '__main__':
    cancer_data = sklearn.datasets.load_breast_cancer(return_X_y=False)
    X = pd.DataFrame(cancer_data['data'], columns=cancer_data['feature_names'])
    X[LABEL] = cancer_data[LABEL]

    X_train, X_test, y_train, y_test = generate_train_test_split(X=X.drop(LABEL, axis=1), y=X[LABEL], problem_type='binary', test_size=0.2)

    X = X_train
    X[LABEL] = y_train
    X_test[LABEL] = y_test

    X = X.reset_index(drop=True)
    X_test = X_test.reset_index(drop=True)

    predictor_stack = task.fit(
        time_limits=200,
        train_data=X, label=LABEL,
        hyperparameters={
            'GBM': {'num_boost_round': 100},
            'CAT': {'iterations': 100},
            'KNN': {},
        },
        num_bagging_folds=2, stack_ensemble_levels=1,
        num_bagging_sets=2,
    )

    predictor_stack.leaderboard()
    predictor_stack.leaderboard(X_test)

    predictor_stack.leaderboard(only_breakpoints=True)
    predictor_stack.leaderboard(X_test, only_breakpoints=True)
```

Example Output:

```
                                 model  score_val  pred_time_val   fit_time  pred_time_val_marginal  fit_time_marginal  stack_level
0              weighted_ensemble_k0_l2   0.978022       1.165332   7.604892                0.002507           0.333681            2
1              weighted_ensemble_k0_l1   0.975824       0.534352   4.711088                0.005186           0.331667            1
2        LightGBMClassifier_STACKER_l1   0.975824       1.162825   7.271211                0.055676           1.288956            1
3        CatboostClassifier_STACKER_l0   0.973626       0.034891   4.207038                0.034891           4.207038            0
4        CatboostClassifier_STACKER_l1   0.971429       1.148347  10.240033                0.041198           4.257777            1
5        LightGBMClassifier_STACKER_l0   0.969231       0.050904   1.436202                0.050904           1.436202            0
6  KNeighborsClassifierUnif_STACKER_l0   0.940659       0.494274   0.172384                0.494274           0.172384            0
7  KNeighborsClassifierDist_STACKER_l0   0.936264       0.527079   0.166632                0.527079           0.166632            0
8  KNeighborsClassifierDist_STACKER_l1   0.934066       1.631801   6.077256                0.524652           0.095001            1
9  KNeighborsClassifierUnif_STACKER_l1   0.931868       1.625837   6.067221                0.518688           0.084965            1
                                 model  score_test  score_val  pred_time_test  pred_time_val   fit_time  pred_time_test_marginal  pred_time_val_marginal  fit_time_marginal  stack_level
0              weighted_ensemble_k0_l1    0.964912   0.975824        0.486373       0.534352   4.711088                 0.004835                0.005186           0.331667            1
1        LightGBMClassifier_STACKER_l0    0.956140   0.969231        0.054836       0.050904   1.436202                 0.054836                0.050904           1.436202            0
2        CatboostClassifier_STACKER_l1    0.956140   0.971429        1.013497       1.148347  10.240033                 0.025127                0.041198           4.257777            1
3        LightGBMClassifier_STACKER_l1    0.956140   0.975824        1.044854       1.162825   7.271211                 0.056484                0.055676           1.288956            1
4              weighted_ensemble_k0_l2    0.956140   0.978022        1.048074       1.165332   7.604892                 0.003219                0.002507           0.333681            2
5  KNeighborsClassifierUnif_STACKER_l1    0.947368   0.931868        1.448323       1.625837   6.067221                 0.459953                0.518688           0.084965            1
6        CatboostClassifier_STACKER_l0    0.938596   0.973626        0.024499       0.034891   4.207038                 0.024499                0.034891           4.207038            0
7  KNeighborsClassifierDist_STACKER_l0    0.938596   0.936264        0.451996       0.527079   0.166632                 0.451996                0.527079           0.166632            0
8  KNeighborsClassifierUnif_STACKER_l0    0.929825   0.940659        0.457039       0.494274   0.172384                 0.457039                0.494274           0.172384            0
9  KNeighborsClassifierDist_STACKER_l1    0.929825   0.934066        1.448437       1.631801   6.077256                 0.460067                0.524652           0.095001            1
                           model  score_val  pred_time_val  fit_time  pred_time_val_marginal  fit_time_marginal  stack_level
0        weighted_ensemble_k0_l2   0.978022       1.165332  7.604892                0.002507           0.333681            2
1        weighted_ensemble_k0_l1   0.975824       0.534352  4.711088                0.005186           0.331667            1
2  CatboostClassifier_STACKER_l0   0.973626       0.034891  4.207038                0.034891           4.207038            0
                           model  score_test  score_val  pred_time_test  pred_time_val  fit_time  pred_time_test_marginal  pred_time_val_marginal  fit_time_marginal  stack_level
0        weighted_ensemble_k0_l1    0.964912   0.975824        0.507465       0.534352  4.711088                 0.004592                0.005186           0.331667            1
1  LightGBMClassifier_STACKER_l0    0.956140   0.969231        0.059575       0.050904  1.436202                 0.059575                0.050904           1.436202            0
2  CatboostClassifier_STACKER_l0    0.938596   0.973626        0.024316       0.034891  4.207038                 0.024316                0.034891           4.207038            0
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
