### PR TITLE
Added confusion matrix metric for binary and multi-class classification

### DIFF
--- a/tests/unittests/utils/tabular/metrics/test_classification_metrics.py
+++ b/tests/unittests/utils/tabular/metrics/test_classification_metrics.py
@@ -1,0 +1,125 @@
+import numpy as np
+import pytest
+from autogluon.utils.tabular.metrics.classification_metrics import confusion_matrix
+
+
+def test_confusion_matrix_with_valid_inputs_without_labels_and_weights():
+    # Given
+    input_solution = [2, 0, 2, 2, 0, 1]
+    input_prediction = [0, 0, 2, 2, 0, 2]
+    expected_output = np.array([[2, 0, 0], [0, 0, 1], [1, 0, 2]])
+
+    # When
+    observed_output = confusion_matrix(input_solution, input_prediction)
+
+    # Then
+    assert(np.array_equal(expected_output, observed_output))
+
+
+def test_confusion_matrix_with_valid_inputs_with_labels_and_without_weights():
+    # Given
+    input_solution = ["cat", "ant", "cat", "cat", "ant", "bird"]
+    input_prediction = ["ant", "ant", "cat", "cat", "ant", "cat"]
+    labels = ["ant", "bird", "cat"]
+    expected_output = np.array([[2, 0, 0], [0, 0, 1], [1, 0, 2]])
+
+    # When
+    observed_output = confusion_matrix(input_solution, input_prediction, labels=labels)
+
+    # Then
+    assert(np.array_equal(expected_output, observed_output))
+
+
+def test_confusion_matrix_with_valid_inputs_with_labels_and_with_weights():
+    # Given
+    input_solution = ["cat", "ant", "cat", "cat", "ant", "bird"]
+    input_prediction = ["ant", "ant", "cat", "cat", "ant", "cat"]
+    labels = ["ant", "bird", "cat"]
+    weights = [0.1, 0.3, 1.0, 0.8, 0.2, 2.0]
+    expected_output = np.array([[0.5, 0.0, 0.0], [0.0, 0.0, 2.0], [0.1, 0.0, 1.8]])
+
+    # When
+    observed_output = confusion_matrix(input_solution, input_prediction, labels=labels, weights=weights)
+
+    # Then
+    assert(np.array_equal(expected_output, observed_output))
+
+
+def test_confusion_matrix_with_valid_inputs_with_lesser_number_of_labels_and_without_weights():
+    # Given
+    input_solution = ["cat", "ant", "cat", "cat", "ant", "bird"]
+    input_prediction = ["ant", "ant", "cat", "cat", "ant", "cat"]
+    labels = ["bird", "cat"]
+    expected_output = np.array([[0, 1], [0, 2]])
+
+    # When
+    observed_output = confusion_matrix(input_solution, input_prediction, labels=labels)
+
+    # Then
+    assert(np.array_equal(expected_output, observed_output))
+
+
+def test_confusion_matrix_with_unequal_samples():
+    # Given
+    input_solution = ["cat", "ant", "cat"]
+    input_prediction = ["ant", "ant", "cat", "cat", "ant", "cat"]
+
+    # When-Then
+    with pytest.raises(ValueError):
+        observed_output = confusion_matrix(input_solution, input_prediction)
+
+
+def test_confusion_matrix_with_multioutput_samples():
+    # Given
+    input_solution = [["cat", "ant", "cat"]]
+    input_prediction = [["ant", "ant", "cat"]]
+
+    # When-Then
+    with pytest.raises(ValueError):
+        observed_output = confusion_matrix(input_solution, input_prediction)
+
+
+def test_confusion_matrix_with_empty_labels():
+    # Given
+    input_solution = ["cat", "ant", "cat", "cat", "ant", "bird"]
+    input_prediction = ["ant", "ant", "cat", "cat", "ant", "cat"]
+    labels = []
+
+    # When-Then
+    with pytest.raises(ValueError):
+        observed_output = confusion_matrix(input_solution, input_prediction, labels=labels)
+
+
+def test_confusion_matrix_with_multiDimensional_labels():
+    # Given
+    input_solution = ["cat", "ant", "cat", "cat", "ant", "bird"]
+    input_prediction = ["ant", "ant", "cat", "cat", "ant", "cat"]
+    labels = [["ant", "bird"], "cat"]
+
+    # When-Then
+    with pytest.raises(ValueError):
+        observed_output = confusion_matrix(input_solution, input_prediction, labels=labels)
+
+
+def test_confusion_matrix_with_invalid_weights():
+    # Given
+    input_solution = ["cat", "ant", "cat", "cat", "ant", "bird"]
+    input_prediction = ["ant", "ant", "cat", "cat", "ant", "cat"]
+    labels = [[1, 2], 0.1, [0.1], 3, 1]
+
+    # When-Then
+    with pytest.raises(ValueError):
+        observed_output = confusion_matrix(input_solution, input_prediction, labels=labels)
+
+def test_confusion_matrix_with_empty_inputs():
+    # Given
+    input_solution = []
+    input_prediction = []
+    labels = ["bird", "cat"]
+    expected_output = np.array([[0, 0], [0, 0]])
+
+    # When
+    observed_output = confusion_matrix(input_solution, input_prediction, labels = labels)
+
+    # Then
+    assert(np.array_equal(expected_output, observed_output))


### PR DESCRIPTION
*Issue #544 :*

**Motivation**
Added confusion matrix metric into tabular classification metrics library with corresponding unit tests

**Implementation**
- Checked if both true and predicted targets are of same shape and are of type binary or multi-class
- Checked if labels (if passed as a parameter) is a 1-D binary or multi-class array without duplicate elements
- Checked if weights (if passed as a parameter) is a 1-D binary, multi-class or continuous array
- Removed indexes having targets that are not included in the desired label array
- Returned coordinate matrix with the processed targets, labels and weights

**Testing**
Unit tests passed 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
