### PR TITLE
Fix broken/missing links in tutorial docs

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -10,19 +10,19 @@ Image Classification
       :title: Quick Start Using FIT
       :link: image_classification/beginner.html
 
-      Quick start tutorial.
+      5 min tutorial on classifying images.
 
    .. card::
       :title: Customized Search and HPO
       :link: image_classification/hpo.html
 
-      Image classification HPO tutorial.
+      Hyperparameter tuning to improve image classification accuracy.
 
    .. card::
       :title: Use Your Own Dataset
       :link: image_classification/kaggle.html
 
-      Participate Kaggle competition.
+      Example use of AutoGluon for image classification competition on Kaggle.
 
 
 Object Detection
@@ -33,7 +33,7 @@ Object Detection
       :title: Quick Start Using FIT
       :link: object_detection/beginner.html
 
-      Quick start tutorial.
+      5 min tutorial on detecting objects in images.
 
 
 Tabular Prediction
@@ -44,7 +44,7 @@ Tabular Prediction
       :title: Quick Start Tutorial
       :link: tabular_prediction/tabular-quickstart.html
 
-      Quick tutorial on fitting models with tabular datasets.
+      5 min tutorial on fitting models with tabular datasets.
 
    .. card::
       :title: In-depth FIT Tutorial
@@ -90,17 +90,17 @@ Neural Architecture Search
 .. container:: cards
 
    .. card::
-      :title: Reinforcement Learing
+      :title: Reinforcement Learning
       :link: nas/rl_searcher.html
 
-      Compare Reinforcement Learning with Random Searcher.
+      Comparing search via Reinforcement Learning against Random search.
 
    .. card::
       :title: Efficient NAS on Target Hardware
       :link: nas/enas_mnist.html
 
       Efficient Neural Architecture Search for low latency model
-      on Target Hardware.
+      on target hardware.
 
 
 .. toctree::

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -24,6 +24,7 @@ Image Classification
 
       Participate Kaggle competition.
 
+
 Object Detection
 ----------------
 .. container:: cards
@@ -49,32 +50,39 @@ Tabular Prediction
       :title: In-depth FIT Tutorial
       :link: tabular_prediction/tabular-indepth.html
 
-      In-depth tutorial on controlling various aspects of model fitting.
+      In-depth tutorial on boosting accuracy and controlling model fitting.
 
-Customize AutoGluon
--------------------
+   .. card::
+      :title: Kaggle Tutorial
+      :link: tabular_prediction/tabular-kaggle.html
+
+      Using AutoGluon for Kaggle competitions with tabular data.
+
+
+Tuning Custom Models
+--------------------
 .. container:: cards
    
    .. card::
       :title: Search Space and Decorator
       :link: course/core.html
 
-      Learn AutoGluon Core API for customized search spaces,
-      customize searchable objects, and training functions.
+      AutoGluon's Core API for search spaces and searchable 
+      objects used to tune any training function's argument-values.
 
    .. card::
       :title: Search Algorithms
       :link: course/algorithm.html
 
-      Learning AutoGluon built-in search algorithms and
-      early-stopping scheduling strategy.
+      Use AutoGluon's search algorithms to tune 
+      arbitrary models/training-scripts.
 
    .. card::
       :title: Distributed Search Tutorial
-      :link: cource/distributed.md
+      :link: course/distributed.html
 
-      Easily scale up training across multiple machines using
-      automatic distributed search.
+      Easily distribute AutoGluon tuning 
+      across multiple machines.
 
 
 Neural Architecture Search


### PR DESCRIPTION
- fix broken distributed tutorial link
- add missing tabular kaggle tutorial card to tutorials page
- improve core tutorial descriptions to emphasize these are for tuning custom model/training-script
