### PR TITLE
fastai v1 tabular model

### DIFF
--- a/autogluon/utils/tabular/contrib/tabular_nn_pytorch/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/contrib/tabular_nn_pytorch/hyperparameters/parameters.py
@@ -1,0 +1,48 @@
+from autogluon.utils.tabular.ml.constants import BINARY, MULTICLASS, REGRESSION
+
+
+def get_param_baseline(problem_type, num_classes=None):
+    if problem_type == BINARY:
+        return get_param_binary_baseline()
+    elif problem_type == MULTICLASS:
+        return get_param_multiclass_baseline()
+    elif problem_type == REGRESSION:
+        return get_param_regression_baseline()
+    else:
+        return get_param_binary_baseline()
+
+
+def get_param_multiclass_baseline():
+    params = {
+        # See docs: https://docs.fast.ai/tabular.models.html
+        'layers': None,  # layers configuration; None - use model's heuristics
+        'emb_drop': 0.1,  # embedding layers dropout
+        'ps': [0.1],  # linear layers dropout
+        'bs': 256,  # batch size
+
+        # maximum learning rate for one cycle policy https://docs.fast.ai/train.html#fit_one_cycle
+        # One-cycle policy paper: https://arxiv.org/abs/1803.09820
+        'lr': 1e-2,
+        'epochs': 30,  # number of epochs
+        'metric': 'accuracy',
+
+        # Early stopping settings. See more details here: https://docs.fast.ai/callbacks.tracker.html#EarlyStoppingCallback
+        'early.stopping.min_delta': 0.001,
+        'early.stopping.patience': 7,
+
+        # If > 0, then use LabelSmoothingCrossEntropy loss function for binary/multi-class classification;
+        # otherwise use default loss function for this type of problem
+        'smoothing': 0.0,
+    }
+    return params
+
+
+def get_param_binary_baseline():
+    params = get_param_multiclass_baseline()
+    return params
+
+
+def get_param_regression_baseline():
+    params = get_param_multiclass_baseline()
+    params['metric'] = 'root_mean_squared_error'
+    return params

--- a/autogluon/utils/tabular/contrib/tabular_nn_pytorch/hyperparameters/searchspaces.py
+++ b/autogluon/utils/tabular/contrib/tabular_nn_pytorch/hyperparameters/searchspaces.py
@@ -1,0 +1,40 @@
+from ....ml.constants import BINARY, MULTICLASS, REGRESSION
+from ......core import Categorical, Real, Int
+
+
+def get_default_searchspace(problem_type, num_classes=None):
+    if problem_type == BINARY:
+        return get_searchspace_binary().copy()
+    elif problem_type == MULTICLASS:
+        return get_searchspace_multiclass(num_classes=num_classes)
+    elif problem_type == REGRESSION:
+        return get_searchspace_regression().copy()
+    else:
+        return get_searchspace_binary().copy()
+
+
+def get_searchspace_binary():
+    spaces = {
+        # See docs: https://docs.fast.ai/tabular.models.html
+        'layers': Categorical(None, [200, 100], [256], [100, 50], [200, 100, 50], [50, 25], [300, 150]),
+        'emb_drop': Real(0.0, 0.5, default=0.1),
+        'ps': Real(0.0, 0.5, default=0.1),
+        'bs': Categorical(256, 64, 128, 512, 1024, 2048, 4096),
+        'lr': Real(5e-5, 1e-1, default=1e-2, log=True),
+        'epochs': Int(lower=5, upper=30, default=30),
+        'metric': 'accuracy',
+        'early.stopping.min_delta': 0.001,
+        'early.stopping.patience': 7,
+        'smoothing': Real(0.0, 0.3, default=0.0, log=True),
+    }
+    return spaces
+
+
+def get_searchspace_multiclass(num_classes):
+    return get_searchspace_binary()
+
+
+def get_searchspace_regression():
+    spaces = get_searchspace_binary()
+    spaces['metric'] = 'root_mean_squared_error'
+    return spaces

