### PR TITLE
Tabular: Fixed major defect in NN causing crashes with categoricals

### DIFF
--- a/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
@@ -691,6 +691,7 @@ class TabularNeuralNetModel(AbstractModel):
             transformers.append( ('onehot', onehot_transformer, onehot_features) )
         if len(embed_features) > 0: # Ordinal transformer applied to convert to-be-embedded categorical features to integer levels
             ordinal_transformer = Pipeline(steps=[
+                ('to_str', FunctionTransformer(self.convert_df_dtype_to_str)),
                 ('imputer', SimpleImputer(strategy='constant', fill_value=self.unique_category_str)),
                 ('ordinal', OrdinalMergeRaresHandleUnknownEncoder(max_levels=max_category_levels))]) # returns 0-n when max_category_levels = n-1. category n is reserved for unknown test-time categories.
             transformers.append( ('ordinal', ordinal_transformer, embed_features) )


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Defect introduced in #518 

Fixed major defect in NN causing crashes with categoricals. Since 0.0.11 release, any dataset with categoricals that cause embeddings to be created in the NN will cause the NN to fail during training.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
