### PR TITLE
[HPO][Scheduler] Add `get_best_task_id`

### DIFF
--- a/autogluon/scheduler/fifo.py
+++ b/autogluon/scheduler/fifo.py
@@ -455,6 +455,15 @@ class FIFOScheduler(TaskScheduler):
         """
         return self.searcher.get_best_config()
 
+    def get_best_task_id(self):
+        """Get the task id that results in the best configuration/best reward"""
+        best_config = self.get_best_config()
+        for task_id, config in self.config_history.items():
+            if pickle.dumps(best_config) == pickle.dumps(config):
+                return task_id
+        raise RuntimeError('The best config {} is not found in config history = {}. '
+                           'This should never happen!'.format(best_config, self.config_history))
+
     def get_best_reward(self):
         """Get the best reward from the finished jobs.
         """

--- a/autogluon/scheduler/fifo.py
+++ b/autogluon/scheduler/fifo.py
@@ -456,7 +456,10 @@ class FIFOScheduler(TaskScheduler):
         return self.searcher.get_best_config()
 
     def get_best_task_id(self):
-        """Get the task id that results in the best configuration/best reward"""
+        """Get the task id that results in the best configuration/best reward.
+
+        If there are duplicated configurations, we return the id of the first one.
+        """
         best_config = self.get_best_config()
         for task_id, config in self.config_history.items():
             if pickle.dumps(best_config) == pickle.dumps(config):

--- a/tests/unittests/test_scheduler.py
+++ b/tests/unittests/test_scheduler.py
@@ -1,5 +1,7 @@
 import numpy as np
+import pickle
 import autogluon as ag
+
 
 @ag.args(
     lr=ag.space.Real(1e-3, 1e-2, log=True),
@@ -29,6 +31,10 @@ def test_fifo_scheduler():
                                            checkpoint=None)
     scheduler.run()
     scheduler.join_jobs()
+    best_config = scheduler.get_best_config()
+    best_task_id = scheduler.get_best_task_id()
+    assert pickle.dumps(scheduler.config_history[best_task_id]) == pickle.dumps(best_config)
+
 
 def test_hyperband_scheduler():
     scheduler = ag.scheduler.HyperbandScheduler(train_fn,
@@ -40,6 +46,10 @@ def test_hyperband_scheduler():
                                                 checkpoint=None)
     scheduler.run()
     scheduler.join_jobs()
+    best_config = scheduler.get_best_config()
+    best_task_id = scheduler.get_best_task_id()
+    assert pickle.dumps(scheduler.config_history[best_task_id]) == pickle.dumps(best_config)
+
 
 def test_rl_scheduler():
     scheduler = ag.scheduler.RLScheduler(rl_train_fn,
@@ -50,3 +60,6 @@ def test_rl_scheduler():
                                          checkpoint=None)
     scheduler.run()
     scheduler.join_jobs()
+    best_config = scheduler.get_best_config()
+    best_task_id = scheduler.get_best_task_id()
+    assert pickle.dumps(scheduler.config_history[best_task_id]) == pickle.dumps(best_config)


### PR DESCRIPTION
Sometimes, we will want to load the weights of the best model searched via HPO. This is similar to the `get_best_logdir` option in ray/tune (See https://docs.ray.io/en/latest/tune/tutorials/tune-tutorial.html#tune-tutorial).

Thus, I added this `get_best_task_id` method to FIFOScheduler.
