### PR TITLE
Small fix to documentation

### DIFF
--- a/autogluon/task/image_classification/classifier.py
+++ b/autogluon/task/image_classification/classifier.py
@@ -105,6 +105,7 @@ class Classifier(BasePredictor):
             Whether to plot the image being classified.
         set_prob_thresh: float
             Results with probability below threshold are set to 0 by default.
+
         Examples
         --------
         >>> from autogluon import ImageClassification as task


### PR DESCRIPTION
I believe the reason the example is [not rendering correctly](https://autogluon.mxnet.io/api/autogluon.task.html#autogluon.task.ImageClassification.Classifier.predict) in the docs is because it's missing the linebreak between the end of the docstring and example.

*Issue #, if available:*

*Description of changes: Just adding a linebreak so that the example renders correctly in the docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
