### PR TITLE
[Fix] [Documentation] Update installation guide

### DIFF
--- a/docs/install-faq.rst
+++ b/docs/install-faq.rst
@@ -1,31 +1,31 @@
 * I cannot install the package and it reports the error "XXX is not a supported wheel on this platform".
 
-One possibility is that you are using an older version of pip. Try to upgrade your pip to a version later than "19.0.0",
+   One possibility is that you are using an older version of pip. Try to upgrade your pip to a version later than "19.0.0",
 e.g., use the following command:
 
-.. code-block::
+   .. code-block::
 
-  python3 -m pip install --upgrade pip --user
+     python3 -m pip install --upgrade pip --user
 
 * I see the error "ERROR: No matching distribution found for mxnet<2.0.0,>=1.7.0b20200713".
 
-It might be due to the out-dated pip version. Try to upgrade the pip via:
+   It might be due to the out-dated pip version. Try to upgrade the pip via:
 
-.. code-block::
+   .. code-block::
 
-  python3 -m pip install --upgrade pip --user
+     python3 -m pip install --upgrade pip --user
 
 * How can I install the customized mxnet (incubating) on SageMaker Notebook?
 
-You should choose the **conda_python3** kernel and then install the MXNet via
+   You should choose the **conda_python3** kernel and then install the MXNet via
 
-.. code-block::
+   .. code-block::
 
-  # For CPU users
-  python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+     # For CPU users
+     python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
 
-  # For GPU users, CUDA 101
-  python3 -m pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+     # For GPU users, CUDA 101
+     python3 -m pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
 
 * While running AutoGluon, I get error message "Check failed: e == cudaSuccess: CUDA: initialization error".
 

--- a/docs/install-faq.rst
+++ b/docs/install-faq.rst
@@ -29,7 +29,5 @@ You should choose the **conda_python3** kernel and then install the MXNet via
 
 * While running AutoGluon, I get error message "Check failed: e == cudaSuccess: CUDA: initialization error".
 
-.. code-block::
-
   You may have the wrong version of MXNet installed for your CUDA version.
   Match the CUDA version carefully when following the installation instructions.

--- a/docs/install-faq.rst
+++ b/docs/install-faq.rst
@@ -1,35 +1,35 @@
-... I cannot install the package and it reports the error "XXX is not a supported wheel on this platform".
+* I cannot install the package and it reports the error "XXX is not a supported wheel on this platform".
 
-   One possibility is that you are using an older version of pip. Try to upgrade your pip to a version later than "19.0.0",
+One possibility is that you are using an older version of pip. Try to upgrade your pip to a version later than "19.0.0",
 e.g., use the following command:
 
-   .. code-block::
+.. code-block::
 
-      python3 -m pip install --upgrade pip --user
+  python3 -m pip install --upgrade pip --user
 
-... I see the error "ERROR: No matching distribution found for mxnet<2.0.0,>=1.7.0b20200713".
+* I see the error "ERROR: No matching distribution found for mxnet<2.0.0,>=1.7.0b20200713".
 
-   It might be due to the out-dated pip version. Try to upgrade the pip via:
+It might be due to the out-dated pip version. Try to upgrade the pip via:
 
-   .. code-block::
+.. code-block::
 
-      python3 -m pip install --upgrade pip --user
+  python3 -m pip install --upgrade pip --user
 
-... How can I install the customized mxnet (incubating) on SageMaker Notebook?
+* How can I install the customized mxnet (incubating) on SageMaker Notebook?
 
-   You should choose the **conda_python3** kernel and then install the MXNet via
+You should choose the **conda_python3** kernel and then install the MXNet via
 
-   .. code-block::
+.. code-block::
 
-      # For CPU users
-      python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+  # For CPU users
+  python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
 
-      # For GPU users, CUDA 101
-      python3 -m pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+  # For GPU users, CUDA 101
+  python3 -m pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
 
-... While running AutoGluon, I get error message "Check failed: e == cudaSuccess: CUDA: initialization error".
+* While running AutoGluon, I get error message "Check failed: e == cudaSuccess: CUDA: initialization error".
 
-   .. code-block::
+.. code-block::
 
