### PR TITLE
Tabular: Refactor FeatureGenerator (Part 1)

### DIFF
--- a/autogluon/task/tabular_prediction/dataset.py
+++ b/autogluon/task/tabular_prediction/dataset.py
@@ -34,6 +34,7 @@ class TabularDataset(pd.DataFrame):
     copy : bool (optional, default=False)
         If True and `df` is passed, then `df` will be deep copied, resulting in two instances of the provided data in memory.
         If False, the original `df` and the new `TabularDataset` will share the same underlying data.
+        Set `copy=True` if you don't want AutoGluon to be able to modify the original DataFrame during it's training process (and your machine has enough memory).
 
     Attributes
     ----------

--- a/autogluon/task/tabular_prediction/dataset.py
+++ b/autogluon/task/tabular_prediction/dataset.py
@@ -30,7 +30,10 @@ class TabularDataset(pd.DataFrame):
     subsample : int (optional)
         If specified = k, we only keep first k rows of the provided dataset.
     name : str (optional)
-         Optional name to assign to dataset (has no effect beyond being accessible via `TabularDataset.name`).
+        Optional name to assign to dataset (has no effect beyond being accessible via `TabularDataset.name`).
+    copy : bool (optional, default=False)
+        If True and `df` is passed, then `df` will be deep copied, resulting in two instances of the provided data in memory.
+        If False, the original `df` and the new `TabularDataset` will share the same underlying data.
 
     Attributes
     ----------
@@ -71,6 +74,7 @@ class TabularDataset(pd.DataFrame):
         feature_types = kwargs.get('feature_types', None)
         df = kwargs.get('df', None)
         subsample = kwargs.get('subsample', None)
+        copy = kwargs.get('copy', False)
         construct_from_df = False  # whether or not we are constructing new dataset object from scratch based on provided DataFrame.
         # if df is None and file_path is None: # Cannot be used currently!
         #     raise ValueError("Must specify either named argument 'file_path' or 'df' in order to construct tabular Dataset")
@@ -80,7 +84,8 @@ class TabularDataset(pd.DataFrame):
                 raise ValueError("'df' must be existing pandas DataFrame. To read dataset from file instead, use 'file_path' string argument.")
             if file_path is not None:
                 warnings.warn("Both 'df' and 'file_path' supplied. Creating dataset based on DataFrame 'df' rather than reading from file_path.")
-            df = df.copy(deep=True)
+            if copy:
+                df = df.copy(deep=True)
         elif file_path is not None:  # Read from file to create dataset
             construct_from_df = True
             df = load_pd.load(file_path)

--- a/autogluon/utils/tabular/features/abstract_feature_generator.py
+++ b/autogluon/utils/tabular/features/abstract_feature_generator.py
@@ -411,10 +411,10 @@ class AbstractFeatureGenerator:
         logger.log(20, 'Generated Features (special dtypes):')
         for key, val in self.feature_types_metadata.feature_types_special.items():
             if val: logger.log(20, '\t%s features: %s' % (key, len(val)))
-        logger.log(20, 'Final Features (raw dtypes):')
+        logger.log(20, 'Processed Features (raw dtypes):')
         for key, val in self.feature_types_metadata.feature_types_raw.items():
             if val: logger.log(20, '\t%s features: %s' % (key, len(val)))
-        logger.log(20, 'Final Features:')
+        logger.log(20, 'Processed Features:')
         for key, val in self.get_feature_types_metadata_full().items():
             if val: logger.log(20, '\t%s features: %s' % (key, len(val)))
 

--- a/autogluon/utils/tabular/features/auto_ml_feature_generator.py
+++ b/autogluon/utils/tabular/features/auto_ml_feature_generator.py
@@ -99,7 +99,8 @@ class AutoMLFeatureGenerator(AbstractFeatureGenerator):
             for datetime_feature in self.feature_transformations['datetime']:
                 X_features[datetime_feature] = pd.to_datetime(X[datetime_feature])
                 X_features[datetime_feature] = pd.to_numeric(X_features[datetime_feature])  # TODO: Use actual date info
-                self.feature_type_family_generated['datetime'].append(datetime_feature)
+                if not self.fit:
+                    self.feature_type_family_generated['datetime'].append(datetime_feature)
                 # TODO: Add fastai date features
 
         if self.feature_transformations['text_ngram']:

--- a/autogluon/utils/tabular/features/auto_ml_feature_generator.py
+++ b/autogluon/utils/tabular/features/auto_ml_feature_generator.py
@@ -68,12 +68,12 @@ class AutoMLFeatureGenerator(AbstractFeatureGenerator):
             else:
                 X[column].fillna(np.nan, inplace=True)
 
-        X_text_features_combined = []
+        X_text_special_combined = []
         if self.feature_transformations['text_special']:
             for nlp_feature in self.feature_transformations['text_special']:
-                X_text_features = self.generate_text_special(X[nlp_feature], nlp_feature)
-                X_text_features_combined.append(X_text_features)
-            X_text_features_combined = pd.concat(X_text_features_combined, axis=1)
+                X_text_special = self.generate_text_special(X[nlp_feature], nlp_feature)
+                X_text_special_combined.append(X_text_special)
+            X_text_special_combined = pd.concat(X_text_special_combined, axis=1)
 
         X = self.preprocess(X)
 
@@ -84,16 +84,17 @@ class AutoMLFeatureGenerator(AbstractFeatureGenerator):
             X_categoricals = X[self.feature_transformations['category']]
             # TODO: Add stateful categorical generator, merge rare cases to an unknown value
             # TODO: What happens when training set has no unknown/rare values but test set does? What models can handle this?
-            if 'text' in self.feature_type_family:
-                self.feature_type_family_generated['text_as_category'] += self.feature_type_family['text']
+            if not self.fit:
+                if 'text' in self.feature_type_family:
+                    self.feature_type_family_generated['text_as_category'] += self.feature_type_family['text']
             X_categoricals = X_categoricals.astype('category')
             X_features = X_features.join(X_categoricals)
 
         if self.feature_transformations['text_special']:
             if not self.fit:
-                self.features_binned += list(X_text_features_combined.columns)
-                self.feature_type_family_generated['text_special'] += list(X_text_features_combined.columns)
-            X_features = X_features.join(X_text_features_combined)
+                self.features_binned += list(X_text_special_combined.columns)
+                self.feature_type_family_generated['text_special'] += list(X_text_special_combined.columns)
+            X_features = X_features.join(X_text_special_combined)
 
         if self.feature_transformations['datetime']:
             for datetime_feature in self.feature_transformations['datetime']:


### PR DESCRIPTION
*Issue #, if available:*
#579

*Description of changes:*

- Fixed datetime features to avoid repeated appending to feature name list (no impact on predictions, only on memory usage after many calls to predict).
- Fixed similar defect in text_as_category features.
- Removed inplace=True from reset_index calls to avoid outward propagation of index changes.
- Disabled default df.copy(deep=True) call in TabularDataset init, to avoid unnecessarily doubling memory usage.
- Various code cleanup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
