### PR TITLE
Transductive Learning

### DIFF
--- a/autogluon/task/tabular_prediction/predictor.py
+++ b/autogluon/task/tabular_prediction/predictor.py
@@ -91,6 +91,7 @@ class TabularPredictor(BasePredictor):
         self.class_labels = self._learner.class_labels
         self.class_labels_internal = self._learner.label_cleaner.ordered_class_labels_transformed
         self.class_labels_internal_map = self._learner.label_cleaner.inv_map
+        self.fit_transductively = self._learner.fit_transductively
 
     @property
     def model_names(self):
@@ -1006,7 +1007,7 @@ class TabularPredictor(BasePredictor):
         """
         Distill AutoGluon's most accurate ensemble-predictor into single models which are simpler/faster and require less memory/compute.
         Distillation can produce a model that is more accurate than the same model fit directly on the original training data.
-        After calling `distill()`, there will be more models available in this Predictor, which can be evaluated using `predictor.leaderboard(test_data)` and deployed with: `predictor.predict(test_data, model=MODEL_NAME)`.
+        After calling `distill()`, there will be more models available in this Predictor (with suffix '_DSTL' in their names), which can be evaluated using `predictor.leaderboard(test_data)` and deployed with: `predictor.predict(test_data, model=MODEL_NAME)`.
         This will raise an exception if `cache_data=False` was previously set in `task.fit()`.
 
         NOTE: Until catboost v0.24 is released, `distill()` with CatBoost students in multiclass classification requires you to first install catboost-dev: `pip install catboost-dev`

--- a/autogluon/utils/tabular/ml/learner/abstract_learner.py
+++ b/autogluon/utils/tabular/ml/learner/abstract_learner.py
@@ -54,6 +54,7 @@ class AbstractLearner:
         self.label_cleaner: LabelCleaner = None
         self.feature_generator: PipelineFeatureGenerator = feature_generator
         self.feature_generators = [self.feature_generator]
+        self.fit_transductively = False
 
         self.trainer: AbstractTrainer = None
         self.trainer_type = None

--- a/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/abstract_trainer.py
@@ -91,7 +91,7 @@ class AbstractTrainer:
         # self.models_level_all['aux1'][1] # Stacker level 1 aux models, such as weighted_ensemble
         # self.models_level_all['core'][2] # Stacker level 2
         self.models_level = defaultdict(dd_list)
-
+        self.model_name_suffix = ''
         self.model_best = None
 
         self.model_performance = {}  # TODO: Remove in future, use networkx.
@@ -567,7 +567,7 @@ class AbstractTrainer:
     def stack_new_level_aux(self, X, y, level, fit=True, time_limit=None):
         stack_name = 'aux1'
         X_train_stack_preds = self.get_inputs_to_stacker(X, level_start=0, level_end=level, fit=fit)
-        return self.generate_weighted_ensemble(X=X_train_stack_preds, y=y, level=level, kfolds=0, n_repeats=1, stack_name=stack_name, time_limit=time_limit)
+        return self.generate_weighted_ensemble(X=X_train_stack_preds, y=y, level=level, kfolds=0, n_repeats=1, stack_name=stack_name, time_limit=time_limit, name_suffix=self.model_name_suffix)
 
     def generate_weighted_ensemble(self, X, y, level, kfolds=0, n_repeats=1, stack_name=None, hyperparameters=None, time_limit=None, base_model_names=None, name_suffix='', save_bagged_folds=None, check_if_best=True, child_hyperparameters=None):
         if save_bagged_folds is None:

--- a/autogluon/utils/tabular/ml/trainer/auto_trainer.py
+++ b/autogluon/utils/tabular/ml/trainer/auto_trainer.py
@@ -11,10 +11,11 @@ logger = logging.getLogger(__name__)
 # This Trainer handles model training details
 class AutoTrainer(AbstractTrainer):
     def get_models(self, hyperparameters, hyperparameter_tune=False, level='default', extra_ag_args_fit=None, **kwargs):
-        return get_preset_models(path=self.path, problem_type=self.problem_type, eval_metric=self.eval_metric, stopping_metric=self.stopping_metric,
-                                 num_classes=self.num_classes, hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, level=level, extra_ag_args_fit=extra_ag_args_fit)
+        return get_preset_models(path=self.path, problem_type=self.problem_type, eval_metric=self.eval_metric, stopping_metric=self.stopping_metric, num_classes=self.num_classes,
+                                 hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, level=level, extra_ag_args_fit=extra_ag_args_fit, name_suffix=self.model_name_suffix)
 
     def train(self, X_train, y_train, X_val=None, y_val=None, hyperparameter_tune=True, feature_prune=False, holdout_frac=0.1, hyperparameters=None, ag_args_fit=None, excluded_model_types=None, **kwargs):
+        self.model_name_suffix = kwargs.get('name_suffix', '')
         if hyperparameters is None:
             hyperparameters = {}
         self.hyperparameters = self._process_hyperparameters(hyperparameters=hyperparameters, ag_args_fit=ag_args_fit, excluded_model_types=excluded_model_types)

--- a/autogluon/utils/tabular/ml/utils.py
+++ b/autogluon/utils/tabular/ml/utils.py
@@ -324,3 +324,12 @@ def augment_rare_classes(X, label, threshold):
         raise RuntimeError("augment_rare_classes failed to produce enough data from rare classes")
     logger.log(15, "Replicated some data from rare classes in training set because eval_metric requires all classes")
     return X
+
+
+def check_features_match(df1, df2=None, label=None):
+    if df2 is not None:
+        features1 = np.array([column for column in df1.columns if column != label])
+        features2 = np.array([column for column in df2.columns if column != label])
+        if (len(features1) != len(features2)) or np.any(features1 != features2):
+            return False
+    return True

--- a/tests/unittests/test_tabular.py
+++ b/tests/unittests/test_tabular.py
@@ -286,10 +286,13 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
                 warnings.warn("Performance on dataset %s is %s times worse than previous performance." %
                               (dataset['name'], performance_vals[idx]/(EPS+dataset['performance_val'])))
             if run_distill:
+                print("running distillation ...")
                 predictor.distill(time_limits=60, augment_args={'size_factor':0.5})
 
             if run_transductive:
-                transductive_predictor = task.fit(train_data=train_data, unlabeled_test_data=test_data.head(50), label=label_column, output_directory=savedir, **fit_args)
+                print("running transductive fit ...")
+                unlabeled_test_data = test_data[[column for column in test_data.columns if column in train_data.columns]].head(50)  # ensure no extra columns
+                transductive_predictor = task.fit(train_data=train_data, unlabeled_test_data=unlabeled_test_data, label=label_column, output_directory=savedir, **fit_args)
 
     # Summarize:
     avg_perf = np.mean(performance_vals)

--- a/tests/unittests/test_tabular.py
+++ b/tests/unittests/test_tabular.py
@@ -201,7 +201,7 @@ def run_tabular_benchmark_toy(fit_args):
         raise AssertionError(f'{dataset["name"]} should raise an exception.')
 
 
-def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_val, fit_args, dataset_indices=None, run_distill=False):
+def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_val, fit_args, dataset_indices=None, run_distill=False, run_transductive=False):
     print("Running fit with args:")
     print(fit_args)
     # Each train/test dataset must be located in single directory with the given names.
@@ -287,6 +287,10 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
                               (dataset['name'], performance_vals[idx]/(EPS+dataset['performance_val'])))
             if run_distill:
                 predictor.distill(time_limits=60, augment_args={'size_factor':0.5})
+
+            if run_transductive:
+                transductive_predictor = task.fit(train_data=train_data, unlabeled_test_data=test_data.head(50), label=label_column, output_directory=savedir, **fit_args)
+
     # Summarize:
     avg_perf = np.mean(performance_vals)
     median_perf = np.median(performance_vals)
@@ -308,6 +312,7 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
 
     print("Ran fit with args:")
     print(fit_args)
+
     # List all warnings again to make sure they are seen:
     print("\n\n WARNINGS:")
     for w in caught_warnings:
@@ -556,5 +561,5 @@ def test_tabular_bagstack():
         fit_args['num_bagging_sets'] = 2
     ###################################################################
     run_tabular_benchmarks(fast_benchmark=fast_benchmark, subsample_size=subsample_size, perf_threshold=perf_threshold,
-                           seed_val=seed_val, fit_args=fit_args, run_distill=True)
+                           seed_val=seed_val, fit_args=fit_args, run_distill=True, run_transductive=True)
 


### PR DESCRIPTION
Adds basic version of pseudolabeling specifically designed for test data. The new argument added is `unlabeled_test_data` as the transductive setting is sufficiently distinct from the semi-supervised setting, especially as we add shift-detection and other test-data-specific functionality, it will be crucial to have a dedicated argument that makes it clear the resulting models are specifically designed for the test data (rather than any new data).  This also avoids merge conflict with the TabTransformer PR's use of `unlabeled_data` argument.

Example code:

```
from autogluon import TabularPrediction as task

label_column = 'class'

train_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
val_data = train_data[1000:1500]
train_data = train_data.head(500)
test_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')
test_data = test_data.head(5000)
y_test = test_data[label_column]
test_data_nolab = test_data.drop(labels=[label_column],axis=1)

hyperparameters = {'GBM': {},'CAT':{}}  # Just here to ensure quicker run

# Transductive learning w validation data:
predictor = task.fit(train_data=train_data, tuning_data=val_data, unlabeled_test_data=test_data_nolab, label=label_column, hyperparameters=hyperparameters)

# Transductive learning:
predictor = task.fit(train_data=train_data, unlabeled_test_data=test_data_nolab, label=label_column, hyperparameters=hyperparameters)

# Transductive learning w stacking:
predictor = task.fit(train_data=train_data, unlabeled_test_data=test_data_nolab, label=label_column, auto_stack=True, hyperparameters=hyperparameters)


y_pred = predictor.predict(test_data_nolab)
perf = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred)
predictor.leaderboard(test_data)


## Transductive regression:
label_column = 'age'
y_test = test_data[label_column]
test_data_nolab = test_data.drop(labels=[label_column],axis=1) # delete labels from test data since we wouldn't have them in practice

predictor = task.fit(train_data=train_data, unlabeled_test_data=test_data_nolab, label=label_column, hyperparameters=hyperparameters)
predictor.leaderboard(test_data)


## Transductive multiclass classification:
label_column = 'native-country'
y_test = test_data[label_column]
test_data_nolab = test_data.drop(labels=[label_column],axis=1) # delete labels from test data since we wouldn't have them in practice

predictor = task.fit(train_data=train_data, unlabeled_test_data=test_data_nolab, label=label_column, hyperparameters=hyperparameters)
predictor.leaderboard(test_data)
```