-      You may have the wrong version of MXNet installed for your CUDA version.
-      Match the CUDA version carefully when following the installation instructions.
+  You may have the wrong version of MXNet installed for your CUDA version.
+  Match the CUDA version carefully when following the installation instructions.

--- a/docs/install-faq.rst
+++ b/docs/install-faq.rst
@@ -1,0 +1,35 @@
+... I cannot install the package and it reports the error "XXX is not a supported wheel on this platform".
+
+   One possibility is that you are using an older version of pip. Try to upgrade your pip to a version later than "19.0.0",
+e.g., use the following command:
+
+   .. code-block::
+
+      python3 -m pip install --upgrade pip --user
+
+... I see the error "ERROR: No matching distribution found for mxnet<2.0.0,>=1.7.0b20200713".
+
+   It might be due to the out-dated pip version. Try to upgrade the pip via:
+
+   .. code-block::
+
+      python3 -m pip install --upgrade pip --user
+
+... How can I install the customized mxnet (incubating) on SageMaker Notebook?
+
+   You should choose the **conda_python3** kernel and then install the MXNet via
+
+   .. code-block::
+
+      # For CPU users
+      python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+
+      # For GPU users, CUDA 101
+      python3 -m pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+
+... While running AutoGluon, I get error message "Check failed: e == cudaSuccess: CUDA: initialization error".
+
+   .. code-block::
+
+      You may have the wrong version of MXNet installed for your CUDA version.
+      Match the CUDA version carefully when following the installation instructions.

--- a/docs/install-include.rst
+++ b/docs/install-include.rst
@@ -2,7 +2,7 @@
 
   AutoGluon requires `Python <https://www.python.org/downloads/release/python-370/>`_ version 3.6 or 3.7.
   Linux is the only operating system fully supported for now (complete Mac OSX and Windows versions will be available soon).
-  In case you met with any issues in the installation. You may check the `Install Page <install.html>`_ for trouble shooting.
+  For troubleshooting the installation process, you can check the `Installation FAQ <install.html#installation-faq>`_.
 
 
 Select your preferences below and run the corresponding install commands:

--- a/docs/install-include.rst
+++ b/docs/install-include.rst
@@ -2,17 +2,7 @@
 
   AutoGluon requires `Python <https://www.python.org/downloads/release/python-370/>`_ version 3.6 or 3.7.
   Linux is the only operating system fully supported for now (complete Mac OSX and Windows versions will be available soon).
-
-  In addition, if you met issues in installing MXNet, e.g., you see the following error message:
-
-  `ERROR: Could not find a version that satisfies the requirement mxnet<2.0.0,>=1.7.0b20200713`
-
-  You can try to upgrade your pip package to a version larger than 20.0.0 and try again:
-
-  `python3 -m pip install --upgrade pip --user`
-
-  For more details, you may refer to https://sxjscience.github.io/KDD2020/ to see how to solve common
-  installation issues.
+  In case you met with any issues in the installation. You may check the `Install Page <install.html>`_ for trouble shooting.
 
 
 Select your preferences below and run the corresponding install commands:

--- a/docs/install-include.rst
+++ b/docs/install-include.rst
@@ -3,6 +3,17 @@
   AutoGluon requires `Python <https://www.python.org/downloads/release/python-370/>`_ version 3.6 or 3.7.
   Linux is the only operating system fully supported for now (complete Mac OSX and Windows versions will be available soon).
 
+  In addition, if you met issues in installing MXNet, e.g., you see the following error message:
+
+  `ERROR: Could not find a version that satisfies the requirement mxnet<2.0.0,>=1.7.0b20200713`
+
+  You can try to upgrade your pip package to a version larger than 20.0.0 and try again:
+
+  `python3 -m pip install --upgrade pip --user`
+
+  For more details, you may refer to https://sxjscience.github.io/KDD2020/ to see how to solve common
+  installation issues.
+
 
 Select your preferences below and run the corresponding install commands:
 
@@ -58,8 +69,8 @@ Select your preferences below and run the corresponding install commands:
 
               .. code-block:: bash
 
-                 pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
-                 pip install autogluon
+                 python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+                 python3 -m pip install autogluon
 
            .. container:: gpu
 
