### PR TITLE
Fix dead link in docs/install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,7 +15,7 @@ Next steps
 - Checkout `beta.mxnet.io <http://beta.mxnet.io/install/index.html>`_ for more options such as ARM devices and docker images.
 - `Verify your MXNet installation <https://beta.mxnet.io/install/validate-mxnet.html>`_
 - `Configure MXNet environment variables <https://mxnet.incubator.apache.org/versions/master/faq/env_var.html>`_
-- For new users: `60-minute Gluon crash course <https://beta.mxnet.io/guide/getting-started/crash-course/index.html>`_
+- For new users: `60-minute Gluon crash course <https://gluon-crash-course.mxnet.io/>`_
 - For experienced users: `MXNet Guides. <https://beta.mxnet.io/guide/getting-started/crash-course/index.html>`_
 - For advanced users: `MXNet API <https://beta.mxnet.io/api/index.html>`_ and `GluonCV API <../api/index.html>`_.
 


### PR DESCRIPTION
*Description of changes:*

Replaced the 60-minute Gluon crash course link


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