--- a/autogluon/utils/tabular/contrib/tabular_nn_pytorch/tabular_nn_fastai.py
+++ b/autogluon/utils/tabular/contrib/tabular_nn_pytorch/tabular_nn_fastai.py
@@ -1,0 +1,322 @@
+import contextlib
+import logging
+import shutil
+import tempfile
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from fastai.basic_data import DatasetType
+from fastai.basic_train import load_learner
+from fastai.callbacks import SaveModelCallback, EarlyStoppingCallback
+from fastai.data_block import FloatList
+from fastai.layers import LabelSmoothingCrossEntropy
+from fastai.metrics import mean_absolute_error, accuracy, root_mean_squared_error, AUROC, mean_squared_error, r2_score, FBeta, Precision, Recall
+from fastai.tabular import tabular_learner, TabularList, FillMissing, Categorify, Normalize
+from fastai.utils.mod_display import progress_disabled_ctx
+from sklearn.compose import ColumnTransformer
+from sklearn.impute import SimpleImputer
+from sklearn.pipeline import Pipeline
+
+from autogluon.utils.tabular.contrib.tabular_nn_pytorch.hyperparameters.parameters import get_param_baseline
+from autogluon.utils.tabular.contrib.tabular_nn_pytorch.hyperparameters.searchspaces import get_default_searchspace
+from autogluon.utils.tabular.ml.constants import REGRESSION, BINARY, MULTICLASS
+from autogluon.utils.tabular.ml.models.abstract.abstract_model import AbstractModel
+from autogluon.utils.tabular.ml.models.tabular_nn.categorical_encoders import OrdinalMergeRaresHandleUnknownEncoder
+from autogluon.utils.tabular.utils.loaders import load_pkl
+from autogluon.utils.tabular.utils.savers import save_pkl
+
+# FIXME: Has a leak somewhere, training additional models in a single python script will slow down training for each additional model. Gets very slow after 20+ models (10x+ slowdown)
+#  Slowdown does not appear to impact Mac OS
+# Reproduced with raw torch: https://github.com/pytorch/pytorch/issues/31867
+# https://forums.fast.ai/t/runtimeerror-received-0-items-of-ancdata/48935
+# https://github.com/pytorch/pytorch/issues/973
+# https://pytorch.org/docs/master/multiprocessing.html#file-system-file-system
+# Slowdown bug not experienced on Linux if 'torch.multiprocessing.set_sharing_strategy('file_system')' commented out
+# NOTE: If below line is commented out, Torch uses many file descriptors. If issues arise, increase ulimit through 'ulimit -n 2048' or larger. Default on Linux is 1024.
+# torch.multiprocessing.set_sharing_strategy('file_system')
+
+LABEL = '__label__'
+
+logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def make_temp_directory():
+    temp_dir = tempfile.mkdtemp()
+    try:
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir)
+
+
+# TODO: Add to contrib
+
+# TODO: On regression problems, can sometimes give insane predictions on unseen data. Cap the y valuees between min and max seen, else this can give REALLY bad results to test data.
+# TODO: Takes extremely long (infinite?) time prior to training start if many (10000) continuous features from ngrams, debug
+class NNFastAiTabularModel(AbstractModel):
+    model_internals_file_name = 'model-internals.pkl'
+    unique_category_str = '!missing!'
+    metrics_map = {
+        # Regression
+        'root_mean_squared_error': root_mean_squared_error,
+        'mean_squared_error': mean_squared_error,
+        'mean_absolute_error': mean_absolute_error,
+        'r2': r2_score,
+        # Not supported: median_absolute_error
+
+        # Classification
+        'accuracy': accuracy,
+
+        'f1': FBeta(beta=1),
+        'f1_macro': FBeta(beta=1, average='macro'),
+        'f1_micro': FBeta(beta=1, average='micro'),
+        'f1_weighted': FBeta(beta=1, average='weigthed'),  # this one has some issues
+
+        'roc_auc': AUROC(),
+
+        'precision': Precision(),
+        'precision_macro': Precision(average='macro'),
+        'precision_micro': Precision(average='micro'),
+        'precision_weigthed': Precision(average='weigthed'),
+
+        'recall': Recall(),
+        'recall_macro': Recall(average='macro'),
+        'recall_micro': Recall(average='micro'),
+        'recall_weigthed': Recall(average='weigthed'),
+        # Not supported: pac_score
+
+    }
+
+    def __init__(self, path, name, problem_type, objective_func, stopping_metric=None, hyperparameters=None, features=None, feature_types_metadata=None,
+                 debug=0, max_unique_categorical_values=10000,
+                 y_scaler=None):
+        super().__init__(path=path, name=name, problem_type=problem_type, objective_func=objective_func, hyperparameters=hyperparameters, features=features,
+                         feature_types_metadata=feature_types_metadata, debug=debug)
+        self.procs = [FillMissing, Categorify, Normalize]
+        self.cat_names = []
+        self.cont_names = []
+        self.max_unique_categorical_values = max_unique_categorical_values
+        self.eval_result = None
+
+        self.col_after_transformer = None
+        self.col_transformer = None
+        self.y_scaler = y_scaler
+
+    def _set_default_params(self):
+        default_params = get_param_baseline(problem_type=self.problem_type)
+        for param, val in default_params.items():
+            self._set_default_param_value(param, val)
+
+    def _get_default_searchspace(self, problem_type):
+        spaces = {}
+        return spaces
+
+    def preprocess(self, X, fit=False):
+        if fit:
+            self.col_after_transformer = list(X.columns)
+            self.col_transformer, self.col_after_transformer = self._construct_transformer(X=X)
+            X = self.col_transformer.fit_transform(X)
+        else:
+            X = self.col_transformer.transform(X)
+        X = pd.DataFrame(data=X, columns=self.col_after_transformer)
+        X = super().preprocess(X)
+        return X
+
+    def __get_feature_type_if_present(self, feature_type):
+        return self.feature_types_metadata[feature_type] if feature_type in self.feature_types_metadata else []
+
+    def _construct_transformer(self, X):
+        transformers = []
+        if len(self.cont_names) > 0:
+            continuous_transformer = Pipeline(steps=[
+                ('imputer', SimpleImputer(strategy='median')),
+                # ('scaler', StandardScaler())
+            ])
+            transformers.append(('continuous', continuous_transformer, self.cont_names))
+        if len(self.cat_names) > 0:
+            ordinal_transformer = Pipeline(steps=[
+                ('imputer', SimpleImputer(strategy='constant', fill_value=self.unique_category_str)),
+                ('ordinal', OrdinalMergeRaresHandleUnknownEncoder(max_levels=self.max_unique_categorical_values))
+                # returns 0-n when max_category_levels = n-1. category n is reserved for unknown test-time categories.
+            ])
+            transformers.append(('ordinal', ordinal_transformer, self.cat_names))
+        cols_to_use = self.cont_names + self.cat_names
+        col_after_transformer = [col for col in X.columns if col in cols_to_use]
+        return ColumnTransformer(transformers=transformers), col_after_transformer
+
+    def preprocess_train(self, X_train, Y_train, X_test, Y_test):
+        self.cat_names = self.__get_feature_type_if_present('object') + self.__get_feature_type_if_present('bool')
+        if self.problem_type == REGRESSION and self.y_scaler is not None:
+            Y_train_norm = pd.Series(self.y_scaler.fit_transform(Y_train.values.reshape(-1, 1)).reshape(-1))
+            Y_test_norm = pd.Series(self.y_scaler.transform(Y_test.values.reshape(-1, 1)).reshape(-1)) if Y_test is not None else None
+            logger.log(15, f'Training with scaled targets: {self.y_scaler} - !!! NN training metric will be different from the final results !!!')
+        else:
+            Y_train_norm = Y_train
+            Y_test_norm = Y_test
+        try:
+            X_train_stats = X_train.describe(include='all').T.reset_index()
+            cat_cols_to_drop = X_train_stats[(X_train_stats['unique'] > self.max_unique_categorical_values) | (X_train_stats['unique'].isna())]['index'].values
+        except:
+            cat_cols_to_drop = []
+        cat_cols_to_keep = [col for col in X_train.columns.values if (col not in cat_cols_to_drop)]
+        cat_cols_to_use = [col for col in self.cat_names if col in cat_cols_to_keep]
+        logger.log(15, f'Using {len(cat_cols_to_use)}/{len(self.cat_names)} categorical features')
+        self.cat_names = cat_cols_to_use
+        self.cat_names = [feature for feature in self.cat_names if feature in list(X_train.columns)]
+        self.cont_names = self.__get_feature_type_if_present('float') + self.__get_feature_type_if_present('int') + self.__get_feature_type_if_present(
+            'datetime')  # + self.__get_feature_type_if_present('vectorizers')  # Disabling vectorizers until more performance testing is done
+        self.cont_names = [feature for feature in self.cont_names if feature in list(X_train.columns)]
+        logger.log(15, f'Using {len(self.cont_names)} cont features')
+        X_train = self.preprocess(X_train, fit=True)
+        if X_test is not None:
+            X_test = self.preprocess(X_test)
+        df_train, train_idx, val_idx = self._generate_datasets(X_train, Y_train_norm, X_test, Y_test_norm)
+        label_class = FloatList if self.problem_type == REGRESSION else None
+        data = (TabularList.from_df(df_train, path=self.path, cat_names=self.cat_names, cont_names=self.cont_names, procs=self.procs)
+                .split_by_idxs(train_idx, val_idx)
+                .label_from_df(cols=LABEL, label_cls=label_class)
+                .databunch(bs=self.params['bs'] if len(X_train) > self.params['bs'] else 32))
+        return data
+
+    def _generate_datasets(self, X_train, Y_train, X_test, Y_test):
+        df_train = pd.concat([X_train, X_test], ignore_index=True)
+        df_train[LABEL] = pd.concat([Y_train, Y_test], ignore_index=True)
+        train_idx = np.arange(len(X_train))
+        val_idx = np.arange(len(X_test)) + len(X_train)
+
+        return df_train, train_idx, val_idx
+
+    def fit(self, X_train, Y_train, X_test=None, Y_test=None, **kwargs):
+        logger.log(15, f'Fitting Neural Network with parameters {self.params}...')
+        data = self.preprocess_train(X_train, Y_train, X_test, Y_test)
+
+        nn_metric, objective_func_name = self.__get_objective_func_name()
+        objective_func_name_to_monitor = self.__get_objective_func_to_monitor(objective_func_name)
+        objective_optim_mode = 'min' if objective_func_name in [
+            'root_mean_squared_error', 'mean_squared_error', 'mean_absolute_error', 'r2'  # Regression objectives
+        ] else 'auto'
+
+        # TODO: calculate max emb concat layer size and use 1st layer as that value and 2nd in between number of classes and the value
+        if self.params.get('layers', None) is not None:
+            layers = self.params['layers']
+        elif self.problem_type in [REGRESSION, BINARY]:
+            layers = [200, 100]
+        else:
+            base_size = max(len(data.classes) * 2, 100)
+            layers = [base_size * 2, base_size]
+
+        early_stopping_fn = partial(EarlyStoppingCallback, monitor=objective_func_name_to_monitor, mode=objective_optim_mode,
+                                    min_delta=self.params['early.stopping.min_delta'], patience=self.params['early.stopping.patience'])
+
+        loss_func = None
+        if self.problem_type in [BINARY, MULTICLASS] and self.params.get('smoothing', 0.0) > 0.0:
+            loss_func = LabelSmoothingCrossEntropy(self.params['smoothing'])
+
+        ps = self.params['ps']
+        if type(ps) != list:
+            ps = [ps]
+
+        self.model = tabular_learner(
+            data, layers=layers, ps=ps, emb_drop=self.params['emb_drop'], metrics=nn_metric,
+            loss_func=loss_func, callback_fns=[early_stopping_fn]
+        )
+        logger.log(15, self.model.model)
+
+        with make_temp_directory() as temp_dir:
+            save_callback = SaveModelCallback(self.model, monitor=objective_func_name_to_monitor, mode=objective_optim_mode, name=self.name)
+            with progress_disabled_ctx(self.model) as model:
+                original_path = model.path
+                model.path = Path(temp_dir)
+                model.fit_one_cycle(self.params['epochs'], self.params['lr'], callbacks=save_callback)
+
+                # Load the best one and export it
+                model.load(self.name)
+
+                if objective_func_name == 'log_loss':
+                    self.eval_result = model.validate()[0]
+                else:
+                    self.eval_result = model.validate()[1].numpy().reshape(-1)[0]
+
+                logger.log(15, f'Model validation metrics: {self.eval_result}')
+                model.path = original_path
+
+    def __get_objective_func_name(self):
+        objective_func_name = self.objective_func.name
+        if objective_func_name in self.metrics_map.keys():
+            nn_metric = self.metrics_map[objective_func_name]
+        elif objective_func_name is None:
+            objective_func_name = self.params['metric']
+            nn_metric = self.metrics_map[self.params['metric']]
+        else:
+            nn_metric = None
+        return nn_metric, objective_func_name
+
+    def __get_objective_func_to_monitor(self, objective_func_name):
+        monitor_obj_func = {
+            'roc_auc': 'auroc',
+
+            'f1': 'f_beta',
+            'f1_macro': 'f_beta',
+            'f1_micro': 'f_beta',
+            'f1_weighted': 'f_beta',
+
+            'precision_macro': 'precision',
+            'precision_micro': 'precision',
+            'precision_weigthed': 'precision',
+
+            'recall_macro': 'recall',
+            'recall_micro': 'recall',
+            'recall_weigthed': 'recall',
+            'log_loss': 'valid_loss',
+        }
+        objective_func_name_to_monitor = objective_func_name
+        if objective_func_name in monitor_obj_func:
+            objective_func_name_to_monitor = monitor_obj_func[objective_func_name]
+        return objective_func_name_to_monitor
+
+    def predict(self, X, preprocess=True):
+        return super().predict(X, preprocess)
+
+    def predict_proba(self, X, preprocess=True):
+        if preprocess:
+            X = self.preprocess(X)
+        self.model.data.add_test(TabularList.from_df(X, cat_names=self.cat_names, cont_names=self.cont_names, procs=self.procs))
+        with progress_disabled_ctx(self.model) as model:
+            preds, _ = model.get_preds(ds_type=DatasetType.Test)
+        if self.problem_type == REGRESSION:
+            if self.y_scaler is not None:
+                return self.y_scaler.inverse_transform(preds.numpy()).reshape(-1)
+            else:
+                return preds.numpy().reshape(-1)
+        if self.problem_type == BINARY:
+            return preds[:, 1].numpy()
+        else:
+            return preds.numpy()
+
+    def save(self, file_prefix='', directory=None, return_filename=False, verbose=True):
+        # Export model
+        save_pkl.save_with_fn(f'{self.path}{self.model_internals_file_name}', self.model, lambda m, buffer: m.export(buffer, destroy=True), verbose=verbose)
+        self.model = {}
+        return super().save(file_prefix=file_prefix, directory=directory, return_filename=return_filename, verbose=verbose)
+
+    @classmethod
+    def load(cls, path: str, file_prefix='', reset_paths=False, verbose=True):
+        obj = super().load(path, file_prefix=file_prefix, reset_paths=reset_paths, verbose=verbose)
+        obj.model = load_pkl.load_with_fn(f'{obj.path}{obj.model_internals_file_name}', lambda p: load_learner(obj.path, p), verbose=verbose)
+        return obj
+
+    def _get_default_searchspace(self, problem_type):
+        return get_default_searchspace(problem_type)
+
+    def hyperparameter_tune(self, X_train, X_test, Y_train, Y_test, scheduler_options=None, **kwargs):
+        # TODO: add warning regarding dataloader leak: https://github.com/pytorch/pytorch/issues/31867
+        # TODO that hyperparameter-tuning is not yet implemented
+        self.fit(X_train=X_train, X_test=X_test, Y_train=Y_train, Y_test=Y_test, **kwargs)
+        hpo_model_performances = {self.name: self.score(X_test, Y_test)}
+        hpo_results = {}
+        self.save()
+        hpo_models = {self.name: self.path}
+
+        return hpo_models, hpo_model_performances, hpo_results

