### PR TITLE
Clean up argument checking and default value imputation for schedulers

### DIFF
--- a/autogluon/scheduler/fifo.py
+++ b/autogluon/scheduler/fifo.py
@@ -19,10 +19,35 @@ from ..core.decorator import _autogluon_method
 from ..searcher import BaseSearcher
 from ..searcher.searcher_factory import searcher_factory
 from ..utils import save, load, mkdir, try_import_mxboard
+from ..utils.default_arguments import check_and_merge_defaults, \
+    Float, Integer, String, Boolean
 
 __all__ = ['FIFOScheduler']
 
 logger = logging.getLogger(__name__)
+
+
+_DEFAULT_OPTIONS = {
+    'resource': {'num_cpus': 1, 'num_gpus': 0},
+    'searcher': 'random',
+    'resume': False,
+    'reward_attr': 'accuracy',
+    'time_attr': 'epoch',
+    'visualizer': 'none',
+    'training_history_callback_delta_secs': 60,
+    'delay_get_config': True}
+
+_CONSTRAINTS = {
+    'checkpoint': String(),
+    'resume': Boolean(),
+    'num_trials': Integer(1, None),
+    'time_out': Float(0.0, None),
+    'max_reward': Float(),
+    'reward_attr': String(),
+    'time_attr': String(),
+    'visualizer': String(),
+    'training_history_callback_delta_secs': Integer(1, None),
+    'delay_get_config': Boolean()}
 
 
 class FIFOScheduler(TaskScheduler):
