### PR TITLE
[CI refactoring] Updated docs publication process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,8 +96,9 @@ stage("Build Docs") {
             cacheControl = ''
         } else {
             isMaster = env.BRANCH_NAME == 'master'
+            isDev = env.BRANCH_NAME == 'dev'
             bucket = 'autogluon.mxnet.io'
-            path = isMaster ? 'dev' : "${env.BRANCH_NAME}"
+            path = isMaster ? 'dev' : isDev ? 'dev-branch' : "${env.BRANCH_NAME}"
             site = "${bucket}/${path}"
             flags = isMaster ? '' : '--delete'
             cacheControl = '--cache-control max-age=7200'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,7 +167,7 @@ stage("Build Docs") {
         python3 -m pip install --upgrade -e .
         cd ..
 
-        sed -i -e 's/###_PLACEHOLDER_WEB_CONTENT_ROOT_###/https:\\/\\/${escaped_context_root}/g' docs/config.ini
+        sed -i -e 's/###_PLACEHOLDER_WEB_CONTENT_ROOT_###/http:\\/\\/${escaped_context_root}/g' docs/config.ini
 
         cd docs && bash build_doc.sh
         aws s3 sync ${flags} _build/html/ s3://${bucket}/${path} --acl public-read ${cacheControl}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,20 +87,28 @@ stage("Build Docs") {
         checkout scm
         VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
 
+        index_update_str = ''
         if (env.BRANCH_NAME.startsWith("PR-")) {
             bucket = 'autogluon-staging'
-            path = "${env.BRANCH_NAME}/${env.BUILD_NUMBER}/"
-            site = "${bucket}.s3-website-us-west-2.amazonaws.com/${path}index.html"
+            path = "${env.BRANCH_NAME}/${env.BUILD_NUMBER}"
+            site = "${bucket}.s3-website-us-west-2.amazonaws.com/${path}"
             flags = '--delete'
             cacheControl = ''
         } else {
             isMaster = env.BRANCH_NAME == 'master'
             bucket = 'autogluon.mxnet.io'
-            path = isMaster ? '' : "${env.BRANCH_NAME}/"
+            path = isMaster ? 'dev' : "${env.BRANCH_NAME}"
             site = "${bucket}/${path}"
             flags = isMaster ? '' : '--delete'
             cacheControl = '--cache-control max-age=7200'
+            if (isMaster) {
+                index_update_str = """
+                            aws s3 cp root_index.html s3://${bucket}/index.html --acl public-read ${cacheControl}
+                            echo "Uploaded root_index.html s3://${bucket}/index.html"
+                        """
+            }
         }
+        escaped_context_root = site.replaceAll('\\/', '\\\\/')
 
         sh """#!/bin/bash
         set -ex
@@ -158,9 +166,13 @@ stage("Build Docs") {
         python3 -m pip install --upgrade -e .
         cd ..
 
+        sed -i -e 's/###_PLACEHOLDER_WEB_CONTENT_ROOT_###/https:\\/\\/${escaped_context_root}/g' docs/config.ini
+
         cd docs && bash build_doc.sh
         aws s3 sync ${flags} _build/html/ s3://${bucket}/${path} --acl public-read ${cacheControl}
-        echo "Uploaded doc to http://${site}"
+        echo "Uploaded doc to http://${site}/index.html"
+
+        ${index_update_str}
         """
 
         if (env.BRANCH_NAME.startsWith("PR-")) {

--- a/autogluon/setup.py
+++ b/autogluon/setup.py
@@ -44,12 +44,12 @@ long_description = open(os.path.join('..', 'README.md')).read()
 MIN_PYTHON_VERSION = '>=3.6.*'
 
 requirements = [
-    'autogluon.core',
-    'autogluon.tabular',
-    'autogluon.mxnet',
-    'autogluon.extra',
-    'autogluon.text',
-    'autogluon.vision'
+    f'autogluon.core=={version}',
+    f'autogluon.tabular=={version}',
+    f'autogluon.mxnet=={version}',
+    f'autogluon.extra=={version}',
+    f'autogluon.text=={version}',
+    f'autogluon.vision=={version}'
 ]
 
 test_requirements = [

--- a/docs/ReleaseInstructions.md
+++ b/docs/ReleaseInstructions.md
@@ -1,0 +1,27 @@
+### Release process
+
+* Update version `title` in `root_index.html`.
+* Tag release with format `v0.0.x`
+* Cut a release branch with format `0.0.x` (no v) - this branch is required to publish docs to versioned path
+* Push release branch and tags
+* Build the release branch docs in [CI](https://ci.mxnet.io/job/autogluon/).
+* Verify it's available at `https://autogluon.mxnet.io/0.0.x/index.html`
+* Ensure that the mainline code you are planning to release is stable: Benchmark, ensure CI passes, check with team, etc.
+* Ensure latest pre-release is working via `pip install --pre --upgrade autogluon` and testing to get an idea of how the actual release will function (Ideally with fresh venv). DO NOT RELEASE if the pre-release does not work.
+* Perform version release by going to https://github.com/awslabs/autogluon/releases and click 'Draft a new release' in top right.
+* DO NOT use the 'Save draft' option during the creation of the release. This breaks GitHub pipelines.
+* Name the release identically to the tag (ex: `v0.x.y`)
+* Include all merged PRs into the notes and mention all PR authors / contributors (refer to past releases for examples). Prioritize major features before minor features when ordering, otherwise order by merge date.
+* Click 'Publish release' and the release will go live.
+* Wait ~10 minutes and then locally test that the PyPi package is available and working with the latest release version, ask team members to also independently verify.
+* IF THERE IS A MAJOR ISSUE: Do an emergency hot-fix and a new release ASAP. Releases cannot be deleted, so a new release will have to be done.
+* Send release update to internal and external slack channels and mailing lists
+* Publish any blogs / talks planned for release to generate interest.
+
+After release is published, on the mainline branch:
+* Update header links pointing to the **previous** version in `docs/config.ini` 
+    ```
+    header_links = v0.0.x Documentation, https://autogluon.mxnet.io/0.0.x/index.html, fas fa-book,
+    ```
+* Update `release` in `docs/config.ini`
+* Increment version in the `VERSION` file

--- a/docs/config.ini
+++ b/docs/config.ini
@@ -12,17 +12,17 @@ author = AutoGluon contributors
 
 copyright = 2019, All developers. Licensed under the Apache License, Version 2.0.
 
-release = 0.0.1
+release = 0.0.15
 
 [html]
 
 # A list of links that is displayed on the navbar. A link consists of three
 # items: name, URL, and a fontawesome icon
 # (https://fontawesome.com/icons?d=gallery). Items are separated by commas.
-header_links = v0.0.14 Documentation, https://autogluon.mxnet.io/v0.0.14/index.html, fas fa-book,
-               API, http://autogluon.mxnet.io/api/index.html, fas fa-book,
-               Installation, http://autogluon.mxnet.io/install.html, fas fa-download,
-               Tutorials, http://autogluon.mxnet.io/tutorials/index.html, fas fa-external-link-alt,
+header_links = Stable Version Documentation, https://autogluon.mxnet.io/stable/index.html, fas fa-book,
+               API, ###_PLACEHOLDER_WEB_CONTENT_ROOT_###/api/index.html, fas fa-book,
+               Installation, ###_PLACEHOLDER_WEB_CONTENT_ROOT_###/install.html, fas fa-download,
+               Tutorials, ###_PLACEHOLDER_WEB_CONTENT_ROOT_###/tutorials/index.html, fas fa-external-link-alt,
                Github, https://github.com/awslabs/autogluon, fab fa-github
 
 favicon = static/favicon.png

--- a/docs/root_index.html
+++ b/docs/root_index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+
+<meta http-equiv="refresh" content="0; url=https://autogluon.mxnet.io/stable/index.html" />
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+      <meta charset="utf-8"/>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+      <meta http-equiv="x-ua-compatible" content="ie=edge">
+
+      <title>AutoGluon: AutoML Toolkit for Deep Learning &#8212; AutoGluon Documentation</title>
+
+      <link rel="stylesheet" href="_static/basic.css" type="text/css"/>
+      <link rel="stylesheet" href="_static/pygments.css" type="text/css"/>
+      <link rel="stylesheet" type="text/css" href="_static/jupyter-sphinx.css"/>
+      <link rel="stylesheet" type="text/css" href="_static/thebelab.css"/>
+      <link rel="stylesheet" type="text/css" href="_static/d2l.css"/>
+      <link rel="stylesheet" href="_static/material-design-lite-1.3.0/material.blue-deep_orange.min.css" type="text/css"/>
+      <link rel="stylesheet" href="_static/sphinx_materialdesign_theme.css" type="text/css"/>
+      <link rel="stylesheet" href="_static/fontawesome/all.css" type="text/css"/>
+      <link rel="stylesheet" href="_static/fonts.css" type="text/css"/>
+      <script id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
+      <script src="_static/jquery.js"></script>
+      <script src="_static/underscore.js"></script>
+      <script src="_static/doctools.js"></script>
+      <script src="_static/language_data.js"></script>
+      <script src="_static/thebelab-helper.js"></script>
+      <script src="_static/d2l.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js"></script>
+      <script src="https://unpkg.com/@jupyter-widgets/html-manager@^0.18.0/dist/embed-amd.js"></script>
+      <link rel="shortcut icon" href="_static/favicon.png"/>
+      <link rel="index" title="Index" href="genindex.html"/>
+      <link rel="search" title="Search" href="search.html"/>
+      <link rel="next" title="Tabular Prediction" href="tutorials/tabular_prediction/index.html"/>
+      <link rel="canonical" href="https://autogluon.mxnet.io/stable/index.html" />
+  </head>
+
+</html>

--- a/extra/setup.py
+++ b/extra/setup.py
@@ -46,7 +46,7 @@ requirements = [
     'bokeh',
     'pandas>=1.0.0,<2.0',
     'scikit-learn>=0.22.0,<0.24',
-    'autogluon.core'
+    f'autogluon.core=={version}'
 ]
 
 test_requirements = [

--- a/mxnet/setup.py
+++ b/mxnet/setup.py
@@ -43,7 +43,7 @@ requirements = [
     'matplotlib',
     'pandas>=1.0.0,<2.0',
     'scikit-learn>=0.22.0,<0.24',
-    'autogluon.core'
+    f'autogluon.core=={version}'
 ]
 
 test_requirements = [

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -46,6 +46,7 @@ requirements = [
     'psutil>=5.0.0,<=5.7.0',  # TODO: psutil 5.7.1/5.7.2 has non-deterministic error on CI doc build -  ImportError: cannot import name '_psutil_linux' from 'psutil'
     'scikit-learn>=0.22.0,<0.24',
     'networkx>=2.3,<3.0',
+    'gluoncv>=0.5.0,<1.0',
     f'autogluon.core=={version}'
 ]
 

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -46,7 +46,7 @@ requirements = [
     'psutil>=5.0.0,<=5.7.0',  # TODO: psutil 5.7.1/5.7.2 has non-deterministic error on CI doc build -  ImportError: cannot import name '_psutil_linux' from 'psutil'
     'scikit-learn>=0.22.0,<0.24',
     'networkx>=2.3,<3.0',
-    'autogluon.core'
+    f'autogluon.core=={version}'
 ]
 
 test_requirements = [

--- a/text/setup.py
+++ b/text/setup.py
@@ -45,8 +45,8 @@ requirements = [
     'tqdm>=4.38.0',
     'pandas>=1.0.0,<2.0',
     'scikit-learn>=0.22.0,<0.24',
-    'autogluon.core',
-    'autogluon.mxnet'
+    f'autogluon.core=={version}',
+    f'autogluon.mxnet=={version}'
 ]
 
 text_requirements = [

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -46,8 +46,8 @@ requirements = [
     'gluoncv>=0.5.0,<1.0',
     'graphviz<0.9.0,>=0.8.1',
     'pandas>=1.0.0,<2.0',
-    'autogluon.core',
-    'autogluon.mxnet',
+    f'autogluon.core=={version}',
+    f'autogluon.mxnet=={version}'
 ]
 
 test_requirements = [


### PR DESCRIPTION
*Description of changes:*
* master branch will no longer publish docs into the root https://autogluon.mxnet.io/ 
* master branch will publish all docs to https://autogluon.mxnet.io/dev/
* master branch will publish root_index.html (new file) into root index.html. The only thing this file is going to do is to immediately redirect into https://autogluon.mxnet.io/stable/
* docs updated
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
* restricted internal cross-module versions to a specific version
* doc links in headers are now replaced dynamically to a correct branch during the build time