### PR TITLE
Tabular: Added persist_models, unpersist_models methods to TabularPredictor

### DIFF
--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -622,20 +622,22 @@ class TabularPredictor(BasePredictor):
 
         return self._learner.get_feature_importance(model=model, X=dataset, features=features, feature_stage=feature_stage, subsample_size=subsample_size, silent=silent)
 
-    def persist_models(self, models=None, with_ancestors=True, max_memory=0.1) -> list:
+    def persist_models(self, models='best', with_ancestors=True, max_memory=0.1) -> list:
         """
         Persist models in memory for reduced inference latency. This is particularly important if the models are being used for online-inference where low latency is critical.
         If models are not persisted in memory, they are loaded from disk every time they are asked to make predictions.
 
         Parameters
         ----------
-        models : list of str or str, default = None
+        models : list of str or str, default = 'best'
             Model names of models to persist.
-            If None then all models are persisted.
-            If 'best' then the model with the highest validation score is persisted.
+            If 'best' then the model with the highest validation score is persisted (this is the model used for prediction by default).
+            If 'all' then all models are persisted.
             Valid models are listed in this `predictor` by calling `predictor.get_model_names()`.
         with_ancestors : bool, default = True
             If True, all ancestor models of the provided models will also be persisted.
+            If False, stacker models will not have the models they depend on persisted unless those models were specified in `models`. This will slow down inference as the ancestor models will still need to be loaded from disk for each predict call.
+            Only relevant for stacker models.
         max_memory : float, default = 0.1
             Proportion of total available memory to allow for the persisted models to use.
             If the models' summed memory usage requires a larger proportion of memory than max_memory, they are not persisted. In this case, the output will be an empty list.
@@ -647,16 +649,17 @@ class TabularPredictor(BasePredictor):
         """
         return self._learner.persist_trainer(low_memory=False, models=models, with_ancestors=with_ancestors, max_memory=max_memory)
 
-    def unpersist_models(self, models=None) -> list:
+    def unpersist_models(self, models='all') -> list:
         """
         Unpersist models in memory for reduced memory usage.
         If models are not persisted in memory, they are loaded from disk every time they are asked to make predictions.
+        Note: Another way to reset the predictor and unpersist models is to reload the predictor from disk via `predictor = TabularPredictor.load(predictor.output_directory)`.
 
         Parameters
         ----------
-        models : list of str, default = None
+        models : list of str or str, default = 'all'
             Model names of models to unpersist.
-            If None then all models are unpersisted.
+            If 'all' then all models are unpersisted.
             Valid models are listed in this `predictor` by calling `predictor.get_model_names_persisted()`.
 
         Returns

--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -622,6 +622,49 @@ class TabularPredictor(BasePredictor):
 
         return self._learner.get_feature_importance(model=model, X=dataset, features=features, feature_stage=feature_stage, subsample_size=subsample_size, silent=silent)
 
+    def persist_models(self, models=None, with_ancestors=True, max_memory=0.1) -> list:
+        """
+        Persist models in memory for reduced inference latency. This is particularly important if the models are being used for online-inference where low latency is critical.
+        If models are not persisted in memory, they are loaded from disk every time they are asked to make predictions.
+
+        Parameters
+        ----------
+        models : list of str or str, default = None
+            Model names of models to persist.
+            If None then all models are persisted.
+            If 'best' then the model with the highest validation score is persisted.
+            Valid models are listed in this `predictor` by calling `predictor.get_model_names()`.
+        with_ancestors : bool, default = True
+            If True, all ancestor models of the provided models will also be persisted.
+        max_memory : float, default = 0.1
+            Proportion of total available memory to allow for the persisted models to use.
+            If the models' summed memory usage requires a larger proportion of memory than max_memory, they are not persisted. In this case, the output will be an empty list.
+            If None, then models are persisted regardless of estimated memory usage. This can cause out-of-memory errors.
+
+        Returns
+        -------
+        List of persisted model names.
+        """
+        return self._learner.persist_trainer(low_memory=False, models=models, with_ancestors=with_ancestors, max_memory=max_memory)
+
+    def unpersist_models(self, models=None) -> list:
+        """
+        Unpersist models in memory for reduced memory usage.
+        If models are not persisted in memory, they are loaded from disk every time they are asked to make predictions.
+
+        Parameters
+        ----------
+        models : list of str, default = None
+            Model names of models to unpersist.
+            If None then all models are unpersisted.
+            Valid models are listed in this `predictor` by calling `predictor.get_model_names_persisted()`.
+
+        Returns
+        -------
+        List of unpersisted model names.
+        """
+        return self._learner.load_trainer().unpersist_models(model_names=models)
+
     def refit_full(self, model='all'):
         """
         Retrain model on all of the data (training + validation).