@@ -105,29 +130,23 @@ class FIFOScheduler(TaskScheduler):
     >>> scheduler.get_training_curves(plot=True)
     """
 
-    def __init__(self, train_fn, args=None, resource=None,
-                 searcher=None, search_options=None,
-                 checkpoint=None,
-                 resume=False, num_trials=None,
-                 time_out=None, max_reward=None, reward_attr='accuracy',
-                 time_attr='epoch',
-                 visualizer='none', dist_ip_addrs=None,
-                 training_history_callback=None,
-                 training_history_callback_delta_secs=60,
-                 delay_get_config=True):
-        super().__init__(dist_ip_addrs)
-        if resource is None:
-            resource = {'num_cpus': 1, 'num_gpus': 0}
-        self.resource = resource
+    def __init__(self, train_fn, **kwargs):
+        super().__init__(kwargs.get('dist_ip_addrs'))
+        # Check values and impute default values
+        kwargs = check_and_merge_defaults(
+            kwargs, set(), _DEFAULT_OPTIONS, _CONSTRAINTS,
+            dict_name='scheduler_options')
 
-        if searcher is None:
-            searcher = 'random'  # RandomSearcher
+        self.resource = kwargs['resource']
+        searcher = kwargs['searcher']
+        search_options = kwargs.get('search_options')
         if isinstance(searcher, str):
             if search_options is None:
                 search_options = dict()
             _search_options = search_options.copy()
             _search_options['configspace'] = train_fn.cs
-            _search_options['reward_attribute'] = reward_attr
+            _search_options['reward_attribute'] = kwargs['reward_attr']
+            _search_options['resource_attribute'] = kwargs['time_attr']
             # Adjoin scheduler info to search_options, if not already done by
             # subclass
             if 'scheduler' not in _search_options:
@@ -140,28 +159,32 @@ class FIFOScheduler(TaskScheduler):
 
         assert isinstance(train_fn, _autogluon_method)
         self.train_fn = train_fn
+        args = kwargs.get('args')
         self.args = args if args else train_fn.args
+        num_trials = kwargs.get('num_trials')
+        time_out = kwargs.get('time_out')
         if num_trials is None:
             assert time_out is not None, \
                 "Need stopping criterion: Either num_trials or time_out"
         self.num_trials = num_trials
         self.time_out = time_out
-        self.max_reward = max_reward
+        self.max_reward = kwargs.get('max_reward')
         # meta data
         self.metadata = {
             'search_space': train_fn.kwspaces,
             'search_strategy': searcher,
             'stop_criterion': {
-                'time_limits': time_out, 'max_reward': max_reward},
-            'resources_per_trial': resource}
+                'time_limits': time_out,
+                'max_reward': kwargs.get('max_reward')},
+            'resources_per_trial': self.resource}
 
+        checkpoint = kwargs.get('checkpoint')
         self._checkpoint = checkpoint
-        self._reward_attr = reward_attr
-        self._time_attr = time_attr
-        self.visualizer = visualizer.lower()
+        self._reward_attr = kwargs['reward_attr']
+        self._time_attr = kwargs['time_attr']
+        self.visualizer = kwargs['visualizer'].lower()
         if self.visualizer == 'tensorboard' or self.visualizer == 'mxboard':
-            assert checkpoint is not None, \
-                "Need checkpoint to be set"
+            assert checkpoint is not None, "Need checkpoint to be set"
             try_import_mxboard()
             from mxboard import SummaryWriter
             self.mxboard = SummaryWriter(
@@ -182,12 +205,12 @@ class FIFOScheduler(TaskScheduler):
         self._start_time = None
         self._training_history_callback_last_block = None
         self._training_history_callback_last_len = None
-        self.training_history_callback = training_history_callback
+        self.training_history_callback = kwargs.get('training_history_callback')
         self.training_history_callback_delta_secs = \
-            training_history_callback_delta_secs
-        self._delay_get_config = delay_get_config
+            kwargs['training_history_callback_delta_secs']
+        self._delay_get_config = kwargs['delay_get_config']
         # Resume experiment from checkpoint?
-        if resume:
+        if kwargs['resume']:
             assert checkpoint is not None, \
                 "Need checkpoint to be set if resume = True"
             if os.path.isfile(checkpoint):

--- a/autogluon/scheduler/fifo.py
+++ b/autogluon/scheduler/fifo.py
@@ -20,12 +20,18 @@ from ..searcher import BaseSearcher
 from ..searcher.searcher_factory import searcher_factory
 from ..utils import save, load, mkdir, try_import_mxboard
 from ..utils.default_arguments import check_and_merge_defaults, \
-    Float, Integer, String, Boolean
+    Float, Integer, String, Boolean, assert_no_invalid_options
 
 __all__ = ['FIFOScheduler']
 
 logger = logging.getLogger(__name__)
 
+
+_ARGUMENT_KEYS = {
+    'args', 'resource', 'searcher', 'search_options', 'checkpoint', 'resume',
+    'num_trials', 'time_out', 'max_reward', 'reward_attr', 'time_attr',
+    'dist_ip_addrs', 'visualizer', 'training_history_callback',
+    'training_history_callback_delta_secs', 'delay_get_config'}
 
 _DEFAULT_OPTIONS = {
     'resource': {'num_cpus': 1, 'num_gpus': 0},
@@ -133,6 +139,8 @@ class FIFOScheduler(TaskScheduler):
     def __init__(self, train_fn, **kwargs):
         super().__init__(kwargs.get('dist_ip_addrs'))
         # Check values and impute default values
+        assert_no_invalid_options(
+            kwargs, _ARGUMENT_KEYS, name='FIFOScheduler')
         kwargs = check_and_merge_defaults(
             kwargs, set(), _DEFAULT_OPTIONS, _CONSTRAINTS,
             dict_name='scheduler_options')
@@ -175,7 +183,7 @@ class FIFOScheduler(TaskScheduler):
             'search_strategy': searcher,
             'stop_criterion': {
                 'time_limits': time_out,
-                'max_reward': kwargs.get('max_reward')},
+                'max_reward': self.max_reward},
             'resources_per_trial': self.resource}
 
         checkpoint = kwargs.get('checkpoint')

--- a/autogluon/scheduler/hyperband.py
+++ b/autogluon/scheduler/hyperband.py
@@ -11,12 +11,17 @@ from .hyperband_promotion import HyperbandPromotion_Manager
 from .reporter import DistStatusReporter
 from ..utils import load
 from ..utils.default_arguments import check_and_merge_defaults, \
-    Integer, Boolean, Categorical
+    Integer, Boolean, Categorical, filter_by_key
 
 __all__ = ['HyperbandScheduler']
 
 logger = logging.getLogger(__name__)
 
+
+_ARGUMENT_KEYS = {
+    'max_t', 'grace_period', 'reduction_factor', 'brackets', 'type',
+    'keep_size_ratios', 'maxt_pending', 'searcher_data', 'do_snapshots'
+}
 
 _DEFAULT_OPTIONS = {
     'resume': False,
@@ -241,7 +246,8 @@ class HyperbandScheduler(FIFOScheduler):
         # Pass resume=False here. Resume needs members of this object to be
         # created
         kwargs['resume'] = False
-        super().__init__(train_fn=train_fn, **kwargs)
+        super().__init__(
+            train_fn=train_fn, **filter_by_key(kwargs, _ARGUMENT_KEYS))
 
         self.max_t = max_t
         self.reduction_factor = reduction_factor

--- a/autogluon/scheduler/rl_scheduler.py
+++ b/autogluon/scheduler/rl_scheduler.py
@@ -16,10 +16,32 @@ from ..core.decorator import _autogluon_method
 from ..searcher import RLSearcher
 from .fifo import FIFOScheduler
 from .reporter import DistStatusReporter
+from ..utils.default_arguments import check_and_merge_defaults, \
+    Integer, Boolean, Float, String
 
 __all__ = ['RLScheduler']
 
 logger = logging.getLogger(__name__)
+
+
+_DEFAULT_OPTIONS = {
+    'resume': False,
+    'reward_attr': 'accuracy',
+    'checkpoint': './exp/checkpoint.ag',
+    'controller_lr': 1e-3,
+    'ema_baseline_decay': 0.95,
+    'controller_resource': {'num_cpus': 0, 'num_gpus': 0},
+    'controller_batch_size': 1,
+    'sync': True}
+
+_CONSTRAINTS = {
+    'resume': Boolean(),
+    'reward_attr': String(),
+    'checkpoint': String(),
+    'controller_lr': Float(0.0, None),
+    'ema_baseline_decay': Float(0.0, 1.0),
+    'controller_batch_size': Integer(1, None),
+    'sync': Boolean()}
 
 
 class RLScheduler(FIFOScheduler):
@@ -71,49 +93,59 @@ class RLScheduler(FIFOScheduler):
     >>> scheduler.join_jobs()
     >>> scheduler.get_training_curves(plot=True)
     """
