### PR TITLE
[Bugfix] Use a special unicode as the separator in search space

### DIFF
--- a/autogluon/core/decorator.py
+++ b/autogluon/core/decorator.py
@@ -8,7 +8,7 @@ import multiprocessing as mp
 import ConfigSpace as CS
 
 from .space import *
-from .space import _add_hp, _add_cs, _rm_hp, _strip_config_space, SPLTTER
+from .space import _add_hp, _add_cs, _rm_hp, _strip_config_space, SPLITTER
 from ..utils import EasyDict as ezdict
 from ..utils.deprecate import make_deprecate
 
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def sample_config(args, config):
     args = copy.deepcopy(args)
-    striped_keys = [k.split(SPLTTER)[0] for k in config.keys()]
+    striped_keys = [k.split(SPLITTER)[0] for k in config.keys()]
     if isinstance(args, (argparse.Namespace, argparse.ArgumentParser)):
         args_dict = vars(args)
     else:
@@ -33,7 +33,7 @@ def sample_config(args, config):
                 sub_config = _strip_config_space(config, prefix=k)
                 args_dict[k] = v.sample(**sub_config)
             else:
-                if SPLTTER in k:
+                if SPLITTER in k:
                     continue
                 args_dict[k] = config[k]
         elif isinstance(v, AutoGluonObject):
@@ -104,9 +104,9 @@ class _autogluon_method(object):
         for k, v in self.kwvars.items():
             if isinstance(v, NestedSpace):
                 if isinstance(v, Categorical):
-                    kw_spaces['{}{}choice'.format(k, SPLTTER)] = v
+                    kw_spaces['{}{}choice'.format(k, SPLITTER)] = v
                 for sub_k, sub_v in v.kwspaces.items():
-                    new_k = '{}{}{}'.format(k, SPLTTER, sub_k)
+                    new_k = '{}{}{}'.format(k, SPLITTER, sub_k)
                     kw_spaces[new_k] = sub_v
             elif isinstance(v, Space):
                 kw_spaces[k] = v

--- a/autogluon/core/decorator.py
+++ b/autogluon/core/decorator.py
@@ -8,7 +8,7 @@ import multiprocessing as mp
 import ConfigSpace as CS
 
 from .space import *
-from .space import _add_hp, _add_cs, _rm_hp, _strip_config_space
+from .space import _add_hp, _add_cs, _rm_hp, _strip_config_space, SPILTTER
 from ..utils import EasyDict as ezdict
 from ..utils.deprecate import make_deprecate
 