--- a/autogluon/utils/tabular/ml/models/fastainn/callbacks.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/callbacks.py
@@ -1,8 +1,11 @@
 import logging
+import os
 import time
+from typing import Any
 
 from fastai.basic_train import Learner
-from fastai.callbacks import EarlyStoppingCallback
+from fastai.callbacks import EarlyStoppingCallback, TrackerCallback
+from torch import Tensor
 
 logger = logging.getLogger(__name__)
 
@@ -22,3 +25,37 @@ class EarlyStoppingCallbackWithTimeLimit(EarlyStoppingCallback):
                 logger.log(20, "\tRan out of time, stopping training early.")
                 return {'stop_training': True}
         return super().on_epoch_end(epoch, **kwargs)
+
+
+class SaveModelCallback(TrackerCallback):
+    """A `TrackerCallback` that saves the model when monitored quantity is best."""
+
+    def __init__(self, learn: Learner, monitor: str = 'valid_loss', mode: str = 'auto', every: str = 'improvement', name: str = 'bestmodel'):
+        super().__init__(learn, monitor=monitor, mode=mode)
+        self.every, self.name, self.best = every, name, None
+        if self.every not in ['improvement', 'epoch']:
+            logger.warning(f'SaveModel every {self.every} is invalid, falling back to "improvement".')
+            self.every = 'improvement'
+
+    def jump_to_epoch(self, epoch: int) -> None:
+        try:
+            self.learn.load(f'{self.name}_{epoch - 1}', purge=False)
+            logger.info(15, f"Loaded {self.name}_{epoch - 1}")
+        except:
+            logger.info(15, f'Model {self.name}_{epoch - 1} not found.')
+
+    def on_epoch_end(self, epoch: int, **kwargs: Any) -> None:
+        """Compare the value monitored to its best score and maybe save the model."""
+        if self.every == "epoch":
+            self.learn.save(f'{self.name}_{epoch}')
+        else:  # every="improvement"
+            current = self.get_monitor_value()
+            if isinstance(current, Tensor): current = current.cpu()
+            if current is not None and self.operator(current, self.best):
+                logger.log(15, f'Better model found at epoch {epoch} with {self.monitor} value: {current}.')
+                self.best = current
+                self.learn.save(f'{self.name}')
+
+    def on_train_end(self, **kwargs):
+        if self.every == "improvement" and os.path.isfile(self.path / self.model_dir / f'{self.name}.pth'):
+            self.learn.load(f'{self.name}', purge=False)

