### PR TITLE
Tabular: Added presets, save_bagged_models, keep_only_best, and save_space

### DIFF
--- a/autogluon/task/tabular_prediction/hyperparameter_configs.py
+++ b/autogluon/task/tabular_prediction/hyperparameter_configs.py
@@ -29,7 +29,7 @@ hyperparameter_config_dict = dict(
         'GBM': {},
         'CAT': {},
     },
-    # Results in extremely small models. Only use this when prototyping, as the model quality will be severely reduced.
+    # Results in extremely quick to train models. Only use this when prototyping, as the model accuracy will be severely reduced.
     toy={
         'NN': {'num_epochs': 10},
         'GBM': {'num_boost_round': 10},

--- a/autogluon/task/tabular_prediction/hyperparameter_configs.py
+++ b/autogluon/task/tabular_prediction/hyperparameter_configs.py
@@ -1,0 +1,49 @@
+
+import copy
+
+
+# Dictionary of preset hyperparameter configurations.
+hyperparameter_config_dict = dict(
+    # Default AutoGluon hyperparameters intended to maximize accuracy without significant regard to inference time or disk usage.
+    default={
+        'NN': {},
+        'GBM': {},
+        'CAT': {},
+        'RF': {},
+        'XT': {},
+        'KNN': {},
+        'custom': ['GBM'],
+    },
+    # Results in smaller models. Generally will make inference speed much faster and disk usage much lower, but with worse accuracy.
+    light={
+        'NN': {},
+        'GBM': {},
+        'CAT': {},
+        'RF': {'max_depth': 15},
+        'XT': {'max_depth': 15},
+        'custom': ['GBM'],
+    },
+    # Results in much smaller models. Behaves similarly to 'light', but in many cases with over 10x less disk usage and a further reduction in accuracy.
+    very_light={
+        'NN': {},
+        'GBM': {},
+        'CAT': {},
+    },
+    # Results in extremely small models. Only use this when prototyping, as the model quality will be severely reduced.
+    toy={
+        'NN': {'num_epochs': 10},
+        'GBM': {'num_boost_round': 10},
+        'CAT': {'iterations': 10},
+    }
+)
+
+
+def get_hyperparameter_config_options():
+    return list(hyperparameter_config_dict.keys())
+
+
+def get_hyperparameter_config(config_name):
+    config_options = get_hyperparameter_config_options()
+    if config_name not in config_options:
+        raise ValueError(f'Valid hyperparameter config names are: {config_options}, but \'{config_name}\' was given instead.')
+    return copy.deepcopy(hyperparameter_config_dict[config_name])

--- a/autogluon/task/tabular_prediction/presets_configs.py
+++ b/autogluon/task/tabular_prediction/presets_configs.py
@@ -1,7 +1,10 @@
 
+import functools
+
 
 def unpack(g):
     def _unpack_inner(f):
+        @functools.wraps(f)
         def _call(**kwargs):
             return f(**g(**kwargs))
         return _call

--- a/autogluon/task/tabular_prediction/presets_configs.py
+++ b/autogluon/task/tabular_prediction/presets_configs.py
@@ -10,27 +10,27 @@ def unpack(g):
 
 # Dictionary of preset fit() parameter configurations.
 preset_dict = dict(
-    # Best quality with little consideration to inference time or disk usage. Achieve even better results by specifying a large time_limits value.
-    # Recommended for applications that benefit from the best possible model quality.
+    # Best predictive accuracy with little consideration to inference time or disk usage. Achieve even better results by specifying a large time_limits value.
+    # Recommended for applications that benefit from the best possible model accuracy.
     best_quality={'auto_stack': True},
 
-    # Identical to best_quality but additionally trains refit_full models that have slightly lower quality but are over 10x faster during inference and require 10x less disk space.
+    # Identical to best_quality but additionally trains refit_full models that have slightly lower predictive accuracy but are over 10x faster during inference and require 10x less disk space.
     best_quality_with_high_quality_refit={'auto_stack': True, 'refit_full': True},
 
-    # High quality with fast inference. ~10x-200x faster inference and ~10x-200x lower disk usage than `best_quality`.
+    # High predictive accuracy with fast inference. ~10x-200x faster inference and ~10x-200x lower disk usage than `best_quality`.
     # Recommended for applications that require reasonable inference speed and/or model size.
     high_quality_fast_inference_only_refit={'auto_stack': True, 'refit_full': True, 'set_best_to_refit_full': True, 'save_bagged_folds': False},
 
-    # Good quality with very fast inference. ~4x faster inference and ~4x lower disk usage than `high_quality_fast_inference_only_refit`.
+    # Good predictive accuracy with very fast inference. ~4x faster inference and ~4x lower disk usage than `high_quality_fast_inference_only_refit`.
     # Recommended for applications that require fast inference speed.
     good_quality_faster_inference_only_refit={'auto_stack': True, 'refit_full': True, 'set_best_to_refit_full': True, 'save_bagged_folds': False, 'hyperparameters': 'light'},
 
-    # Medium quality with very fast inference and very fast training time. ~20x faster training than `good_quality_faster_inference_only_refit`.
-    # This is the default preset in AutoGluon, but should generally only be used for quick prototyping, as `good_quality_faster_inference_only_refit` results in significantly better quality and faster inference time.
-    medium_quality_fastest_train={'auto_stack': False},
+    # Medium predictive accuracy with very fast inference and very fast training time. ~20x faster training than `good_quality_faster_inference_only_refit`.
+    # This is the default preset in AutoGluon, but should generally only be used for quick prototyping, as `good_quality_faster_inference_only_refit` results in significantly better predictive accuracy and faster inference time.
+    medium_quality_faster_train={'auto_stack': False},
 
     # Optimizes result immediately for deployment by deleting unused models and removing training artifacts.
-    # Often can reduce disk usage by ~2-4x with no negatives to model quality or inference speed.
+    # Often can reduce disk usage by ~2-4x with no negatives to model accuracy or inference speed.
     # This will disable numerous advanced functionality, but has no impact on inference.
     # Recommended for applications where the inner details of AutoGluon's training is not important and there is no intention of manually choosing between the final models.
     # This preset pairs well with the other presets such as `good_quality_faster_inference_only_refit` to make a very compact final model.
@@ -40,6 +40,8 @@ preset_dict = dict(
     # Disables automated feature generation when text features are detected.
     # This is useful to determine how beneficial text features are to the end result, as well as to ensure features are not mistaken for text when they are not.
     ignore_text={'feature_generator_kwargs': {'enable_nlp_vectorizer_features': False, 'enable_nlp_ratio_features': False}},
+
+    # TODO: Consider HPO-enabled configs if training time doesn't matter but inference latency does.
 )
 
 

--- a/autogluon/task/tabular_prediction/presets_configs.py
+++ b/autogluon/task/tabular_prediction/presets_configs.py
@@ -1,0 +1,68 @@
+
+
+def unpack(g):
+    def _unpack_inner(f):
+        def _call(**kwargs):
+            return f(**g(**kwargs))
+        return _call
+    return _unpack_inner
+
+
+# Dictionary of preset fit() parameter configurations.
+preset_dict = dict(
+    # Best quality with little consideration to inference time or disk usage. Achieve even better results by specifying a large time_limits value.
+    # Recommended for applications that benefit from the best possible model quality.
+    best_quality={'auto_stack': True},
+
+    # Identical to best_quality but additionally trains refit_full models that have slightly lower quality but are over 10x faster during inference and require 10x less disk space.
+    best_quality_with_high_quality_refit={'auto_stack': True, 'refit_full': True},
+
+    # High quality with fast inference. ~10x-200x faster inference and ~10x-200x lower disk usage than `best_quality`.
+    # Recommended for applications that require reasonable inference speed and/or model size.
+    high_quality_fast_inference_only_refit={'auto_stack': True, 'refit_full': True, 'set_best_to_refit_full': True, 'save_bagged_folds': False},
+
+    # Good quality with very fast inference. ~4x faster inference and ~4x lower disk usage than `high_quality_fast_inference_only_refit`.
+    # Recommended for applications that require fast inference speed.
+    good_quality_faster_inference_only_refit={'auto_stack': True, 'refit_full': True, 'set_best_to_refit_full': True, 'save_bagged_folds': False, 'hyperparameters': 'light'},
+
+    # Medium quality with very fast inference and very fast training time. ~20x faster training than `good_quality_faster_inference_only_refit`.
+    # This is the default preset in AutoGluon, but should generally only be used for quick prototyping, as `good_quality_faster_inference_only_refit` results in significantly better quality and faster inference time.
+    medium_quality_fastest_train={'auto_stack': False},
+
+    # Optimizes result immediately for deployment by deleting unused models and removing training artifacts.
+    # Often can reduce disk usage by ~2-4x with no negatives to model quality or inference speed.
+    # This will disable numerous advanced functionality, but has no impact on inference.
+    # Recommended for applications where the inner details of AutoGluon's training is not important and there is no intention of manually choosing between the final models.
+    # This preset pairs well with the other presets such as `good_quality_faster_inference_only_refit` to make a very compact final model.
+    # Identical to calling `predictor.delete_models(models_to_keep='best', dry_run=False)` and `predictor.save_space()` directly after `fit()`.
+    optimize_for_deployment={'keep_only_best': True, 'save_space': True},
+
+    # Disables automated feature generation when text features are detected.
+    # This is useful to determine how beneficial text features are to the end result, as well as to ensure features are not mistaken for text when they are not.
+    ignore_text={'feature_generator_kwargs': {'enable_nlp_vectorizer_features': False, 'enable_nlp_ratio_features': False}},
+)
+
+
+def set_presets(**kwargs):
+    if 'presets' in kwargs:
+        presets = kwargs['presets']
+        if presets is None:
+            return kwargs
+        if not isinstance(presets, list):
+            presets = [presets]
+        preset_kwargs = {}
+        for preset in presets:
+            if isinstance(preset, str):
+                preset_orig = preset
+                preset = preset_dict.get(preset, None)
+                if preset is None:
+                    raise ValueError(f'Preset \'{preset_orig}\' was not found. Valid presets: {list(preset_dict.keys())}')
+            if isinstance(preset, dict):
+                for key in preset:
+                    preset_kwargs[key] = preset[key]
+            else:
+                raise TypeError(f'Preset of type {type(preset)} was given, but only presets of type [dict, str] are valid.')
+        for key in preset_kwargs:
+            if key not in kwargs:
+                kwargs[key] = preset_kwargs[key]
+    return kwargs

--- a/autogluon/task/tabular_prediction/tabular_prediction.py
+++ b/autogluon/task/tabular_prediction/tabular_prediction.py
@@ -104,36 +104,36 @@ class TabularPrediction(BaseTask):
             It is recommended to only use one `quality` based preset in a given call to `fit()` as they alter many of the same arguments and are not compatible with each-other.
 
             In-depth Preset Info:
-                # Best predictive accuracy with little consideration to inference time or disk usage. Achieve even better results by specifying a large time_limits value.
-                # Recommended for applications that benefit from the best possible model accuracy.
-                best_quality={'auto_stack': True},
+                best_quality={'auto_stack': True}
+                    Best predictive accuracy with little consideration to inference time or disk usage. Achieve even better results by specifying a large time_limits value.
+                    Recommended for applications that benefit from the best possible model accuracy.
 
-                # Identical to best_quality but additionally trains refit_full models that have slightly lower predictive accuracy but are over 10x faster during inference and require 10x less disk space.
-                best_quality_with_high_quality_refit={'auto_stack': True, 'refit_full': True},
+                best_quality_with_high_quality_refit={'auto_stack': True, 'refit_full': True}
+                    Identical to best_quality but additionally trains refit_full models that have slightly lower predictive accuracy but are over 10x faster during inference and require 10x less disk space.
 
-                # High predictive accuracy with fast inference. ~10x-200x faster inference and ~10x-200x lower disk usage than `best_quality`.
-                # Recommended for applications that require reasonable inference speed and/or model size.
-                high_quality_fast_inference_only_refit={'auto_stack': True, 'refit_full': True, 'set_best_to_refit_full': True, 'save_bagged_folds': False},
+                high_quality_fast_inference_only_refit={'auto_stack': True, 'refit_full': True, 'set_best_to_refit_full': True, 'save_bagged_folds': False}
+                    High predictive accuracy with fast inference. ~10x-200x faster inference and ~10x-200x lower disk usage than `best_quality`.
+                    Recommended for applications that require reasonable inference speed and/or model size.
 
-                # Good predictive accuracy with very fast inference. ~4x faster inference and ~4x lower disk usage than `high_quality_fast_inference_only_refit`.
-                # Recommended for applications that require fast inference speed.
-                good_quality_faster_inference_only_refit={'auto_stack': True, 'refit_full': True, 'set_best_to_refit_full': True, 'save_bagged_folds': False, 'hyperparameters': 'light'},
+                good_quality_faster_inference_only_refit={'auto_stack': True, 'refit_full': True, 'set_best_to_refit_full': True, 'save_bagged_folds': False, 'hyperparameters': 'light'}
+                    Good predictive accuracy with very fast inference. ~4x faster inference and ~4x lower disk usage than `high_quality_fast_inference_only_refit`.
+                    Recommended for applications that require fast inference speed.
 
-                # Medium predictive accuracy with very fast inference and very fast training time. ~20x faster training than `good_quality_faster_inference_only_refit`.
-                # This is the default preset in AutoGluon, but should generally only be used for quick prototyping, as `good_quality_faster_inference_only_refit` results in significantly better predictive accuracy and faster inference time.
-                medium_quality_faster_train={'auto_stack': False},
+                medium_quality_faster_train={'auto_stack': False}
+                    Medium predictive accuracy with very fast inference and very fast training time. ~20x faster training than `good_quality_faster_inference_only_refit`.
+                    This is the default preset in AutoGluon, but should generally only be used for quick prototyping, as `good_quality_faster_inference_only_refit` results in significantly better predictive accuracy and faster inference time.
 
-                # Optimizes result immediately for deployment by deleting unused models and removing training artifacts.
-                # Often can reduce disk usage by ~2-4x with no negatives to model accuracy or inference speed.
-                # This will disable numerous advanced functionality, but has no impact on inference.
-                # Recommended for applications where the inner details of AutoGluon's training is not important and there is no intention of manually choosing between the final models.
-                # This preset pairs well with the other presets such as `good_quality_faster_inference_only_refit` to make a very compact final model.
-                # Identical to calling `predictor.delete_models(models_to_keep='best', dry_run=False)` and `predictor.save_space()` directly after `fit()`.
-                optimize_for_deployment={'keep_only_best': True, 'save_space': True},
+                optimize_for_deployment={'keep_only_best': True, 'save_space': True}
+                    Optimizes result immediately for deployment by deleting unused models and removing training artifacts.
+                    Often can reduce disk usage by ~2-4x with no negatives to model accuracy or inference speed.
+                    This will disable numerous advanced functionality, but has no impact on inference.
+                    Recommended for applications where the inner details of AutoGluon's training is not important and there is no intention of manually choosing between the final models.
+                    This preset pairs well with the other presets such as `good_quality_faster_inference_only_refit` to make a very compact final model.
+                    Identical to calling `predictor.delete_models(models_to_keep='best', dry_run=False)` and `predictor.save_space()` directly after `fit()`.
 
-                # Disables automated feature generation when text features are detected.
-                # This is useful to determine how beneficial text features are to the end result, as well as to ensure features are not mistaken for text when they are not.
-                ignore_text={'feature_generator_kwargs': {'enable_nlp_vectorizer_features': False, 'enable_nlp_ratio_features': False}},
+                ignore_text={'feature_generator_kwargs': {'enable_nlp_vectorizer_features': False, 'enable_nlp_ratio_features': False}}
+                    Disables automated feature generation when text features are detected.
+                    This is useful to determine how beneficial text features are to the end result, as well as to ensure features are not mistaken for text when they are not.
 
         problem_type : str, default = None
             Type of prediction problem, i.e. is this a binary/multiclass classification or regression problem (options: 'binary', 'multiclass', 'regression').
@@ -258,7 +258,7 @@ class TabularPrediction(BaseTask):
             List of IP addresses corresponding to remote workers, in order to leverage distributed computation.
         visualizer : str
             How to visualize the neural network training progress during `fit()`. Options: ['mxboard', 'tensorboard', 'none'].
-        verbosity: int, default = 2
+        verbosity : int, default = 2
             Verbosity levels range from 0 to 4 and control how much information is printed during fit().
             Higher levels correspond to more detailed print statements (you can set verbosity = 0 to suppress warnings).
             If using logging, you can alternatively control amount of information printed via `logger.setLevel(L)`,

--- a/autogluon/utils/tabular/ml/learner/default_learner.py
+++ b/autogluon/utils/tabular/ml/learner/default_learner.py
@@ -28,9 +28,10 @@ class DefaultLearner(AbstractLearner):
                          problem_type=problem_type, objective_func=objective_func, stopping_metric=stopping_metric, is_trainer_present=is_trainer_present, random_seed=random_seed)
         self.trainer_type = trainer_type
 
+    # TODO: Add trainer_kwargs to simplify parameter count and extensibility
     def fit(self, X: DataFrame, X_test: DataFrame = None, scheduler_options=None, hyperparameter_tune=True,
             feature_prune=False, holdout_frac=0.1, num_bagging_folds=0, num_bagging_sets=1, stack_ensemble_levels=0,
-            hyperparameters={'NN': {'num_epochs': 300}, 'GBM': {'num_boost_round': 10000}}, time_limit=None, save_data=False, verbosity=2):
+            hyperparameters=None, time_limit=None, save_data=False, save_bagged_folds=True, verbosity=2):
         """ Arguments:
                 X (DataFrame): training data
                 X_test (DataFrame): data used for hyperparameter tuning. Note: final model may be trained using this data as well as training data
@@ -46,6 +47,8 @@ class DefaultLearner(AbstractLearner):
                     Ignored unless kfolds is also set >= 2
                 hyperparameters (dict): keys = hyperparameters + search-spaces for each type of model we should train.
         """