@@ -68,8 +79,8 @@ Select your preferences below and run the corresponding install commands:
                  # Here we assume CUDA 10.1 is installed.  You should change the number
                  # according to your own CUDA version (e.g. mxnet_cu100 for CUDA 10.0).
                  # You may refer to https://sxjscience.github.io/KDD2020/ for more details.
-                 pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
-                 pip install autogluon
+                 python3 -m pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+                 python3 -m pip install autogluon
 
         .. container:: source
 
@@ -77,19 +88,19 @@ Select your preferences below and run the corresponding install commands:
 
               .. code-block:: bash
 
-                 pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+                 python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
                  git clone https://github.com/awslabs/autogluon
-                 cd autogluon && python setup.py develop
+                 cd autogluon && python3 setup.py develop
 
            .. container:: gpu
 
               .. code-block:: bash
 
                  # Here we assume CUDA 10.1 is installed.  You should change the number
-                 # according to your own CUDA version (e.g. mxnet_cu100 for CUDA 10.0).
-                 pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+                 # according to your own CUDA version (e.g. mxnet_cu102 for CUDA 10.2).
+                 python3 -m pip install -U --pre "mxnet_cu101>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
                  git clone https://github.com/awslabs/autogluon
-                 cd autogluon && python setup.py develop
+                 cd autogluon && python3 setup.py develop
 
      .. container:: mac
 
@@ -109,8 +120,8 @@ Select your preferences below and run the corresponding install commands:
 
               .. code-block:: bash
 
-                 pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
-                 pip install autogluon
+                 python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+                 python3 -m pip install autogluon
 
               .. note::
               
@@ -138,13 +149,14 @@ Select your preferences below and run the corresponding install commands:
 
               .. code-block:: bash
 
-                 pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
+                 python3 -m pip install -U --pre "mxnet>=1.7.0b20200713, <2.0.0" -f https://sxjscience.github.io/KDD2020/
                  git clone https://github.com/awslabs/autogluon
-                 cd autogluon && python setup.py develop
+                 cd autogluon && python3 setup.py develop
 
               .. note::
               
-                 AutoGluon is not yet fully functional on Mac OSX. If you encounter MXNet system errors, please use Linux instead.  However, you can currently use AutoGluon for less compute-intensive TabularPrediction tasks on your Mac laptop (but only with hyperparameter_tune = False).
+                 AutoGluon is not yet fully functional on Mac OSX. If you encounter MXNet system errors, please use Linux instead.
+                 However, you can currently use AutoGluon for less compute-intensive TabularPrediction tasks on your Mac laptop (but only with hyperparameter_tune = False).
 
            .. container:: gpu
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,8 +8,8 @@ Installation
    <style>.disabled { display: none; }</style>
    <script type="text/javascript" src='../_static/install-options.js'></script>
 
-Installation Trouble Shooting
------------------------------
+Installation FAQ
+----------------
 
 .. include:: install-faq.rst
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -8,6 +8,10 @@ Installation
    <style>.disabled { display: none; }</style>
    <script type="text/javascript" src='../_static/install-options.js'></script>
 
+Installation Trouble Shooting
+-----------------------------
+
+.. include:: install-faq.rst
 
 Next steps
 ~~~~~~~~~~
@@ -17,7 +21,7 @@ Next steps
 - `Configure MXNet environment variables <https://mxnet.incubator.apache.org/versions/master/faq/env_var.html>`_
 - For new users: `60-minute Gluon crash course <https://gluon-crash-course.mxnet.io/>`_
 - For experienced users: `MXNet Guides. <https://beta.mxnet.io/guide/getting-started/crash-course/index.html>`_
-- For advanced users: `MXNet API <https://beta.mxnet.io/api/index.html>`_ and `GluonCV API <../api/index.html>`_.
+- For advanced users: `MXNet API <https://beta.mxnet.io/api/index.html>`_ and `AutoGluon API <../api/index.html>`_.
 
 .. raw:: html
 