-    def __init__(self, train_fn, args=None, resource=None, searcher=None, checkpoint='./exp/checkpoint.ag',
-                 resume=False, num_trials=None, time_attr='epoch', reward_attr='accuracy',
-                 visualizer='none', controller_lr=1e-3, ema_baseline_decay=0.95,
-                 controller_resource={'num_cpus': 0, 'num_gpus': 0},
-                 controller_batch_size=1,
-                 dist_ip_addrs=[], sync=True, **kwargs):
+    def __init__(self, train_fn, **kwargs):
         assert isinstance(train_fn, _autogluon_method), 'Please use @ag.args ' + \
                 'to decorate your training script.'
-        self.ema_baseline_decay = ema_baseline_decay
-        self.sync = sync
-        # create RL searcher/controller
+        # Check values and impute default values (only for arguments new to
+        # this class)
+        kwargs = check_and_merge_defaults(
+            kwargs, set(), _DEFAULT_OPTIONS, _CONSTRAINTS,
+            dict_name='scheduler_options')
+        resume = kwargs['resume']
+
+        self.ema_baseline_decay = kwargs['ema_baseline_decay']
+        self.sync = kwargs['sync']
+        # create RL searcher if not passed
+        searcher = kwargs.get('searcher')
         if not isinstance(searcher, RLSearcher):
-            searcher = RLSearcher(
-                train_fn.kwspaces, reward_attribute=reward_attr)
-        super(RLScheduler,self).__init__(
-                train_fn, train_fn.args, resource, searcher,
-                checkpoint=checkpoint, resume=False, num_trials=num_trials,
-                time_attr=time_attr, reward_attr=reward_attr,
-                visualizer=visualizer, dist_ip_addrs=dist_ip_addrs, **kwargs)
+            if searcher is not None:
+                logger.warning("Argument 'searcher' must be of type RLSearcher. Ignoring 'searcher' and creating searcher here.")
+            kwargs['searcher'] = RLSearcher(
+                train_fn.kwspaces, reward_attribute=kwargs['reward_attr'])
+        # Pass resume=False here. Resume needs members of this object to be
+        # created
+        kwargs['resume'] = False
+        super().__init__(train_fn, **kwargs)
         # reserve controller computation resource on master node
         master_node = self.remote_manager.get_master_node()
+        controller_resource = kwargs['controller_resource']
         self.controller_resource = DistributedResource(**controller_resource)
         assert self.resource_manager.reserve_resource(
-                master_node, self.controller_resource), 'Not Enough Resource on Master Node' + \
-                    ' for Training Controller'
-        self.controller_ctx = [mx.gpu(i) for i in self.controller_resource.gpu_ids] if \
-                controller_resource['num_gpus'] > 0 else [mx.cpu()]
+            master_node, self.controller_resource),\
+            "Not Enough Resource on Master Node for Training Controller"
+        if controller_resource['num_gpus'] > 0:
+            self.controller_ctx = [
+                mx.gpu(i) for i in self.controller_resource.gpu_ids]
+        else:
+            self.controller_ctx = [mx.cpu()]
         # controller setup
