### PR TITLE
Tabular: Added extra_info argument to predictor.leaderboard()

### DIFF
--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -252,7 +252,7 @@ class TabularPredictor(BasePredictor):
                 This requires additional computation as advanced info data is calculated on demand.
                 Additional output columns when `extra_info=True` include:
                     'num_features': Number of input features used by the model.
-                    'num_models': Number of models this model represents.
+                    'num_models': Number of models that actually make up this "model" object.
                         For non-bagged models, this is 1. For bagged models, this is equal to the number of child models (models trained on bagged folds) the bagged ensemble contains.
                     'num_models_w_ancestors': Equivalent to the sum of 'num_models' values for the model and its' ancestors.
                     'memory_size': The amount of memory in bytes the model requires when persisted in memory. This is not equivalent to the amount of memory the model may use during inference.
@@ -271,9 +271,15 @@ class TabularPredictor(BasePredictor):
                     'num_descendants': Number of descendant models for the given model.
                     'model_type': The model type. If the model is an ensemble type, 'child_model_type' will indicate the inner model type. A stack ensemble of bagged LightGBM models would have 'StackerEnsembleModel' as its model type.
                     'child_model_type': The child model type. None if the model is not an ensemble. A stack ensemble of bagged LightGBM models would have 'LGBModel' as its child type.
+                        child models are models which are used as a group to generate a given bagged ensemble model's predictions. These are the models trained on each fold of a bagged ensemble.
+                        For 10-fold bagging, the bagged ensemble model would have 10 child models.
+                        For 10-fold bagging with 3 repeats, the bagged ensemble model would have 30 child models.
+                        Note that child models are distinct from ancestors and descendants.
                     'hyperparameters': The input hyperparameters to the model.
-                    'hyperparameters_fit': The hyperparameters set by the model during fit. This will override the 'hyperparameters' value for a particular key if present in 'hyperparameters_fit'.
+                    'hyperparameters_fit': The hyperparameters set by the model during fit. This overrides the 'hyperparameters' value for a particular key if present in 'hyperparameters_fit' to determine the fit model's final hyperparameters.
                         This is most commonly set for hyperparameters that indicate model training iterations or epochs, as early stopping can find a different value from what 'hyperparameters' indicated.
+                        In these cases, the provided hyperparameter in 'hyperparameters' is used as a maximum for the model, but the model is still able to early stop at a smaller value during training to achieve a better validation score or to satisfy time constraints.
+                        For example, if a NN model was given `epochs=500` as a hyperparameter, but found during training that `epochs=60` resulted in optimal validation score, it would use `epoch=60` and `hyperparameters_fit={'epoch': 60}` would be set.
                     'AG_args_fit': Special AutoGluon arguments that influence model fit. See the documentation of the `hyperparameters` argument in `task.fit` for more information.
                     'features': List of feature names used by the model.
                     'child_hyperparameters': Equivalent to 'hyperparameters', but for the model's children.

--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -640,6 +640,9 @@ class AbstractModel:
             hyperparameters=self.params,
             hyperparameters_fit=self.params_trained,  # TODO: Explain in docs that this is for hyperparameters that differ in final model from original hyperparameters, such as epochs (from early stopping)
             hyperparameters_nondefault=self.nondefault_params,
+            AG_args_fit=self.params_aux,
+            num_features=len(self.features) if self.features else None,
+            features=self.features,
             # disk_size=self.get_disk_size(),
             memory_size=self.get_memory_size(),  # Memory usage of model in bytes
         )

--- a/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
@@ -322,11 +322,12 @@ class BaggedEnsembleModel(AbstractModel):
         model_compressed.set_contexts(self.path_root + model_compressed.name + os.path.sep)
         return model_compressed
 
-    def _get_compressed_params(self):
-        model_params_list = [
-            self.load_child(child).get_trained_params()
-            for child in self.models
-        ]
+    def _get_compressed_params(self, model_params_list=None):
+        if model_params_list is None:
+            model_params_list = [
+                self.load_child(child).get_trained_params()
+                for child in self.models
+            ]
 
         model_params_compressed = dict()
         for param in model_params_list[0].keys():
@@ -346,6 +347,13 @@ class BaggedEnsembleModel(AbstractModel):
                     compressed_val = model_param_vals[0]
             model_params_compressed[param] = compressed_val
         return model_params_compressed
