### PR TITLE
Add mqcnn

### DIFF
--- a/autogluon/task/tabular_prediction/tabular_prediction.py
+++ b/autogluon/task/tabular_prediction/tabular_prediction.py
@@ -80,6 +80,9 @@ class TabularPrediction(BaseTask):
             dist_ip_addrs=None,
             visualizer='none',
             verbosity=2,
+            index_column="index",
+            date_column="date",
+            target_column="target",
             **kwargs):
         """
         Fit models to predict a column of data table based on the other columns.
@@ -594,7 +597,7 @@ class TabularPrediction(BaseTask):
         print("before learner")
         learner = Learner(path_context=output_directory, label=label, problem_type=problem_type, eval_metric=eval_metric, stopping_metric=stopping_metric,
                           id_columns=id_columns, feature_generator=feature_generator, trainer_type=trainer_type,
-                          label_count_threshold=label_count_threshold, random_seed=random_seed)
+                          label_count_threshold=label_count_threshold, random_seed=random_seed, index_column=index_column, date_column=date_column, target_column=target_column)
         learner.fit(X=train_data, X_val=tuning_data, scheduler_options=scheduler_options,
                     hyperparameter_tune=hyperparameter_tune, feature_prune=feature_prune,
                     holdout_frac=holdout_frac, num_bagging_folds=num_bagging_folds, num_bagging_sets=num_bagging_sets, stack_ensemble_levels=stack_ensemble_levels,

--- a/autogluon/task/tabular_prediction/tabular_prediction.py
+++ b/autogluon/task/tabular_prediction/tabular_prediction.py
@@ -591,6 +591,7 @@ class TabularPrediction(BaseTask):
             dist_ip_addrs=dist_ip_addrs)
         scheduler_cls = schedulers[search_strategy.lower()]
         scheduler_options = (scheduler_cls, scheduler_options)  # wrap into tuple
+        print("before learner")
         learner = Learner(path_context=output_directory, label=label, problem_type=problem_type, eval_metric=eval_metric, stopping_metric=stopping_metric,
                           id_columns=id_columns, feature_generator=feature_generator, trainer_type=trainer_type,
                           label_count_threshold=label_count_threshold, random_seed=random_seed)

--- a/autogluon/utils/tabular/data/label_cleaner.py
+++ b/autogluon/utils/tabular/data/label_cleaner.py
@@ -5,7 +5,7 @@ from typing import Union
 import numpy as np
 from pandas import DataFrame, Series
 
-from ..ml.constants import BINARY, MULTICLASS, REGRESSION
+from ..ml.constants import BINARY, MULTICLASS, REGRESSION, FORECAST
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +35,8 @@ class LabelCleaner:
                 return LabelCleanerMulticlass(y, y_uncleaned)
         elif problem_type == REGRESSION:
             return LabelCleanerDummy(problem_type=problem_type)
+        elif problem_type == FORECAST:
+            return LabelCleanerForecast()
         else:
             raise NotImplementedError
 
@@ -64,6 +66,23 @@ class LabelCleaner:
             y = Series(y)
         elif isinstance(y, Series) and y.dtype.name == 'category':
             y = y.astype('object')
+        return y
+
+# TODO: What should we implement for forecast problem type?
+class LabelCleanerForecast(LabelCleaner):
+    def __init__(self):
+        pass
+
+    def transform(self, y: Series) -> Series:
+        raise NotImplementedError
+
+    def inverse_transform(self, y: Series) -> Series:
+        raise NotImplementedError
+
+    def transform_proba(self, y):
+        return y
+
+    def inverse_transform_proba(self, y):
         return y
 
 class LabelCleanerMulticlass(LabelCleaner):

--- a/autogluon/utils/tabular/data/label_cleaner.py
+++ b/autogluon/utils/tabular/data/label_cleaner.py
@@ -19,7 +19,7 @@ class LabelCleaner:
     problem_type_transform = None
 
     @staticmethod
-    def construct(problem_type: str, y: Union[Series, np.ndarray, list], y_uncleaned: Union[Series, np.ndarray, list] = None):
+    def construct(problem_type: str, y: Union[Series, np.ndarray, list, None], y_uncleaned: Union[Series, np.ndarray, list] = None):
         y = LabelCleaner._convert_to_valid_series(y)
         if y_uncleaned is not None:
             y_uncleaned = LabelCleaner._convert_to_valid_series(y_uncleaned)

--- a/autogluon/utils/tabular/ml/constants.py
+++ b/autogluon/utils/tabular/ml/constants.py
@@ -3,7 +3,9 @@ BINARY = 'binary'
 MULTICLASS = 'multiclass'
 REGRESSION = 'regression'
 SOFTCLASS = 'softclass' # classification with soft-target (rather than classes, labels are probabilities of each class).
+FORECAST = 'forecast'
 
+PROBLEM_TYPES_FORECAST = [FORECAST]
 PROBLEM_TYPES_CLASSIFICATION = [BINARY, MULTICLASS]
 PROBLEM_TYPES_REGRESSION = [REGRESSION]
 PROBLEM_TYPES = PROBLEM_TYPES_CLASSIFICATION + PROBLEM_TYPES_REGRESSION + [SOFTCLASS]

--- a/autogluon/utils/tabular/ml/learner/default_learner.py
+++ b/autogluon/utils/tabular/ml/learner/default_learner.py
@@ -75,7 +75,7 @@ class DefaultLearner(AbstractLearner):
 
         trainer = self.trainer_type(
             path=self.model_context,
-            problem_type=self.trainer_problem_type,
+            problem_type=self.problem_type,
             eval_metric=self.eval_metric,
             stopping_metric=self.stopping_metric,
             num_classes=self.label_cleaner.num_classes,

--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -294,6 +294,7 @@ class AbstractModel:
             return self.model.predict(X)
 
         y_pred_proba = self.model.predict_proba(X)
+        print("proba", self, y_pred_proba)
         if self.problem_type == BINARY:
             if len(y_pred_proba.shape) == 1:
                 return y_pred_proba

--- a/autogluon/utils/tabular/ml/models/mqcnn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/mqcnn/hyperparameters/parameters.py
@@ -3,7 +3,7 @@ def get_default_parameters():
         "seed": 42,
         "freq": "D",
         "context_length": 5,
-        "prediction_length": 20,
+        "prediction_length": 19,
         "quantiles": [0.9],
         "epochs": 3,
         "num_batches_per_epoch": 3,

--- a/autogluon/utils/tabular/ml/models/mqcnn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/mqcnn/hyperparameters/parameters.py
@@ -3,8 +3,8 @@ def get_default_parameters():
         "seed": 42,
         "freq": "D",
         "context_length": 5,
-        "prediction_length": 3,
-        "quantiles": [0.5, 0.1],
+        "prediction_length": 20,
+        "quantiles": [0.9],
         "epochs": 3,
         "num_batches_per_epoch": 3,
     }

--- a/autogluon/utils/tabular/ml/models/mqcnn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/mqcnn/hyperparameters/parameters.py
@@ -1,0 +1,12 @@
+def get_default_parameters():
+    hps = {
+        "seed": 42,
+        "freq": "D",
+        "context_length": 5,
+        "prediction_length": 3,
+        "quantiles": [0.5, 0.1],
+        "epochs": 3,
+        "num_batches_per_epoch": 3,
+    }
+    return hps
+

--- a/autogluon/utils/tabular/ml/models/mqcnn/mqcnn_model.py
+++ b/autogluon/utils/tabular/ml/models/mqcnn/mqcnn_model.py
@@ -1,0 +1,44 @@
+import logging
+import re
+
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+from gluonts.model.seq2seq import MQCNNEstimator
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.impute import SimpleImputer
+from sklearn.pipeline import FeatureUnion, Pipeline
+from sklearn.preprocessing import StandardScaler, QuantileTransformer
+from gluonts.model.seq2seq import MQCNNEstimator
+# from .hyperparameters.parameters import get_param_baseline, get_model_params, get_default_params, INCLUDE, IGNORE, ONLY
+# from .hyperparameters.searchspaces import get_default_searchspace
+# from .lr_preprocessing_utils import NlpDataPreprocessor, OheFeaturesGenerator, NumericDataPreprocessor
+from ...constants import BINARY, REGRESSION
+from ....ml.models.abstract.abstract_model import AbstractModel
+from .hyperparameters.parameters import get_default_parameters
+from gluonts.dataset.common import ListDataset
+from gluonts.dataset.field_names import FieldName
+
+
+class MQCNNModel(AbstractModel):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.params = get_default_parameters()
+
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, **kwargs):
+        X_train = self.preprocess(X_train)
+        print(X_train)
+        estimator = MQCNNEstimator.from_hyperparameters(**self.params)
+        self.model = estimator.train(X_train)
+
+    def preprocess(self, X):
+        # TODO: transform dataframe into gluon-ts ListDataset
+        target_values = X.drop("index", axis=1).values
+        processed_X = ListDataset([
+            {
+                FieldName.TARGET: target,
+                FieldName.START: pd.Timestamp("2020-01-01", freq="1D"),
+            }
+            for (target, ) in zip(target_values,)
+        ], freq="D")
+        return processed_X

--- a/autogluon/utils/tabular/ml/models/mqcnn/mqcnn_model.py
+++ b/autogluon/utils/tabular/ml/models/mqcnn/mqcnn_model.py
@@ -3,42 +3,83 @@ import re
 
 import numpy as np
 import pandas as pd
-from pandas import DataFrame
 from gluonts.model.seq2seq import MQCNNEstimator
-from sklearn.feature_extraction.text import TfidfVectorizer
-from sklearn.impute import SimpleImputer
-from sklearn.pipeline import FeatureUnion, Pipeline
-from sklearn.preprocessing import StandardScaler, QuantileTransformer
-from gluonts.model.seq2seq import MQCNNEstimator
-# from .hyperparameters.parameters import get_param_baseline, get_model_params, get_default_params, INCLUDE, IGNORE, ONLY
-# from .hyperparameters.searchspaces import get_default_searchspace
-# from .lr_preprocessing_utils import NlpDataPreprocessor, OheFeaturesGenerator, NumericDataPreprocessor
-from ...constants import BINARY, REGRESSION
+from gluonts.evaluation.backtest import make_evaluation_predictions
 from ....ml.models.abstract.abstract_model import AbstractModel
 from .hyperparameters.parameters import get_default_parameters
 from gluonts.dataset.common import ListDataset
 from gluonts.dataset.field_names import FieldName
+from tqdm.autonotebook import tqdm
 
 
 class MQCNNModel(AbstractModel):
-    def __init__(self, **kwargs):
+
+    def __init__(self, index_column="index", date_column="date", target_column="target", **kwargs):
         super().__init__(**kwargs)
+        self.index_column = index_column
+        self.date_column = date_column
+        self.target_column = target_column
         self.params = get_default_parameters()
+
+    def fit(self, **kwargs):
+        kwargs = self._preprocess_fit_args(**kwargs)
+        self._fit(**kwargs)
 
     def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, **kwargs):
         X_train = self.preprocess(X_train)
-        print(X_train)
         estimator = MQCNNEstimator.from_hyperparameters(**self.params)
+        print(estimator)
         self.model = estimator.train(X_train)
 
     def preprocess(self, X):
-        # TODO: transform dataframe into gluon-ts ListDataset
-        target_values = X.drop("index", axis=1).values
+        date_list = sorted(list(set(X[self.date_column])))
+
+        def transform_dataframe(df):
+            data_dic = {self.index_column: list(set(df[self.index_column]))}
+
+            for date in date_list:
+                tmp = df[df[self.date_column] == date][[self.index_column, self.date_column, self.target_column]]
+                tmp = tmp.pivot(index=self.index_column, columns=self.date_column, values=self.target_column)
+                tmp_values = tmp[date].values
+                data_dic[date] = tmp_values
+            return pd.DataFrame(data_dic)
+
+        X = transform_dataframe(X)
+
+        target_values = X.drop(self.index_column, axis=1).values
         processed_X = ListDataset([
             {
                 FieldName.TARGET: target,
-                FieldName.START: pd.Timestamp("2020-01-01", freq="1D"),
+                FieldName.START: pd.Timestamp("2020-01-22", freq="1D"),
             }
             for (target, ) in zip(target_values,)
-        ], freq="D")
+        ], freq="1D")
         return processed_X
+
+    def predict(self, X, preprocess=True):
+        if preprocess:
+            X = self.preprocess(X=X)
+
+        forecast_it, ts_it = make_evaluation_predictions(
+            dataset=X,
+            predictor=self.model,
+            num_samples=100
+        )
+        return [forecast.forecast_array for forecast in list(tqdm(forecast_it, total=len(X)))]
+
+    def score(self, X, y=None, quantiles=[0.9], eval_metric=None, metric_needs_y_pred=None, preprocess=True, index_column="index", date_column="date", target_column="target"):
+        from gluonts.evaluation import Evaluator
+        # evaluator = Evaluator(quantiles=quantiles)
+        processed_X = self.preprocess(X=X)
+        tss = processed_X.list_data
+        forecasts = self.predict(processed_X, preprocess=False)
+        prediction_length = self.model.prediction_length
+        diff = 0
+        for idx in range(len(forecasts)):
+            forecast = np.mean(forecasts[idx], axis=0)
+            true_values = np.array(tss[idx]["target"][-prediction_length:])
+            diff += (np.sum((forecast - true_values) ** 2) / prediction_length) ** 0.5
+        return diff / len(forecasts)
+        # agg_metrics, item_metrics = evaluator(iter(tss), iter(forecasts), num_series=num_series)
+        # print(json.dumps(agg_metrics, indent=4))
+        # return agg_metrics["mean_wQuantileLoss"]

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -248,6 +248,7 @@ class AbstractTrainer:
     def train_and_save(self, X_train, y_train, X_val, y_val, model: AbstractModel, stack_name='core', kfolds=None, k_fold_start=0, k_fold_end=None, n_repeats=None, n_repeat_start=0, level=0, time_limit=None):
         fit_start_time = time.time()
         model_names_trained = []
+        print("train_and_save", model)
         try:
             if time_limit is not None:
                 if time_limit <= 0:
@@ -455,7 +456,7 @@ class AbstractTrainer:
             model_name_trained_lst = self.train_single_full(X_train, y_train, X_val, y_val, model, hyperparameter_tune=hyperparameter_tune, feature_prune=feature_prune, stack_name=stack_name,
                                                             kfolds=kfolds, k_fold_start=k_fold_start, k_fold_end=k_fold_end,
                                                             n_repeats=n_repeats, n_repeat_start=n_repeat_start, level=level, time_limit=time_left)
-
+            print("train_multi_fold:", model_name_trained_lst)
             if self.low_memory:
                 del model
             models_valid += model_name_trained_lst

--- a/autogluon/utils/tabular/ml/trainer/auto_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/auto_trainer.py
@@ -10,15 +10,24 @@ logger = logging.getLogger(__name__)
 
 # This Trainer handles model training details
 class AutoTrainer(AbstractTrainer):
+    def __init__(self, index_column="index", date_column="date", target_column="target", **kwargs):
+
+        super().__init__(**kwargs)
+        self.index_column = index_column
+        self.date_column = date_column
+        self.target_column = target_column
+
     def get_models(self, hyperparameters, hyperparameter_tune=False, level='default', extra_ag_args_fit=None, **kwargs):
         return get_preset_models(path=self.path, problem_type=self.problem_type, eval_metric=self.eval_metric, stopping_metric=self.stopping_metric,
-                                 num_classes=self.num_classes, hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, level=level, extra_ag_args_fit=extra_ag_args_fit)
+                                 num_classes=self.num_classes, hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, level=level, extra_ag_args_fit=extra_ag_args_fit,
+                                 index_column=self.index_column, date_column=self.date_column, target_column=self.target_column)
 
     def train(self, X_train, y_train, X_val=None, y_val=None, hyperparameter_tune=True, feature_prune=False, holdout_frac=0.1, hyperparameters=None, ag_args_fit=None, excluded_model_types=None, **kwargs):
         if hyperparameters is None:
             hyperparameters = {}
         self.hyperparameters = self._process_hyperparameters(hyperparameters=hyperparameters, ag_args_fit=ag_args_fit, excluded_model_types=excluded_model_types)
-        models = self.get_models(hyperparameters=self.hyperparameters, hyperparameter_tune=hyperparameter_tune, level=0)
+        models = self.get_models(hyperparameters=self.hyperparameters, hyperparameter_tune=hyperparameter_tune, level=0,
+                                 index_column=self.index_column, date_column=self.date_column, target_column=self.target_column)
         if self.bagged_mode:
             if (y_val is not None) and (X_val is not None):
                 # TODO: User could be intending to blend instead. Perhaps switch from OOF preds to X_val preds while still bagging? Doubt a user would want this.

--- a/autogluon/utils/tabular/ml/trainer/auto_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/auto_trainer.py
@@ -4,7 +4,7 @@ import pandas as pd
 from .abstract_trainer import AbstractTrainer
 from .model_presets.presets import get_preset_models
 from ..utils import generate_train_test_split
-
+from ..constants import BINARY, MULTICLASS, REGRESSION, FORECAST
 logger = logging.getLogger(__name__)
 
 
@@ -28,6 +28,11 @@ class AutoTrainer(AbstractTrainer):
             X_val = None
             y_val = None
         else:
-            if (y_val is None) or (X_val is None):
-                X_train, X_val, y_train, y_val = generate_train_test_split(X_train, y_train, problem_type=self.problem_type, test_size=holdout_frac, random_state=self.random_seed)
+            if self.problem_type == FORECAST:
+                if X_val is None:
+                    # TODO: do split here
+                    pass
+            else:
+                if (y_val is None) or (X_val is None):
+                    X_train, X_val, y_train, y_val = generate_train_test_split(X_train, y_train, problem_type=self.problem_type, test_size=holdout_frac, random_state=self.random_seed)
         self.train_multi_and_ensemble(X_train, y_train, X_val, y_val, models, hyperparameter_tune=hyperparameter_tune, feature_prune=feature_prune)

--- a/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
+++ b/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from sklearn.linear_model import LogisticRegression, LinearRegression
 
-from ...constants import AG_ARGS, AG_ARGS_FIT, BINARY, MULTICLASS, REGRESSION, SOFTCLASS, PROBLEM_TYPES_CLASSIFICATION
+from ...constants import AG_ARGS, AG_ARGS_FIT, BINARY, MULTICLASS, REGRESSION, SOFTCLASS, PROBLEM_TYPES_CLASSIFICATION, FORECAST
 from ...models.abstract.abstract_model import AbstractModel
 from ...models.lgb.lgb_model import LGBModel
 from ...models.lr.lr_model import LinearModel
@@ -14,6 +14,7 @@ from ...models.rf.rf_model import RFModel
 from ...models.knn.knn_model import KNNModel
 from ...models.catboost.catboost_model import CatboostModel
 from ...models.xt.xt_model import XTModel
+from ...models.mqcnn.mqcnn_model import MQCNNModel
 from ....metrics import soft_log_loss, mean_squared_error
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ DEFAULT_SOFTCLASS_PRIORITY = dict(
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 
 MODEL_TYPES = dict(
+    MQCNN=MQCNNModel,
     RF=RFModel,
     XT=XTModel,
     KNN=KNNModel,
@@ -95,7 +97,8 @@ DEFAULT_MODEL_TYPE_SUFFIX['regressor'].update({LinearModel: ''})
 # TODO: special optional AG arg for only training model if eval_metric in list / not in list. Useful for F1 and 'is_unbalanced' arg in LGBM.
 def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None, hyperparameter_tune=False,
                       level='default', extra_ag_args_fit=None, name_suffix='', default_priorities=DEFAULT_MODEL_PRIORITY):
-    if problem_type not in [BINARY, MULTICLASS, REGRESSION, SOFTCLASS]:
+    print(problem_type)
+    if problem_type not in [BINARY, MULTICLASS, REGRESSION, SOFTCLASS, FORECAST]:
         raise NotImplementedError
 
     if level in hyperparameters.keys():
@@ -154,7 +157,7 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
 
     for model in models:
         model.rename(model.name + name_suffix)
-
+    print("get_model results:", models)
     return models
 
 

--- a/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
+++ b/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
@@ -95,7 +95,7 @@ DEFAULT_MODEL_TYPE_SUFFIX['regressor'].update({LinearModel: ''})
 # TODO: Add banned_model_types arg
 # TODO: Add option to update hyperparameters with only added keys, so disabling CatBoost would just be {'CAT': []}, which keeps the other models as is.
 # TODO: special optional AG arg for only training model if eval_metric in list / not in list. Useful for F1 and 'is_unbalanced' arg in LGBM.
-def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None, hyperparameter_tune=False,
+def get_preset_models(path, problem_type, eval_metric, hyperparameters, index_column="index", date_column="date", target_column="target", stopping_metric=None, num_classes=None, hyperparameter_tune=False,
                       level='default', extra_ag_args_fit=None, name_suffix='', default_priorities=DEFAULT_MODEL_PRIORITY):
     print(problem_type)
     if problem_type not in [BINARY, MULTICLASS, REGRESSION, SOFTCLASS, FORECAST]:
@@ -152,7 +152,16 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
             if AG_ARGS_FIT not in model_params:
                 model_params[AG_ARGS_FIT] = {}
             model_params[AG_ARGS_FIT].update(extra_ag_args_fit.copy())  # TODO: Consider case of overwriting user specified extra args.
-        model_init = model_type(path=path, name=name, problem_type=problem_type, eval_metric=eval_metric, stopping_metric=stopping_metric, num_classes=num_classes, hyperparameters=model_params)
+        if model_type is MQCNNModel:
+            model_init = model_type(path=path, name=name, problem_type=problem_type, eval_metric=eval_metric,
+                                    stopping_metric=stopping_metric, num_classes=num_classes,
+                                    hyperparameters=model_params,
+                                    index_column=index_column, date_column=date_column, target_column=target_column)
+        else:
+            model_init = model_type(path=path, name=name, problem_type=problem_type, eval_metric=eval_metric,
+                                    stopping_metric=stopping_metric, num_classes=num_classes,
+                                    hyperparameters=model_params)
+        print(model_init, model_type)
         models.append(model_init)
 
     for model in models:

--- a/autogluon/utils/tabular/ml/utils.py
+++ b/autogluon/utils/tabular/ml/utils.py
@@ -9,7 +9,7 @@ import pandas as pd
 from pandas import DataFrame, Series
 from sklearn.model_selection import KFold, StratifiedKFold, RepeatedKFold, RepeatedStratifiedKFold, train_test_split
 
-from .constants import BINARY, REGRESSION, MULTICLASS, SOFTCLASS
+from .constants import BINARY, REGRESSION, MULTICLASS, SOFTCLASS, FORECAST
 from ..metrics import accuracy, root_mean_squared_error, Scorer
 
 logger = logging.getLogger(__name__)
@@ -47,24 +47,27 @@ def generate_kfold(X, y=None, n_splits=5, random_state=0, stratified=False, n_re
 def generate_train_test_split(X: DataFrame, y: Series, problem_type: str, test_size: float = 0.1, random_state=0) -> (DataFrame, DataFrame, Series, Series):
     if (test_size <= 0.0) or (test_size >= 1.0):
         raise ValueError("fraction of data to hold-out must be specified between 0 and 1")
-
-    if problem_type in [REGRESSION, SOFTCLASS]:
-        stratify = None
+    if problem_type == FORECAST:
+    # TODO: implement train-test split for forecasting problem
+        pass
     else:
-        stratify = y
+        if problem_type in [REGRESSION, SOFTCLASS]:
+            stratify = None
+        else:
+            stratify = y
 
-    # TODO: Enable stratified split when y class would result in 0 samples in test.
-    #  One approach: extract low frequency classes from X/y, add back (1-test_size)% to X_train, y_train, rest to X_test
-    #  Essentially stratify the high frequency classes, random the low frequency (While ensuring at least 1 example stays for each low frequency in train!)
-    #  Alternatively, don't test low frequency at all, trust it to work in train set. Risky, but highest quality for predictions.
-    X_train, X_test, y_train, y_test = train_test_split(X, y.values, test_size=test_size, shuffle=True, random_state=random_state, stratify=stratify)
-    if problem_type != SOFTCLASS:
-        y_train = pd.Series(y_train, index=X_train.index)
-        y_test = pd.Series(y_test, index=X_test.index)
-    else:
-        y_train = pd.DataFrame(y_train, index=X_train.index)
-        y_test = pd.DataFrame(y_test, index=X_test.index)
-    return X_train, X_test, y_train, y_test
+        # TODO: Enable stratified split when y class would result in 0 samples in test.
+        #  One approach: extract low frequency classes from X/y, add back (1-test_size)% to X_train, y_train, rest to X_test
+        #  Essentially stratify the high frequency classes, random the low frequency (While ensuring at least 1 example stays for each low frequency in train!)
+        #  Alternatively, don't test low frequency at all, trust it to work in train set. Risky, but highest quality for predictions.
+        X_train, X_test, y_train, y_test = train_test_split(X, y.values, test_size=test_size, shuffle=True, random_state=random_state, stratify=stratify)
+        if problem_type != SOFTCLASS:
+            y_train = pd.Series(y_train, index=X_train.index)
+            y_test = pd.Series(y_test, index=X_test.index)
+        else:
+            y_train = pd.DataFrame(y_train, index=X_train.index)
+            y_test = pd.DataFrame(y_test, index=X_test.index)
+        return X_train, X_test, y_train, y_test
 
 
 def convert_categorical_to_int(X):

--- a/examples/tabular/basic_mqcnn_model.py
+++ b/examples/tabular/basic_mqcnn_model.py
@@ -1,0 +1,111 @@
+""" Example script for defining and using custom models in AutoGluon Tabular """
+import time
+
+from autogluon import TabularPrediction as task
+from autogluon.task.tabular_prediction.hyperparameter_configs import get_hyperparameter_config
+from autogluon.utils.tabular.data.label_cleaner import LabelCleaner
+from autogluon.utils.tabular.ml.models.abstract.abstract_model import AbstractModel
+from autogluon.utils.tabular.ml.utils import infer_problem_type
+from gluonts.model.seq2seq import MQCNNEstimator
+from gluonts.dataset.common import ListDataset
+from gluonts.dataset.field_names import FieldName
+from gluonts.evaluation.backtest import make_evaluation_predictions
+from autogluon.utils.tabular.ml.constants import FORECAST
+from autogluon.utils.tabular.ml.models.mqcnn.hyperparameters.parameters import get_default_parameters
+from tqdm.autonotebook import tqdm
+import pandas as pd
+import numpy as np
+import json
+#########################
+# Create a custom model #
+#########################
+
+
+def make_dummy_datasets(ts_n=1, ts_length=100, freq="D", prediction_length=5):
+    targets = []
+    for i in range(ts_n):
+        for j in range(ts_length):
+            targets.append(j)
+    ts_index = []
+    for i in range(ts_n):
+        for j in range(ts_length):
+            ts_index.append(i)
+    n = ts_n * ts_length
+    date = pd.date_range(start="2020", freq=freq, periods=ts_length)
+    return pd.DataFrame({"index": ts_index,"date": date, "target": targets, "freq": [freq for i in range(n)], "prediction_length": [prediction_length for i in range(n)]})
+
+
+class MQCNNModel(AbstractModel):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.params = get_default_parameters()
+
+    def fit(self, index_column="index", date_column="date", target_column="target", **kwargs):
+        kwargs = self._preprocess_fit_args(**kwargs)
+        self._fit(index_column=index_column, date_column=date_column, target_column=target_column, **kwargs)
+
+    def _fit(self, X_train, y_train, index_column="index", date_column="date", target_column="target", X_val=None, y_val=None, time_limit=None, **kwargs):
+        X_train = self.preprocess(X_train, index_column=index_column, date_column=date_column, target_column=target_column)
+        estimator = MQCNNEstimator.from_hyperparameters(**self.params)
+        print(estimator)
+        self.model = estimator.train(X_train)
+
+    def preprocess(self, X, index_column="index", date_column="date", target_column="target"):
+        date_list = sorted(list(set(X[date_column])))
+
+        def transform_dataframe(df):
+            data_dic = {index_column: list(set(df[index_column]))}
+
+            for date in date_list:
+                tmp = df[df[date_column] == date][[index_column, date_column, target_column]]
+                tmp = tmp.pivot(index=index_column, columns=date_column, values=target_column)
+                tmp_values = tmp[date].values
+                data_dic[date] = tmp_values
+            return pd.DataFrame(data_dic)
+
+        X = transform_dataframe(X)
+
+        target_values = X.drop(index_column, axis=1).values
+        processed_X = ListDataset([
+            {
+                FieldName.TARGET: target,
+                FieldName.START: pd.Timestamp("2020-01-01", freq="1D"),
+            }
+            for (target, ) in zip(target_values,)
+        ], freq="1D")
+        return processed_X
+
+    def predict(self, X, index_column="index", date_column="date", target_column="target", preprocess=True):
+        if preprocess:
+            X = self.preprocess(X=X, index_column=index_column, date_column=date_column, target_column=target_column)
+
+        forecast_it, ts_it = make_evaluation_predictions(
+            dataset=X,
+            predictor=self.model,
+            num_samples=100
+        )
+        return list(tqdm(forecast_it, total=len(X))), list(tqdm(ts_it, total=len(X))), len(X)
+
+    def score(self, X, y=None, quantiles=[0.5, 0.9], eval_metric=None, metric_needs_y_pred=None, preprocess=True, index_column="index", date_column="date", target_column="target"):
+        from gluonts.evaluation import Evaluator
+        evaluator = Evaluator(quantiles=quantiles)
+        forecasts, tss, num_series = self.predict(X, index_column=index_column, date_column=date_column, target_column=target_column)
+        agg_metrics, item_metrics = evaluator(iter(tss), iter(forecasts), num_series=num_series)
+        print(json.dumps(agg_metrics, indent=4))
+        return agg_metrics["mean_wQuantileLoss"]
+
+
+
+# dummy data
+# train_data = make_dummy_datasets(ts_length=200)
+# test_data = make_dummy_datasets(ts_length=10)
+train_data = pd.read_csv("./COV19/processed_train.csv")
+test_data = pd.read_csv("./COV19/processed_test.csv")
+
+mqcnn_model = MQCNNModel(path='AutogluonModels/', name='CustomMQCNN', problem_type=FORECAST)
+mqcnn_model.fit(X_train=train_data, y_train=None, index_column="name", date_column="Date", target_column="ConfirmedCases")
+
+test_pred = mqcnn_model.predict(test_data, index_column="name", date_column="Date", target_column="ConfirmedCases")
+
+score = mqcnn_model.score(test_data, index_column="name", date_column="Date", target_column="ConfirmedCases")
+

--- a/examples/tabular/basic_mqcnn_model.py
+++ b/examples/tabular/basic_mqcnn_model.py
@@ -51,11 +51,11 @@ class MQCNNModel(AbstractModel):
     def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, **kwargs):
         X_train = self.preprocess(X_train)
         estimator = MQCNNEstimator.from_hyperparameters(**self.params)
-        print(estimator)
         self.model = estimator.train(X_train)
 
     def preprocess(self, X):
         date_list = sorted(list(set(X[self.date_column])))
+        freq = pd.infer_freq(date_list)
 
         def transform_dataframe(df):
             data_dic = {self.index_column: list(set(df[self.index_column]))}
@@ -73,10 +73,10 @@ class MQCNNModel(AbstractModel):
         processed_X = ListDataset([
             {
                 FieldName.TARGET: target,
-                FieldName.START: pd.Timestamp("2020-01-22", freq="1D"),
+                FieldName.START: pd.Timestamp("2020-01-22", freq=freq),
             }
             for (target, ) in zip(target_values,)
-        ], freq="1D")
+        ], freq=freq)
         return processed_X
 
     def predict(self, X, preprocess=True):
@@ -106,7 +106,6 @@ class MQCNNModel(AbstractModel):
         # agg_metrics, item_metrics = evaluator(iter(tss), iter(forecasts), num_series=num_series)
         # print(json.dumps(agg_metrics, indent=4))
         # return agg_metrics["mean_wQuantileLoss"]
-
 
 
 # dummy data

--- a/examples/tabular/example_simple_tabular_forecasting.py
+++ b/examples/tabular/example_simple_tabular_forecasting.py
@@ -36,68 +36,6 @@ def make_dummy_datasets(ts_n=1, ts_length=100, freq="D", prediction_length=5):
 train_data = make_dummy_datasets(ts_length=200)
 test_data = make_dummy_datasets(ts_length=10)
 
-# def make_dummy_datasets_with_features(
-#     num_ts: int = 5,
-#     start: str = "2018-01-01",
-#     freq: str = "D",
-#     min_length: int = 5,
-#     max_length: int = 10,
-#     prediction_length: int = 3,
-#     cardinality: List[int] = [],
-#     num_feat_dynamic_real: int = 0,
-#     num_past_feat_dynamic_real: int = 0,
-# ) -> Tuple[ListDataset, ListDataset]:
-#
-#     data_iter_train = []
-#     data_iter_test = []
-#
-#     for k in range(num_ts):
-#         ts_length = randint(min_length, max_length)
-#         data_entry_train = {
-#             FieldName.START: start,
-#             FieldName.TARGET: [0.0] * ts_length,
-#         }
-#         if len(cardinality) > 0:
-#             data_entry_train[FieldName.FEAT_STATIC_CAT] = [
-#                 randint(0, c) for c in cardinality
-#             ]
-#         # Since used directly in predict and not in make_evaluate_predictions,
-#         # where the test target would be chopped, test and train target have the same lengths
-#         data_entry_test = data_entry_train.copy()
-#         if num_feat_dynamic_real > 0:
-#             data_entry_train[FieldName.FEAT_DYNAMIC_REAL] = [
-#                 [float(1 + k)] * ts_length
-#                 for k in range(num_feat_dynamic_real)
-#             ]
-#             data_entry_test[FieldName.FEAT_DYNAMIC_REAL] = [
-#                 [float(1 + k)] * (ts_length + prediction_length)
-#                 for k in range(num_feat_dynamic_real)
-#             ]
-#         data_iter_train.append(data_entry_train)
-#         data_iter_test.append(data_entry_test)
-#
-#     return (
-#         ListDataset(data_iter=data_iter_train, freq=freq),
-#         ListDataset(data_iter=data_iter_test, freq=freq),
-#     )
-#
-# hps = {
-#         "seed": 42,
-#         "freq": "D",
-#         "context_length": 5,
-#         "prediction_length": 3,
-#         "quantiles": [0.5, 0.1],
-#         "epochs": 3,
-#         "num_batches_per_epoch": 3,
-#     }
-#
-# train_data, test_data = make_dummy_datasets_with_features(
-#     cardinality=[3, 10],
-#     num_feat_dynamic_real=2,
-#     num_past_feat_dynamic_real=4,
-#     freq=hps["freq"],
-#     prediction_length=hps["prediction_length"],
-# )
 print(train_data)
 hyperparams = {'MQCNN': {'context_length': ag.Int(10, 20)} }
 savedir = 'ag_models/'

--- a/examples/tabular/example_simple_tabular_forecasting.py
+++ b/examples/tabular/example_simple_tabular_forecasting.py
@@ -1,0 +1,107 @@
+""" Example script for predicting columns of tables, demonstrating simple use-case """
+
+from autogluon.utils.tabular.ml.constants import FORECAST
+from autogluon import TabularPrediction as task
+import autogluon as ag
+# Training time:
+# Standard library imports
+from functools import partial
+from random import randint
+from typing import List, Tuple
+
+# Third-party imports
+import numpy as np
+import pytest
+import pandas as pd
+
+# First-party imports
+from gluonts.dataset.common import ListDataset
+from gluonts.dataset.field_names import FieldName
+
+
+def make_dummy_datasets(ts_n=1, ts_length=100, freq="D", prediction_length=5):
+    targets = []
+    for i in range(ts_n):
+        for j in range(ts_length):
+            targets.append(j)
+    ts_index = []
+    for i in range(ts_n):
+        for j in range(ts_length):
+            ts_index.append(i)
+    n = ts_n * ts_length
+    date = pd.date_range(start="2020", freq=freq, periods=ts_length)
+    return pd.DataFrame({"index": ts_index,"date": date, "target": targets, "freq": [freq for i in range(n)], "prediction_length": [prediction_length for i in range(n)]})
+
+
+train_data = make_dummy_datasets(ts_length=200)
+test_data = make_dummy_datasets(ts_length=10)
+
+# def make_dummy_datasets_with_features(
+#     num_ts: int = 5,
+#     start: str = "2018-01-01",
+#     freq: str = "D",
+#     min_length: int = 5,
+#     max_length: int = 10,
+#     prediction_length: int = 3,
+#     cardinality: List[int] = [],
+#     num_feat_dynamic_real: int = 0,
+#     num_past_feat_dynamic_real: int = 0,
+# ) -> Tuple[ListDataset, ListDataset]:
+#
+#     data_iter_train = []
+#     data_iter_test = []
+#
+#     for k in range(num_ts):
+#         ts_length = randint(min_length, max_length)
+#         data_entry_train = {
+#             FieldName.START: start,
+#             FieldName.TARGET: [0.0] * ts_length,
+#         }
+#         if len(cardinality) > 0:
+#             data_entry_train[FieldName.FEAT_STATIC_CAT] = [
+#                 randint(0, c) for c in cardinality
+#             ]
+#         # Since used directly in predict and not in make_evaluate_predictions,
+#         # where the test target would be chopped, test and train target have the same lengths
+#         data_entry_test = data_entry_train.copy()
+#         if num_feat_dynamic_real > 0:
+#             data_entry_train[FieldName.FEAT_DYNAMIC_REAL] = [
+#                 [float(1 + k)] * ts_length
+#                 for k in range(num_feat_dynamic_real)
+#             ]
+#             data_entry_test[FieldName.FEAT_DYNAMIC_REAL] = [
+#                 [float(1 + k)] * (ts_length + prediction_length)
+#                 for k in range(num_feat_dynamic_real)
+#             ]
+#         data_iter_train.append(data_entry_train)
+#         data_iter_test.append(data_entry_test)
+#
+#     return (
+#         ListDataset(data_iter=data_iter_train, freq=freq),
+#         ListDataset(data_iter=data_iter_test, freq=freq),
+#     )
+#
+# hps = {
+#         "seed": 42,
+#         "freq": "D",
+#         "context_length": 5,
+#         "prediction_length": 3,
+#         "quantiles": [0.5, 0.1],
+#         "epochs": 3,
+#         "num_batches_per_epoch": 3,
+#     }
+#
+# train_data, test_data = make_dummy_datasets_with_features(
+#     cardinality=[3, 10],
+#     num_feat_dynamic_real=2,
+#     num_past_feat_dynamic_real=4,
+#     freq=hps["freq"],
+#     prediction_length=hps["prediction_length"],
+# )
+print(train_data)
+hyperparams = {'MQCNN': {'context_length': ag.Int(10, 20)} }
+savedir = 'ag_models/'
+predictor = task.fit(train_data=train_data, hyperparameters=hyperparams, output_directory=savedir, label="target", problem_type=FORECAST, id_columns=["index"])
+# NOTE: Default settings above are intended to ensure reasonable runtime at the cost of accuracy. To maximize predictive accuracy, do this instead:  predictor = task.fit(train_data=train_data, label=label_column, output_directory=savedir, presets='best_quality', eval_metric=YOUR_METRIC_NAME)
+results = predictor.fit_summary()
+

--- a/examples/tabular/example_simple_tabular_forecasting.py
+++ b/examples/tabular/example_simple_tabular_forecasting.py
@@ -33,13 +33,15 @@ def make_dummy_datasets(ts_n=1, ts_length=100, freq="D", prediction_length=5):
     return pd.DataFrame({"index": ts_index,"date": date, "target": targets, "freq": [freq for i in range(n)], "prediction_length": [prediction_length for i in range(n)]})
 
 
-train_data = make_dummy_datasets(ts_length=200)
-test_data = make_dummy_datasets(ts_length=10)
+# train_data = make_dummy_datasets(ts_length=200)
+# test_data = make_dummy_datasets(ts_length=10)
+train_data = pd.read_csv("./COV19/processed_train.csv")
+test_data = pd.read_csv("./COV19/processed_test.csv")
 
 print(train_data)
 hyperparams = {'MQCNN': {'context_length': ag.Int(10, 20)} }
 savedir = 'ag_models/'
-predictor = task.fit(train_data=train_data, hyperparameters=hyperparams, output_directory=savedir, label="target", problem_type=FORECAST, id_columns=["index"])
+predictor = task.fit(train_data=train_data, tuning_data=test_data, hyperparameters=hyperparams, output_directory=savedir, label="", problem_type=FORECAST, index_column="name", date_column="Date", target_column="ConfirmedCases")
 # NOTE: Default settings above are intended to ensure reasonable runtime at the cost of accuracy. To maximize predictive accuracy, do this instead:  predictor = task.fit(train_data=train_data, label=label_column, output_directory=savedir, presets='best_quality', eval_metric=YOUR_METRIC_NAME)
 results = predictor.fit_summary()
 


### PR DESCRIPTION
*Issue #, if available:*
This PR aims to enable mqcnn estimator in gluonts for autogluon. Currently it is an attempt and has some bugs. It would be very appreciated if anyone can give me some suggestions. 

There is a testing script ```examples/tabular/example_simple_tabular_forecasting.py```.

The script will fail when it comes to the ```Fitting model: weighted_ensemble_k0_l1 ...```.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