-        self.controller = searcher.controller
+        self.controller = self.searcher.controller
         self.controller.collect_params().reset_ctx(self.controller_ctx)
+        controller_batch_size = kwargs['controller_batch_size']
+        learning_rate = kwargs['controller_lr'] * controller_batch_size
         self.controller_optimizer = mx.gluon.Trainer(
-                self.controller.collect_params(), 'adam',
-                optimizer_params={'learning_rate': controller_lr*controller_batch_size})
+            self.controller.collect_params(), 'adam',
+            optimizer_params={'learning_rate': learning_rate})
         self.controller_batch_size = controller_batch_size
         self.baseline = None
         self.lock = mp.Lock()
         # async buffers
-        if not sync:
+        if not self.sync:
             self.mp_count = mp.Value('i', 0)
             self.mp_seed = mp.Value('i', 0)
             self.mp_fail = mp.Value('i', 0)
-
         if resume:
+            checkpoint = kwargs.get('checkpoint')
             if os.path.isfile(checkpoint):
                 self.load_state_dict(load(checkpoint))
             else:

--- a/autogluon/scheduler/rl_scheduler.py
+++ b/autogluon/scheduler/rl_scheduler.py
@@ -17,12 +17,16 @@ from ..searcher import RLSearcher
 from .fifo import FIFOScheduler
 from .reporter import DistStatusReporter
 from ..utils.default_arguments import check_and_merge_defaults, \
-    Integer, Boolean, Float, String
+    Integer, Boolean, Float, String, filter_by_key
 
 __all__ = ['RLScheduler']
 
 logger = logging.getLogger(__name__)
 
+
+_ARGUMENT_KEYS = {
+    'controller_lr', 'ema_baseline_decay', 'controller_resource',
+    'controller_batch_size', 'sync'}
 
 _DEFAULT_OPTIONS = {
     'resume': False,
@@ -115,7 +119,8 @@ class RLScheduler(FIFOScheduler):
         # Pass resume=False here. Resume needs members of this object to be
         # created
         kwargs['resume'] = False
-        super().__init__(train_fn, **kwargs)
+        super().__init__(
+            train_fn=train_fn, **filter_by_key(kwargs, _ARGUMENT_KEYS))
         # reserve controller computation resource on master node
         master_node = self.remote_manager.get_master_node()
         controller_resource = kwargs['controller_resource']

--- a/autogluon/searcher/bayesopt/autogluon/searcher_factory.py
+++ b/autogluon/searcher/bayesopt/autogluon/searcher_factory.py
@@ -35,7 +35,6 @@ from autogluon.searcher.bayesopt.gpmxnet.debug_gp_regression import \
 
 __all__ = ['gp_fifo_searcher_factory',
            'gp_multifidelity_searcher_factory',
-           'from_argparse',
            'gp_fifo_searcher_defaults',
            'gp_multifidelity_searcher_defaults']
 
@@ -217,64 +216,6 @@ def gp_multifidelity_searcher_factory(**kwargs) -> GPMultiFidelitySearcher:
         first_is_default=kwargs['first_is_default'],
         debug_log=debug_log)
     return gp_searcher