+
+    def _get_compressed_params_trained(self):
+        model_params_list = [
+            self.load_child(child).params_trained
+            for child in self.models
+        ]
+        return self._get_compressed_params(model_params_list=model_params_list)
 
     def _get_model_base(self):
         if self.model_base is None:
@@ -493,7 +501,7 @@ class BaggedEnsembleModel(AbstractModel):
             min_memory_size = info['memory_size'] - sum_memory_size_child + max_memory_size_child
 
         bagged_info = dict(
-            child_type=self._child_type.__name__,
+            child_model_type=self._child_type.__name__,
             num_child_models=len(self.models),
             child_model_names=self._get_model_names(),
             _n_repeats=self._n_repeats,
@@ -506,9 +514,16 @@ class BaggedEnsembleModel(AbstractModel):
             bagged_mode=self.bagged_mode,
             max_memory_size=max_memory_size,  # Memory used when all children are loaded into memory at once.
             min_memory_size=min_memory_size,  # Memory used when only the largest child is loaded into memory.
+            child_hyperparameters=self._get_model_base().params,
+            child_hyperparameters_fit = self._get_compressed_params_trained(),
+            child_AG_args_fit = self._get_model_base().params_aux,
         )
         info['bagged_info'] = bagged_info
         info['children_info'] = children_info
+
+        child_features_full = list(set().union(*[child['features'] for child in children_info.values()]))
+        info['features'] = child_features_full
+        info['num_features'] = len(child_features_full)
 
         return info
 

--- a/autogluon/utils/tabular/ml/models/lgb/lgb_model.py
+++ b/autogluon/utils/tabular/ml/models/lgb/lgb_model.py
@@ -137,7 +137,10 @@ class LGBModel(AbstractModel):
         try_import_lightgbm()
         import lightgbm as lgb
         self.model = lgb.train(**train_params)
-        self.params_trained['num_boost_round'] = self.model.best_iteration
+        if dataset_val is not None:
+            self.params_trained['num_boost_round'] = self.model.best_iteration
+        else:
+            self.params_trained['num_boost_round'] = self.model.current_iteration()
 
     def _predict_proba(self, X, preprocess=True):
         if preprocess:

--- a/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
+++ b/autogluon/utils/tabular/ml/models/tabular_nn/tabular_nn_model.py
@@ -384,7 +384,7 @@ class TabularNeuralNetModel(AbstractModel):
                 final_val_metric = -np.inf
             logger.log(15, "Best model found in epoch %d. Val %s: %s" %
                   (best_val_epoch, self.eval_metric_name, final_val_metric))
-        self.params_trained['num_epochs'] = best_val_epoch
+        self.params_trained['num_epochs'] = best_val_epoch + 1
         return
 
     def _predict_proba(self, X, preprocess=True):

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -1156,16 +1156,33 @@ class AbstractTrainer:
 
     # Sums the attribute value across all models that the provided model depends on, including itself.
     # For instance, this function can return the expected total predict_time of a model.
-    # attribute is the name of the desired attribute to be summed.
-    def get_model_attribute_full(self, model, attribute):
+    # attribute is the name of the desired attribute to be summed, or a dictionary of model name -> attribute value if the attribute is not present in the graph.
+    def get_model_attribute_full(self, model, attribute, func=sum):
         base_model_set = self.get_minimum_model_set(model)
+        if isinstance(attribute, dict):
+            is_dict = True
+        else:
+            is_dict = False
         if len(base_model_set) == 1:
-            return self.model_graph.nodes[base_model_set[0]][attribute]
-        attribute_full = 0
+            if is_dict:
+                return attribute[model]
+            else:
+                return self.model_graph.nodes[base_model_set[0]][attribute]
+        # attribute_full = 0
+        attribute_lst = []
         for base_model in base_model_set:
-            if self.model_graph.nodes[base_model][attribute] is None:
+            if is_dict:
+                attribute_base_model = attribute[base_model]
+            else:
+                attribute_base_model = self.model_graph.nodes[base_model][attribute]
+            if attribute_base_model is None:
                 return None
-            attribute_full += self.model_graph.nodes[base_model][attribute]
+            attribute_lst.append(attribute_base_model)
+            # attribute_full += attribute_base_model
+        if attribute_lst:
+            attribute_full = func(attribute_lst)
+        else:
+            attribute_full = 0
         return attribute_full
 
     # Returns dictionary of model name -> attribute value for the provided attribute
