### PR TITLE
Fix warnings in Python 3.8

### DIFF
--- a/autogluon/task/text_prediction/dataset.py
+++ b/autogluon/task/text_prediction/dataset.py
@@ -1,4 +1,5 @@
 import collections
+import collections.abc
 import numpy as np
 import pandas as pd
 import json

--- a/autogluon/utils/pil_transforms.py
+++ b/autogluon/utils/pil_transforms.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 import mxnet as mx
 from PIL import Image, ImageEnhance
-import collections
+import collections.abc
 
 __all__ = ['Compose', 'RandomResizedCrop', 'RandomHorizontalFlip', 'ColorJitter',
            'Resize', 'CenterCrop', 'ToTensor', 'RandomCrop', 'ToNDArray', 'ToPIL']
@@ -374,7 +374,7 @@ class Resize(object):
     """
 
     def __init__(self, size, interpolation=Image.BILINEAR):
-        assert isinstance(size, int) or (isinstance(size, collections.Iterable) and len(size) == 2)
+        assert isinstance(size, int) or (isinstance(size, collections.abc.Iterable) and len(size) == 2)
         self.size = size
         self.interpolation = interpolation
 
@@ -432,7 +432,7 @@ def crop(img, top, left, height, width):
     return img.crop((left, top, left + width, top + height))
 
 def resize(img, size, interpolation=Image.BILINEAR):
-    if not (isinstance(size, int) or (isinstance(size, collections.Iterable) and len(size) == 2)):
+    if not (isinstance(size, int) or (isinstance(size, collections.abc.Iterable) and len(size) == 2)):
         raise TypeError('Got inappropriate size arg: {}'.format(size))
 
     if isinstance(size, int):

--- a/autogluon/utils/tabular/features/types.py
+++ b/autogluon/utils/tabular/features/types.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 def get_type_family_raw(dtype) -> str:
     """From dtype, gets the dtype family."""
     try:
-        if dtype.name is 'category':
+        if dtype.name == 'category':
             return 'category'
         if 'datetime' in dtype.name:
             return 'datetime'

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -905,10 +905,10 @@ class AbstractTrainer:
     # If model is specified, will fit all _FULL models that are ancestors of the provided model, automatically linking them.
     # If no model is specified, all models are refit and linked appropriately.
     def refit_ensemble_full(self, model='all'):
-        if model is 'all':
+        if model == 'all':
             ensemble_set = self.get_model_names_all()
         else:
-            if model is 'best':
+            if model == 'best':
                 model = self.get_model_best()
             ensemble_set = self.get_minimum_model_set(model)
         models_trained_full = self.refit_single_full(models=ensemble_set)
@@ -992,9 +992,9 @@ class AbstractTrainer:
             self.models = models
 
     def persist_models(self, model_names='all', with_ancestors=False, max_memory=None) -> list:
-        if model_names is 'all':
+        if model_names == 'all':
             model_names = self.get_model_names_all()
-        elif model_names is 'best':
+        elif model_names == 'best':
             if self.model_best is not None:
                 model_names = [self.model_best]
             else:
@@ -1055,7 +1055,7 @@ class AbstractTrainer:
             return model_type.load(path=path, reset_paths=self.reset_paths)
 
     def unpersist_models(self, model_names='all') -> list:
-        if model_names is 'all':
+        if model_names == 'all':
             model_names = list(self.models.keys())
         if not isinstance(model_names, list):
             raise ValueError(f'model_names must be a list of model names. Invalid value: {model_names}')


### PR DESCRIPTION
*Issue : Fixes #659 *

*Description of changes:*

* Import ABC from `collections.abc`
* Fix syntax warnings due to comparison of literals using is