### PR TITLE
CatBoost - disabled RSM if GPU training is enabled

### DIFF
--- a/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
+++ b/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
@@ -142,9 +142,10 @@ class CatboostModel(AbstractModel):
                 # Reduce sample iterations to avoid taking unreasonable amounts of time
                 num_sample_iter_max = max(round(num_sample_iter_max/2), 2)
             # Subsample columns to speed up training
-            params['colsample_bylevel'] = max(min(1.0, 1000 / num_features), 0.05)
-            logger.log(30, f'\tMany features detected ({num_features}), dynamically setting \'colsample_bylevel\' to {params["colsample_bylevel"]} to speed up training (Default = 1).')
-            logger.log(30, f'\tTo disable this functionality, explicitly specify \'colsample_bylevel\' in the model hyperparameters.')
+            if params.get('task_type', None) != 'GPU':  # RSM does not work on GPU
+                params['colsample_bylevel'] = max(min(1.0, 1000 / num_features), 0.05)
+                logger.log(30, f'\tMany features detected ({num_features}), dynamically setting \'colsample_bylevel\' to {params["colsample_bylevel"]} to speed up training (Default = 1).')
+                logger.log(30, f'\tTo disable this functionality, explicitly specify \'colsample_bylevel\' in the model hyperparameters.')
 
         if time_limit:
             time_left_start = time_limit - (time.time() - start_time)

--- a/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
+++ b/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
@@ -137,6 +137,15 @@ class CatboostModel(AbstractModel):
 
         params = self.params.copy()
         num_features = len(self.features)
+
+        if params.get('task_type', None) == 'GPU':
+            if 'colsample_bylevel' in params:
+                params.pop('colsample_bylevel')
+                logger.log(30, f'\t\'colsample_bylevel\' is not supported on GPU, using default value (Default = 1).')
+            if 'rsm' in params:
+                params.pop('rsm')
+                logger.log(30, f'\t\'rsm\' is not supported on GPU, using default value (Default = 1).')
+
         if self.problem_type == MULTICLASS and 'rsm' not in params and 'colsample_bylevel' not in params and num_features > 1000:
             if time_limit:
                 # Reduce sample iterations to avoid taking unreasonable amounts of time

--- a/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
+++ b/autogluon/utils/tabular/ml/models/catboost/catboost_model.py
@@ -146,6 +146,9 @@ class CatboostModel(AbstractModel):
                 params['colsample_bylevel'] = max(min(1.0, 1000 / num_features), 0.05)
                 logger.log(30, f'\tMany features detected ({num_features}), dynamically setting \'colsample_bylevel\' to {params["colsample_bylevel"]} to speed up training (Default = 1).')
                 logger.log(30, f'\tTo disable this functionality, explicitly specify \'colsample_bylevel\' in the model hyperparameters.')
+            else:
+                params['colsample_bylevel'] = 1.0
+                logger.log(30, f'\t\'colsample_bylevel\' is not supported on GPU, using default value (Default = 1).')
 
         if time_limit:
             time_left_start = time_limit - (time.time() - start_time)


### PR DESCRIPTION
*Description of changes:*
The RSM optimization works only when trained on CPU - added check if GPU training is active

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
