### PR TITLE
Integrate FAISS index for KNN classifier

### DIFF
--- a/autogluon/utils/tabular/ml/models/knn/knn_model.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_model.py
@@ -4,7 +4,7 @@ import sys
 import time
 
 import psutil
-from .knn_utils import KNeighborsClassifier, KNeighborsRegressor
+from .knn_utils import FAISSNeighborsClassifier, FAISSNeighborsRegressor
 
 from ..abstract import model_trial
 from ..abstract.abstract_model import AbstractModel
@@ -19,9 +19,9 @@ class KNNModel(AbstractModel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         if self.problem_type == REGRESSION:
-            self._model_type = KNeighborsRegressor
+            self._model_type = FAISSNeighborsRegressor
         else:
-            self._model_type = KNeighborsClassifier
+            self._model_type = FAISSNeighborsClassifier
 
     def preprocess(self, X):
         cat_columns = X.select_dtypes(['category']).columns

--- a/autogluon/utils/tabular/ml/models/knn/knn_model.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_model.py
@@ -4,10 +4,10 @@ import sys
 import time
 
 import psutil
-from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+from .knn_utils import KNeighborsClassifier, KNeighborsRegressor
 
 from ..abstract import model_trial
-from ..abstract.abstract_model import SKLearnModel
+from ..abstract.abstract_model import AbstractModel
 from ...constants import REGRESSION
 from ....utils.exceptions import NotEnoughMemoryError
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: Normalize data!
-class KNNModel(SKLearnModel):
+class KNNModel(AbstractModel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         if self.problem_type == REGRESSION:
@@ -32,7 +32,7 @@ class KNNModel(SKLearnModel):
     def _set_default_params(self):
         default_params = {
             'weights': 'uniform',
-            'n_jobs': -1,
+            'index_factory_string' : 'Flat',
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)

--- a/autogluon/utils/tabular/ml/models/knn/knn_model.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_model.py
@@ -32,6 +32,7 @@ class KNNModel(AbstractModel):
     def _set_default_params(self):
         default_params = {
             'weights': 'uniform',
+            'n_jobs': -1,
             'index_factory_string' : 'Flat',
         }
         for param, val in default_params.items():

--- a/autogluon/utils/tabular/ml/models/knn/knn_model.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_model.py
@@ -33,7 +33,7 @@ class KNNModel(AbstractModel):
         default_params = {
             'weights': 'uniform',
             'n_jobs': -1,
-            'index_factory_string' : 'Flat',
+            'index_factory_string': 'Flat',
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)

--- a/autogluon/utils/tabular/ml/models/knn/knn_utils.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_utils.py
@@ -55,6 +55,7 @@ class FAISSNeighborsRegressor:
         """
         try_import_faiss()
         import faiss
+        self.faiss = faiss
         self.index_factory_string = index_factory_string
         self.n_neighbors = n_neighbors
         self.weights = weights
@@ -64,15 +65,14 @@ class FAISSNeighborsRegressor:
             faiss.omp_set_num_threads(n_jobs)
 
     def fit(self, X_train, y_train):
-        import faiss
         if isinstance(X_train, DataFrame):
             X_train = X_train.to_numpy(dtype=np.float32)
-        else: 
+        else:
             X_train = X_train.astype(np.float32)
         if not X_train.flags['C_CONTIGUOUS']:
             X_train = np.ascontiguousarray(X_train)
         d = X_train.shape[1]
-        self.index = faiss.index_factory(d, self.index_factory_string)
+        self.index = self.faiss.index_factory(d, self.index_factory_string)
         self.y = np.array(y_train)
         self.index.train(X_train)
         self.index.add(X_train)
@@ -102,20 +102,20 @@ class FAISSNeighborsRegressor:
         return y_pred
 
     def __getstate__(self):
-        import faiss
         state = {}
-        for k,v in self.__dict__.items():
-            if v is not self.index:
+        for k, v in self.__dict__.items():
+            if (v is not self.index) and (v is not self.faiss):
                 state[k] = v
             else:
-                state[k] = faiss.serialize_index(self.index)
+                state[k] = self.faiss.serialize_index(self.index)
         return state
 
     def __setstate__(self, state):
         try_import_faiss()
         import faiss
         self.__dict__.update(state)
-        self.index = faiss.deserialize_index(self.index)
+        self.faiss = faiss
+        self.index = self.faiss.deserialize_index(self.index)
 
 
 class FAISSNeighborsClassifier:
@@ -131,6 +131,7 @@ class FAISSNeighborsClassifier:
         """
         try_import_faiss()
         import faiss
+        self.faiss = faiss
         self.index_factory_string = index_factory_string
         self.n_neighbors = n_neighbors
         self.weights = weights
@@ -141,7 +142,6 @@ class FAISSNeighborsClassifier:
             faiss.omp_set_num_threads(n_jobs)
 
     def fit(self, X_train, y_train):
-        import faiss
         if isinstance(X_train, DataFrame):
             X_train = X_train.to_numpy(dtype=np.float32)
         else:
@@ -149,7 +149,7 @@ class FAISSNeighborsClassifier:
         if not X_train.flags['C_CONTIGUOUS']:
             X_train = np.ascontiguousarray(X_train)
         d = X_train.shape[1]
-        self.index = faiss.index_factory(d, self.index_factory_string)
+        self.index = self.faiss.index_factory(d, self.index_factory_string)
         self.labels = np.array(y_train)
         self.index.train(X_train)
         self.index.add(X_train)
@@ -192,17 +192,17 @@ class FAISSNeighborsClassifier:
         return probabilities
 
     def __getstate__(self):
-        import faiss
         state = {}
-        for k,v in self.__dict__.items():
-            if v is not self.index:
+        for k, v in self.__dict__.items():
+            if (v is not self.index) and (v is not self.faiss):
                 state[k] = v
             else:
-                state[k] = faiss.serialize_index(self.index)
+                state[k] = self.faiss.serialize_index(self.index)
         return state
 
     def __setstate__(self, state):
         try_import_faiss()
         import faiss
         self.__dict__.update(state)
-        self.index = faiss.deserialize_index(self.index)
+        self.faiss = faiss
+        self.index = self.faiss.deserialize_index(self.index)

--- a/autogluon/utils/tabular/ml/models/knn/knn_utils.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_utils.py
@@ -38,7 +38,7 @@ def _get_weights(dist, weights):
     else:
         raise ValueError("weights not recognized: should be 'uniform', 'distance', or a callable function")
 
-class KNeighborsRegressor:
+class FAISSNeighborsRegressor:
     def __init__(self, n_neighbors = 5, weights='uniform', n_jobs = -1, index_factory_string = "Flat"): 
         """
         Creates a KNN regressor model based on FAISS. FAISS allows you to compose different
@@ -113,7 +113,7 @@ class KNeighborsRegressor:
 
 
 
-class KNeighborsClassifier:
+class FAISSNeighborsClassifier:
     def __init__(self, n_neighbors = 5, weights='uniform', n_jobs = -1, index_factory_string = "Flat"): 
         """
         Creates a KNN classifier model based on FAISS. FAISS allows you to compose different

--- a/autogluon/utils/tabular/ml/models/knn/knn_utils.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+from pandas import DataFrame
 from scipy.stats import mode
 from sklearn.utils.extmath import weighted_mode
 import faiss
@@ -58,8 +59,12 @@ class KNeighborsRegressor:
 
 
     def fit(self, X_train, y_train):
-        X_train = X_train.astype(np.float32)
-        X_train = np.ascontiguousarray(X_train)
+        if isinstance(X_train, DataFrame):
+            X_train = X_train.to_numpy(dtype = np.float32)
+        else: 
+            X_train = X_train.astype(np.float32)
+        if not X_train.flags['C_CONTIGUOUS']: 
+            X_train = np.ascontiguousarray(X_train)
         d = X_train.shape[1]
         self.index = faiss.index_factory(d, self.index_factory_string)
         self.y = np.array(y_train)
@@ -129,8 +134,12 @@ class KNeighborsClassifier:
             faiss.omp_set_num_threads(n_jobs) 
 
     def fit(self, X_train, y_train):
-        X_train = X_train.astype(np.float32)
-        X_train = np.ascontiguousarray(X_train)
+        if isinstance(X_train, DataFrame):
+            X_train = X_train.to_numpy(dtype = np.float32)
+        else: 
+            X_train = X_train.astype(np.float32)
+        if not X_train.flags['C_CONTIGUOUS']: 
+            X_train = np.ascontiguousarray(X_train)
         d = X_train.shape[1]
         self.index = faiss.index_factory(d, self.index_factory_string)
         self.labels = np.array(y_train)

--- a/autogluon/utils/tabular/ml/models/knn/knn_utils.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_utils.py
@@ -2,7 +2,7 @@ import numpy as np
 from pandas import DataFrame
 from scipy.stats import mode
 from sklearn.utils.extmath import weighted_mode
-import faiss
+from .....try_import import try_import_faiss
 
 import logging
 
@@ -43,7 +43,7 @@ def _get_weights(dist, weights):
 
 
 class FAISSNeighborsRegressor:
-    def __init__(self, n_neighbors = 5, weights='uniform', n_jobs = -1, index_factory_string = "Flat"): 
+    def __init__(self, n_neighbors=5, weights='uniform', n_jobs=-1, index_factory_string="Flat"):
         """
         Creates a KNN regressor model based on FAISS. FAISS allows you to compose different
         near-neighbor search algorithms from several different preprocessing / search algorithms
@@ -53,6 +53,8 @@ class FAISSNeighborsRegressor:
 
         The model itself is a clone of the sklearn one
         """
+        try_import_faiss()
+        import faiss
         self.index_factory_string = index_factory_string
         self.n_neighbors = n_neighbors
         self.weights = weights
@@ -62,6 +64,7 @@ class FAISSNeighborsRegressor:
             faiss.omp_set_num_threads(n_jobs)
 
     def fit(self, X_train, y_train):
+        import faiss
         if isinstance(X_train, DataFrame):
             X_train = X_train.to_numpy(dtype=np.float32)
         else: 
@@ -99,6 +102,7 @@ class FAISSNeighborsRegressor:
         return y_pred
 
     def __getstate__(self):
+        import faiss
         state = {}
         for k,v in self.__dict__.items():
             if v is not self.index:
@@ -108,12 +112,14 @@ class FAISSNeighborsRegressor:
         return state
 
     def __setstate__(self, state):
+        try_import_faiss()
+        import faiss
         self.__dict__.update(state)
         self.index = faiss.deserialize_index(self.index)
 
 
 class FAISSNeighborsClassifier:
-    def __init__(self, n_neighbors = 5, weights='uniform', n_jobs = -1, index_factory_string = "Flat"): 
+    def __init__(self, n_neighbors=5, weights='uniform', n_jobs=-1, index_factory_string="Flat"):
         """
         Creates a KNN classifier model based on FAISS. FAISS allows you to compose different
         near-neighbor search algorithms from several different preprocessing / search algorithms
@@ -123,6 +129,8 @@ class FAISSNeighborsClassifier:
 
         The model itself is a clone of the sklearn one
         """
+        try_import_faiss()
+        import faiss
         self.index_factory_string = index_factory_string
         self.n_neighbors = n_neighbors
         self.weights = weights
@@ -133,6 +141,7 @@ class FAISSNeighborsClassifier:
             faiss.omp_set_num_threads(n_jobs)
 
     def fit(self, X_train, y_train):
+        import faiss
         if isinstance(X_train, DataFrame):
             X_train = X_train.to_numpy(dtype=np.float32)
         else:
@@ -183,6 +192,7 @@ class FAISSNeighborsClassifier:
         return probabilities
 
     def __getstate__(self):
+        import faiss
         state = {}
         for k,v in self.__dict__.items():
             if v is not self.index:
@@ -192,5 +202,7 @@ class FAISSNeighborsClassifier:
         return state
 
     def __setstate__(self, state):
+        try_import_faiss()
+        import faiss
         self.__dict__.update(state)
         self.index = faiss.deserialize_index(self.index)

--- a/autogluon/utils/tabular/ml/models/knn/knn_utils.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_utils.py
@@ -1,0 +1,184 @@
+import numpy as np
+from scipy.stats import mode
+from sklearn.utils.extmath import weighted_mode
+import faiss
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Rather than try to import non-public sklearn internals, we implement our own weighting functions here
+# These support the same operations as the sklearn functions - at least as far as possible with FAISS
+def _check_weights(weights):
+    """Check to make sure weights are valid"""
+    if weights in (None, 'uniform', 'distance'):
+        return weights
+    elif callable(weights):
+        return weights
+    else:
+        raise ValueError("weights not recognized: should be 'uniform', 'distance', or a callable function")
+
+def _get_weights(dist, weights):
+    """Get the weights from an array of distances and a parameter weights"""
+    if weights in (None, 'uniform'):
+        return None
+    elif weights == 'distance':
+        # if user attempts to classify a point that was zero distance from one
+        # or more training points, those training points are weighted as 1.0
+        # and the other points as 0.0
+        with np.errstate(divide='ignore'):
+            dist = 1. / dist
+        inf_mask = np.isinf(dist)
+        inf_row = np.any(inf_mask, axis=1)
+        dist[inf_row] = inf_mask[inf_row]
+        return dist
+    elif callable(weights):
+        return weights(dist)
+    else:
+        raise ValueError("weights not recognized: should be 'uniform', 'distance', or a callable function")
+
+class KNeighborsRegressor:
+    def __init__(self, n_neighbors = 5, weights='uniform', index_factory_string = "Flat"): 
+        """
+        Creates a KNN regressor model based on FAISS. FAISS allows you to compose different
+        near-neighbor search algorithms from several different preprocessing / search algorithms
+        This composition is specified by the string that is passed to the FAISS index_factory. 
+        Here are good guidelines for choosing the index string: 
+        https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
+
+        The model itself is a clone of the sklearn one
+        """
+        self.index_factory_string = index_factory_string
+        self.n_neighbors = n_neighbors
+        self.weights = weights
+
+
+    def fit(self, X_train, y_train):
+        X_train = X_train.astype(np.float32)
+        X_train = np.ascontiguousarray(X_train)
+        d = X_train.shape[1]
+        self.index = faiss.index_factory(d, self.index_factory_string)
+        self.y = np.array(y_train)
+        self.index.train(X_train)
+        self.index.add(X_train)
+        return self
+
+    def predict(self, X):
+        X = X.astype(np.float32)
+        X = np.ascontiguousarray(X)
+        if X.ndim == 1:
+            X = X[np.newaxis]
+        D, I = self.index.search(X, self.n_neighbors)
+        outputs = np.squeeze(self.y[I])
+
+        weights = _get_weights(D, self.weights)
+
+        if weights is None:
+            y_pred = np.mean(outputs, axis=1)
+        else:
+            denom = np.sum(weights,axis = 1)
+            if outputs.ndim == 1:
+                y_pred = np.sum(weights * outputs,axis = 1)
+                y_pred /= denom
+            else: 
+                y_pred = np.sum(weights * outputs,axis = 1)
+                y_pred /= denom
+
+        return y_pred
+
+    def __getstate__(self):
+        state = {}
+        for k,v in self.__dict__.items(): 
+            if v is not self.index: 
+                state[k] = v
+            else: 
+                state[k] = faiss.serialize_index(self.index)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.index = faiss.deserialize_index(self.index)
+
+
+
+
+
+
+class KNeighborsClassifier:
+    def __init__(self, n_neighbors = 5, weights='uniform', index_factory_string = "Flat"): 
+        """
+        Creates a KNN classifier model based on FAISS. FAISS allows you to compose different
+        near-neighbor search algorithms from several different preprocessing / search algorithms
+        This composition is specified by the string that is passed to the FAISS index_factory. 
+        Here are good guidelines for choosing the index string: 
+        https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index
+
+        The model itself is a clone of the sklearn one
+        """
+        self.index_factory_string = index_factory_string
+        self.n_neighbors = n_neighbors
+        self.weights = weights
+        self.classes = []
+
+    def fit(self, X_train, y_train):
+        X_train = X_train.astype(np.float32)
+        X_train = np.ascontiguousarray(X_train)
+        d = X_train.shape[1]
+        self.index = faiss.index_factory(d, self.index_factory_string)
+        self.labels = np.array(y_train)
+        self.index.train(X_train)
+        self.index.add(X_train)
+        self.classes = np.unique(y_train)
+        return self
+
+    def predict(self, X):
+        X = X.astype(np.float32)
+        X = np.ascontiguousarray(X)
+        if X.ndim == 1:
+            X = X[np.newaxis]
+        D, I = self.index.search(X, self.n_neighbors)
+        outputs = np.squeeze(self.labels[I])
+        weights = _get_weights(D, self.weights)
+        if weights is None:
+            y_pred, _ = mode(outputs, axis = 1)
+        else: 
+            y_pred,_ = weighted_mode(outputs, weights, axis = 1)
+        return y_pred
+
+    def predict_proba(self, X):
+        X = X.astype(np.float32)
+        X = np.ascontiguousarray(X)
+        if X.ndim == 1:
+            X = X[np.newaxis]
+        D, I = self.index.search(X, self.n_neighbors)  
+        outputs = np.squeeze(self.labels[I])
+        weights = _get_weights(D, self.weights)
+        if weights is None:
+            weights = np.ones_like(I)
+
+        probabilities = np.empty((X.shape[0], len(self.classes)), dtype = np.float64)
+        for k, class_k in enumerate(self.classes): 
+            proba_k = np.sum( np.multiply(outputs == class_k, weights ), axis = 1 )
+            probabilities[:,k] = proba_k
+
+        normalizer = np.sum(probabilities, axis = 1)
+        normalizer[normalizer == 0.0] = 1.0
+        probabilities /= normalizer[:,np.newaxis]
+        return probabilities
+
+    def __getstate__(self):
+        state = {}
+        for k,v in self.__dict__.items(): 
+            if v is not self.index: 
+                state[k] = v
+            else: 
+                state[k] = faiss.serialize_index(self.index)
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.index = faiss.deserialize_index(self.index)
+
+
+
+

--- a/autogluon/utils/tabular/ml/models/knn/knn_utils.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_utils.py
@@ -38,7 +38,7 @@ def _get_weights(dist, weights):
         raise ValueError("weights not recognized: should be 'uniform', 'distance', or a callable function")
 
 class KNeighborsRegressor:
-    def __init__(self, n_neighbors = 5, weights='uniform', index_factory_string = "Flat"): 
+    def __init__(self, n_neighbors = 5, weights='uniform', n_jobs = -1, index_factory_string = "Flat"): 
         """
         Creates a KNN regressor model based on FAISS. FAISS allows you to compose different
         near-neighbor search algorithms from several different preprocessing / search algorithms
@@ -51,6 +51,10 @@ class KNeighborsRegressor:
         self.index_factory_string = index_factory_string
         self.n_neighbors = n_neighbors
         self.weights = weights
+        self.n_jobs = n_jobs
+        if n_jobs > 0:
+            # global config, affects all faiss indexes
+            faiss.omp_set_num_threads(n_jobs)
 
 
     def fit(self, X_train, y_train):
@@ -105,7 +109,7 @@ class KNeighborsRegressor:
 
 
 class KNeighborsClassifier:
-    def __init__(self, n_neighbors = 5, weights='uniform', index_factory_string = "Flat"): 
+    def __init__(self, n_neighbors = 5, weights='uniform', n_jobs = -1, index_factory_string = "Flat"): 
         """
         Creates a KNN classifier model based on FAISS. FAISS allows you to compose different
         near-neighbor search algorithms from several different preprocessing / search algorithms
@@ -119,6 +123,10 @@ class KNeighborsClassifier:
         self.n_neighbors = n_neighbors
         self.weights = weights
         self.classes = []
+        self.n_jobs = n_jobs
+        if n_jobs > 0:
+            # global config, affects all faiss indexes
+            faiss.omp_set_num_threads(n_jobs) 
 
     def fit(self, X_train, y_train):
         X_train = X_train.astype(np.float32)

--- a/autogluon/utils/try_import.py
+++ b/autogluon/utils/try_import.py
@@ -74,3 +74,11 @@ def try_import_gluonnlp():
             "without installing gluonnlp. "
             "A quick tip is to install via `pip install gluonnlp==0.8.1`. ")
     return gluonnlp
+
+def try_import_faiss():
+    try:
+        import faiss
+    except ImportError:
+        raise ImportError(
+            "Unable to import dependency faiss"
+            "A quick tip is to install via `pip install faiss-cpu`. ")

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ requirements = [
     'pandas>=0.24.0,<1.0',
     'psutil>=5.0.0,<=5.7.0',  # TODO: psutil 5.7.1/5.7.2 has non-deterministic error on CI doc build -  ImportError: cannot import name '_psutil_linux' from 'psutil'
     'scikit-learn>=0.22.0,<0.23',
-    'networkx>=2.3,<3.0'
+    'networkx>=2.3,<3.0',
+    'faiss-cpu>=1.6.3'
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,7 @@ requirements = [
     'pandas>=0.24.0,<1.0',
     'psutil>=5.0.0,<=5.7.0',  # TODO: psutil 5.7.1/5.7.2 has non-deterministic error on CI doc build -  ImportError: cannot import name '_psutil_linux' from 'psutil'
     'scikit-learn>=0.22.0,<0.23',
-    'networkx>=2.3,<3.0',
-    'faiss-cpu>=1.6.3'
+    'networkx>=2.3,<3.0'
 ]
 
 test_requirements = [


### PR DESCRIPTION
*Description of changes:*
This code adds 

The new KNeighborsClassifier is a drop-in replacement for the sklearn model, but is built on top of the FAISS index. There is one additional optional parameter for the model: index_factory_string, which describes what type of FAISS index to use (this just gets passed to FAISS's index construction method).

There is one new dependency on faiss-cpu. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
