### PR TITLE
Tabular: Fixed category dtype label input crash on LGBM

### DIFF
--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -44,7 +44,6 @@ class AbstractLearner:
         self.submission_columns = id_columns
         self.threshold = label_count_threshold
         self.problem_type = problem_type
-        self.trainer_problem_type = None
         self.eval_metric = eval_metric
         self.stopping_metric = stopping_metric
         self.is_trainer_present = is_trainer_present
@@ -133,7 +132,7 @@ class AbstractLearner:
 
         if len(X_cache_miss) > 0:
             y_pred_proba = self.predict_proba(X=X_cache_miss, model=model, inverse_transform=False)
-            problem_type = self.trainer_problem_type or self.problem_type
+            problem_type = self.label_cleaner.problem_type_transform or self.problem_type
             y_pred = get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=problem_type)
             y_pred = self.label_cleaner.inverse_transform(pd.Series(y_pred))
             y_pred.index = X_cache_miss.index

--- a/autogluon/utils/tabular/ml/utils.py
+++ b/autogluon/utils/tabular/ml/utils.py
@@ -230,10 +230,10 @@ def infer_problem_type(y: Series):
     if unique_count == 2:
         problem_type = BINARY
         reason = "only two unique label-values observed"
-    elif unique_values.dtype == 'object':
+    elif y.dtype.name in ['object', 'category']:
         problem_type = MULTICLASS
-        reason = "dtype of label-column == object"
-    elif np.issubdtype(unique_values.dtype, np.floating):
+        reason = f"dtype of label-column == {y.dtype.name}"
+    elif np.issubdtype(y.dtype, np.floating):
         unique_ratio = unique_count / float(num_rows)
         if (unique_ratio <= REGRESS_THRESHOLD) and (unique_count <= MULTICLASS_LIMIT):
             try:
@@ -250,7 +250,7 @@ def infer_problem_type(y: Series):
         else:
             problem_type = REGRESSION
             reason = "dtype of label-column == float and many unique label-values observed"
-    elif np.issubdtype(unique_values.dtype, np.integer):
+    elif np.issubdtype(y.dtype, np.integer):
         unique_ratio = unique_count / float(num_rows)
         if (unique_ratio <= REGRESS_THRESHOLD) and (unique_count <= MULTICLASS_LIMIT):
             problem_type = MULTICLASS  # TODO: Check if integers are from 0 to n-1 for n unique values, if they have a wide spread, it could still be regression
@@ -259,7 +259,7 @@ def infer_problem_type(y: Series):
             problem_type = REGRESSION
             reason = "dtype of label-column == int and many unique label-values observed"
     else:
-        raise NotImplementedError('label dtype', unique_values.dtype, 'not supported!')
+        raise NotImplementedError(f'label dtype {y.dtype} not supported!')
     logger.log(25, f"AutoGluon infers your prediction problem is: {problem_type}  (because {reason}).")
     logger.log(25, f"If this is wrong, please specify `problem_type` argument in fit() instead "
                    f"(You may specify problem_type as one of: {[BINARY, MULTICLASS, REGRESSION]})\n")

