### PR TITLE
Tabular: Added transform_features function to TabularPredictor

### DIFF
--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -387,7 +387,7 @@ class TabularPredictor(BasePredictor):
 
         """
         dataset = self.__get_dataset(dataset) if dataset is not None else dataset
-        return self._learner.get_inputs_to_stacker(dataset=dataset, model_to_get_inputs_for=model, base_models=base_models)
+        return self._learner.get_inputs_to_stacker(dataset=dataset, model=model, base_models=base_models)
 
     # TODO: Consider adding time_limit option to early stop the feature importance process
     def feature_importance(self, model=None, dataset=None, features=None, raw=True, subsample_size=10000, silent=False):

--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -387,7 +387,17 @@ class TabularPredictor(BasePredictor):
 
         """
         dataset = self.__get_dataset(dataset) if dataset is not None else dataset
-        return self._learner.get_inputs_to_stacker(dataset=dataset, model=model, base_models=base_models)
+        # TODO: Make this index fix inside of learner/trainer once the defect is identified. For now, this resolves the issue.
+        if dataset is not None:
+            original_indices = copy.deepcopy(dataset.index)
+            dataset = dataset.reset_index(drop=True)
+        else:
+            original_indices = None
+
+        dataset_transformed = self._learner.get_inputs_to_stacker(dataset=dataset, model=model, base_models=base_models)
+        if original_indices is not None:
+            dataset_transformed.index = original_indices
+        return dataset_transformed
 
     # TODO: Consider adding time_limit option to early stop the feature importance process
     def feature_importance(self, model=None, dataset=None, features=None, raw=True, subsample_size=10000, silent=False):

--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -341,6 +341,54 @@ class TabularPredictor(BasePredictor):
             print("*** End of fit() summary ***")
         return results
 
+    def transform_features(self, dataset=None, model=None, base_models=None):
+        """
+        Transforms dataset features through the AutoGluon feature generator.
+        This is useful to gain an understanding of how AutoGluon interprets the dataset features.
+        The output of this function can be used to train further models, even outside of AutoGluon.
+        When `dataset=None`, `base_models=[{best_model}], and bagging was enabled during fit():
+            This returns the out-of-fold predictions of the best model, which can be used as training input to a custom user stacker model.
+
+        Parameters
+        ----------
+        dataset : str or :class:`TabularDataset` or `pandas.DataFrame` (optional)
+            The dataset to apply feature transformation to.
+            This dataset does not require the label column.
+            If str is passed, `dataset` will be loaded using the str value as the file path.
+            If not specified, the original dataset used during fit() will be used if `cache_data=True`. Otherwise, an exception will be raised.
+                For non-bagged mode predictors:
+                    The dataset used when not specified is the validation set.
+                    This can either be an automatically generated validation set or the user-defined `tuning_data` if passed during fit().
+                    If the original training set is desired, it can be passed in through `dataset`.
+                        Warning: Do not pass the original training set if `model` or `base_models` are set. This will result in overfit feature transformation.
+                For bagged mode predictors:
+                    The dataset used when not specified is the full training set.
+                    `base_model` features generated in this instance will be from out-of-fold predictions.
+                    Note that the training set may differ from the training set originally passed during fit(), as AutoGluon may choose to drop or duplicate rows during training.
+                    Warning: Do not pass the original training set through `dataset` if `model` or `base_models` are set. This will result in overfit feature transformation. Instead set `dataset=None`.
+        model : str, default = None
+            Model to generate input features for.
+            The output data will be equivalent to the input data that would be sent into `model.predict_proba(data)`.
+                Note: This only applies to cases where `dataset` is not the training data.
+            If `None`, then only return generically preprocessed features prior to any model fitting.
+            Valid models are listed in this `predictor` by calling `predictor.model_names`.
+            Specifying a `refit_full` model will cause an exception if `dataset=None`.
+            `base_models=None` is a requirement when specifying `model`.
+        base_models : list, default = None
+            List of model names to use as base_models for a hypothetical stacker model when generating input features.
+            If `None`, then only return generically preprocessed features prior to any model fitting.
+            Valid models are listed in this `predictor` by calling `predictor.model_names`.
+            If a stacker model S exists with `base_models=M`, then setting `base_models=M` is equivalent to setting `model=S`.
+            `model=None` is a requirement when specifying `base_models`.
+
+        Returns
+        -------
+        Pandas `pandas.DataFrame` of the provided `dataset` after feature transformation has been applied.
+
+        """
+        dataset = self.__get_dataset(dataset) if dataset is not None else dataset
+        return self._learner.get_inputs_to_stacker(dataset=dataset, model_to_get_inputs_for=model, base_models=base_models)
+
     # TODO: Consider adding time_limit option to early stop the feature importance process
     def feature_importance(self, model=None, dataset=None, features=None, raw=True, subsample_size=10000, silent=False):
         """
@@ -358,7 +406,7 @@ class TabularPredictor(BasePredictor):
             Model to get feature importances for, if None the best model is chosen.
             Valid models are listed in this `predictor` by calling `predictor.model_names`
         dataset : str or :class:`TabularDataset` or `pandas.DataFrame` (optional)
-            This Dataset must also contain the label-column with the same column-name as specified during fit().
+            This dataset must also contain the label-column with the same column-name as specified during fit().
             If specified, then the dataset is used to calculate the feature importance scores.
             If str is passed, `dataset` will be loaded using the str value as the file path.
             If not specified, the original dataset used during fit() will be used if `cache_data=True`. Otherwise, an exception will be raised.
@@ -383,6 +431,7 @@ class TabularPredictor(BasePredictor):
         Pandas `pandas.Series` of feature importance scores.
 
         """