+        if hyperparameters is None:
+            hyperparameters = {'NN': {}, 'GBM': {}}
         # TODO: if provided, feature_types in X, X_test are ignored right now, need to pass to Learner/trainer and update this documentation.
         if time_limit:
             self.time_limit = time_limit
@@ -84,6 +87,7 @@ class DefaultLearner(AbstractLearner):
             scheduler_options=scheduler_options,
             time_limit=time_limit_trainer,
             save_data=save_data,
+            save_bagged_folds=save_bagged_folds,
             random_seed=self.random_seed,
             verbosity=verbosity
         )

--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -107,9 +107,13 @@ class AbstractModel:
             self.nondefault_params = list(hyperparameters.keys())[:]  # These are hyperparameters that user has specified.
         self.params_trained = dict()
 
-    # Checks if model is ready to make predictions for final result
+    # Checks if model is capable of inference on new data (if normal model) or has produced out-of-fold predictions (if bagged model)
     def is_valid(self):
         return self.is_fit()
+
+    # Checks if model is capable of inference on new data
+    def can_infer(self):
+        return self.is_valid()
 
     # Checks if a model has been fit
     def is_fit(self):

--- a/autogluon/utils/tabular/ml/models/ensemble/stacker_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/stacker_ensemble_model.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 #  To solve this, this model must know full context of stacker, and only get preds once for each required model
 #  This is already done in trainer, but could be moved internally.
 class StackerEnsembleModel(BaggedEnsembleModel):
