### PR TITLE
Tabular: Fixed incorrect metric score calculation in evaluate

### DIFF
--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -134,6 +134,7 @@ class TabularPredictor(BasePredictor):
 
     def predict_proba(self, dataset, model=None, as_pandas=False, as_multiclass=False):
         """ Use trained models to produce predicted class probabilities rather than class-labels (if task is classification).
+            If `predictor.problem_type` is regression, this functions identically to `predict`, returning the same output.
 
             Parameters
             ----------


### PR DESCRIPTION
*Issue #, if available:*
Resolves #565 
#544 

*Description of changes:*

- Fixed defect where ndarray y_pred and series y_true were sent as input to `predictor.evaluate_predictions` and y_true's index was not reset causing index misalignment and incorrect scoring of eval_metric.
- Improved code clarity / quality + added TODO's for future improvements
- Improved return value of confusion matrix to be a DataFrame instead of a json string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
