### PR TITLE
Fix default for num_trials: If time_limits given, this can be None

### DIFF
--- a/autogluon/scheduler/fifo.py
+++ b/autogluon/scheduler/fifo.py
@@ -142,7 +142,6 @@ class FIFOScheduler(TaskScheduler):
         if num_trials is None:
             assert time_out is not None, \
                 "Need stopping criterion: Either num_trials or time_out"
-            num_trials = 100000  # time_out is what matters
         self.num_trials = num_trials
         self.time_out = time_out
         self.max_reward = max_reward
@@ -211,11 +210,15 @@ class FIFOScheduler(TaskScheduler):
 
         logger.info('Starting Experiments')
         logger.info(f'Num of Finished Tasks is {self.num_finished_tasks}')
-        logger.info(f'Num of Pending Tasks is {num_trials - self.num_finished_tasks}')
+        if num_trials is not None:
+            logger.info(f'Num of Pending Tasks is {num_trials - self.num_finished_tasks}')
+            tbar = tqdm(range(self.num_finished_tasks, num_trials))
+        else:
+            # In this case, only stopping by time_out is used. We do not display
+            # a progress bar then
+            tbar = range(self.num_finished_tasks, 100000)
         if time_out is not None:
             logger.info(f'Time out (secs) is {time_out}')
-        # TODO: This bar is misleading if num_trials not set
-        tbar = tqdm(range(self.num_finished_tasks, num_trials))
         for _ in tbar:
             if (time_out and time.time() - start_time >= time_out) or \
                     (self.max_reward and self.get_best_reward() >= self.max_reward):

--- a/autogluon/task/image_classification/image_classification.py
+++ b/autogluon/task/image_classification/image_classification.py
@@ -84,11 +84,11 @@ class ImageClassification(BaseTask):
             search_options=None,
             plot_results=False,
             verbose=False,
+            num_trials=None,
             time_limits=None,
             resume=False,
             output_directory='checkpoint/',
             visualizer='none',
