### PR TITLE
Fix wrong function overloading.

### DIFF
--- a/autogluon/searcher/rl_controller.py
+++ b/autogluon/searcher/rl_controller.py
@@ -60,9 +60,6 @@ class RLSearcher(BaseSearcher):
     def get_config(self, **kwargs):
         return self.controller.sample()[0]
 
-    def get_best_config(self):
-        return self.controller.inference()
-
     def state_dict(self, destination=None):
         if destination is None:
             destination = OrderedDict()


### PR DESCRIPTION
I was using RL NAS part of Autogluon. But I found that `rl_scheduler.get_best_config()` wasn't returning the best config.

So I check the code of Autogluon and found wrong overloading. The `RLSearcher` is inherited from `BaseSearcher`. While `BaseSearcher` has the right `get_best_config()`, `RLSearcher` overloaded this function with simply `inference()` which is obviously wrong. 

So I remove the wrong overloading and everything works fine again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
