### PR TITLE
[HPO][BugFix] Fix the bug in scheduler

### DIFF
--- a/autogluon/scheduler/scheduler.py
+++ b/autogluon/scheduler/scheduler.py
@@ -2,6 +2,8 @@
 import os
 import pickle
 import logging
+import sys
+import distributed
 from warnings import warn
 import multiprocessing as mp
 from collections import OrderedDict
@@ -196,8 +198,11 @@ class TaskScheduler(object):
         for task_dict in self.scheduled_tasks:
             try:
                 task_dict['Job'].result(timeout=timeout)
-            except TimeoutError as e:
+            except distributed.TimeoutError as e:
                 logger.error(str(e))
+            except:
+                print("Unexpected error:", sys.exc_info()[0])
+                raise
             self._clean_task_internal(task_dict)
         self._cleaning_tasks()
 

--- a/autogluon/scheduler/scheduler.py
+++ b/autogluon/scheduler/scheduler.py
@@ -201,7 +201,7 @@ class TaskScheduler(object):
             except distributed.TimeoutError as e:
                 logger.error(str(e))
             except:
-                print("Unexpected error:", sys.exc_info()[0])
+                logger.error("Unexpected error:", sys.exc_info()[0])
                 raise
             self._clean_task_internal(task_dict)
         self._cleaning_tasks()

--- a/tests/unittests/test_scheduler.py
+++ b/tests/unittests/test_scheduler.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pickle
+import time
 import autogluon as ag
 
 
@@ -63,3 +64,23 @@ def test_rl_scheduler():
     best_config = scheduler.get_best_config()
     best_task_id = scheduler.get_best_task_id()
     assert pickle.dumps(scheduler.config_history[best_task_id]) == pickle.dumps(best_config)
+
+
+def test_timeout_scheduler():
+    @ag.args(lr=ag.space.Real(1E-5, 1E-3))
+    def foo(args, reporter):
+        start_tick = time.time()
+        for i in range(10):
+            # Sleep for 1 second
+            time.sleep(1)
+            reporter(reward=time.time() - start_tick,
+                     time_attr=i)
+    scheduler = ag.scheduler.FIFOScheduler(foo,
+                                           resource={'num_cpus': 4, 'num_gpus': 0},
+                                           num_trials=3,
+                                           reward_attr='reward',
+                                           time_attr='time_attr',
+                                           time_out=3,
+                                           checkpoint=None)
+    scheduler.run()
+    best_config = scheduler.join_jobs(timeout=3)


### PR DESCRIPTION
According to the document of dask: https://distributed.dask.org/en/latest/api.html#distributed.Future.result

`.result(timeout)` will raise a `distributed.TimeoutError`. However, in the code base, the try + except just handles the `TimeoutError`.

We may use the following tiny example to understand the issue. If the exception is handled correctly, it will print 123. However, it actually raises the Exception.

```python
import distributed
try:
    raise(distributed.TimeoutError)
except TimeoutError:
    print(123)
```

Output:
```
TimeoutError: 
```

@zhreshold 