### PR TITLE
Tabular: Added delete_models and reduce_memory_size functions

### DIFF
--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -506,6 +506,16 @@ class AbstractModel:
     def reduce_memory_size(self, remove_fit=True, remove_info=False, requires_save=True, **kwargs):
         pass
 
+    # Deletes the model from disk.
+    # WARNING: This will DELETE ALL FILES in the self.path directory, regardless if they were created by AutoGluon or not.
+    #  DO NOT STORE FILES INSIDE OF THE MODEL DIRECTORY THAT ARE UNRELATED TO AUTOGLUON.
+    def delete_from_disk(self):
+        logger.log(30, f'Deleting model {self.name}. All files under {self.path} will be removed.')
+        from pathlib import Path
+        import shutil
+        model_path = Path(self.path)
+        shutil.rmtree(path=model_path, ignore_errors=True)
+
     def get_info(self):
         info = dict(
             name=self.name,

--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -514,6 +514,7 @@ class AbstractModel:
         from pathlib import Path
         import shutil
         model_path = Path(self.path)
+        # TODO: Report errors?
         shutil.rmtree(path=model_path, ignore_errors=True)
 
     def get_info(self):

--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -499,6 +499,13 @@ class AbstractModel:
     def get_memory_size(self):
         return sys.getsizeof(pickle.dumps(self, protocol=4))
 
+    # Removes non-essential objects from the model to reduce memory and disk footprint.
+    # If `remove_fit=True`, enables the removal of variables which are required for fitting the model. If the model is already fully trained, then it is safe to remove these.
+    # If `remove_info=True`, enables the removal of variables which are used during model.get_info(). The values will be None when calling model.get_info().
+    # If `requires_save=True`, enables the removal of variables which are part of the model.pkl object, requiring an overwrite of the model to disk if it was previously persisted.
+    def reduce_memory_size(self, remove_fit=True, remove_info=False, requires_save=True, **kwargs):
+        pass
+
     def get_info(self):
         info = dict(
             name=self.name,

--- a/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
@@ -124,6 +124,7 @@ class BaggedEnsembleModel(AbstractModel):
             self._n_repeats_finished = 1
             self._k_per_n_repeat = [1]
             self.bagged_mode = False
+            model_base.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
             if self.low_memory:
                 self.save_child(model_base, verbose=False)
                 self.models = [model_base.name]
@@ -191,6 +192,7 @@ class BaggedEnsembleModel(AbstractModel):
                 fold_model.fit_time = time_train_end_fold - time_start_fold
                 fold_model.predict_time = time_predict_end_fold - time_train_end_fold
                 fold_model.val_score = fold_model.score_with_y_pred_proba(y=y_test, y_pred_proba=pred_proba)
+                fold_model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
                 if self.low_memory:
                     self.save_child(fold_model, verbose=False)
                     models.append(fold_model.name)

--- a/autogluon/utils/tabular/ml/models/ensemble/stacker_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/stacker_ensemble_model.py
@@ -83,8 +83,9 @@ class StackerEnsembleModel(BaggedEnsembleModel):
                 for stack_column_prefix in self.stack_column_prefix_lst:
                     base_model_name = self.stack_column_prefix_to_model_map[stack_column_prefix]
                     if fit:
-                        base_model = self.load_base_model(base_model_name)
-                        y_pred_proba = base_model.oof_pred_proba
+                        base_model_type = self.base_model_types_dict[base_model_name]
+                        base_model_path = self.base_model_paths_dict[base_model_name]
+                        y_pred_proba = base_model_type.load_oof(path=base_model_path)
                     elif model_pred_proba_dict and base_model_name in model_pred_proba_dict:
                         y_pred_proba = model_pred_proba_dict[base_model_name]
                     else:

--- a/autogluon/utils/tabular/ml/models/ensemble/weighted_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/weighted_ensemble_model.py
@@ -28,6 +28,7 @@ class WeightedEnsembleModel(StackerEnsembleModel):
         self.stack_columns, self.num_pred_cols_per_model = self.set_stack_columns(stack_column_prefix_lst=self.stack_column_prefix_lst)
         min_stack_column_prefix_to_model_map = {k: v for k, v in self.stack_column_prefix_to_model_map.items() if k in self.stack_column_prefix_lst}
         self.base_model_names = [base_model_name for base_model_name in self.base_model_names if base_model_name in min_stack_column_prefix_to_model_map.values()]
+        self.stack_column_prefix_to_model_map = min_stack_column_prefix_to_model_map
 
     def _get_model_weights(self):
         weights_dict = defaultdict(int)

--- a/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
@@ -364,6 +364,10 @@ class TabularNeuralNetModel(AbstractModel):
 
         if test_dataset is not None:
             self.model.load_parameters(net_filename)  # Revert back to best model
+            try:
+                os.remove(net_filename)
+            except FileNotFoundError:
+                pass
         if test_dataset is None:
             logger.log(15, "Best model found in epoch %d" % best_val_epoch)
         else: # evaluate one final time:
@@ -818,6 +822,11 @@ class TabularNeuralNetModel(AbstractModel):
         info = super().get_info()
         info['hyperparameters_post_fit'] = self.params_post_fit
         return info
+
+    def reduce_memory_size(self, remove_fit=True, requires_save=True, **kwargs):
+        super().reduce_memory_size(remove_fit=remove_fit, requires_save=requires_save, **kwargs)
+        if remove_fit and requires_save:
+            self.optimizer = None
 
 
 """ General TODOs:

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -1306,7 +1306,7 @@ class AbstractTrainer:
                 for model in models_to_remove:
                     model = self.load_model(model)
                     logger.log(30, f'\tDirectory {model.path} would have been deleted.')
-            logger.log(30, f'To perform the deletion, set dry_run=True')
+            logger.log(30, f'To perform the deletion, set dry_run=False')
             return
 
         self.model_graph.remove_nodes_from(models_to_remove)

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -957,6 +957,8 @@ class AbstractTrainer:
         return max(perfs, key=lambda i: i[1])[0]
 
     def save_model(self, model):
+        # TODO: In future perhaps give option for the reduce_memory_size arguments, perhaps trainer level variables specified by user?
+        model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
         if self.low_memory:
             model.save()
         else:

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -179,10 +179,7 @@ class AbstractTrainer:
         save_pkl.save(path=path, object=y, verbose=verbose)
 
     def get_model_names_all(self):
-        model_names = []
-        for stack_name in self.models_level.keys():
-            model_names += self.get_model_names(stack_name)
-        return model_names
+        return list(self.model_graph.nodes)
 
     def get_model_names(self, stack_name):
         model_names = []
@@ -737,17 +734,21 @@ class AbstractTrainer:
         for model_name in model_pred_order:
             if record_pred_time:
                 time_start = time.time()
-            model = self.load_model(model_name=model_name)
+
             if fit:
-                if isinstance(model, BaggedEnsembleModel):
-                    model_pred_proba_dict[model_name] = model.oof_pred_proba
+                model_type = self.model_types[model_name]
+                if issubclass(model_type, BaggedEnsembleModel):
+                    model_path = self.model_paths[model_name]
+                    model_pred_proba_dict[model_name] = model_type.load_oof(path=model_path)
                 else:
                     raise AssertionError(f'Model {model.name} must be a BaggedEnsembleModel to return oof_pred_proba')
-            elif isinstance(model, StackerEnsembleModel):
-                X_input = model.preprocess(X=X, preprocess=True, infer=False, model_pred_proba_dict=model_pred_proba_dict)
-                model_pred_proba_dict[model_name] = model.predict_proba(X_input, preprocess=False)
             else:
-                model_pred_proba_dict[model_name] = model.predict_proba(X)
+                model = self.load_model(model_name=model_name)
+                if isinstance(model, StackerEnsembleModel):
+                    X_input = model.preprocess(X=X, preprocess=True, infer=False, model_pred_proba_dict=model_pred_proba_dict)
+                    model_pred_proba_dict[model_name] = model.predict_proba(X_input, preprocess=False)
+                else:
+                    model_pred_proba_dict[model_name] = model.predict_proba(X)
 
             if record_pred_time:
                 time_end = time.time()
@@ -956,9 +957,10 @@ class AbstractTrainer:
             raise AssertionError('No fit models exist with a validation score to choose the best model.')
         return max(perfs, key=lambda i: i[1])[0]
 
-    def save_model(self, model):
+    def save_model(self, model, reduce_memory=True):
         # TODO: In future perhaps give option for the reduce_memory_size arguments, perhaps trainer level variables specified by user?
-        model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
+        if reduce_memory:
+            model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
         if self.low_memory:
             model.save()
         else:
@@ -1243,6 +1245,93 @@ class AbstractTrainer:
             else:
                 model_info_dict[model.name] = model.get_info()
         return model_info_dict
+
+    def reduce_memory_size(self, remove_data=True, remove_fit_stack=False, remove_fit=True, remove_info=False, requires_save=True, reduce_children=False, **kwargs):
+        if remove_data and self.is_data_saved:
+            data_files = [
+                self.path_data + 'X_train.pkl',
+                self.path_data + 'X_val.pkl',
+                self.path_data + 'y_train.pkl',
+                self.path_data + 'y_val.pkl',
+            ]
+            for data_file in data_files:
+                try:
+                    os.remove(data_file)
+                except FileNotFoundError:
+                    pass
+            if requires_save:
+                self.is_data_saved = False
+
+        models = self.get_model_names_all()
+        for model in models:
+            model = self.load_model(model)
+            model.reduce_memory_size(remove_fit_stack=remove_fit_stack, remove_fit=remove_fit, remove_info=remove_info, requires_save=requires_save, reduce_children=reduce_children, **kwargs)
+            if requires_save:
+                self.save_model(model, reduce_memory=False)
+        if requires_save:
+            self.save()
+
+    # TODO: Also enable deletion of models which didn't succeed in training (files may still be persisted)
+    #  This includes the original HPO fold for stacking
+    # Deletes specified models from trainer and from disk (if delete_from_disk=True).
+    def delete_models(self, models_to_keep=None, models_to_delete=None, allow_delete_cascade=False, delete_from_disk=True, dry_run=True):
+        if models_to_keep is not None and models_to_delete is not None:
+            raise ValueError('Exactly one of [models_to_keep, models_to_delete] must be set.')
+        if models_to_keep is not None:
+            if not isinstance(models_to_keep, list):
+                models_to_keep = [models_to_keep]
+            minimum_model_set = set()
+            for model in models_to_keep:
+                minimum_model_set.update(self.get_minimum_model_set(model))
+            minimum_model_set = list(minimum_model_set)
+            models_to_remove = [model for model in self.get_model_names_all() if model not in minimum_model_set]
+        elif models_to_delete is not None:
+            if not isinstance(models_to_delete, list):
+                models_to_delete = [models_to_delete]
+            minimum_model_set = set(models_to_delete)
+            minimum_model_set_orig = copy.deepcopy(minimum_model_set)
+            for model in models_to_delete:
+                minimum_model_set.update(nx.algorithms.dag.descendants(self.model_graph, model))
+            if not allow_delete_cascade:
+                if minimum_model_set != minimum_model_set_orig:
+                    raise AssertionError('models_to_delete contains models which cause a delete cascade due to other models being dependent on them. Set allow_delete_cascade=True to enable the deletion.')
+            minimum_model_set = list(minimum_model_set)
+            models_to_remove = [model for model in self.get_model_names_all() if model in minimum_model_set]
+        else:
+            raise ValueError('Exactly one of [models_to_keep, models_to_delete] must be set.')
+
+        if dry_run:
+            logger.log(30, f'Dry run enabled, AutoGluon would have deleted the following models: {models_to_remove}')
+            if delete_from_disk:
+                for model in models_to_remove:
+                    model = self.load_model(model)
+                    logger.log(30, f'\tDirectory {model.path} would have been deleted.')
+            logger.log(30, f'To perform the deletion, set dry_run=True')
+            return
+
+        self.model_graph.remove_nodes_from(models_to_remove)
+        for model in models_to_remove:
+            if model in self.models:
+                self.models.pop(model)
+
+        models_kept = self.get_model_names_all()
+        # TODO: Refactor this part, link models_level to model_graph
+        for key in self.models_level:
+            for level in self.models_level[key]:
+                self.models_level[key][level] = [model for model in self.models_level[key][level] if model in models_kept]
+
+        if self.model_best is not None and self.model_best not in models_kept:
+            try:
+                self.model_best = self.get_model_best()
+            except AssertionError:
+                self.model_best = None
+
+        # TODO: Delete from all the other model dicts
+        self.save()
+        if delete_from_disk:
+            for model in models_to_remove:
+                model = self.load_model(model)
+                model.delete_from_disk()
 
     @classmethod
     def load(cls, path, reset_paths=False):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Major changes:
- Optimized Tabular NN disk and memory usage to house the model to be reduced by ~80%+ in most cases. This brings NN disk/memory usage from 3 MB -> 500 KB in most cases, which also speeds up inference times on small datasets by >20% due to faster model loading.
- Added delete_models function which allows user to delete unwanted models from predictor. This is extremely useful for users that want to create a model endpoint and don't want the extra unused models taking up disk space on their machines.
- Added reduce_memory_size function which allows user to remove unwanted information such as OOF predictions and train/val data caches to reduce disk usage.
- Moved OOF predictions outside of bagged models into a separate oof.pkl file. This dramatically speeds up inference times and reduces memory usage in cases where OOF predictions were large. For example, in Dionis which has 355 classes, OOF predictions took up 1 GB of disk and memory for each model (~10 GB total for the ensemble). Previously, these 10 GB of data had to be loaded into memory prior to any call to inference, but now they are not loaded at all.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
