### PR TITLE
[Bug Fix] BaseTask: fix silent exception, handle None in best config result

### DIFF
--- a/core/src/autogluon/core/scheduler/fifo.py
+++ b/core/src/autogluon/core/scheduler/fifo.py
@@ -225,7 +225,7 @@ class FIFOScheduler(TaskScheduler):
                 self.load_state_dict(load(checkpoint))
             else:
                 msg = f'checkpoint path {checkpoint} is not available for resume.'
-                logger.exception(msg)
+                logger.critical(msg)
                 raise FileExistsError(msg)
 
     def run(self, **kwargs):
@@ -399,7 +399,7 @@ class FIFOScheduler(TaskScheduler):
             reported_result = reporter.fetch()
             if 'traceback' in reported_result:
                 # Evaluation has failed
-                logger.exception(reported_result['traceback'])
+                logger.critical(reported_result['traceback'])
                 self.searcher.evaluation_failed(
                     config=task.args['config'], **reported_result)
                 reporter.move_on()

--- a/core/src/autogluon/core/task/base/base_task.py
+++ b/core/src/autogluon/core/task/base/base_task.py
@@ -1,5 +1,6 @@
 import collections
 import copy
+import logging
 import time
 from abc import abstractmethod
 
@@ -22,6 +23,8 @@ schedulers = {
     'bayesopt': FIFOScheduler,
     'bayesopt_hyperband': HyperbandScheduler}
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
 
 def create_scheduler(train_fn, search_strategy, scheduler_options):
     if isinstance(search_strategy, str):
@@ -67,6 +70,8 @@ class BaseTask(object):
             plot_training_curves = scheduler_options['checkpoint'].replace('exp1.ag', 'plot_training_curves.png')
             scheduler.get_training_curves(filename=plot_training_curves, plot=True, use_legend=False)
         record_args = copy.deepcopy(args)
+        if results is None:
+            logger.warning('No valid results obtained with best config, the result may not be useful...')
         results.update(best_reward=best_reward,
                        best_config=best_config,
                        total_time=total_time,

--- a/core/src/autogluon/core/task/base/base_task.py
+++ b/core/src/autogluon/core/task/base/base_task.py
@@ -72,6 +72,7 @@ class BaseTask(object):
         record_args = copy.deepcopy(args)
         if results is None:
             logger.warning('No valid results obtained with best config, the result may not be useful...')
+            results = {}
         results.update(best_reward=best_reward,
                        best_config=best_config,
                        total_time=total_time,

--- a/core/tests/unittests/test_base_task.py
+++ b/core/tests/unittests/test_base_task.py
@@ -1,0 +1,48 @@
+from autogluon.core.decorator import sample_config
+from autogluon.core.scheduler.resource import get_cpu_count, get_gpu_count
+from autogluon.core.task.base import BaseTask
+import autogluon.core as ag
+
+@ag.args()
+def _train_fn_bad(args, reporter):
+    raise NotImplementedError
+
+@ag.args()
+def _train_fn_good(args, reporter):
+    reporter(epoch=1, accuracy=0)
+
+class TestTask(BaseTask):
+    def __init__(self, fn):
+        self.fn = fn
+        self._config = {}
+        nthreads_per_trial = get_cpu_count()
+        ngpus_per_trial = get_gpu_count()
+        self._config['search_strategy'] = self._config.get('search_strategy', 'random')
+        self._config['scheduler_options'] = {
+            'resource': {'num_cpus': nthreads_per_trial, 'num_gpus': ngpus_per_trial},
+            'num_trials': self._config.get('num_trials', 2),
+            'time_out': self._config.get('time_limits', 60 * 60),
+            'time_attr': 'epoch',
+            'reward_attr': 'accuracy',
+            'searcher': self._config.get('search_strategy', {}),
+            'search_options': self._config.get('search_options', None)}
+        if self._config['search_strategy'] == 'hyperband':
+            self._config['scheduler_options'].update({
+                'searcher': 'random',
+                'max_t': self._config.get('epochs', 50),
+                'grace_period': self._config.get('grace_period',  100)})
+
+    def fit(self):
+        config = {'lr': ag.Categorical(0.1, 0.2, 0.3)}
+        self.fn.register_args(**config)
+        results = self.run_fit(self.fn, self._config['search_strategy'],
+                               self._config['scheduler_options'])
+
+def test_valid_fn():
+    task = TestTask(_train_fn_good)
+    task.fit()
+
+def test_invalid_fn():
+    # should catch, print but won't raise
+    task = TestTask(_train_fn_bad)
+    task.fit()


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/issues/488

*Description of changes:*
Found the root error during another experiment. There are two issues with existing BaseTask
- If logging level not properly set, the stacktrace of failed task won't be displayed
- If training config with best config failed, `None` object is returned, causing #488 

The solution is to ensure the stacktrace will be printed, and catch the `None.update` issue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
