### PR TITLE
Updated version to 0.0.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
-version = '0.0.8'
+version = '0.0.9'
 """
 To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
 a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,12 @@ requirements = [
     'gluonnlp==0.8.1',
     'graphviz',
     'scikit-optimize',
-    'catboost',
+    'catboost<0.24',
     'boto3',
     'lightgbm>=2.3.0,<3.0',
     'pandas>=0.24.0,<1.0',
     'psutil>=5.0.0',
-    'scikit-learn>=0.20.0',
+    'scikit-learn>=0.20.0,<0.23',
     'networkx>=2.3,<3.0',
 ]
 


### PR DESCRIPTION
*Issue #, if available:*
#461 

*Description of changes:*

Updated version to 0.0.9. This will enable the daily PyPi pre-releases to be installable through `pip install autogluon --pre`

Fixes defect caused by `import skopt` after sklearn released 0.23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