-
-
-def from_argparse(args) -> (dict, dict):
-    """
-    Given result from ArgumentParser.parse_args() from run_benchmarks script,
-    create both search_options (kwargs in XYZ_searcher_factory above) and
-    scheduler_options.
-
-    :param args: See above
-    :return: search_options, scheduler_options
-
-    """
-    # Options for searcher
-    search_options = dict()
-    search_options['random_seed'] = args.run_id  # TODO: Change this
-    search_options['opt_skip_num_max_resource'] = args.opt_skip_num_max_resource
-    search_options['opt_skip_init_length'] = args.opt_skip_init_length
-    search_options['opt_skip_period'] = args.opt_skip_period
-    search_options['profiler'] = args.profiler
-    search_options['gp_resource_kernel'] = args.gp_searcher_resource_kernel
-    search_options['opt_maxiter'] = args.opt_maxiter
-    search_options['opt_nstarts'] = args.opt_nstarts
-    search_options['opt_warmstart'] = args.opt_warmstart
-    search_options['opt_verbose'] = args.opt_verbose
-    search_options['opt_debug_writer'] = args.opt_debug_writer
-    if args.opt_debug_writer:
-        pref = 'debug_gpr_{}'.format(args.run_id)
-        search_options['opt_debug_writer_fmask'] = pref + '_{}'
-    search_options['num_fantasy_samples'] = args.gp_searcher_num_fantasy_samples
-    search_options['num_init_random'] = args.gp_searcher_num_init_random
-    search_options['num_init_candidates'] = args.gp_searcher_num_init_candidates
-    search_options['resource_acq'] = args.gp_searcher_resource_acq
-    search_options['first_is_default'] = not args.first_is_not_default
-    search_options['debug_log'] = args.debug_log
-    search_options['initial_scoring'] = args.gp_searcher_initial_scoring
-
-    # Options for scheduler
-    scheduler_options = dict()
-    scheduler_options['num_trials'] = args.num_trials
-    scheduler_options['time_out'] = args.scheduler_timeout
-    scheduler_options['checkpoint'] = args.checkpoint
-    scheduler_options['resume'] = args.resume
-    scheduler_options['scheduler'] = args.scheduler
-    if args.scheduler == 'hyperband_stopping':
-        scheduler_options['type'] = 'stopping'
-    elif args.scheduler == 'hyperband_promotion':
-        scheduler_options['type'] = 'promotion'
-    scheduler_options['reduction_factor'] = args.reduction_factor
-    scheduler_options['max_t'] = args.epochs
-    scheduler_options['grace_period'] = args.grace_period
-    scheduler_options['brackets'] = args.brackets
-    scheduler_options['maxt_pending'] = args.maxt_pending
-    scheduler_options['keep_size_ratios'] = args.scheduler_keep_size_ratios
-    scheduler_options['searcher_data'] = args.gp_searcher_data
-    scheduler_options['store_results_period'] = args.store_results_period
-    scheduler_options['delay_get_config'] = not args.no_delay_get_config
-
-    return search_options, scheduler_options
 
 
 def _common_defaults(is_hyperband: bool) -> (Set[str], dict, dict):

--- a/autogluon/searcher/bayesopt/autogluon/searcher_factory.py
+++ b/autogluon/searcher/bayesopt/autogluon/searcher_factory.py
@@ -23,7 +23,7 @@ from autogluon.searcher.bayesopt.models.gpmxnet_transformers import \
     GPMXNetModelArgs
 from autogluon.searcher.bayesopt.models.nphead_acqfunc import \
     EIAcquisitionFunction
-from autogluon.searcher.default_arguments import Integer, Categorical, Boolean
+from autogluon.utils.default_arguments import Integer, Categorical, Boolean
 from autogluon.searcher.bayesopt.tuning_algorithms.default_algorithm import \
     DEFAULT_NUM_INITIAL_CANDIDATES, DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS
 from autogluon.searcher.bayesopt.datatypes.hp_ranges import HyperparameterRanges  # DEBUG!
@@ -300,6 +300,7 @@ def _common_defaults(is_hyperband: bool) -> (Set[str], dict, dict):
         default_options['opt_skip_num_max_resource'] = False
         default_options['gp_resource_kernel'] = 'matern52'
         default_options['resource_acq'] = 'bohb'
