### PR TITLE
more robust method to automatically set up output directory (#614)

### DIFF
--- a/autogluon/utils/tabular/ml/utils.py
+++ b/autogluon/utils/tabular/ml/utils.py
@@ -79,7 +79,14 @@ def setup_outputdir(output_directory):
         utcnow = datetime.utcnow()
         timestamp = utcnow.strftime("%Y%m%d_%H%M%S")
         output_directory = f"AutogluonModels/ag-{timestamp}{os.path.sep}"
-        os.makedirs(output_directory)
+        for i in range(1, 1000):
+            try:
+                os.makedirs(output_directory, exist_ok=False)
+                break
+            except FileExistsError as e:
+                output_directory = f"AutogluonModels/ag-{timestamp}-{i:03d}{os.path.sep}"
+        else:
+            raise RuntimeError("more than 1000 jobs launched in the same second")
         logger.log(25, f"No output_directory specified. Models will be saved in: {output_directory}")
     output_directory = os.path.expanduser(output_directory)  # replace ~ with absolute path if it exists
     if output_directory[-1] != os.path.sep:


### PR DESCRIPTION
avoid crashes when two autogluon jobs launched in the same second.

*Issue #, if available:* #614 

*Description of changes:*
As described in the issue, repeatedly add a increasing sequential number to the output directory until we find one that is available. As a guardrail, we limit the number of tries to 1000.

Tests:

Change savedir in the example script to None, and run the following command:
```
for i in $(seq 4); do python examples/tabular/example_simple_tabular.py & done
```

Before the change, two or three jobs will fail due to FileExistsError.

After the change, all four jobs succeed, with jobs launched in the same second go to different output directories
```
ag-20200817_004754
ag-20200817_004754-001
ag-20200817_004754-002
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