@@ -18,9 +18,10 @@ __all__ = ['args', 'obj', 'func', 'sample_config',
 
 logger = logging.getLogger(__name__)
 
+
 def sample_config(args, config):
     args = copy.deepcopy(args)
-    striped_keys = [k.split('.')[0] for k in config.keys()]
+    striped_keys = [k.split(SPILTTER)[0] for k in config.keys()]
     if isinstance(args, (argparse.Namespace, argparse.ArgumentParser)):
         args_dict = vars(args)
     else:
@@ -32,7 +33,8 @@ def sample_config(args, config):
                 sub_config = _strip_config_space(config, prefix=k)
                 args_dict[k] = v.sample(**sub_config)
             else:
-                if '.' in k: continue
+                if SPILTTER in k:
+                    continue
                 args_dict[k] = config[k]
         elif isinstance(v, AutoGluonObject):
             args_dict[k] = v.init()
@@ -102,9 +104,9 @@ class _autogluon_method(object):
         for k, v in self.kwvars.items():
             if isinstance(v, NestedSpace):
                 if isinstance(v, Categorical):
-                    kw_spaces['{}.choice'.format(k)] = v
+                    kw_spaces['{}{}choice'.format(k, SPILTTER)] = v
                 for sub_k, sub_v in v.kwspaces.items():
-                    new_k = '{}.{}'.format(k, sub_k)
+                    new_k = '{}{}{}'.format(k, SPILTTER, sub_k)
                     kw_spaces[new_k] = sub_v
             elif isinstance(v, Space):
                 kw_spaces[k] = v
@@ -118,7 +120,7 @@ class _autogluon_method(object):
         return repr(self.f)
 
 
-def args(default={}, **kwvars):
+def args(default=None, **kwvars):
     """Decorator for a Python training script that registers its arguments as hyperparameters. 
        Each hyperparameter takes fixed value or is a searchable space, and the arguments may either be:
        built-in Python objects (e.g. floats, strings, lists, etc.), AutoGluon objects (see :func:`autogluon.obj`), 
@@ -131,6 +133,8 @@ def args(default={}, **kwvars):
     >>> def train_func(args):
     ...     print('Batch size is {}, LR is {}'.format(args.batch_size, arg.lr))
     """
+    if default is None:
+        default = dict()
     kwvars['_default_config'] = default
     def registered_func(func):
         @_autogluon_method

--- a/autogluon/core/decorator.py
+++ b/autogluon/core/decorator.py
@@ -8,7 +8,7 @@ import multiprocessing as mp
 import ConfigSpace as CS
 
 from .space import *
-from .space import _add_hp, _add_cs, _rm_hp, _strip_config_space, SPILTTER
+from .space import _add_hp, _add_cs, _rm_hp, _strip_config_space, SPLTTER
 from ..utils import EasyDict as ezdict
 from ..utils.deprecate import make_deprecate
 
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def sample_config(args, config):
     args = copy.deepcopy(args)
-    striped_keys = [k.split(SPILTTER)[0] for k in config.keys()]
+    striped_keys = [k.split(SPLTTER)[0] for k in config.keys()]
     if isinstance(args, (argparse.Namespace, argparse.ArgumentParser)):
         args_dict = vars(args)
     else:
@@ -33,7 +33,7 @@ def sample_config(args, config):
                 sub_config = _strip_config_space(config, prefix=k)
                 args_dict[k] = v.sample(**sub_config)
             else:
-                if SPILTTER in k:
+                if SPLTTER in k:
                     continue
                 args_dict[k] = config[k]
         elif isinstance(v, AutoGluonObject):
@@ -104,9 +104,9 @@ class _autogluon_method(object):
         for k, v in self.kwvars.items():
             if isinstance(v, NestedSpace):
                 if isinstance(v, Categorical):
-                    kw_spaces['{}{}choice'.format(k, SPILTTER)] = v
+                    kw_spaces['{}{}choice'.format(k, SPLTTER)] = v
                 for sub_k, sub_v in v.kwspaces.items():
-                    new_k = '{}{}{}'.format(k, SPILTTER, sub_k)
+                    new_k = '{}{}{}'.format(k, SPLTTER, sub_k)
                     kw_spaces[new_k] = sub_v
             elif isinstance(v, Space):
                 kw_spaces[k] = v

--- a/autogluon/core/space.py
+++ b/autogluon/core/space.py
@@ -7,7 +7,7 @@ from ..utils import DeprecationHelper, EasyDict, classproperty
 __all__ = ['Space', 'NestedSpace', 'AutoGluonObject', 'List', 'Dict',
            'Categorical', 'Choice', 'Real', 'Int', 'Bool']
 
-SPILTTER = u'▁'  # Use U+2581 as the special symbol for splitting the space
+SPLTTER = u'▁'  # Use U+2581 as the special symbol for splitting the space
 
 
 class Space(object):
@@ -196,7 +196,7 @@ class List(NestedSpace):
         """
         ret = []
         kwspaces = self.kwspaces
-        striped_keys = [k.split(SPILTTER)[0] for k in config.keys()]
+        striped_keys = [k.split(SPLTTER)[0] for k in config.keys()]
         for idx, obj in enumerate(self.data):
             if isinstance(obj, NestedSpace):
                 sub_config = _strip_config_space(config, prefix=str(idx))
@@ -230,7 +230,7 @@ class List(NestedSpace):
             if isinstance(obj, NestedSpace):
                 kw_spaces[k] = obj
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}{}{}'.format(k, SPILTTER, sub_k)
+                    new_k = '{}{}{}'.format(k, SPLTTER, sub_k)
                     kw_spaces[new_k] = sub_v
             elif isinstance(obj, Space):
                 kw_spaces[k] = obj
@@ -298,7 +298,7 @@ class Dict(NestedSpace):
             if isinstance(obj, NestedSpace):
                 kw_spaces[k] = obj
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}{}{}'.format(k, SPILTTER, sub_k)
+                    new_k = '{}{}{}'.format(k, SPLTTER, sub_k)
                     kw_spaces[new_k] = sub_v
                     kw_spaces[new_k] = sub_v
             elif isinstance(obj, Space):
@@ -312,7 +312,7 @@ class Dict(NestedSpace):
         ret.update(self.data)
         kwspaces = self.kwspaces
         kwspaces.update(config)
-        striped_keys = [k.split(SPILTTER)[0] for k in config.keys()]
+        striped_keys = [k.split(SPLTTER)[0] for k in config.keys()]
         for k, v in kwspaces.items():
             if k in striped_keys:
                 if isinstance(v, NestedSpace):
@@ -389,7 +389,7 @@ class Categorical(NestedSpace):
         for idx, obj in enumerate(self.data):
             if isinstance(obj, NestedSpace):
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}{}{}'.format(idx, SPILTTER, sub_k)
+                    new_k = '{}{}{}'.format(idx, SPLTTER, sub_k)
                     kw_spaces[new_k] = sub_v
         return kw_spaces
 
@@ -488,7 +488,7 @@ def _add_cs(master_cs, sub_cs, prefix, delimiter='.', parent_hp=None):
         if new_parameter.name == '':
             new_parameter.name = prefix
         elif not prefix == '':
-            new_parameter.name = "{}{}{}".format(prefix, SPILTTER, new_parameter.name)
+            new_parameter.name = "{}{}{}".format(prefix, SPLTTER, new_parameter.name)
         new_parameters.append(new_parameter)
     for hp in new_parameters:
         _add_hp(master_cs, hp)

--- a/autogluon/core/space.py
+++ b/autogluon/core/space.py
@@ -7,10 +7,14 @@ from ..utils import DeprecationHelper, EasyDict, classproperty
 __all__ = ['Space', 'NestedSpace', 'AutoGluonObject', 'List', 'Dict',
            'Categorical', 'Choice', 'Real', 'Int', 'Bool']
 
+SPILTTER = u'▁'  # Use U+2581 as the special symbol for splitting the space
+
+
 class Space(object):
     """Basic search space describing set of possible values for hyperparameter.
     """
     pass
+
 
 class SimpleSpace(Space):
     """Non-nested search space (i.e. corresponds to a single simple hyperparameter).
@@ -192,7 +196,7 @@ class List(NestedSpace):
         """
         ret = []
         kwspaces = self.kwspaces
-        striped_keys = [k.split('.')[0] for k in config.keys()]
+        striped_keys = [k.split(SPILTTER)[0] for k in config.keys()]
         for idx, obj in enumerate(self.data):
             if isinstance(obj, NestedSpace):
                 sub_config = _strip_config_space(config, prefix=str(idx))
@@ -226,7 +230,7 @@ class List(NestedSpace):
             if isinstance(obj, NestedSpace):
                 kw_spaces[k] = obj
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}.{}'.format(k, sub_k)
+                    new_k = '{}{}{}'.format(k, SPILTTER, sub_k)
                     kw_spaces[new_k] = sub_v
             elif isinstance(obj, Space):
                 kw_spaces[k] = obj
@@ -294,7 +298,7 @@ class Dict(NestedSpace):
             if isinstance(obj, NestedSpace):
                 kw_spaces[k] = obj
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}.{}'.format(k, sub_k)
+                    new_k = '{}{}{}'.format(k, SPILTTER, sub_k)
                     kw_spaces[new_k] = sub_v
                     kw_spaces[new_k] = sub_v
             elif isinstance(obj, Space):
@@ -308,7 +312,7 @@ class Dict(NestedSpace):
         ret.update(self.data)
         kwspaces = self.kwspaces
         kwspaces.update(config)
-        striped_keys = [k.split('.')[0] for k in config.keys()]
+        striped_keys = [k.split(SPILTTER)[0] for k in config.keys()]
         for k, v in kwspaces.items():
             if k in striped_keys:
                 if isinstance(v, NestedSpace):
@@ -321,6 +325,7 @@ class Dict(NestedSpace):
     def __repr__(self):
         reprstr = self.__class__.__name__ + str(self.data)
         return reprstr
+
 
 class Categorical(NestedSpace):
     """Nested search space for hyperparameters which are categorical. Such a hyperparameter takes one value out of the discrete set of provided options.
@@ -384,7 +389,7 @@ class Categorical(NestedSpace):
         for idx, obj in enumerate(self.data):
             if isinstance(obj, NestedSpace):
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}.{}'.format(idx, sub_k)
+                    new_k = '{}{}{}'.format(idx, SPILTTER, sub_k)
                     kw_spaces[new_k] = sub_v
         return kw_spaces
 