--- a/tests/unittests/utils/tabular/data/test_label_cleaner.py
+++ b/tests/unittests/utils/tabular/data/test_label_cleaner.py
@@ -1,0 +1,197 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.utils.tabular.data.label_cleaner import LabelCleaner, LabelCleanerBinary, LabelCleanerMulticlass, LabelCleanerMulticlassToBinary, LabelCleanerDummy
+from autogluon.utils.tabular.ml.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS
+
+
+def test_label_cleaner_binary():
+    # Given
+    problem_type = BINARY
+    input_labels_numpy = np.array(['l1', 'l2', 'l2', 'l1', 'l1', 'l2'])
+    input_labels = pd.Series(input_labels_numpy)
+    input_labels_category = input_labels.astype('category')
+    input_labels_with_shifted_index = input_labels.copy()
+    input_labels_with_shifted_index.index += 5
+    input_labels_new = np.array(['new', 'l1', 'l2'])
+    expected_output_labels = pd.Series([0, 1, 1, 0, 0, 1])
+    expected_output_labels_new = pd.Series([np.nan, 0, 1])
+    expected_output_labels_new_inverse = pd.Series([np.nan, 'l1', 'l2'])
+
+    # When
+    label_cleaner = LabelCleaner.construct(problem_type=problem_type, y=input_labels)
+
+    # Raise exception
+    with pytest.raises(AssertionError):
+        LabelCleaner.construct(problem_type=problem_type, y=input_labels_new)
+
+    # Then
+    assert isinstance(label_cleaner, LabelCleanerBinary)
+    assert label_cleaner.problem_type_transform == BINARY
+    assert label_cleaner.cat_mappings_dependent_var == {0: 'l1', 1: 'l2'}
+
+    output_labels = label_cleaner.transform(input_labels)
+    output_labels_with_numpy = label_cleaner.transform(input_labels_numpy)
+    output_labels_category = label_cleaner.transform(input_labels_category)
+    output_labels_with_shifted_index = label_cleaner.transform(input_labels_with_shifted_index)
+    output_labels_new = label_cleaner.transform(input_labels_new)
+
+    output_labels_inverse = label_cleaner.inverse_transform(output_labels)
+    output_labels_with_shifted_index_inverse = label_cleaner.inverse_transform(output_labels_with_shifted_index)
+    output_labels_new_inverse = label_cleaner.inverse_transform(output_labels_new)
+
+    assert expected_output_labels.equals(output_labels)
+    assert expected_output_labels.equals(output_labels_with_numpy)
+    assert expected_output_labels.equals(output_labels_category)
+    assert not expected_output_labels.equals(output_labels_with_shifted_index)
+    output_labels_with_shifted_index.index -= 5
+    assert expected_output_labels.equals(output_labels_with_shifted_index)
+    assert expected_output_labels_new.equals(output_labels_new)
+
+    assert input_labels.equals(output_labels_inverse)
+    assert input_labels_with_shifted_index.equals(output_labels_with_shifted_index_inverse)
+    assert expected_output_labels_new_inverse.equals(output_labels_new_inverse)
+
+
+def test_label_cleaner_multiclass():
+    # Given
+    problem_type = MULTICLASS
+    input_labels_numpy = np.array([2, 4, 2, 2, 4, 1])
+    input_labels = pd.Series(input_labels_numpy)
+    input_labels_category = input_labels.astype('category')
+    input_labels_with_shifted_index = input_labels.copy()
+    input_labels_with_shifted_index.index += 5
+    input_labels_new = np.array([3, 5, 2])
+    expected_output_labels = pd.Series([1, 2, 1, 1, 2, 0])
+    expected_output_labels_new = pd.Series([np.nan, np.nan, 1])
+    expected_output_labels_new_inverse = pd.Series([np.nan, np.nan, 2])
+
+    # When
+    label_cleaner = LabelCleaner.construct(problem_type=problem_type, y=input_labels, y_uncleaned=input_labels)
+
+    # Then
+    assert isinstance(label_cleaner, LabelCleanerMulticlass)
+    assert label_cleaner.problem_type_transform == MULTICLASS
+    assert label_cleaner.cat_mappings_dependent_var == {0: 1, 1: 2, 2: 4}
+
+    output_labels = label_cleaner.transform(input_labels)
+    output_labels_with_numpy = label_cleaner.transform(input_labels_numpy)
+    output_labels_category = label_cleaner.transform(input_labels_category)
+    output_labels_with_shifted_index = label_cleaner.transform(input_labels_with_shifted_index)
+    output_labels_new = label_cleaner.transform(input_labels_new)
+
+    output_labels_inverse = label_cleaner.inverse_transform(output_labels)
+    output_labels_with_shifted_index_inverse = label_cleaner.inverse_transform(output_labels_with_shifted_index)
+    output_labels_new_inverse = label_cleaner.inverse_transform(output_labels_new)
+
+    assert expected_output_labels.equals(output_labels)
+    assert expected_output_labels.equals(output_labels_with_numpy)
+    assert expected_output_labels.equals(output_labels_category)
+    assert not expected_output_labels.equals(output_labels_with_shifted_index)
+    output_labels_with_shifted_index.index -= 5
+    assert expected_output_labels.equals(output_labels_with_shifted_index)
+    assert expected_output_labels_new.equals(output_labels_new)
+
+    assert input_labels.equals(output_labels_inverse)
+    assert input_labels_with_shifted_index.equals(output_labels_with_shifted_index_inverse)
+    assert expected_output_labels_new_inverse.equals(output_labels_new_inverse)
+
+
+def test_label_cleaner_multiclass_to_binary():
+    # Given
+    problem_type = MULTICLASS
+    input_labels_numpy = np.array(['l1', 'l2', 'l2', 'l1', 'l1', 'l2'])
+    input_labels = pd.Series(input_labels_numpy)
+    input_labels_uncleaned = pd.Series(['l0', 'l1', 'l2', 'l2', 'l1', 'l1', 'l2', 'l3', 'l4'])
+    input_labels_category = input_labels.astype('category')
+    input_labels_with_shifted_index = input_labels.copy()
+    input_labels_with_shifted_index.index += 5
+    input_labels_new = np.array(['l0', 'l1', 'l2'])
+    input_labels_proba_transformed = pd.Series([0.7, 0.2, 0.5], index=[5, 2, 8])
+    expected_output_labels = pd.Series([0, 1, 1, 0, 0, 1])
+    expected_output_labels_new = pd.Series([np.nan, 0, 1])
+    expected_output_labels_new_inverse = pd.Series([np.nan, 'l1', 'l2'])
+    expected_output_labels_proba_transformed_inverse = pd.DataFrame(
+        data=[
+            [0, 0.3, 0.7, 0, 0],
+            [0, 0.8, 0.2, 0, 0],
+            [0, 0.5, 0.5, 0, 0]
+        ], index=[5, 2, 8], columns=['l0', 'l1', 'l2', 'l3', 'l4'], dtype=np.float64
+    )
+
+    # When
+    label_cleaner = LabelCleaner.construct(problem_type=problem_type, y=input_labels, y_uncleaned=input_labels_uncleaned)
+
+    # Then
+    assert isinstance(label_cleaner, LabelCleanerMulticlassToBinary)
+    assert label_cleaner.problem_type_transform == BINARY
+    assert label_cleaner.cat_mappings_dependent_var == {0: 'l1', 1: 'l2'}
+
+    output_labels = label_cleaner.transform(input_labels)
+    output_labels_with_numpy = label_cleaner.transform(input_labels_numpy)
+    output_labels_category = label_cleaner.transform(input_labels_category)
+    output_labels_with_shifted_index = label_cleaner.transform(input_labels_with_shifted_index)
+    output_labels_new = label_cleaner.transform(input_labels_new)
+
+    output_labels_inverse = label_cleaner.inverse_transform(output_labels)
+    output_labels_with_shifted_index_inverse = label_cleaner.inverse_transform(output_labels_with_shifted_index)
+    output_labels_new_inverse = label_cleaner.inverse_transform(output_labels_new)
+
+    assert expected_output_labels.equals(output_labels)
+    assert expected_output_labels.equals(output_labels_with_numpy)
+    assert expected_output_labels.equals(output_labels_category)
+    assert not expected_output_labels.equals(output_labels_with_shifted_index)
+    output_labels_with_shifted_index.index -= 5
+    assert expected_output_labels.equals(output_labels_with_shifted_index)
+    assert expected_output_labels_new.equals(output_labels_new)
+
+    assert input_labels.equals(output_labels_inverse)
+    assert input_labels_with_shifted_index.equals(output_labels_with_shifted_index_inverse)
+    assert expected_output_labels_new_inverse.equals(output_labels_new_inverse)
+
+    output_labels_proba_transformed_inverse = label_cleaner.inverse_transform_proba(input_labels_proba_transformed, as_pandas=True)
+
+    pd.testing.assert_frame_equal(expected_output_labels_proba_transformed_inverse, output_labels_proba_transformed_inverse)
+
+
+def test_label_cleaner_regression():
+    # Given
+    problem_type = REGRESSION
+    input_labels_numpy = np.array([2, 4, 2, 2, 4, 1])
+    input_labels = pd.Series(input_labels_numpy)
+    input_labels_new = pd.Series([3, 5, 2])
+    expected_output_labels = input_labels.copy()
+    expected_output_labels_new = input_labels_new.copy()
+    expected_output_labels_new_inverse = input_labels_new.copy()
+
+    # When
+    label_cleaner = LabelCleaner.construct(problem_type=problem_type, y=input_labels, y_uncleaned=None)
+
+    # Then
+    assert isinstance(label_cleaner, LabelCleanerDummy)
+    assert label_cleaner.problem_type_transform == REGRESSION
+
+    output_labels = label_cleaner.transform(input_labels)
+    output_labels_with_numpy = label_cleaner.transform(input_labels_numpy)
+    output_labels_new = label_cleaner.transform(input_labels_new)
+
+    output_labels_inverse = label_cleaner.inverse_transform(output_labels)
+    output_labels_new_inverse = label_cleaner.inverse_transform(output_labels_new)
+
+    assert expected_output_labels.equals(output_labels)
+    assert expected_output_labels.equals(output_labels_with_numpy)
+    assert expected_output_labels_new.equals(output_labels_new)
+
+    assert input_labels.equals(output_labels_inverse)
+    assert expected_output_labels_new_inverse.equals(output_labels_new_inverse)
+
+
+def test_label_softclass():
+    # Given
+    problem_type = SOFTCLASS
+    input_labels = pd.Series([2, 4, 2, 2, 4, 1])
+
+    # Raise exception
+    with pytest.raises(NotImplementedError):
+        LabelCleaner.construct(problem_type=problem_type, y=input_labels, y_uncleaned=None)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed crash that occurs on LGBM training when label dtype was category instead of object.
- Improved type consistency in internal label, converts category to object
- Added unit tests for LabelCleaner

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
