### PR TITLE
Tabular: Updated CatBoost to 0.24.x

### DIFF
--- a/autogluon/utils/tabular/ml/models/rf/rf_model.py
+++ b/autogluon/utils/tabular/ml/models/rf/rf_model.py
@@ -45,6 +45,7 @@ class RFModel(AbstractModel):
         default_params = {
             'n_estimators': 300,
             'n_jobs': -1,
+            'random_state': 0,
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ requirements = [
     'graphviz<0.9.0,>=0.8.1',
     'fastparquet==0.4.1',
     'scikit-optimize',
-    'catboost<0.24',
+    'catboost>=0.23.0,<0.25',
     'pyarrow<=1.0.0',
     'boto3',
     'lightgbm>=3.0,<4.0',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updated CatBoost version
- Made RF and XT models deterministic by default (random_state=0) so that their results can be reproduced on repeated runs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