@@ -483,7 +488,7 @@ def _add_cs(master_cs, sub_cs, prefix, delimiter='.', parent_hp=None):
         if new_parameter.name == '':
             new_parameter.name = prefix
         elif not prefix == '':
-            new_parameter.name = "%s%s%s" % (prefix, '.', new_parameter.name)
+            new_parameter.name = "{}{}{}".format(prefix, SPILTTER, new_parameter.name)
         new_parameters.append(new_parameter)
     for hp in new_parameters:
         _add_hp(master_cs, hp)
@@ -492,5 +497,5 @@ def _rm_hp(cs, k):
     if k in cs._hyperparameters:
         cs._hyperparameters.pop(k)
     for hp in cs.get_hyperparameters():
-        if  hp.name.startswith("%s."%(k)):
+        if  hp.name.startswith('{}'.format(k)):
             cs._hyperparameters.pop(hp.name)

--- a/autogluon/core/space.py
+++ b/autogluon/core/space.py
@@ -7,7 +7,7 @@ from ..utils import DeprecationHelper, EasyDict, classproperty
 __all__ = ['Space', 'NestedSpace', 'AutoGluonObject', 'List', 'Dict',
            'Categorical', 'Choice', 'Real', 'Int', 'Bool']
 
-SPLTTER = u'▁'  # Use U+2581 as the special symbol for splitting the space
+SPLITTER = u'▁'  # Use U+2581 as the special symbol for splitting the space
 
 
 class Space(object):
