### PR TITLE
add sample command to convert ipynb to markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ python3 -m pytest path_to_file
 
 - Remember to update all existing examples/tutorials/documentation affected by your code changes.
 
-- We also encourage you to contribute new tutorials or example scripts using AutoGluon for applications you think other users will be interested in. Please see [`docs/tutorials/`](https://github.com/awslabs/autogluon/tree/master/docs/tutorials) or [`examples/`](https://github.com/awslabs/autogluon/tree/master/examples). All tutorials should be Jupyter notebooks converted into markdown (our build system will rebuild the .ipynb files from the markdown file and execute the notebooks). This is especially important for major new functionality.
+- We also encourage you to contribute new tutorials or example scripts using AutoGluon for applications you think other users will be interested in. Please see [`docs/tutorials/`](https://github.com/awslabs/autogluon/tree/master/docs/tutorials) or [`examples/`](https://github.com/awslabs/autogluon/tree/master/examples). All tutorials should be Jupyter notebooks converted into markdown by running the command `jupyter nbconvert --ClearOutputPreprocessor.enabled=True --to markdown tutorial.ipynb`. The command also clear out any output cells as our build system will rebuild the .ipynb files from the markdown file and execute the notebooks. This is especially important for major new functionality.
 
 - After you open your pull request, our CI system will run for little while to check your code and report found errors. Please check back and fix any errors encountered at this stage (you can retrigger a new CI check by pushing updated code to the same PR in a new commit).
 


### PR DESCRIPTION
Add sample command to convert ipynb to markdown files, and clear output cells

*Issue #, if available:* N/A

*Description of changes:* minor


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
