### PR TITLE
Tabular: Reduced maximum allowed memory usage for RF, XT, and KNN models

### DIFF
--- a/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
+++ b/autogluon/utils/tabular/ml/models/abstract/abstract_model.py
@@ -1,4 +1,5 @@
 import copy
+import gc
 import logging
 import math
 import os
@@ -611,6 +612,7 @@ class AbstractModel:
     #  This is generally not an issue because the model already needed to do this when being saved to disk, so the error would have been triggered earlier.
     #  Consider using Pympler package for memory efficiency: https://pympler.readthedocs.io/en/latest/asizeof.html#asizeof
     def get_memory_size(self):
+        gc.collect()  # Try to avoid OOM error
         return sys.getsizeof(pickle.dumps(self, protocol=4))
 
     # Removes non-essential objects from the model to reduce memory and disk footprint.

--- a/autogluon/utils/tabular/ml/models/knn/knn_model.py
+++ b/autogluon/utils/tabular/ml/models/knn/knn_model.py
@@ -65,9 +65,9 @@ class KNNModel(AbstractModel):
         if expected_final_model_size_bytes > 10000000:  # Only worth checking if expected model size is >10MB
             available_mem = psutil.virtual_memory().available
             model_memory_ratio = expected_final_model_size_bytes / available_mem
-            if model_memory_ratio > (0.30 * max_memory_usage_ratio):
-                logger.warning(f'\tWarning: Model is expected to require {model_memory_ratio * 100} percent of available memory...')
-            if model_memory_ratio > (0.40 * max_memory_usage_ratio):
+            if model_memory_ratio > (0.20 * max_memory_usage_ratio):
+                logger.warning(f'\tWarning: Model is expected to require {round(model_memory_ratio * 100, 2)}% of available memory...')
+            if model_memory_ratio > (0.25 * max_memory_usage_ratio):
                 raise NotEnoughMemoryError  # don't train full model to avoid OOM error
 
     def hyperparameter_tune(self, X_train, y_train, X_val, y_val, scheduler_options=None, **kwargs):

--- a/autogluon/utils/tabular/ml/models/rf/rf_model.py
+++ b/autogluon/utils/tabular/ml/models/rf/rf_model.py
@@ -77,7 +77,7 @@ class RFModel(SKLearnModel):
         expected_memory_usage = bytes_per_estimator * n_estimators_final / available_mem
         expected_min_memory_usage = bytes_per_estimator * n_estimators_minimum / available_mem
         if expected_min_memory_usage > (0.5 * max_memory_usage_ratio):  # if minimum estimated size is greater than 50% memory
-            logger.warning(f'\tWarning: Model is expected to require {expected_min_memory_usage * 100} percent of available memory (Estimated before training)...')
+            logger.warning(f'\tWarning: Model is expected to require {round(expected_min_memory_usage * 100, 2)}% of available memory (Estimated before training)...')
             raise NotEnoughMemoryError
 
         if n_estimators_final > n_estimators_test * 2:
@@ -106,14 +106,14 @@ class RFModel(SKLearnModel):
                 available_mem = psutil.virtual_memory().available
                 model_memory_ratio = expected_final_model_size_bytes / available_mem
 
-                ideal_memory_ratio = 0.25 * max_memory_usage_ratio
+                ideal_memory_ratio = 0.18 * max_memory_usage_ratio
                 n_estimators_ideal = min(n_estimators_final, math.floor(ideal_memory_ratio / model_memory_ratio * n_estimators_final))
 
                 if n_estimators_final > n_estimators_ideal:
                     if n_estimators_ideal < n_estimators_minimum:
-                        logger.warning(f'\tWarning: Model is expected to require {round(model_memory_ratio*100, 1)}% of available memory...')
+                        logger.warning(f'\tWarning: Model is expected to require {round(model_memory_ratio*100, 2)}% of available memory...')
                         raise NotEnoughMemoryError  # don't train full model to avoid OOM error
-                    logger.warning(f'\tWarning: Reducing model \'n_estimators\' from {n_estimators_final} -> {n_estimators_ideal} due to low memory. Expected memory usage reduced from {round(model_memory_ratio*100, 1)}% -> {round(ideal_memory_ratio*100, 1)}% of available memory...')
+                    logger.warning(f'\tWarning: Reducing model \'n_estimators\' from {n_estimators_final} -> {n_estimators_ideal} due to low memory. Expected memory usage reduced from {round(model_memory_ratio*100, 2)}% -> {round(ideal_memory_ratio*100, 2)}% of available memory...')
 
                 if time_limit is not None:
                     time_expected = time_train_start - time_start + (time_elapsed * n_estimators_ideal / n_estimators)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Reduced maximum allowed memory usage for RF, XT, and KNN models to avoid OOM errors during memory size calculation in .info

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