--- a/autogluon/utils/tabular/ml/models/fastainn/callbacks.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/callbacks.py
@@ -1,0 +1,24 @@
+import logging
+import time
+
+from fastai.basic_train import Learner
+from fastai.callbacks import EarlyStoppingCallback
+
+logger = logging.getLogger(__name__)
+
+
+class EarlyStoppingCallbackWithTimeLimit(EarlyStoppingCallback):
+
+    def __init__(self, learn: Learner, time_limit=None, **kwargs):
+        super().__init__(learn, **kwargs)
+        self.time_limit = time_limit
+        self.start_time = time.time()
+
+    def on_epoch_end(self, epoch, **kwargs):
+        if self.time_limit:
+            time_elapsed = time.time() - self.start_time
+            time_left = self.time_limit - time_elapsed
+            if time_left <= 0:
+                logger.log(20, "\tRan out of time, stopping training early.")
+                return {'stop_training': True}
+        return super().on_epoch_end(epoch, **kwargs)

--- a/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
@@ -38,11 +38,8 @@ def get_param_multiclass_baseline():
 
 
 def get_param_binary_baseline():
-    params = get_param_multiclass_baseline()
-    return params
+    return get_param_multiclass_baseline()
 
 
 def get_param_regression_baseline():
-    params = get_param_multiclass_baseline()
-    params['metric'] = 'root_mean_squared_error'
-    return params
+    return get_param_multiclass_baseline()

--- a/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
@@ -13,6 +13,7 @@ def get_param_baseline(problem_type, num_classes=None):
 
 
 def get_param_multiclass_baseline():
