### PR TITLE
Fix SageMaker sync keyword

### DIFF
--- a/autogluon/utils/sync_remote.py
+++ b/autogluon/utils/sync_remote.py
@@ -18,7 +18,7 @@ def sagemaker_setup():
     if current_host == sorted(hosts)[0]:
         _wait_for_worker_nodes_to_start_sshd(hosts)
     else:
-        sync_training_processes('agremote', current_host)
+        sync_training_processes('dask-scheduler', current_host)
 
 def _wait_for_worker_nodes_to_start_sshd(hosts, interval=1, timeout_in_seconds=180):
     with timeout(seconds=timeout_in_seconds):


### PR DESCRIPTION
*Issue #, if available:*

Fixes the synchronization across multiple SageMaker machines. 
```
Worker algo-2 exiting: training not started in 300 seconds.
Host rank 1 exit.
```

*Description of changes:*

Original keyword was for master node, but we need the worker node keyword to grap. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