+        dataset = self.__get_dataset(dataset) if dataset is not None else dataset
         if (dataset is None) and (not self._trainer.is_data_saved):
             raise AssertionError('No dataset was provided and there is no cached data to load for feature importance calculation. `cache_data=True` must be set in the `TabularPrediction.fit()` call to enable this functionality when dataset is not specified.')
 
@@ -484,11 +533,11 @@ class TabularPredictor(BasePredictor):
     def __get_dataset(dataset):
         if isinstance(dataset, TabularDataset):
             return dataset
-        if isinstance(dataset, str):
-            return TabularDataset(file_path=dataset)
-        if isinstance(dataset, pd.DataFrame):
+        elif isinstance(dataset, pd.DataFrame):
             return TabularDataset(df=dataset)
-        if isinstance(dataset, pd.Series):
+        elif isinstance(dataset, str):
+            return TabularDataset(file_path=dataset)
+        elif isinstance(dataset, pd.Series):
             raise TypeError("dataset must be TabularDataset or pandas.DataFrame, not pandas.Series. \
                    To predict on just single example (ith row of table), use dataset.iloc[[i]] rather than dataset.iloc[i]")
         else:

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -152,10 +152,10 @@ class AbstractLearner:
             y_pred = pd.Series(data=y_pred, name=self.label)
         return y_pred
 
-    def get_inputs_to_stacker(self, dataset=None, model_to_get_inputs_for=None, base_models: list = None):
-        if model_to_get_inputs_for is not None or base_models is not None:
-            if model_to_get_inputs_for is not None and base_models is not None:
-                raise AssertionError('Only one of `model_to_get_inputs_for`, `base_models` is allowed to be set.')
+    def get_inputs_to_stacker(self, dataset=None, model=None, base_models: list = None):
+        if model is not None or base_models is not None:
+            if model is not None and base_models is not None:
+                raise AssertionError('Only one of `model`, `base_models` is allowed to be set.')
 
         trainer = self.load_trainer()
         if dataset is None:
@@ -170,8 +170,11 @@ class AbstractLearner:
             fit = False
         if base_models is not None:
             dataset_preprocessed = trainer.get_inputs_to_stacker_v2(X=dataset_preprocessed, base_models=base_models, fit=fit)
