### PR TITLE
Tabular: Fixed refit_full models without bagging

### DIFF
--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -379,7 +379,7 @@ class AbstractModel:
         template = self.convert_to_template()
         template.params.update(params_trained)
         template.name = template.name + REFIT_FULL_SUFFIX
-        template.path = template.create_contexts(self.path + template.name + os.path.sep)
+        template.set_contexts(self.path_root + template.name + os.path.sep)
         return template
 
     def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options, **kwargs):

--- a/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
@@ -321,7 +321,7 @@ class BaggedEnsembleModel(AbstractModel):
         model_compressed.feature_types_metadata = self.feature_types_metadata  # TODO: Don't pass this here
         model_compressed.params = compressed_params
         model_compressed.name = model_compressed.name + REFIT_FULL_SUFFIX
-        model_compressed.set_contexts(self.path + model_compressed.name + os.path.sep)
+        model_compressed.set_contexts(self.path_root + model_compressed.name + os.path.sep)
         return model_compressed
 
     def _get_compressed_params(self):


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Fixed refit_full models without bagging being in subdirectory of their original model.

This previously caused 'optimize_for_deployment' preset to crash when auto_stack=False, refit_full=True, and set_best_to_refit_full=True. This now works correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
