### PR TITLE
Tabular: Defaulted CatBoost 'allow_writing_files' to False

### DIFF
--- a/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
+++ b/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
@@ -39,7 +39,8 @@ class CatboostModel(AbstractModel):
             self._set_default_param_value(param, val)
         self._set_default_param_value('random_seed', 0)  # Remove randomness for reproducibility
         self._set_default_param_value('eval_metric', construct_custom_catboost_metric(self.stopping_metric, True, not self.stopping_metric_needs_y_pred, self.problem_type))
-        self._set_default_param_value('allow_writing_files', False)  # Disables creation of catboost logging files during training
+        # Set 'allow_writing_files' to True in order to keep log files created by catboost during training (these will be saved in the directory where AutoGluon stores this model)
+        self._set_default_param_value('allow_writing_files', False)  # Disables creation of catboost logging files during training by default
 
     def _get_default_searchspace(self):
         return get_default_searchspace(self.problem_type, num_classes=self.num_classes)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/openml/automlbenchmark/pull/109

*Description of changes:*

Removed unnecessary logging files produced by catboost in the root directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
