### PR TITLE
[Bugfix] Removed str types from categorical columns - not supported by selector

### DIFF
--- a/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
+++ b/autogluon/utils/tabular/ml/models/fastainn/tabular_nn_fastai.py
@@ -102,7 +102,7 @@ class NNFastAiTabularModel(AbstractModel):
         from fastai.tabular import FillMissing, Categorify, Normalize
 
         self.cat_columns = X_train.select_dtypes([
-            'category', 'object', 'bool', 'bool_', 'str', 'string_', 'unicode_'
+            'category', 'object', 'bool', 'bool_'
         ]).columns.values.tolist()
 
         self.cont_columns = X_train.select_dtypes([


### PR DESCRIPTION
pandas `select_dtypes()` does not accepts the types `'str', 'string_', 'unicode_'` - removed those

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
