### PR TITLE
Fix gp fifo searcher

### DIFF
--- a/autogluon/searcher/bayesopt/autogluon/searcher_factory.py
+++ b/autogluon/searcher/bayesopt/autogluon/searcher_factory.py
@@ -1,4 +1,5 @@
 from typing import Set
+import numpy as np
 
 from .debug_log import DebugLogPrinter
 from .gp_fifo_searcher import GPFIFOSearcher, map_reward, MapReward, DEFAULT_INITIAL_SCORING, SUPPORTED_INITIAL_SCORING
@@ -207,7 +208,7 @@ def _common_defaults(is_hyperband: bool) -> (Set[str], dict, dict):
     mandatory = set()
 
     default_options = {
-        'random_seed': 31415927,
+        'random_seed': np.random.randint(10000),
         'opt_skip_init_length': 150,
         'opt_skip_period': 1,
         'profiler': False,
@@ -217,6 +218,7 @@ def _common_defaults(is_hyperband: bool) -> (Set[str], dict, dict):
         'opt_verbose': False,
         'opt_debug_writer': False,
         'num_fantasy_samples': 20,
+        'scheduler': 'fifo',
         'num_init_random': DEFAULT_NUM_INITIAL_RANDOM_EVALUATIONS,
         'num_init_candidates': DEFAULT_NUM_INITIAL_CANDIDATES,
         'initial_scoring': DEFAULT_INITIAL_SCORING,

--- a/autogluon/searcher/gp_searcher.py
+++ b/autogluon/searcher/gp_searcher.py
@@ -113,9 +113,10 @@ class GPFIFOSearcher(BaseSearcher):
     ...     train_fn, searcher='bayesopt', searcher_options=searcher_options,
     ...     num_trials=10, reward_attr='accuracy')
     """
-    def __init__(self, **kwargs):
+    def __init__(self, configspace, **kwargs):
         _gp_searcher = kwargs.get('_gp_searcher')
         if _gp_searcher is None:
+            kwargs['configspace'] = configspace
             _kwargs = check_and_merge_defaults(
                 kwargs, *gp_fifo_searcher_defaults(),
                 dict_name='search_options')


### PR DESCRIPTION
Fixes issue #685 . It also changes the default to a random seed and makes it mandatory to pass the confispace argument to the GPFIFOSearcher 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
