### PR TITLE
Bug fix in SamePadding that pad_width and pad_height are misplaced

### DIFF
--- a/autogluon/model_zoo/models/utils.py
+++ b/autogluon/model_zoo/models/utils.py
@@ -56,16 +56,16 @@ class SamePadding(HybridBlock):
 
     def hybrid_forward(self, F, x):
         if self.pad_h > 0 or self.pad_w > 0:
-            x = F.pad(x, mode='constant', pad_width=(0, 0, 0, 0, self.pad_w//2, self.pad_w -self.pad_w//2,
-                                                     self.pad_h//2, self.pad_h - self.pad_h//2))
+            x = F.pad(x, mode='constant', pad_width=(0, 0, 0, 0, self.pad_h//2, self.pad_h - self.pad_h//2,
+                                                     self.pad_w//2, self.pad_w -self.pad_w//2))
             return x
         return x
 
     def __repr__(self):
         s = '{}({}, {}, {}, {})'
         return s.format(self.__class__.__name__,
-                        self.pad_w//2, self.pad_w -self.pad_w//2,
-                        self.pad_h//2, self.pad_h - self.pad_h//2)
+                        self.pad_h//2, self.pad_h - self.pad_h//2,
+                        self.pad_w//2, self.pad_w -self.pad_w//2)
     
 
 #class swish(mx.autograd.Function):


### PR DESCRIPTION
*Issue #, if available:*
Pad_width and pad_height are misplaced. It may cause the following conv layer's output has a different size when stride param of SamePadding is a tuple and stride[0] != stride[1].

*Description of changes:*
swap the pad_width and pad_height.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