+    # TODO: explore/add other hyperparameters like weight decay, use of batch-norm, activation-function choice, etc.
     params = {
         # See docs: https://docs.fast.ai/tabular.models.html
         'layers': None,  # layers configuration; None - use model's heuristics
@@ -23,12 +24,11 @@ def get_param_multiclass_baseline():
         # maximum learning rate for one cycle policy https://docs.fast.ai/train.html#fit_one_cycle
         # One-cycle policy paper: https://arxiv.org/abs/1803.09820
         'lr': 1e-2,
-        'epochs': 30,  # number of epochs
-        'metric': 'accuracy',
+        'epochs': 30,  # maximum number of epochs
 
         # Early stopping settings. See more details here: https://docs.fast.ai/callbacks.tracker.html#EarlyStoppingCallback
         'early.stopping.min_delta': 0.0001,
-        'early.stopping.patience': 10,
+        'early.stopping.patience': 20,
 
         # If > 0, then use LabelSmoothingCrossEntropy loss function for binary/multi-class classification;
         # otherwise use default loss function for this type of problem

--- a/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
@@ -1,6 +1,6 @@
 from .....ml.constants import BINARY, MULTICLASS, REGRESSION
 
-# TODO this method is generalizable method and potentially should be moved out into framework
+# TODO this method is generalizable and potentially should be moved out into framework
 def get_param_baseline(problem_type, num_classes=None):
     if problem_type == BINARY:
         return get_param_binary_baseline()

--- a/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
@@ -1,4 +1,4 @@
-from autogluon.utils.tabular.ml.constants import BINARY, MULTICLASS, REGRESSION
+from .....ml.constants import BINARY, MULTICLASS, REGRESSION
 
 
 def get_param_baseline(problem_type, num_classes=None):
@@ -27,8 +27,8 @@ def get_param_multiclass_baseline():
         'metric': 'accuracy',
 
         # Early stopping settings. See more details here: https://docs.fast.ai/callbacks.tracker.html#EarlyStoppingCallback
-        'early.stopping.min_delta': 0.001,
-        'early.stopping.patience': 7,
+        'early.stopping.min_delta': 0.0001,
+        'early.stopping.patience': 10,
 
         # If > 0, then use LabelSmoothingCrossEntropy loss function for binary/multi-class classification;
         # otherwise use default loss function for this type of problem

--- a/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/parameters.py
@@ -1,6 +1,6 @@
 from .....ml.constants import BINARY, MULTICLASS, REGRESSION
 
-
+# TODO this method is generalizable method and potentially should be moved out into framework
 def get_param_baseline(problem_type, num_classes=None):
     if problem_type == BINARY:
         return get_param_binary_baseline()

--- a/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/searchspaces.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/searchspaces.py
@@ -1,5 +1,5 @@
-from ....ml.constants import BINARY, MULTICLASS, REGRESSION
-from ......core import Categorical, Real, Int
+from .....ml.constants import BINARY, MULTICLASS, REGRESSION
+from .......core import Categorical, Real, Int
 
 
 def get_default_searchspace(problem_type, num_classes=None):

--- a/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/searchspaces.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/hyperparameters/searchspaces.py
@@ -16,15 +16,14 @@ def get_default_searchspace(problem_type, num_classes=None):
 def get_searchspace_binary():
     spaces = {
         # See docs: https://docs.fast.ai/tabular.models.html
-        'layers': Categorical(None, [200, 100], [256], [100, 50], [200, 100, 50], [50, 25], [300, 150]),
+        'layers': Categorical(None, [200, 100], [200], [500], [1000], [500, 200], [50, 25], [1000, 500], [200, 100, 50], [500, 200, 100], [1000, 500, 200]),
         'emb_drop': Real(0.0, 0.5, default=0.1),
         'ps': Real(0.0, 0.5, default=0.1),
         'bs': Categorical(256, 64, 128, 512, 1024, 2048, 4096),
         'lr': Real(5e-5, 1e-1, default=1e-2, log=True),
         'epochs': Int(lower=5, upper=30, default=30),
-        'metric': 'accuracy',
-        'early.stopping.min_delta': 0.001,
-        'early.stopping.patience': 7,
+        'early.stopping.min_delta': 0.0001,
+        'early.stopping.patience': 20,
         'smoothing': Real(0.0, 0.3, default=0.0, log=True),
     }
     return spaces
@@ -35,6 +34,4 @@ def get_searchspace_multiclass(num_classes):
 
 
 def get_searchspace_regression():
-    spaces = get_searchspace_binary()
-    spaces['metric'] = 'root_mean_squared_error'
-    return spaces
+    return get_searchspace_binary()

--- a/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
@@ -16,12 +16,12 @@ from fastai.metrics import root_mean_squared_error, mean_squared_error, mean_abs
 from fastai.tabular import FillMissing, Categorify, Normalize, TabularList, tabular_learner
 from fastai.utils.mod_display import progress_disabled_ctx
 
-from autogluon.utils.tabular.contrib.tabular_nn_pytorch.hyperparameters.parameters import get_param_baseline
-from autogluon.utils.tabular.contrib.tabular_nn_pytorch.hyperparameters.searchspaces import get_default_searchspace
-from autogluon.utils.tabular.ml.constants import REGRESSION, BINARY, MULTICLASS
-from autogluon.utils.tabular.ml.models.abstract.abstract_model import AbstractModel
-from autogluon.utils.tabular.utils.loaders import load_pkl
-from autogluon.utils.tabular.utils.savers import save_pkl
+from .hyperparameters.parameters import get_param_baseline
+from .hyperparameters.searchspaces import get_default_searchspace
+from ..abstract.abstract_model import AbstractModel
+from ...constants import REGRESSION, BINARY, MULTICLASS
+from ....utils.loaders import load_pkl
+from ....utils.savers import save_pkl
 
 # FIXME: Has a leak somewhere, training additional models in a single python script will slow down training for each additional model. Gets very slow after 20+ models (10x+ slowdown)
 #  Slowdown does not appear to impact Mac OS
@@ -32,6 +32,8 @@ from autogluon.utils.tabular.utils.savers import save_pkl
 # Slowdown bug not experienced on Linux if 'torch.multiprocessing.set_sharing_strategy('file_system')' commented out
 # NOTE: If below line is commented out, Torch uses many file descriptors. If issues arise, increase ulimit through 'ulimit -n 2048' or larger. Default on Linux is 1024.
 # torch.multiprocessing.set_sharing_strategy('file_system')
+
+# MacOS issue: torchvision==0.7.0 + torch==1.6.0 can cause segfaults; use torch==1.2.0 torchvision==0.4.0
 
 LABEL = '__label__'
 

--- a/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
@@ -44,6 +44,7 @@ def make_temp_directory():
 
 
 # TODO: Takes extremely long time prior to training start if many (10000) continuous features from ngrams, debug - explore TruncateSVD option to reduce input dimensionality
+# TODO: currently fastai automatically detect and use CUDA if available - add code to honor autogluon settings
 class NNFastAiTabularModel(AbstractModel):
     """ Class for fastai v1 neural network models that operate on tabular data.
 
@@ -229,19 +230,19 @@ class NNFastAiTabularModel(AbstractModel):
             'f1': FBeta(beta=1),
             'f1_macro': FBeta(beta=1, average='macro'),
             'f1_micro': FBeta(beta=1, average='micro'),
-            'f1_weighted': FBeta(beta=1, average='weigthed'),  # this one has some issues
+            'f1_weighted': FBeta(beta=1, average='weighted'),  # this one has some issues
 
             'roc_auc': AUROC(),
 
             'precision': Precision(),
             'precision_macro': Precision(average='macro'),
             'precision_micro': Precision(average='micro'),
-            'precision_weigthed': Precision(average='weigthed'),
+            'precision_weighted': Precision(average='weighted'),
 
             'recall': Recall(),
             'recall_macro': Recall(average='macro'),
             'recall_micro': Recall(average='micro'),
-            'recall_weigthed': Recall(average='weigthed'),
+            'recall_weighted': Recall(average='weighted'),
             # Not supported: pac_score
         }
 
@@ -266,11 +267,11 @@ class NNFastAiTabularModel(AbstractModel):
 
             'precision_macro': 'precision',
             'precision_micro': 'precision',
-            'precision_weigthed': 'precision',
+            'precision_weighted': 'precision',
 
             'recall_macro': 'recall',
             'recall_micro': 'recall',
-            'recall_weigthed': 'recall',
+            'recall_weighted': 'recall',
             'log_loss': 'valid_loss',
         }
         objective_func_name_to_monitor = objective_func_name

--- a/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
@@ -51,11 +51,40 @@ def make_temp_directory():
         shutil.rmtree(temp_dir)
 
 
-# TODO: Add to contrib
-
-# TODO: On regression problems, can sometimes give insane predictions on unseen data. Cap the y valuees between min and max seen, else this can give REALLY bad results to test data.
-# TODO: Takes extremely long (infinite?) time prior to training start if many (10000) continuous features from ngrams, debug
+# TODO: Takes extremely long time prior to training start if many (10000) continuous features from ngrams, debug - explore TruncateSVD option to reduce input dimensionality
 class NNFastAiTabularModel(AbstractModel):
+    """ Class for fastai v1 neural network models that operate on tabular data.
+
+        Attributes:
+            y_scaler: on a regression problems, the model can give unreasonable predictions on unseen data.
+            This attribute allows to pass a scaler for y values to address this problem. Please note that intermediate
+            iteration metrics will be affected by this transform and as a result intermediate iteration scores will be
+            different from the final ones (these will be correct).
+            https://scikit-learn.org/stable/modules/classes.html#module-sklearn.preprocessing
+
+        Hyperparameters:
+            'layers': list of hidden layers sizes; None - use model's heuristics; default is None
+
+            'emb_drop': embedding layers dropout; defaut is 0.1
+
+            'ps': linear layers dropout - list of values applied to every layer in `layers`; default is [0.1]
+
+            'bs': batch size; default is 256
+
+            'lr': maximum learning rate for one cycle policy; default is 1e-2;
+            see also https://fastai1.fast.ai/train.html#fit_one_cycle, One-cycle policy paper: https://arxiv.org/abs/1803.09820
+
+            'epochs': number of epochs; default is 30
+
+            # Early stopping settings. See more details here: https://fastai1.fast.ai/callbacks.tracker.html#EarlyStoppingCallback
+            'early.stopping.min_delta': 0.0001,
+            'early.stopping.patience': 10,
+
+            'smoothing': If > 0, then use LabelSmoothingCrossEntropy loss function for binary/multi-class classification;
+            otherwise use default loss function for this type of problem; default is 0.0.
+            See: https://docs.fast.ai/layers.html#LabelSmoothingCrossEntropy
+    """
+
     model_internals_file_name = 'model-internals.pkl'
     unique_category_str = '!missing!'
     metrics_map = {

--- a/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
@@ -243,15 +243,21 @@ class NNFastAiTabularModel(AbstractModel):
             'recall_macro': Recall(average='macro'),
             'recall_micro': Recall(average='micro'),
             'recall_weighted': Recall(average='weighted'),
+            'log_loss': None,
             # Not supported: pac_score
         }
 
+        # Unsupported metrics will be replaced by defaults for a given problem type
         objective_func_name = self.eval_metric.name
+        if objective_func_name not in metrics_map.keys():
+            if self.problem_type == REGRESSION:
+                objective_func_name = 'mean_squared_error'
+            else:
+                objective_func_name = 'log_loss'
+            logger.warning(f'Metric {self.eval_metric.name} is not supported by this model - using {objective_func_name} instead')
+
         if objective_func_name in metrics_map.keys():
             nn_metric = metrics_map[objective_func_name]
-        elif objective_func_name is None:
-            objective_func_name = self.params['metric']
-            nn_metric = metrics_map[self.params['metric']]
         else:
             nn_metric = None
         return nn_metric, objective_func_name

--- a/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
+++ b/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
@@ -7,7 +7,6 @@ from sklearn.linear_model import LogisticRegression, LinearRegression
 
 from ...constants import AG_ARGS, AG_ARGS_FIT, BINARY, MULTICLASS, REGRESSION, SOFTCLASS, PROBLEM_TYPES_CLASSIFICATION
 from ...models.abstract.abstract_model import AbstractModel
-from ...models.fastainn.tabular_nn_fastai import NNFastAiTabularModel
 from ...models.lgb.lgb_model import LGBModel
 from ...models.lr.lr_model import LinearModel
 from ...models.tabular_nn.tabular_nn_model import TabularNeuralNetModel
@@ -49,7 +48,6 @@ MODEL_TYPES = dict(
     CAT=CatboostModel,
     NN=TabularNeuralNetModel,
     LR=LinearModel,
-    FASTAINN=NNFastAiTabularModel,
 )
 
 DEFAULT_MODEL_NAMES = {
@@ -60,7 +58,6 @@ DEFAULT_MODEL_NAMES = {
     CatboostModel: 'Catboost',
     TabularNeuralNetModel: 'NeuralNet',
     LinearModel: 'LinearModel',
-    NNFastAiTabularModel: 'FastAINeuralNet',
 }
 
 

--- a/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
+++ b/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
@@ -7,6 +7,7 @@ from sklearn.linear_model import LogisticRegression, LinearRegression
 
 from ...constants import AG_ARGS, AG_ARGS_FIT, BINARY, MULTICLASS, REGRESSION, SOFTCLASS, PROBLEM_TYPES_CLASSIFICATION
 from ...models.abstract.abstract_model import AbstractModel
+from ...models.fastainn.tabular_nn_fastai import NNFastAiTabularModel
 from ...models.lgb.lgb_model import LGBModel
 from ...models.lr.lr_model import LinearModel
 from ...models.tabular_nn.tabular_nn_model import TabularNeuralNetModel
@@ -48,6 +49,7 @@ MODEL_TYPES = dict(
     CAT=CatboostModel,
     NN=TabularNeuralNetModel,
     LR=LinearModel,
+    FASTAINN=NNFastAiTabularModel,
 )
 
 DEFAULT_MODEL_NAMES = {
@@ -58,6 +60,7 @@ DEFAULT_MODEL_NAMES = {
     CatboostModel: 'Catboost',
     TabularNeuralNetModel: 'NeuralNet',
     LinearModel: 'LinearModel',
+    NNFastAiTabularModel: 'FastAINeuralNet',
 }
 
 

--- a/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
+++ b/autogluon/utils/tabular/ml/trainer/model_presets/presets.py
@@ -49,7 +49,7 @@ MODEL_TYPES = dict(
     CAT=CatboostModel,
     NN=TabularNeuralNetModel,
     LR=LinearModel,
-    FASTAINN=NNFastAiTabularModel,
+    FASTAI=NNFastAiTabularModel,
 )
 
 DEFAULT_MODEL_NAMES = {

--- a/autogluon/utils/try_import.py
+++ b/autogluon/utils/try_import.py
@@ -90,6 +90,6 @@ def try_import_fastai_v1():
         import fastai
         fastai_version = parse_version(fastai.__version__)
         assert parse_version('1.0.61') <= fastai_version < parse_version('2.0.0'), 'Currently, we only support 1.0.61<=fastai<2.0.0'
-    except OSError as e:
+    except ModuleNotFoundError as e:
         raise ImportError("Import fastai failed. A quick tip is to install via `pip install fastai==1.*`. "
-                          "If you are using Mac OSX, please use this torch version to avoid compatibility issues: `pip install torch==1.2.0`.")
+                          "If you are using Mac OSX, please use this torch version to avoid compatibility issues: `pip install torch==1.6.0`.")

--- a/autogluon/utils/try_import.py
+++ b/autogluon/utils/try_import.py
@@ -83,3 +83,12 @@ def try_import_faiss():
         raise ImportError(
             "Unable to import dependency faiss"
             "A quick tip is to install via `pip install faiss-cpu`. ")
+
+def try_import_fastai_v1():
+    try:
+        from pkg_resources import parse_version  # pylint: disable=import-outside-toplevel
+        import fastai
+        fastai_version = parse_version(fastai.__version__)
+        assert parse_version('1.0.61') <= fastai_version < parse_version('2.0.0'), 'Currently, we only support 1.0.61<=gluonnlp<2.0.0'
+    except OSError as e:
+        raise ImportError("Import fastai failed.")

--- a/autogluon/utils/try_import.py
+++ b/autogluon/utils/try_import.py
@@ -1,5 +1,5 @@
 __all__ = ['try_import_catboost', 'try_import_lightgbm', 'try_import_mxboard', 'try_import_mxnet',
-           'try_import_cv2', 'try_import_gluonnlp']
+           'try_import_cv2', 'try_import_gluonnlp', 'try_import_fastai_v1']
 
 def try_import_catboost():
     try:

--- a/autogluon/utils/try_import.py
+++ b/autogluon/utils/try_import.py
@@ -89,6 +89,7 @@ def try_import_fastai_v1():
         from pkg_resources import parse_version  # pylint: disable=import-outside-toplevel
         import fastai
         fastai_version = parse_version(fastai.__version__)
-        assert parse_version('1.0.61') <= fastai_version < parse_version('2.0.0'), 'Currently, we only support 1.0.61<=gluonnlp<2.0.0'
+        assert parse_version('1.0.61') <= fastai_version < parse_version('2.0.0'), 'Currently, we only support 1.0.61<=fastai<2.0.0'
     except OSError as e:
-        raise ImportError("Import fastai failed.")
+        raise ImportError("Import fastai failed. A quick tip is to install via `pip install fastai==1.*`. "
+                          "If you are using Mac OSX, please use this torch version to avoid compatibility issues: `pip install torch==1.2.0`.")


### PR DESCRIPTION
This code adds tabular neural networks using pytorch/fastAI frameworks. 

```python
custom_hyperparameters = {'FASTAI': {}}
predictor = task.fit(train_data=train_data, label=label_column, hyperparameters=custom_hyperparameters) 
predictor.leaderboard()
```

openml 10-minute benchmarks results:
|id                 |task                                  |framework       |constraint|fold|result   |metric |mode |version|params                               |tag   |utc                |duration|models|seed      |info|acc     |auc     |logloss  |models_ensemble_count|predict_duration|
|-------------------|--------------------------------------|----------------|----------|----|---------|-------|-----|-------|-------------------------------------|------|-------------------|--------|------|----------|----|--------|--------|---------|---------------------|----------------|
|openml.org/t/189354|Airlines                              |AutoGluon_fastai|test      |0   |0.722356 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T17:46:17|611.8   |2     |1699782500|    |0.670387|0.722356|0.606545 |2                    |0.956357        |
|openml.org/t/189356|Albert                                |AutoGluon_fastai|test      |0   |0.757223 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T17:59:08|694.8   |2     |1699782500|    |0.68907 |0.757223|0.584956 |2                    |4.62582         |
|openml.org/t/7593  |Covertype                             |AutoGluon_fastai|test      |0   |0.323193 |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T18:10:16|635.1   |2     |1699782500|    |0.869505|        |0.323193 |2                    |1.74763         |
|openml.org/t/189355|Dionis                                |AutoGluon_fastai|test      |0   |0.356598 |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T18:21:58|632.7   |2     |1699782500|    |0.909561|        |0.356598 |2                    |2.13912         |
|openml.org/t/7592  |adult                                 |AutoGluon_fastai|test      |0   |0.916446 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T18:25:07|56.4    |2     |1860274422|    |0.859365|0.916446|0.305309 |2                    |0.26264         |
|openml.org/t/34539 |Amazon_employee_access                |AutoGluon_fastai|test      |0   |0.844355 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T18:27:05|105.6   |2     |1860274422|    |0.937748|0.844355|0.370688 |2                    |0.245396        |
|openml.org/t/168868|APSFailure                            |AutoGluon_fastai|test      |0   |0.95759  |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T18:38:17|613.5   |2     |1860274422|    |0.992895|0.95759 |0.0383348|2                    |1.07713         |
|openml.org/t/14965 |bank-marketing                        |AutoGluon_fastai|test      |0   |0.937911 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T18:39:33|61.0    |2     |1860274422|    |0.907784|0.937911|0.192449 |2                    |0.233975        |
|openml.org/t/146195|connect-4                             |AutoGluon_fastai|test      |0   |0.3259   |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T18:43:14|199.6   |2     |1860274422|    |0.87167 |        |0.3259   |2                    |0.370888        |
|openml.org/t/146825|Fashion-MNIST                         |AutoGluon_fastai|test      |0   |0.294203 |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T18:48:02|122.1   |2     |1860274422|    |0.897286|        |0.294203 |2                    |1.33875         |
|openml.org/t/168337|guillermo                             |AutoGluon_fastai|test      |0   |0.893953 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:05:29|177.1   |2     |1860274422|    |0.8205  |0.893953|1.19878  |2                    |5.02546         |
|openml.org/t/168329|Helena                                |AutoGluon_fastai|test      |0   |2.57515  |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:07:20|88.2    |2     |1860274422|    |0.380061|        |2.57515  |2                    |0.262888        |
|openml.org/t/146606|higgs                                 |AutoGluon_fastai|test      |0   |0.818434 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:10:00|126.6   |2     |1860274422|    |0.740031|0.818434|0.518757 |2                    |0.325395        |
|openml.org/t/168330|Jannis                                |AutoGluon_fastai|test      |0   |0.675886 |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:11:45|71.0    |2     |1860274422|    |0.724385|        |0.675886 |2                    |0.289565        |
|openml.org/t/167119|jungle_chess_2pcs_raw_endgame_complete|AutoGluon_fastai|test      |0   |0.216643 |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:12:37|39.0    |2     |1860274422|    |0.880634|        |0.216643 |2                    |0.18019         |
|openml.org/t/3945  |KDDCup09_appetency                    |AutoGluon_fastai|test      |0   |0.769092 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:19:39|383.9   |2     |1860274422|    |0.9816  |0.769092|0.0840278|2                    |1.27593         |
|openml.org/t/168335|MiniBooNE                             |AutoGluon_fastai|test      |0   |0.950745 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:21:11|44.9    |2     |1860274422|    |0.767971|0.950745|0.512851 |2                    |0.398064        |
|openml.org/t/9977  |nomao                                 |AutoGluon_fastai|test      |0   |0.99263  |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:22:58|83.9    |2     |1860274422|    |0.960545|0.99263 |0.103583 |2                    |0.349721        |
|openml.org/t/167120|numerai28.6                           |AutoGluon_fastai|test      |0   |0.521831 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:24:11|46.3    |2     |1860274422|    |0.514639|0.521831|0.693063 |2                    |0.303659        |
|openml.org/t/168338|riccardo                              |AutoGluon_fastai|test      |0   |0.997171 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:40:29|143.3   |2     |1860274422|    |0.9925  |0.997171|0.0358956|2                    |5.02055         |
|openml.org/t/168332|Robert                                |AutoGluon_fastai|test      |0   |1.59847  |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:57:01|95.9    |2     |1860274422|    |0.451   |        |1.59847  |2                    |7.99774         |
|openml.org/t/146212|Shuttle                               |AutoGluon_fastai|test      |0   |0.0159396|logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:57:58|40.5    |2     |1860274422|    |0.997586|        |0.0159396|2                    |0.183591        |
|openml.org/t/168331|Volkert                               |AutoGluon_fastai|test      |0   |0.827611 |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T19:59:51|61.7    |2     |1860274422|    |0.700737|        |0.827611 |2                    |0.387196        |
|openml.org/t/146818|Australian                            |AutoGluon_fastai|test      |0   |0.925297 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:00:10|6.1     |2     |217222661 |    |0.84058 |0.925297|0.41665  |2                    |0.137678        |
|openml.org/t/10101 |blood-transfusion                     |AutoGluon_fastai|test      |0   |0.756823 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:00:19|5.6     |2     |217222661 |    |0.773333|0.756823|0.475472 |2                    |0.103165        |
|openml.org/t/146821|car                                   |AutoGluon_fastai|test      |0   |0.0965006|logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:00:29|7.2     |2     |217222661 |    |0.971098|        |0.0965006|2                    |0.124542        |
|openml.org/t/168908|christine                             |AutoGluon_fastai|test      |0   |0.823164 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:01:06|21.4    |2     |217222661 |    |0.749077|0.823164|0.521499 |2                    |1.72224         |
|openml.org/t/9981  |cnae-9                                |AutoGluon_fastai|test      |0   |3.07076  |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:01:20|7.5     |2     |217222661 |    |0.222222|        |3.07076  |2                    |0.841853        |
|openml.org/t/31    |credit-g                              |AutoGluon_fastai|test      |0   |0.810952 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:01:28|4.8     |2     |217222661 |    |0.73    |0.810952|0.512079 |2                    |0.149085        |
|openml.org/t/168909|dilbert                               |AutoGluon_fastai|test      |0   |0.0870836|logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:02:45|50.9    |2     |217222661 |    |0.978   |        |0.0870836|2                    |2.22393         |
|openml.org/t/168910|fabert                                |AutoGluon_fastai|test      |0   |0.94289  |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:03:10|14.7    |2     |217222661 |    |0.668689|        |0.94289  |2                    |0.873605        |
|openml.org/t/168911|jasmine                               |AutoGluon_fastai|test      |0   |0.846398 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:03:34|19.6    |2     |217222661 |    |0.732441|0.846398|0.70385  |2                    |0.375061        |
|openml.org/t/3917  |kc1                                   |AutoGluon_fastai|test      |0   |0.803334 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:03:44|6.1     |2     |217222661 |    |0.853081|0.803334|0.367038 |2                    |0.131206        |
|openml.org/t/3     |kr-vs-kp                              |AutoGluon_fastai|test      |0   |0.997495 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:04:01|13.3    |2     |217222661 |    |0.990625|0.997495|0.0365937|2                    |0.202577        |
|openml.org/t/12    |mfeat-factors                         |AutoGluon_fastai|test      |0   |0.0910511|logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:04:12|7.0     |2     |217222661 |    |0.975   |        |0.0910511|2                    |0.292757        |
|openml.org/t/9952  |phoneme                               |AutoGluon_fastai|test      |0   |0.941388 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:04:26|10.3    |2     |217222661 |    |0.874307|0.941388|0.280375 |2                    |0.13021         |
|openml.org/t/146822|segment                               |AutoGluon_fastai|test      |0   |0.0803769|logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:04:37|7.2     |2     |217222661 |    |0.987013|        |0.0803769|2                    |0.128366        |
|openml.org/t/168912|sylvine                               |AutoGluon_fastai|test      |0   |0.965163 |auc    |local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:04:48|7.9     |2     |217222661 |    |0.908382|0.965163|0.253462 |2                    |0.149101        |
|openml.org/t/53    |vehicle                               |AutoGluon_fastai|test      |0   |0.389012 |logloss|local|0.0.9  |{'hyperparameters': {'FASTAINN': {}}}|stable|2020-08-26T20:04:57|6.1     |2     |217222661 |    |0.835294|        |0.389012 |2                    |0.124875        |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
