### PR TITLE
[WIP, DO NOT MERGE] Fix conflicting port and lifecycle management for distributed schedulers

### DIFF
--- a/autogluon/scheduler/remote/cli.py
+++ b/autogluon/scheduler/remote/cli.py
@@ -15,10 +15,10 @@ from .remote import DaskRemoteService
 )
 @click.option(
     "--port",
-    default=8786,
+    default=0,
     show_default=True,
     type=int,
-    help="Specify the port number.",
+    help="Specify the port number, 0 means random port.",
 )
 def main(address, port):
     service = DaskRemoteService(address, port)

--- a/autogluon/scheduler/remote/cli_utils.py
+++ b/autogluon/scheduler/remote/cli_utils.py
@@ -1,0 +1,55 @@
+from distributed.deploy import ssh
+from distributed.utils import has_keyword, command_has_keyword
+
+def cli_keywords(d: dict, cls=None, cmd=None):
+    """Convert a kwargs dictionary into a list of CLI keywords
+    Parameters
+    ----------
+    d: dict
+        The keywords to convert
+    cls: callable
+        The callable that consumes these terms to check them for validity
+    cmd: string or object
+        A string with the name of a module, or the module containing a
+        click-generated command with a "main" function, or the function itself.
+        It may be used to parse a module's custom arguments (i.e., arguments that
+        are not part of Worker class), such as nprocs from dask-worker CLI or
+        enable_nvlink from dask-cuda-worker CLI.
+    Examples
+    --------
+    >>> cli_keywords({"x": 123, "save_file": "foo.txt"})
+    ['--x', '123', '--save-file', 'foo.txt']
+    >>> from dask.distributed import Worker
+    >>> cli_keywords({"x": 123}, Worker)
+    Traceback (most recent call last):
+    ...
+    ValueError: Class distributed.worker.Worker does not support keyword x
+    """
+    if cls or cmd:
+        for k in d:
+            if not has_keyword(cls, k) and not command_has_keyword(cmd, k):
+                if cls and cmd:
+                    raise ValueError(
+                        "Neither class %s or module %s support keyword %s"
+                        % (typename(cls), typename(cmd), k)
+                    )
+                elif cls:
+                    raise ValueError(
+                        "Class %s does not support keyword %s" % (typename(cls), k)
+                    )
+                else:
+                    raise ValueError(
+                        "Module %s does not support keyword %s" % (typename(cmd), k)
+                    )
+
+    def convert_value(v):
+        out = str(v)
+        if " " in out and "'" not in out and '"' not in out:
+            out = '"' + out + '"'
+        return out
+
+    return sum(
+        [["--" + k.replace("_", "-"), convert_value(v)] if v != '--no' else ["--no-" + k.replace("_", "-")] for k, v in d.items()], []
+    )
+
+ssh.cli_keywords = cli_keywords

--- a/autogluon/scheduler/remote/remote.py
+++ b/autogluon/scheduler/remote/remote.py
@@ -6,7 +6,7 @@ import weakref
 import logging
 import subprocess
 import concurrent
-from threading import Thread 
+from threading import Thread
 import multiprocessing as mp
 from distributed import Client
 

--- a/autogluon/scheduler/remote/remote_manager.py
+++ b/autogluon/scheduler/remote/remote_manager.py
@@ -80,7 +80,7 @@ class RemoteManager(object):
                 cls.NODES[node_ip] = remote
             remotes.append(remote)
         return remotes
-    
+
     @classmethod
     def shutdown(cls):
         for node in cls.NODES.values():

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ cwd = os.path.dirname(os.path.abspath(__file__))
 
 version = '0.0.14'
 """
-To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
-a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 
+To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
+a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
 You need to increase the version number after stable release, so that the nightly pypi can work properly.
 """
 try:
@@ -59,7 +59,8 @@ requirements = [
     'pandas>=0.24.0,<1.0',
     'psutil>=5.0.0,<=5.7.0',  # TODO: psutil 5.7.1/5.7.2 has non-deterministic error on CI doc build -  ImportError: cannot import name '_psutil_linux' from 'psutil'
     'scikit-learn>=0.22.0,<0.23',
-    'networkx>=2.3,<3.0'
+    'networkx>=2.3,<3.0',
+    'asyncssh'
 ]
 
 text_requirements = [


### PR DESCRIPTION
*Issue #, if available:*
Attempts to improve the scheduler stability on distributed nodes. There are known failure cases caused by `port is already allocated` before remote scheduler and worker to exit disgracefully

*Description of changes:*

- Remove global lock based PORT_ID assignment to remote schedulers
- The scheduler will still be launched in remote nodes due to the constraints in scheduler reporter synchronization, however, instead of using fixed port_id(potential conflict), it now support automatic port finder with dask's builtin `SSHCluster`
- Fixed a dask issue that prevent `no-nanny` worker to be launched with standard cluster setting. 
- Removed usage of manually managed background SSH connections


**note**
code for port_id, ssh_helper may not be necessary anymore after this PR, but I am waiting for more testings before being confidently removing non critical code removals.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
