### PR TITLE
Fix in object detection task to support train and predict on cpu node.

### DIFF
--- a/vision/src/autogluon/vision/object_detection/object_detection.py
+++ b/vision/src/autogluon/vision/object_detection/object_detection.py
@@ -295,7 +295,8 @@ class ObjectDetection(BaseTask):
         args = sample_config(train_object_detection.args, results['best_config'])
         logger.info('The best config: {}'.format(results['best_config']))
 
-        ctx = [mx.gpu(i) for i in range(get_gpu_count())]
+        ngpus = get_gpu_count()
+        ctx = [mx.gpu(i) for i in range(ngpus)] if ngpus > 0 else [mx.cpu()]
         model = get_network(args.meta_arch, args.net, dataset.init().get_classes(), transfer, ctx,
                             syncbn=args.syncbn)
         update_params(model, results.pop('model_params'))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
PR provides a fix in object detection task when ngpus_per_trial is set to 0 for detector. 
**Error observed**
_ind, prob, loc = detector.predict(image_path)_ 
>   File "/usr/local/lib/python3.6/site-packages/autogluon/task/object_detection/detector.py", line 171, in predict
>     net.collect_params().reset_ctx(ctx=mx.cpu())
>   File "/usr/local/lib/python3.6/site-packages/mxnet/gluon/parameter.py", line 929, in reset_ctx
>     i.reset_ctx(ctx)
>   File "/usr/local/lib/python3.6/site-packages/mxnet/gluon/parameter.py", line 493, in reset_ctx
>     "has not been initialized."%self.name)
> ValueError: Cannot reset context for Parameter 'mobilenet0_conv0_weight' because it has not been initialized.


**Fix**
To set the cpu context if num of gpus == 0

**Verification script**
Verified by passing _ngpus_per_trial=0_ to the _detector_
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
