### PR TITLE
Tabular: Fixed defect where model val_score was not updated properly

### DIFF
--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -279,8 +279,7 @@ class AbstractTrainer:
                     model.predict_time = None
                 else:
                     model.predict_time = pred_end_time - fit_end_time
-            if model.val_score is None:
-                model.val_score = score
+            model.val_score = score
             # TODO: Add recursive=True to avoid repeatedly loading models each time this is called for bagged ensembles (especially during repeated bagging)
             self.save_model(model=model)
         except TimeLimitExceeded:


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Issue caused when time_limit specified and repeated bagging occurs. Model will not update val_score beyond its initial score achieved after a single bagged fit. This fix makes it so the val_score is updated each time it is updated as a model in trainer. Before this fix, .leaderboard() would not show correct val_score for these models, however the best_model would still be chosen correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
