### PR TITLE
[Tabular] fast.ai: expanded data types selector to handle wider range of types.

### DIFF
--- a/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
@@ -101,8 +101,16 @@ class NNFastAiTabularModel(AbstractModel):
         from fastai.tabular import TabularList
         from fastai.tabular import FillMissing, Categorify, Normalize
 
-        self.cat_columns = X_train.select_dtypes(['category', 'object']).columns.values.tolist()
-        self.cont_columns = X_train.select_dtypes(['float', 'int', 'datetime']).columns.values.tolist()
+        self.cat_columns = X_train.select_dtypes([
+            'category', 'object', 'bool', 'bool_', 'str', 'string_', 'unicode_'
+        ]).columns.values.tolist()
+
+        self.cont_columns = X_train.select_dtypes([
+            'float', 'float_', 'float16', 'float32', 'float64',
+            'int', 'int_', 'int8', 'int16', 'int32', 'int64', 'uint8', 'uint16', 'uint32', 'uint64',
+            'datetime'
+        ]).columns.values.tolist()
+
         if self.problem_type == REGRESSION and self.y_scaler is not None:
             Y_train_norm = pd.Series(self.y_scaler.fit_transform(Y_train.values.reshape(-1, 1)).reshape(-1))
             Y_test_norm = pd.Series(self.y_scaler.transform(Y_test.values.reshape(-1, 1)).reshape(-1)) if Y_test is not None else None


### PR DESCRIPTION
*Description of changes:*
`select_dtypes(['float'])` will select only float64. If the dataset has float32 or other types, those would be ignored. Expanded list of supported types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