--- a/docs/tutorials/text_prediction/beginner.md
+++ b/docs/tutorials/text_prediction/beginner.md
@@ -9,7 +9,7 @@ This tutorial presents two examples to demonstrate how `TextPrediction` can be u
 
 The general usage is similar to AutoGluon's `TabularPrediction` module. We treat NLP datasets as tables where certain columns contain text fields and a special column contains the labels to predict. 
 Here, the labels can be discrete categories (classification) or numerical values (regression).
-`TextPrediction` fits neural networks to your data via transfer learning from pretrained NLP models like: [BERT](https://arxiv.org/pdf/1810.04805.pdf),
+`TextPrediction` fits neural networks to your data via transfer learning from pretrained NLP models like: [BERT](https://arxiv.org/pdf/1810.04805.pdf),
 [ALBERT](https://arxiv.org/pdf/1909.11942.pdf), and [ELECTRA](https://openreview.net/pdf?id=r1xMH1BtvB).
 `TextPrediction` also trains multiple models with different hyperparameters and returns the best model, a process called Hyperparameter Optimization (HPO).
 

--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -87,7 +87,7 @@ predictor_mrpc = task.fit(train_data,
                           label='label',
                           hyperparameters=hyperparameters,
                           num_trials=5,  # increase this to achieve good performance in your applications
-                          time_limits=60 * 5,
+                          time_limits=60 * 6,
                           ngpus_per_trial=1,
                           seed=123,
                           output_directory='./ag_mrpc_random_search')
@@ -138,7 +138,7 @@ hyperparameters['hpo_params'] = {
 
 predictor_mrpc_skopt = task.fit(train_data, label='label',
                                 hyperparameters=hyperparameters,
-                                time_limits=60 * 5,
+                                time_limits=60 * 6,
                                 num_trials=5,  # increase this to get good performance in your applications
                                 ngpus_per_trial=1, seed=123,
                                 output_directory='./ag_mrpc_custom_space_fifo_skopt')
@@ -190,7 +190,7 @@ hyperparameters['hpo_params'] = {
 ```{.python .input}
 predictor_mrpc_hyperband = task.fit(train_data, label='label',
                                     hyperparameters=hyperparameters,
-                                    time_limits=60 * 5, ngpus_per_trial=1, seed=123,
+                                    time_limits=60 * 6, ngpus_per_trial=1, seed=123,
                                     output_directory='./ag_mrpc_custom_space_hyperband')
 ```
 

--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -87,7 +87,7 @@ predictor_mrpc = task.fit(train_data,
                           label='label',
                           hyperparameters=hyperparameters,
                           num_trials=5,  # increase this to achieve good performance in your applications
-                          time_limits=60 * 10,
+                          time_limits=60 * 5,
                           ngpus_per_trial=1,
                           seed=123,
                           output_directory='./ag_mrpc_random_search')
@@ -138,7 +138,7 @@ hyperparameters['hpo_params'] = {
 
 predictor_mrpc_skopt = task.fit(train_data, label='label',
                                 hyperparameters=hyperparameters,
-                                time_limits=60 * 10,
+                                time_limits=60 * 5,
                                 num_trials=5,  # increase this to get good performance in your applications
                                 ngpus_per_trial=1, seed=123,
                                 output_directory='./ag_mrpc_custom_space_fifo_skopt')
@@ -190,7 +190,7 @@ hyperparameters['hpo_params'] = {
 ```{.python .input}
 predictor_mrpc_hyperband = task.fit(train_data, label='label',
                                     hyperparameters=hyperparameters,
-                                    time_limits=60 * 10, ngpus_per_trial=1, seed=123,
+                                    time_limits=60 * 5, ngpus_per_trial=1, seed=123,
                                     output_directory='./ag_mrpc_custom_space_hyperband')
 ```
 


### PR DESCRIPTION
The temporary solution is to ask the users to install the new version of MXNet by following the guide in https://sxjscience.github.io/KDD2020/.

Here, the user may met the issue that they cannot find the correct MXNet package with `-f https://sxjscience.github.io/KDD2020/`. So I created this fix (Also, I replaced `pip install` to `python3 -m pip install` to ensure that it works for most platforms including Anaconda and EC2 AMI).

In addition, reduce the time_limits to 5 minutes for the TextPrediction-customization tutorial.