@@ -954,6 +997,10 @@ class TabularPredictor(BasePredictor):
     def get_model_names(self):
         """Returns the list of model names trained in this `predictor` object."""
         return self._trainer.get_model_names_all()
+
+    def get_model_names_persisted(self):
+        """Returns the list of model names which are persisted in memory."""
+        return list(self._learner.load_trainer().models.keys())
 
     def distill(self, train_data=None, tuning_data=None, augmentation_data=None, time_limits=None, hyperparameters=None, holdout_frac=None,
                 teacher_preds='soft', augment_method='spunge', augment_args={'size_factor':5,'max_size':int(1e5)}, models_name_suffix=None, verbosity=None):

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -611,7 +611,7 @@ class AbstractLearner:
         else:
             return self.trainer_type.load(path=self.trainer_path, reset_paths=self.reset_paths)
 
-    # Loads models in memory so that they don't have to loaded during predictions
+    # Loads models in memory so that they don't have to be loaded during predictions
     def persist_trainer(self, low_memory=False, models=None, with_ancestors=False, max_memory=None) -> list:
         self.trainer = self.load_trainer()
         if not low_memory:

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -612,7 +612,7 @@ class AbstractLearner:
             return self.trainer_type.load(path=self.trainer_path, reset_paths=self.reset_paths)
 
     # Loads models in memory so that they don't have to be loaded during predictions
-    def persist_trainer(self, low_memory=False, models=None, with_ancestors=False, max_memory=None) -> list:
+    def persist_trainer(self, low_memory=False, models='all', with_ancestors=False, max_memory=None) -> list:
         self.trainer = self.load_trainer()
         if not low_memory:
             return self.trainer.persist_models(models, with_ancestors=with_ancestors, max_memory=max_memory)

--- a/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
+++ b/autogluon/utils/tabular/ml/models/ensemble/bagged_ensemble_model.py
@@ -527,6 +527,13 @@ class BaggedEnsembleModel(AbstractModel):
 
         return info
 
+    def get_memory_size(self):
+        models = self.models
+        self.models = None
+        memory_size = super().get_memory_size()
+        self.models = models
+        return memory_size
+
     def _get_child_info(self):
         child_info_dict = dict()
         for model in self.models:

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -1011,6 +1011,10 @@ class AbstractTrainer:
         if max_memory is not None:
             info = self.get_models_info(model_names)
             model_mem_size_map = {model: info[model]['memory_size'] for model in model_names}
+            for model in model_mem_size_map:
+                if 'children_info' in info[model]:
+                    for child in info[model]['children_info'].values():
+                        model_mem_size_map[model] += child['memory_size']
             total_mem_required = sum(model_mem_size_map.values())
             available_mem = psutil.virtual_memory().available
             memory_proportion = total_mem_required / available_mem
@@ -1028,11 +1032,6 @@ class AbstractTrainer:
             models.append(model)
 
         for model in models:
