### PR TITLE
Updated minimum sklearn version to 0.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ requirements = [
     'lightgbm>=2.3.0,<3.0',
     'pandas>=0.24.0,<1.0',
     'psutil>=5.0.0',
-    'scikit-learn>=0.20.0,<0.23',
+    'scikit-learn>=0.22.0,<0.23',
     'networkx>=2.3,<3.0'
 ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updated minimum sklearn version to 0.22 as Tabular NN raises an exception on lower sklearn versions when onehot encoded features are present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