-        elif model_to_get_inputs_for is not None:
-            dataset_preprocessed = trainer.get_inputs_to_model(model=model_to_get_inputs_for, X=dataset_preprocessed, fit=fit)
+        elif model is not None:
+            base_models = list(trainer.model_graph.predecessors(model))
+            dataset_preprocessed = trainer.get_inputs_to_stacker_v2(X=dataset_preprocessed, base_models=base_models, fit=fit)
+            # Note: Below doesn't quite work here because weighted_ensemble has unique input format returned that isn't a DataFrame.
+            # dataset_preprocessed = trainer.get_inputs_to_model(model=model_to_get_inputs_for, X=dataset_preprocessed, fit=fit)
 
         return dataset_preprocessed
 

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -152,6 +152,29 @@ class AbstractLearner:
             y_pred = pd.Series(data=y_pred, name=self.label)
         return y_pred
 
+    def get_inputs_to_stacker(self, dataset=None, model_to_get_inputs_for=None, base_models: list = None):
+        if model_to_get_inputs_for is not None or base_models is not None:
+            if model_to_get_inputs_for is not None and base_models is not None:
+                raise AssertionError('Only one of `model_to_get_inputs_for`, `base_models` is allowed to be set.')
+
+        trainer = self.load_trainer()
+        if dataset is None:
+            if trainer.bagged_mode:
+                dataset_preprocessed = trainer.load_X_train()
+                fit = True
+            else:
+                dataset_preprocessed = trainer.load_X_val()
+                fit = False
+        else:
+            dataset_preprocessed = self.transform_features(dataset)
+            fit = False
+        if base_models is not None:
+            dataset_preprocessed = trainer.get_inputs_to_stacker_v2(X=dataset_preprocessed, base_models=base_models, fit=fit)
+        elif model_to_get_inputs_for is not None:
+            dataset_preprocessed = trainer.get_inputs_to_model(model=model_to_get_inputs_for, X=dataset_preprocessed, fit=fit)
+
+        return dataset_preprocessed
+
     # TODO: Experimental, not integrated with core code, highly subject to change
     # TODO: Add X, y parameters -> Requires proper preprocessing of train data
     # X should be X_train from original fit call, if None then load saved X_train in trainer (if save_data=True)

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -757,6 +757,18 @@ class AbstractTrainer:
         else:
             return model_pred_proba_dict
 
+    # TODO: Remove get_inputs_to_stacker eventually, move logic internally into this function instead
+    def get_inputs_to_stacker_v2(self, X, base_models, model_pred_proba_dict=None, fit=False):
+        if not fit:
+            model_pred_proba_dict = self.get_model_pred_proba_dict(X=X, models=base_models, model_pred_proba_dict=model_pred_proba_dict)
+            model_pred_proba_list = [model_pred_proba_dict[model] for model in base_models]
+        else:
+            # TODO: After get_inputs_to_stacker is removed, this if/else is not necessary, instead pass fit param to get_model_pred_proba_dict()
+            model_pred_proba_list = None
+
+        X_stacker_input = self.get_inputs_to_stacker(X=X, level_start=0, level_end=1, model_levels={0: base_models}, y_pred_probas=model_pred_proba_list, fit=fit)
+        return X_stacker_input
+
     # TODO: Legacy code, still used during training because it is technically slightly faster and more memory efficient than get_model_pred_proba_dict()
     #  Remove in future as it limits flexibility in stacker inputs during training
     def get_inputs_to_stacker(self, X, level_start, level_end, model_levels=None, y_pred_probas=None, fit=False):


### PR DESCRIPTION
*Issue #, if available:*
#249, #428

*Description of changes:*

Added transform_features function to TabularPredictor

Now users can utilize this function to get feature transformations on their datasets to use with their own custom models outside of AutoGluon, even enabling users to extend the stack ensemble by receiving the out-of-fold prediction features of the AutoGluon ensemble.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