-    def __init__(self, path: str, name: str, model_base: AbstractModel, base_model_names=None, base_models_dict=None, base_model_paths_dict=None, base_model_types_dict=None, base_model_types_inner_dict=None, base_model_performances_dict=None, use_orig_features=True, num_classes=None, hyperparameters=None, objective_func=None, stopping_metric=None, random_state=0, debug=0):
-        super().__init__(path=path, name=name, model_base=model_base, hyperparameters=hyperparameters, objective_func=objective_func, stopping_metric=stopping_metric, random_state=random_state, debug=debug)
+    def __init__(self, path: str, name: str, model_base: AbstractModel, base_model_names=None, base_models_dict=None, base_model_paths_dict=None, base_model_types_dict=None, base_model_types_inner_dict=None, base_model_performances_dict=None, use_orig_features=True, num_classes=None, hyperparameters=None, objective_func=None, stopping_metric=None, save_bagged_folds=True, random_state=0, debug=0):
+        super().__init__(path=path, name=name, model_base=model_base, hyperparameters=hyperparameters, objective_func=objective_func, stopping_metric=stopping_metric, save_bagged_folds=save_bagged_folds, random_state=random_state, debug=debug)
         if base_model_names is None:
             base_model_names = []
         if base_models_dict is None:
@@ -202,6 +202,8 @@ class StackerEnsembleModel(BaggedEnsembleModel):
             stacker._oof_pred_model_repeats = oof_pred_model_repeats
             child.name = child.name + '_fold_0'
             child.set_contexts(stacker.path + child.name + os.path.sep)