-            num_trials=2,
             dist_ip_addrs=None,
             auto_search=True,
             lr_config=Dict(
@@ -141,12 +141,12 @@ class ImageClassification(BaseTask):
             Loss function used during training of the neural network weights.
         num_trials : int
             Maximal number of hyperparameter configurations to try out.
-        split_ratio : float, default = 0.8
-            Fraction of dataset to use for training (rest of data is held-out for tuning hyperparameters).
-            The final returned model may be fit to all of the data (after hyperparameters have been selected).
         time_limits : int
             Approximately how long `fit()` should run for (wallclock time in seconds).
             `fit()` will stop training new models after this amount of time has elapsed (but models which have already started training will continue to completion).
+        split_ratio : float, default = 0.8
+            Fraction of dataset to use for training (rest of data is held-out for tuning hyperparameters).
+            The final returned model may be fit to all of the data (after hyperparameters have been selected).
         nthreads_per_trial : int
             How many CPUs to use in each trial (ie. single training run of a model).
         ngpus_per_trial : int
@@ -248,6 +248,11 @@ class ImageClassification(BaseTask):
 
         nthreads_per_trial = get_cpu_count() if nthreads_per_trial > get_cpu_count() else nthreads_per_trial
         ngpus_per_trial = get_gpu_count() if ngpus_per_trial > get_gpu_count() else ngpus_per_trial
+
+        # If only time_limits is given, the scheduler starts trials until the
+        # time limit is reached
+        if num_trials is None and time_limits is None:
+            num_trials = 2
 
         final_fit_epochs = final_fit_epochs if final_fit_epochs else epochs
         train_image_classification.register_args(

--- a/autogluon/task/object_detection/object_detection.py
+++ b/autogluon/task/object_detection/object_detection.py
@@ -38,7 +38,8 @@ class ObjectDetection(BaseTask):
             split_ratio=0.8,
             batch_size=16,
             epochs=50,
-            num_trials=2,
+            num_trials=None,
+            time_limits=None,
             nthreads_per_trial=12,
             num_workers=32,
             ngpus_per_trial=1,
@@ -46,7 +47,6 @@ class ObjectDetection(BaseTask):
             scheduler_options=None,
             search_strategy='random',
             search_options=None,
-            time_limits=None,
             verbose=False,
             transfer='coco',
             resume='',
@@ -106,6 +106,9 @@ class ObjectDetection(BaseTask):
             How many epochs to train the neural networks for at most.
         num_trials : int
             Maximal number of hyperparameter configurations to try out.
+        time_limits : int
+            Approximately how long should `fit()` should run for (wallclock time in seconds).
+            `fit()` will stop training new models after this amount of time has elapsed (but models which have already started training will continue to completion).
         nthreads_per_trial : int
             How many CPUs to use in each trial (ie. single training run of a model).
         num_workers : int
@@ -122,9 +125,6 @@ class ObjectDetection(BaseTask):
             Options include: 'random' (random search), 'skopt' (SKopt Bayesian optimization), 'grid' (grid search), 'hyperband' (Hyperband), 'rl' (reinforcement learner)
         search_options : dict
             Auxiliary keyword arguments to pass to the searcher that performs hyperparameter optimization. 
-        time_limits : int
-            Approximately how long should `fit()` should run for (wallclock time in seconds).
-            `fit()` will stop training new models after this amount of time has elapsed (but models which have already started training will continue to completion). 
         verbose : bool
             Whether or not to print out intermediate information during training.
         resume : str
@@ -208,6 +208,11 @@ class ObjectDetection(BaseTask):
             logger.warning(
                 "The number of requested GPUs is greater than the number of available GPUs.")
         ngpus_per_trial = get_gpu_count() if ngpus_per_trial > get_gpu_count() else ngpus_per_trial
+
+        # If only time_limits is given, the scheduler starts trials until the
+        # time limit is reached
+        if num_trials is None and time_limits is None:
+            num_trials = 2
 
         train_object_detection.register_args(
             meta_arch=meta_arch,

--- a/autogluon/task/text_classification/text_classification.py
+++ b/autogluon/task/text_classification/text_classification.py
@@ -52,11 +52,11 @@ class TextClassification(BaseTask):
             scheduler_options=None,
             search_strategy='random',
             search_options=None,
+            num_trials=None,
             time_limits=None,
             resume=False,
             checkpoint='checkpoint/exp1.ag',
             visualizer='none',
-            num_trials=2,
             dist_ip_addrs=None,
             auto_search=True,
             verbose=False,
@@ -100,6 +100,9 @@ class TextClassification(BaseTask):
             Whether to utilize early stopping during training to avoid overfitting.
         num_trials : int
             Maximal number of hyperparameter configurations to try out.
+        time_limits : int
+            Approximately how long should `fit()` should run for (wallclock time in seconds).
+            `fit()` will stop training new models after this amount of time has elapsed (but models which have already started training will continue to completion).
         nthreads_per_trial : int
             How many CPUs to use in each trial (ie. single training run of a model).
         ngpus_per_trial : int
@@ -114,9 +117,6 @@ class TextClassification(BaseTask):
             Options include: 'random' (random search), 'skopt' (SKopt Bayesian optimization), 'grid' (grid search), 'hyperband' (Hyperband), 'rl' (reinforcement learner)
         search_options : dict
             Auxiliary keyword arguments to pass to the searcher that performs hyperparameter optimization. 
-        time_limits : int
-            Approximately how long should `fit()` should run for (wallclock time in seconds).
-            `fit()` will stop training new models after this amount of time has elapsed (but models which have already started training will continue to completion). 
         verbose : bool
             Whether or not to print out intermediate information during training.
         checkpoint : str or None
@@ -154,6 +154,11 @@ class TextClassification(BaseTask):
 
         nthreads_per_trial = get_cpu_count() if nthreads_per_trial > get_cpu_count() else nthreads_per_trial
         ngpus_per_trial = get_gpu_count() if ngpus_per_trial > get_gpu_count() else ngpus_per_trial
+
+        # If only time_limits is given, the scheduler starts trials until the
+        # time limit is reached
+        if num_trials is None and time_limits is None:
+            num_trials = 2
 
         train_text_classification.register_args(
             dataset=dataset,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If time_limits is specified, but num_trials is not, you want to keep num_trials = None, in which case the scheduler starts jobs until the time budget is spent. In the old code, it would still only start 2 trials.

One thing to note: If None is passed to FIFOScheduler, but time_limits is given, it will set num_trials to 100000, so that only time_limits is used. This leads to some funny output ("Number of pending trials: 100000"), but it works.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