+        default_options['num_init_random'] = 10
 
     constraints = {
         'random_seed': Integer(),

--- a/autogluon/searcher/gp_searcher.py
+++ b/autogluon/searcher/gp_searcher.py
@@ -1,7 +1,7 @@
 import ConfigSpace as CS
 import multiprocessing as mp
 
-from autogluon.searcher.default_arguments import check_and_merge_defaults
+from autogluon.utils.default_arguments import check_and_merge_defaults
 from autogluon.searcher.bayesopt.autogluon.searcher_factory import \
     gp_fifo_searcher_factory, gp_multifidelity_searcher_factory, \
     gp_fifo_searcher_defaults, gp_multifidelity_searcher_defaults

--- a/autogluon/utils/default_arguments.py
+++ b/autogluon/utils/default_arguments.py
@@ -100,3 +100,23 @@ def check_and_merge_defaults(
                 check.assert_valid(prefix + "Key '{}'".format(key), value)
 
     return result_options
+
+
+def filter_by_key(options: dict, remove_keys: Set[str]) -> dict:
+    """
+    Filter options by removing entries whose keys are in remove_keys.
+    Used to filter kwargs passed to a constructor, before passing it to
+    the superclass constructor.
+
+    :param options:
+    :param remove_keys:
+    :return: Filtered options
+    """
+    return {
+        k: v for k, v in options.items() if k not in remove_keys}
+
+
+def assert_no_invalid_options(options: dict, all_keys: Set[str], name: str):
+    for k in options:
+        assert k in all_keys, \
+            "{}: Invalid argument '{}'".format(name, k)

--- a/autogluon/utils/default_arguments.py
+++ b/autogluon/utils/default_arguments.py
@@ -51,6 +51,11 @@ class Categorical(CheckType):
             "{}: Value = {} must be in {}".format(key, value, self.choices)
 
 
+class String(CheckType):
+    def assert_valid(self, key: str, value):
+        assert isinstance(value, str), "{}: Value = {} must be of type str"
+
+
 class Boolean(CheckType):
     def assert_valid(self, key: str, value):
         assert isinstance(value, bool), \
@@ -59,7 +64,7 @@ class Boolean(CheckType):
 
 def check_and_merge_defaults(
         options: dict, mandatory: Set[str], default_options: dict,
-        constraints: Dict[str, CheckType]=None, dict_name=None) -> dict:
+        constraints: Dict[str, CheckType] = None, dict_name=None) -> dict:
     """
     First, check that all keys in mandatory appear in options. Second, create
     result_options by merging options and default_options, where entries in
@@ -70,6 +75,7 @@ def check_and_merge_defaults(
     :param mandatory:
     :param default_options:
     :param constraints:
+    :param dict_name:
     :return: result_options
     """
     prefix = "" if dict_name is None else "{}: ".format(dict_name)
@@ -77,9 +83,10 @@ def check_and_merge_defaults(
         assert key in options, \
             prefix + "Key '{}' is missing (but is mandatory)".format(key)
     log_msg = ""
-    result_options = options.copy()
+    result_options = {
+        k: v for k, v in options.items() if v is not None}
     for key, value in default_options.items():
-        if key not in options:
+        if key not in result_options:
             log_msg += (prefix + "Key '{}': Imputing default value {}\n".format(
                 key, value))
             result_options[key] = value

--- a/docs/tutorials/nas/rl_searcher.md
+++ b/docs/tutorials/nas/rl_searcher.md
@@ -62,11 +62,10 @@ def rl_simulation(args, reporter):
 ### Random Search Baseline
 
 ```{.python .input}
-random_scheduler = ag.scheduler.FIFOScheduler(rl_simulation, rl_simulation.args,
+random_scheduler = ag.scheduler.FIFOScheduler(rl_simulation,
                                               resource={'num_cpus': 1, 'num_gpus': 0},
                                               num_trials=300,
-                                              reward_attr="accuracy",
-                                              resume=False)
+                                              reward_attr='accuracy')
 random_scheduler.run()
 random_scheduler.join_jobs()
 print('Best config: {}, best reward: {}'.format(random_scheduler.get_best_config(), random_scheduler.get_best_reward()))
@@ -78,12 +77,10 @@ print('Best config: {}, best reward: {}'.format(random_scheduler.get_best_config
 rl_scheduler = ag.scheduler.RLScheduler(rl_simulation,
                                         resource={'num_cpus': 1, 'num_gpus': 0},
                                         num_trials=300,
-                                        reward_attr="accuracy",
+                                        reward_attr='accuracy',
                                         controller_batch_size=4,
                                         controller_lr=5e-3,
-                                        checkpoint='./rl_exp/checkerpoint.ag',
-                                        resume=False,
-                                        sync=True)
+                                        checkpoint='./rl_exp/checkerpoint.ag')
 rl_scheduler.run()
 rl_scheduler.join_jobs()
 print('Best config: {}, best reward: {}'.format(rl_scheduler.get_best_config(), rl_scheduler.get_best_reward()))

--- a/tests/unittests/test_scheduler.py
+++ b/tests/unittests/test_scheduler.py
@@ -50,4 +50,3 @@ def test_rl_scheduler():
                                          checkpoint=None)
     scheduler.run()
     scheduler.join_jobs()
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Extends something I did for GP searchers to schedulers. Arguments are losely type-checked, and default values are maintained consistently (e.g., do not have to copy&paste default values from superclass).
Also, whenever a default value is imputed, this is written into the log, so you later on know what argument values were used.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