@@ -1179,7 +1196,7 @@ class AbstractTrainer:
             model = model.name
         return list(nx.bfs_tree(self.model_graph, model, reverse=True))
 
-    def leaderboard(self):
+    def leaderboard(self, extra_info=False):
         model_names = self.get_model_names_all()
         score_val = []
         fit_time_marginal = []
@@ -1188,6 +1205,7 @@ class AbstractTrainer:
         fit_time = []
         pred_time_val = []
         can_infer = []
+        fit_order = list(range(1,len(model_names)+1))
         score_val_dict = self.get_model_attributes_dict('val_score')
         fit_time_marginal_dict = self.get_model_attributes_dict('fit_time')
         predict_time_marginal_dict = self.get_model_attributes_dict('predict_time')
@@ -1199,6 +1217,56 @@ class AbstractTrainer:
             pred_time_val.append(self.get_model_attribute_full(model=model_name, attribute='predict_time'))
             stack_level.append(self.get_model_level(model_name))
             can_infer.append(self.model_graph.nodes[model_name]['can_infer'])
+
+        model_info_dict = defaultdict(list)
+        if extra_info:
+            # TODO: feature_metadata
+            # TODO: disk size
+            # TODO: load time
+            # TODO: Add persist_if_mem_safe() function to persist in memory all models if reasonable memory size (or a specific model+ancestors)
+            # TODO: Add is_persisted() function to check which models are persisted in memory
+            # TODO: package_dependencies, package_dependencies_full
+
+            info = self.get_info(include_model_info=True)
+            model_info = info['model_info']
+            custom_model_info = {}
+            for model_name in model_info:
+                custom_info = {}
+                bagged_info = model_info[model_name].get('bagged_info', {})
+                custom_info['num_models'] = bagged_info.get('num_child_models', 1)
+                custom_info['memory_size'] = bagged_info.get('max_memory_size', model_info[model_name]['memory_size'])
+                custom_info['memory_size_min'] = bagged_info.get('min_memory_size', model_info[model_name]['memory_size'])
+                custom_info['child_model_type'] = bagged_info.get('child_model_type', None)
+                custom_info['child_hyperparameters'] = bagged_info.get('child_hyperparameters', None)
+                custom_info['child_hyperparameters_fit'] = bagged_info.get('child_hyperparameters_fit', None)
+                custom_info['child_AG_args_fit'] = bagged_info.get('child_AG_args_fit', None)
+                custom_model_info[model_name] = custom_info
+
+            model_info_keys = ['num_features', 'model_type', 'hyperparameters', 'hyperparameters_fit', 'AG_args_fit', 'features']
+            model_info_sum_keys = []
+            for key in model_info_keys:
+                model_info_dict[key] = [model_info[model_name][key] for model_name in model_names]
+                if key in model_info_sum_keys:
+                    key_dict = {model_name: model_info[model_name][key] for model_name in model_names}
+                    model_info_dict[key + '_full'] = [self.get_model_attribute_full(model=model_name, attribute=key_dict) for model_name in model_names]
+
+            model_info_keys = ['num_models', 'memory_size', 'memory_size_min', 'child_model_type', 'child_hyperparameters', 'child_hyperparameters_fit', 'child_AG_args_fit']
+            model_info_full_keys = {'memory_size': [('memory_size_w_ancestors', sum)], 'memory_size_min': [('memory_size_min_w_ancestors', max)], 'num_models': [('num_models_w_ancestors', sum)]}
+            for key in model_info_keys:
+                model_info_dict[key] = [custom_model_info[model_name][key] for model_name in model_names]
+                if key in model_info_full_keys:
+                    key_dict = {model_name: custom_model_info[model_name][key] for model_name in model_names}
+                    for column_name, func in model_info_full_keys[key]:
+                        model_info_dict[column_name] = [self.get_model_attribute_full(model=model_name, attribute=key_dict, func=func) for model_name in model_names]
+
+            ancestors = [list(nx.dag.ancestors(self.model_graph, model_name)) for model_name in model_names]
+            descendants = [list(nx.dag.descendants(self.model_graph, model_name)) for model_name in model_names]
+
+            model_info_dict['num_ancestors'] = [len(ancestor_lst) for ancestor_lst in ancestors]
+            model_info_dict['num_descendants'] = [len(descendant_lst) for descendant_lst in descendants]
+            model_info_dict['ancestors'] = ancestors
+            model_info_dict['descendants'] = descendants
+
         df = pd.DataFrame(data={
             'model': model_names,
             'score_val': score_val,
@@ -1208,8 +1276,39 @@ class AbstractTrainer:
             'fit_time_marginal': fit_time_marginal,
             'stack_level': stack_level,
             'can_infer': can_infer,
+            'fit_order': fit_order,
+            **model_info_dict,
         })
         df_sorted = df.sort_values(by=['score_val', 'pred_time_val', 'model'], ascending=[False, True, False]).reset_index(drop=True)
