### PR TITLE
Tabular: Added memory_size to info + minor fixes to HPO

### DIFF
--- a/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
@@ -149,9 +149,6 @@ class BaggedEnsembleModel(AbstractModel):
             cur_repeat_count = j - n_repeat_start
             fold_start_n_repeat = fold_start + cur_repeat_count * k_fold
             fold_end_n_repeat = min(fold_start_n_repeat + k_fold, fold_end)
-            is_training_from_start = fold_end_n_repeat - fold_start_n_repeat == k_fold
-            if is_training_from_start:
-                self._k_per_n_repeat.append(k_fold)
             # TODO: Consider moving model fit inner for loop to a function to simply this code
             for i in range(fold_start_n_repeat, fold_end_n_repeat):  # For each fold
                 folds_finished = i - fold_start
@@ -202,6 +199,8 @@ class BaggedEnsembleModel(AbstractModel):
                 oof_pred_proba[test_index] += pred_proba
                 oof_pred_model_repeats[test_index] += 1
                 self._add_child_times_to_bag(model=fold_model)
+            if (fold_end_n_repeat != fold_end) or (k_fold == k_fold_end):
+                self._k_per_n_repeat.append(k_fold)
         self.models += models
 
         self.bagged_mode = True

--- a/autogluon/utils/tabular/ml/models/ensemble/stacker_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/stacker_ensemble_model.py
@@ -206,11 +206,12 @@ class StackerEnsembleModel(BaggedEnsembleModel):
                 stacker.models.append(child.name)
             else:
                 stacker.models.append(child)
+            stacker.val_score = child.val_score
             stacker._add_child_times_to_bag(model=child)
 
             stacker.save()
             stackers[stacker.name] = stacker.path
-            stackers_performance[stacker.name] = child.val_score
+            stackers_performance[stacker.name] = stacker.val_score
 
         # TODO: hpo_results likely not correct because no renames
         return stackers, stackers_performance, hpo_results


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes:
- Added memory_size, max_memory_size, and min_memory_size attributes to get_info of models.
- Fixed bagged ensembles incorrectly calculating feature importances when created through HPO.
- Fixed stacker ensembles not having a val_score set after first fold is trained during HPO. (Defect had no impact in previous version, but impacted the development of new functionality.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