@@ -196,7 +196,7 @@ class List(NestedSpace):
         """
         ret = []
         kwspaces = self.kwspaces
-        striped_keys = [k.split(SPLTTER)[0] for k in config.keys()]
+        striped_keys = [k.split(SPLITTER)[0] for k in config.keys()]
         for idx, obj in enumerate(self.data):
             if isinstance(obj, NestedSpace):
                 sub_config = _strip_config_space(config, prefix=str(idx))
@@ -230,7 +230,7 @@ class List(NestedSpace):
             if isinstance(obj, NestedSpace):
                 kw_spaces[k] = obj
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}{}{}'.format(k, SPLTTER, sub_k)
+                    new_k = '{}{}{}'.format(k, SPLITTER, sub_k)
                     kw_spaces[new_k] = sub_v
             elif isinstance(obj, Space):
                 kw_spaces[k] = obj
@@ -298,7 +298,7 @@ class Dict(NestedSpace):
             if isinstance(obj, NestedSpace):
                 kw_spaces[k] = obj
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}{}{}'.format(k, SPLTTER, sub_k)
+                    new_k = '{}{}{}'.format(k, SPLITTER, sub_k)
                     kw_spaces[new_k] = sub_v
                     kw_spaces[new_k] = sub_v
             elif isinstance(obj, Space):
@@ -312,7 +312,7 @@ class Dict(NestedSpace):
         ret.update(self.data)
         kwspaces = self.kwspaces
         kwspaces.update(config)
-        striped_keys = [k.split(SPLTTER)[0] for k in config.keys()]
+        striped_keys = [k.split(SPLITTER)[0] for k in config.keys()]
         for k, v in kwspaces.items():
             if k in striped_keys:
                 if isinstance(v, NestedSpace):
@@ -389,7 +389,7 @@ class Categorical(NestedSpace):
         for idx, obj in enumerate(self.data):
             if isinstance(obj, NestedSpace):
                 for sub_k, sub_v in obj.kwspaces.items():
-                    new_k = '{}{}{}'.format(idx, SPLTTER, sub_k)
+                    new_k = '{}{}{}'.format(idx, SPLITTER, sub_k)
                     kw_spaces[new_k] = sub_v
         return kw_spaces
 
@@ -488,7 +488,7 @@ def _add_cs(master_cs, sub_cs, prefix, delimiter='.', parent_hp=None):
         if new_parameter.name == '':
             new_parameter.name = prefix
         elif not prefix == '':
-            new_parameter.name = "{}{}{}".format(prefix, SPLTTER, new_parameter.name)
+            new_parameter.name = "{}{}{}".format(prefix, SPLITTER, new_parameter.name)
         new_parameters.append(new_parameter)
     for hp in new_parameters:
         _add_hp(master_cs, hp)

--- a/tests/unittests/test_search_space.py
+++ b/tests/unittests/test_search_space.py
@@ -1,53 +1,52 @@
 import autogluon as ag
 
-@ag.obj(
-    name=ag.space.Categorical('auto', 'gluon'),
-)
-class myobj:
-    def __init__(self, name):
-        self.name = name
 
-@ag.func(
-    framework=ag.space.Categorical('mxnet', 'pytorch'),
-)
-def myfunc(framework):
-    return framework
+def test_search_space():
+    @ag.obj(
+        name=ag.space.Categorical('auto', 'gluon'),
+    )
+    class myobj:
+        def __init__(self, name):
+            self.name = name
 
-@ag.args(
-    a=ag.space.Real(1e-3, 1e-2, log=True),
-    b=ag.space.Real(1e-3, 1e-2),
-    c=ag.space.Int(1, 10),
-    d=ag.space.Categorical('a', 'b', 'c', 'd'),
-    e=ag.space.Bool(),
-    f=ag.space.List(
+    @ag.func(
+        framework=ag.space.Categorical('mxnet', 'pytorch'),
+    )
+    def myfunc(framework):
+        return framework
+
+    @ag.args(
+        a=ag.space.Real(1e-3, 1e-2, log=True),
+        b=ag.space.Real(1e-3, 1e-2),
+        c=ag.space.Int(1, 10),
+        d=ag.space.Categorical('a', 'b', 'c', 'd'),
+        e=ag.space.Bool(),
+        f=ag.space.List(
             ag.space.Int(1, 2),
             ag.space.Categorical(4, 5),
         ),
-    g=ag.space.Dict(
+        g=ag.space.Dict(
             a=ag.Real(0, 10),
             obj=myobj(),
         ),
-    h=ag.space.Categorical('test', myobj()),
-    i = myfunc(),
+        h=ag.space.Categorical('test', myobj()),
+        i=myfunc(),
     )
-def train_fn(args, reporter):
-    a, b, c, d, e, f, g, h, i = args.a, args.b, args.c, args.d, args.e, \
-            args.f, args.g, args.h, args.i
-    assert a <= 1e-2 and a >= 1e-3
-    assert b <= 1e-2 and b >= 1e-3
-    assert c <= 10 and c >= 1
-    assert d in ['a', 'b', 'c', 'd']
-    assert e in [True, False]
-    assert f[0] in [1, 2]
-    assert f[1] in [4, 5]
-    assert g['a'] <= 10 and g['a'] >= 0
-    assert g.obj.name in ['auto', 'gluon']
-    assert hasattr(h, 'name') or h == 'test'
-    assert i in ['mxnet', 'pytorch']
-    reporter(epoch=1, accuracy=0)
-
-
-def test_search_space():
+    def train_fn(args, reporter):
+        a, b, c, d, e, f, g, h, i = args.a, args.b, args.c, args.d, args.e, \
+                                    args.f, args.g, args.h, args.i
+        assert a <= 1e-2 and a >= 1e-3
+        assert b <= 1e-2 and b >= 1e-3
+        assert c <= 10 and c >= 1
+        assert d in ['a', 'b', 'c', 'd']
+        assert e in [True, False]
+        assert f[0] in [1, 2]
+        assert f[1] in [4, 5]
+        assert g['a'] <= 10 and g['a'] >= 0
+        assert g.obj.name in ['auto', 'gluon']
+        assert hasattr(h, 'name') or h == 'test'
+        assert i in ['mxnet', 'pytorch']
+        reporter(epoch=1, accuracy=0)
     scheduler = ag.scheduler.FIFOScheduler(train_fn,
                                            resource={'num_cpus': 4, 'num_gpus': 0},
                                            num_trials=10,
@@ -57,3 +56,14 @@ def test_search_space():
     scheduler.run()
     scheduler.join_jobs()
 
+
+def test_search_space_dot_key():
+    @ag.args(
+        **{'model.name': ag.space.Categorical('mxnet', 'pytorch')}
+    )
+    def train_fn(args, reporter):
+        assert args['model.name'] == 'mxnet' or args['model.name'] == 'pytorch'
+
+    scheduler = ag.scheduler.FIFOScheduler(train_fn, num_trials=2)
+    scheduler.run()
+    scheduler.join_jobs()


### PR DESCRIPTION
Issue #: https://github.com/awslabs/autogluon/issues/560

Description of changes:

- Change the splitter in the nested search space to a special unicode character: u'▁'  (U+2581).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
