### PR TITLE
Tabular: Added version check when loading predictor

### DIFF
--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -628,6 +628,7 @@ class TabularPredictor(BasePredictor):
     def load(cls, output_directory, verbosity=2):
         """
         Load a predictor object previously produced by `fit()` from file and returns this object.
+        It is highly recommended the predictor be loaded with the exact AutoGluon version it was fit with.
         Is functionally equivalent to :meth:`autogluon.task.tabular_prediction.TabularPrediction.load`.
 
         Parameters

--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -650,6 +650,26 @@ class TabularPredictor(BasePredictor):
 
         output_directory = setup_outputdir(output_directory)  # replace ~ with absolute path if it exists
         learner = Learner.load(output_directory)
+        try:
+            from ...version import __version__
+            version_inference = __version__
+        except:
+            version_inference = None
+        try:
+            version_fit = learner.version
+        except:
+            version_fit = None
+        if version_fit is None:
+            version_fit = 'Unknown (Likely <=0.0.11)'
+        if version_inference != version_fit:
+            logger.warning('')
+            logger.warning('############################## WARNING ##############################')
+            logger.warning('WARNING: AutoGluon version differs from the version used during the original model fit! This may lead to instability and it is highly recommended the model be loaded with the exact AutoGluon version it was fit with.')
+            logger.warning(f'\tFit Version:     {version_fit}')
+            logger.warning(f'\tCurrent Version: {version_inference}')
+            logger.warning('############################## WARNING ##############################')
+            logger.warning('')
+
         return cls(learner=learner)
 
     def save(self):

--- a/autogluon/task/tabular_prediction/tabular_prediction.py
+++ b/autogluon/task/tabular_prediction/tabular_prediction.py
@@ -34,6 +34,7 @@ class TabularPrediction(BaseTask):
     def load(output_directory, verbosity=2):
         """
         Load a predictor object previously produced by `fit()` from file and returns this object.
+        It is highly recommended the predictor be loaded with the exact AutoGluon version it was fit with.
 
         Parameters
         ----------

--- a/autogluon/task/tabular_prediction/tabular_prediction.py
+++ b/autogluon/task/tabular_prediction/tabular_prediction.py
@@ -49,13 +49,7 @@ class TabularPrediction(BaseTask):
         -------
         :class:`autogluon.task.tabular_prediction.TabularPredictor` object that can be used to make predictions.
         """
-        logger.setLevel(verbosity2loglevel(verbosity)) # Reset logging after load (since we may be in new Python session)
-        if output_directory is None:
-            raise ValueError("output_directory cannot be None in load()")
-
-        output_directory = setup_outputdir(output_directory) # replace ~ with absolute path if it exists
-        learner = Learner.load(output_directory)
-        return TabularPredictor(learner=learner)
+        return TabularPredictor.load(output_directory=output_directory, verbosity=verbosity)
 
     @staticmethod
     @unpack(set_presets)

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -63,6 +63,12 @@ class AbstractLearner:
         self.time_fit_training = None
         self.time_limit = None
 
+        try:
+            from .....version import __version__
+            self.version = __version__
+        except:
+            self.version = None
+
     @property
     def class_labels(self):
         return self.label_cleaner.ordered_class_labels
@@ -546,6 +552,7 @@ class AbstractLearner:
             'time_fit_total': self.time_fit_total,
             'time_limit': self.time_limit,
             'random_seed': self.random_seed,
+            'version': self.version,
         }
 
         learner_info.update(trainer_info)

--- a/autogluon/utils/tabular/ml/learner/default_learner.py
+++ b/autogluon/utils/tabular/ml/learner/default_learner.py
@@ -57,6 +57,7 @@ class DefaultLearner(AbstractLearner):
             self.time_limit = 1e7
             logger.log(20, 'Beginning AutoGluon training ...')
         logger.log(20, f'AutoGluon will save models to {self.path}')
+        logger.log(20, f'AutoGluon Version:  {self.version}')
         logger.log(20, f'Train Data Rows:    {len(X)}')
         logger.log(20, f'Train Data Columns: {len(X.columns)}')
         if X_test is not None:


### PR DESCRIPTION
*Issue #, if available:*
Resolves #535 

*Description of changes:*

- Added version check when loading predictor that warns user if different version
- Added log of version during fit
- Removed duplicate code
- Added version to info output

Log Example:

```
############################## WARNING ##############################
WARNING: AutoGluon version differs from the version used during the original model fit! This may lead to instability and it is highly recommended the model be loaded with the exact AutoGluon version it was fit with.
	Fit Version:     Unknown (Likely <=0.0.11)
	Current Version: 0.0.12
############################## WARNING ##############################
```

```
Beginning AutoGluon training ...
AutoGluon will save models to AutogluonModels/ag-20200625_214800/
AutoGluon Version:  0.0.12
Train Data Rows:    455
Train Data Columns: 31
Preprocessing data ...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