+            if not self.save_bagged_folds:
+                child.model = None
             if stacker.low_memory:
                 stacker.save_child(child, verbose=False)
                 stacker.models.append(child.name)

--- a/autogluon/utils/tabular/ml/models/ensemble/weighted_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/weighted_ensemble_model.py
@@ -11,9 +11,9 @@ logger = logging.getLogger(__name__)
 
 # TODO: Optimize predict speed when fit on kfold, can simply sum weights
 class WeightedEnsembleModel(StackerEnsembleModel):
-    def __init__(self, path: str, name: str, base_model_names, base_model_paths_dict, base_model_types_dict, base_model_types_inner_dict=None, base_model_performances_dict=None, num_classes=None, hyperparameters=None, objective_func=None, stopping_metric=None, random_state=0, debug=0):
+    def __init__(self, path: str, name: str, base_model_names, base_model_paths_dict, base_model_types_dict, base_model_types_inner_dict=None, base_model_performances_dict=None, num_classes=None, hyperparameters=None, objective_func=None, stopping_metric=None, save_bagged_folds=True, random_state=0, debug=0):
         model_0 = base_model_types_dict[base_model_names[0]].load(path=base_model_paths_dict[base_model_names[0]], verbose=False)
-        super().__init__(path=path, name=name, model_base=model_0, base_model_names=base_model_names, base_model_paths_dict=base_model_paths_dict, base_model_types_dict=base_model_types_dict, base_model_types_inner_dict=base_model_types_inner_dict, base_model_performances_dict=base_model_performances_dict, use_orig_features=False, num_classes=num_classes, hyperparameters=hyperparameters, objective_func=objective_func, stopping_metric=stopping_metric, random_state=random_state, debug=debug)
+        super().__init__(path=path, name=name, model_base=model_0, base_model_names=base_model_names, base_model_paths_dict=base_model_paths_dict, base_model_types_dict=base_model_types_dict, base_model_types_inner_dict=base_model_types_inner_dict, base_model_performances_dict=base_model_performances_dict, use_orig_features=False, num_classes=num_classes, hyperparameters=hyperparameters, objective_func=objective_func, stopping_metric=stopping_metric, save_bagged_folds=save_bagged_folds, random_state=random_state, debug=debug)
         self.model_base = GreedyWeightedEnsembleModel(path='', name='greedy_ensemble', num_classes=self.num_classes, base_model_names=self.stack_column_prefix_lst, problem_type=self.problem_type, objective_func=self.objective_func, stopping_metric=self.stopping_metric)
         self._child_type = type(self.model_base)
         self.low_memory = False