-            if isinstance(model, StackerEnsembleModel):
-                for base_model_name in model.base_model_names:
-                    if base_model_name not in model.base_models_dict.keys():
-                        if base_model_name in self.models.keys():
-                            model.base_models_dict[base_model_name] = self.models[base_model_name]
             # TODO: Move this to model code
             if isinstance(model, BaggedEnsembleModel):
                 for fold, fold_model in enumerate(model.models):

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -991,14 +991,16 @@ class AbstractTrainer:
         if self.low_memory:
             self.models = models
 
-    def persist_models(self, model_names: list = None, with_ancestors=False, max_memory=None) -> list:
-        if model_names is None:
+    def persist_models(self, model_names='all', with_ancestors=False, max_memory=None) -> list:
+        if model_names is 'all':
             model_names = self.get_model_names_all()
         elif model_names is 'best':
             if self.model_best is not None:
                 model_names = [self.model_best]
             else:
                 model_names = [self.get_model_best(can_infer=True)]
+        if not isinstance(model_names, list):
+            raise ValueError(f'model_names must be a list of model names. Invalid value: {model_names}')
         if with_ancestors:
             model_names = self.get_minimum_models_set(model_names)
         model_names_already_persisted = [model_name for model_name in model_names if model_name in self.models]
@@ -1052,9 +1054,11 @@ class AbstractTrainer:
                 model_type = self.model_types[model_name]
             return model_type.load(path=path, reset_paths=self.reset_paths)
 
-    def unpersist_models(self, model_names: list = None) -> list:
-        if model_names is None:
+    def unpersist_models(self, model_names='all') -> list:
+        if model_names is 'all':
             model_names = list(self.models.keys())
+        if not isinstance(model_names, list):
+            raise ValueError(f'model_names must be a list of model names. Invalid value: {model_names}')
         unpersisted_models = []
         for model in model_names:
             if model in self.models:

--- a/tests/unittests/test_tabular.py
+++ b/tests/unittests/test_tabular.py
@@ -29,6 +29,7 @@ import pytest
 import autogluon as ag
 from autogluon import TabularPrediction as task
 from autogluon.utils.tabular.ml.constants import BINARY, MULTICLASS, REGRESSION
+from autogluon.task.tabular_prediction.predictor import TabularPredictor
 
 
 def test_tabular():
@@ -96,6 +97,23 @@ def test_advanced_functionality():
     predictor.transform_features()
     predictor.transform_features(dataset=test_data)
     predictor.info()
+
+    assert predictor.get_model_names_persisted() == []  # Assert that no models were persisted during training
+    assert predictor.unpersist_models() == []  # Assert that no models were unpersisted
+    persisted_models = predictor.persist_models(max_memory=None)
+    assert set(predictor.get_model_names_persisted()) == set(persisted_models)  # Ensure all models are persisted
+    assert predictor.persist_models(max_memory=None) == []  # Ensure that no additional models are persisted on repeated calls
+    unpersised_models = predictor.unpersist_models()
+    assert set(unpersised_models) == set(persisted_models)
+    assert predictor.get_model_names_persisted() == []  # Assert that all models were unpersisted
+
+    predictor.persist_models(max_memory=None)
+    predictor.save()  # Save predictor while models are persisted: Intended functionality is that they won't be persisted when loaded.
+    predictor_loaded = TabularPredictor.load(output_directory=predictor.output_directory)  # Assert that predictor loading works
+    leaderboard_loaded = predictor_loaded.leaderboard(dataset=test_data)
+    assert len(leaderboard) == len(leaderboard_loaded)
+    assert predictor_loaded.get_model_names_persisted() == []  # Assert that models were not still persisted after loading predictor
+
     assert(predictor.get_model_full_dict() == dict())
     predictor.refit_full()
     assert(len(predictor.get_model_full_dict()) == num_models)


### PR DESCRIPTION

*Issue #, if available:*
#376 

*Description of changes:*

Added persist_models, unpersist_models methods to TabularPredictor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