+
+        df_columns_lst = df_sorted.columns.tolist()
+        explicit_order = [
+            'model',
+            'score_val',
+            'pred_time_val',
+            'fit_time',
+            'pred_time_val_marginal',
+            'fit_time_marginal',
+            'stack_level',
+            'can_infer',
+            'fit_order',
+            'num_features',
+            'num_models',
+            'num_models_w_ancestors',
+            'memory_size',
+            'memory_size_w_ancestors',
+            'memory_size_min',
+            'memory_size_min_w_ancestors',
+            'num_ancestors',
+            'num_descendants',
+            'model_type',
+            'child_model_type'
+        ]
+        explicit_order = [column for column in explicit_order if column in df_columns_lst]
+        df_columns_other = [column for column in df_columns_lst if column not in explicit_order]
+        df_columns_new = explicit_order + df_columns_other
+        df_sorted = df_sorted[df_columns_new]
+
         return df_sorted
 
     def get_info(self, include_model_info=False):
@@ -1217,13 +1316,21 @@ class AbstractTrainer:
         if self.model_best is not None:
             best_model = self.model_best
         else:
-            best_model = self.get_model_best()
-        best_model_score_val = self.model_performance.get(best_model)
+            try:
+                best_model = self.get_model_best()
+            except AssertionError:
+                best_model = None
+        if best_model is not None:
+            best_model_score_val = self.model_performance.get(best_model)
+            best_model_stack_level = self.get_model_level(best_model)
+        else:
+            best_model_score_val = None
+            best_model_stack_level = None
         # fit_time = None
         num_bagging_folds = self.kfolds
         max_core_stack_level = self.get_max_level('core')
         max_stack_level = self.get_max_level_all()
-        best_model_stack_level = self.get_model_level(best_model)
+
         problem_type = self.problem_type
         eval_metric = self.eval_metric.name
         stopping_metric = self.stopping_metric.name

--- a/tests/unittests/test_tabular.py
+++ b/tests/unittests/test_tabular.py
@@ -83,7 +83,11 @@ def test_advanced_functionality():
     shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
     predictor = task.fit(train_data=train_data, label=label, output_directory=savedir)
     leaderboard = predictor.leaderboard(dataset=test_data)
-    assert(set(predictor.get_model_names()) == set(leaderboard['model']))
+    leaderboard_extra = predictor.leaderboard(dataset=test_data, extra_info=True)
+    assert set(predictor.get_model_names()) == set(leaderboard['model'])
+    assert set(predictor.get_model_names()) == set(leaderboard_extra['model'])
+    assert set(leaderboard_extra.columns).issuperset(set(leaderboard.columns))
+    assert len(leaderboard) == len(leaderboard_extra)
     num_models = len(predictor.get_model_names())
     feature_importances = predictor.feature_importance(dataset=test_data)
     original_features = set(train_data.columns)
@@ -105,8 +109,9 @@ def test_advanced_functionality():
     assert(len(predictor.get_model_names()) == num_models * 2)
     predictor.predict(dataset=test_data)
     predictor.delete_models(models_to_keep=[], dry_run=False)  # Test that dry-run deletes models
-    assert(len(predictor.get_model_names()) == 0)
-    assert(len(predictor.leaderboard()) == 0)
+    assert len(predictor.get_model_names()) == 0
+    assert len(predictor.leaderboard()) == 0
+    assert len(predictor.leaderboard(extra_info=True)) == 0
     try:
         predictor.predict(dataset=test_data)
     except:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added extra_info argument to predictor.leaderboard(). This includes many very useful info columns such as memory usage and model hyperparameters.
- Fixed NN using 1 less epoch then intended during refit_full.
- Fixed LightGBM having wrong hyperparameters_fit value after refit_full.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