--- a/autogluon/utils/tabular/ml/models/tabular_nn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/hyperparameters/parameters.py
@@ -6,7 +6,7 @@ from ....constants import BINARY, MULTICLASS, REGRESSION
 def get_fixed_params():
     """ Parameters that currently cannot be searched during HPO """
     fixed_params = {
-        'num_epochs': 300,  # maximum number of epochs for training NN
+        'num_epochs': 500,  # maximum number of epochs for training NN
         'epochs_wo_improve': 20,  # we terminate training if validation performance hasn't improved in the last 'epochs_wo_improve' # of epochs
         # TODO: Epochs could take a very long time, we may want smarter logic than simply # of epochs without improvement (slope, difference in score, etc.)
         'seed_value': None,  # random seed for reproducibility (set = None to ignore)


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Major Changes:
- Added presets parameter, enables novice users to specify complex options with minimal knowledge.
- Added save_bagged_models parameter, enables users to avoid saving bagged models when they plan to refit_full, reducing disk usage by >10x.
- Added keep_only_best parameter, when True acts as calling predictor.delete_models(models_to_keep='best', dry_run=False) at the end of fit().
- Added save_space parameter, when True acts as calling predictor.save_space() at the end of fit().
- Added option to specify string presets for 'hyperparameters' to simplify interface for novice users.
- can_infer function added to models to enable save_bagged_models parameter
- Improved comprehensiveness of save_space() to delete empty directories and other auxiliary information such as model templates.
- Numerous code consistency improvements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
