### PR TITLE
Fixed website links to point to stable release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 ## Tips for Modifying the Source Code
 
 - Using a fresh virtualenv, install the package via [these instructions](https://auto.gluon.ai/dev/install.html).
-Be sure to select the *Source* option from the installation preferences, and install the package after cloning this repository via:
-```
-python setup.py develop
-```
+Be sure to select the *Source* option from the installation preferences.
 
 - We recommend developing on Linux as this is the only OS where all features are currently 100% functional. Avoid introducing changes that will only work on a particular OS, as we're currently working to support MacOSX and Windows. Changes to existing code that improve cross-platform compatibility are most welcome!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ information to effectively respond to your bug report or contribution.
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/awslabs/auto-ml-with-gluon/issues), or [recently closed](https://github.com/awslabs/auto-ml-with-gluon/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
+When filing an issue, please check [existing open](https://github.com/awslabs/autogluon/issues), or [recently closed](https://github.com/awslabs/autogluon/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 * A reproducible test case or series of steps
@@ -43,7 +43,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 ## Tips for Modifying the Source Code
 
-- Using a fresh virtualenv, install the package via [these instructions](https://autogluon.mxnet.io/install.html).
+- Using a fresh virtualenv, install the package via [these instructions](https://auto.gluon.ai/dev/install.html).
 Be sure to select the *Source* option from the installation preferences, and install the package after cloning this repository via:
 ```
 python setup.py develop
@@ -93,7 +93,7 @@ python3 -m pytest path_to_file
 
 
 ## Finding Contributions to Work On
-Looking at the existing issues is a great way to find something to contribute on. As our project uses the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/auto-ml-with-gluon/labels/help%20wanted) issues is a great place to start.
+Looking at the existing issues is a great way to find something to contribute on. As our project uses the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/autogluon/labels/help%20wanted) issues is a great place to start.
 
 
 ## Code of Conduct
@@ -108,6 +108,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awslabs/auto-ml-with-gluon/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/awslabs/autogluon/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,12 +25,6 @@ stage("Unit Test") {
         pip uninstall -y autogluon.tabular
         pip uninstall -y autogluon.core
         pip uninstall -y autogluon-contrib-nlp
-        pip uninstall -y autogluon-core
-        pip uninstall -y autogluon-extra
-        pip uninstall -y autogluon-mxnet
-        pip uninstall -y autogluon-tabular
-        pip uninstall -y autogluon-text
-        pip uninstall -y autogluon-vision
 
         cd core/
         python3 -m pip install --upgrade -e .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ stage("Build Docs") {
         other_doc_version_text = 'Stable Version Documentation'
         other_doc_version_branch = 'stable'
         if (env.BRANCH_NAME == 'stable') {
-            other_doc_version_text = 'Nightly Version Documentation'
+            other_doc_version_text = 'Dev Version Documentation'
             other_doc_version_branch = 'dev'
         }
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img src="https://user-images.githubusercontent.com/16392542/77208906-224aa500-6aba-11ea-96bd-e81806074030.png" width="350">
 </div>
 
-## AutoML Toolkit for Text, Image, and Tabular Data
+## AutoML Toolkit for Tabular, Text, and Image Data
 
-[![Build Status](http://ci.mxnet.io/view/all/job/autogluon/job/master/badge/icon)](http://ci.mxnet.io/view/all/job/autogluon/job/master/)
+[![Build Status](https://ci.gluon.ai/view/all/job/autogluon/job/master/badge/icon)](https://ci.gluon.ai/view/all/job/autogluon/job/master/)
 [![Pypi Version](https://img.shields.io/pypi/v/autogluon.svg)](https://pypi.org/project/autogluon/#history)
 ![Upload Python Package](https://github.com/awslabs/autogluon/workflows/Upload%20Python%20Package/badge.svg)
 
@@ -29,19 +29,19 @@ performance = predictor.evaluate(test_data)
 ```
 ## News
 
-**Announcement for previous users:** The AutoGluon codebase has been modularized into [namespace packages](https://packaging.python.org/guides/packaging-namespace-packages/), which means you now only need those dependencies relevant to your prediction task of interest! For example, you can now work with tabular data without having to [install](https://autogluon.mxnet.io/install.html) dependencies required for AutoGluon's computer vision tasks (and vice versa). Unfortunately this improvement required a minor API change (eg. instead of `from autogluon import TabularPrediction`, you should now do: `from autogluon.tabular import TabularPrediction`), for all versions newer than v0.0.14. Documentation/tutorials under the old API may still be viewed [for version 0.0.14](https://autogluon.mxnet.io/v0.0.14/index.html) which is the last released version under the old API.
+**Announcement for previous users:** The AutoGluon codebase has been modularized into [namespace packages](https://packaging.python.org/guides/packaging-namespace-packages/), which means you now only need those dependencies relevant to your prediction task of interest! For example, you can now work with tabular data without having to [install](https://auto.gluon.ai/dev/install.html) dependencies required for AutoGluon's computer vision tasks (and vice versa). Unfortunately this improvement required a minor API change (eg. instead of `from autogluon import TabularPrediction`, you should now do: `from autogluon.tabular import TabularPrediction`), for all versions newer than v0.0.14. Documentation/tutorials under the old API may still be viewed [for version 0.0.14](https://auto.gluon.ai/0.0.14/index.html) which is the last released version under the old API.
 
 
 ## Resources
 
-See the [AutoGluon Website](http://autogluon.mxnet.io/index.html) for [documentation](https://autogluon.mxnet.io/api/index.html) and instructions on:
-- [Installing AutoGluon](http://autogluon.mxnet.io/index.html#installation)
-- [Learning with tabular data](http://autogluon.mxnet.io/tutorials/tabular_prediction/tabular-quickstart.html)
-  - [Tips to maximize accuracy](http://autogluon.mxnet.io/tutorials/tabular_prediction/tabular-quickstart.html#maximizing-predictive-performance) (if **benchmarking**, make sure to run `fit()` with argument `presets='best_quality'`).  
-  
-- [Learning with image data](http://autogluon.mxnet.io/tutorials/image_classification/beginner.html)
-- [Learning with text data](http://autogluon.mxnet.io/tutorials/text_prediction/beginner.html)
-- More advanced topics such as [Neural Architecture Search](http://autogluon.mxnet.io/tutorials/nas/index.html)
+See the [AutoGluon Website](https://auto.gluon.ai/stable/index.html) for [documentation](https://auto.gluon.ai/stable/api/index.html) and instructions on:
+- [Installing AutoGluon](https://auto.gluon.ai/stable/index.html#installation)
+- [Learning with tabular data](https://auto.gluon.ai/stable/tutorials/tabular_prediction/tabular-quickstart.html)
+  - [Tips to maximize accuracy](https://auto.gluon.ai/stable/tutorials/tabular_prediction/tabular-quickstart.html#maximizing-predictive-performance) (if **benchmarking**, make sure to run `fit()` with argument `presets='best_quality'`).  
+
+- [Learning with text data](https://auto.gluon.ai/stable/tutorials/text_prediction/beginner.html) 
+- [Learning with image data](https://auto.gluon.ai/stable/tutorials/image_classification/beginner.html)
+- More advanced topics such as [Neural Architecture Search](https://auto.gluon.ai/stable/tutorials/nas/index.html)
 
 ### Scientific Publications
 - [AutoGluon-Tabular: Robust and Accurate AutoML for Structured Data](https://arxiv.org/pdf/2003.06505.pdf) (*Arxiv*, 2020)
@@ -52,7 +52,7 @@ See the [AutoGluon Website](http://autogluon.mxnet.io/index.html) for [documenta
 - [AutoGluon overview & example applications](https://towardsdatascience.com/autogluon-deep-learning-automl-5cdb4e2388ec?source=friends_link&sk=e3d17d06880ac714e47f07f39178fdf2) (*Towards Data Science*, Dec 2019)
 
 ### Hands-on Tutorials
-- [From HPO to NAS: Automated Deep Learning (CVPR 2020)](http://hangzhang.org/CVPR2020/)
+- [From HPO to NAS: Automated Deep Learning (CVPR 2020)](https://hangzhang.org/CVPR2020/)
 - [Practical Automated Machine Learning with Tabular, Text, and Image Data (KDD 2020)](https://jwmueller.github.io/KDD20-tutorial/)
 
 ### Train/Deploy AutoGluon in the Cloud

--- a/docs/ReleaseInstructions.md
+++ b/docs/ReleaseInstructions.md
@@ -4,8 +4,8 @@
 * Tag release with format `v0.0.x`
 * Cut a release branch with format `0.0.x` (no v) - this branch is required to publish docs to versioned path
 * Push release branch and tags
-* Build the release branch docs in [CI](https://ci.mxnet.io/job/autogluon/).
-* Verify it's available at `https://autogluon.mxnet.io/0.0.x/index.html`
+* Build the release branch docs in [CI](https://ci.gluon.ai/job/autogluon/).
+* Verify it's available at `https://auto.gluon.ai/0.0.x/index.html`
 * Ensure that the mainline code you are planning to release is stable: Benchmark, ensure CI passes, check with team, etc.
 * Ensure latest pre-release is working via `pip install --pre --upgrade autogluon` and testing to get an idea of how the actual release will function (Ideally with fresh venv). DO NOT RELEASE if the pre-release does not work.
 * Perform version release by going to https://github.com/awslabs/autogluon/releases and click 'Draft a new release' in top right.
@@ -21,7 +21,7 @@
 After release is published, on the mainline branch:
 * Update header links pointing to the **previous** version in `docs/config.ini` 
     ```
-    header_links = v0.0.x Documentation, https://autogluon.mxnet.io/0.0.x/index.html, fas fa-book,
+    header_links = v0.0.x Documentation, https://auto.gluon.ai/0.0.x/index.html, fas fa-book,
     ```
 * Update `release` in `docs/config.ini`
 * Increment version in the `VERSION` file

--- a/docs/config.ini
+++ b/docs/config.ini
@@ -19,12 +19,12 @@ release = 0.0.15
 # A list of links that is displayed on the navbar. A link consists of three
 # items: name, URL, and a fontawesome icon
 # (https://fontawesome.com/icons?d=gallery). Items are separated by commas.
-header_links = ###_OTHER_VERSIONS_DOCUMENTATION_LABEL_###, https://autogluon.mxnet.io/###_OTHER_VERSIONS_DOCUMENTATION_BRANCH_###/index.html, fas fa-book,
+header_links = ###_OTHER_VERSIONS_DOCUMENTATION_LABEL_###, https://auto.gluon.ai/###_OTHER_VERSIONS_DOCUMENTATION_BRANCH_###/index.html, fas fa-book,
                API, ###_PLACEHOLDER_WEB_CONTENT_ROOT_###/api/index.html, fas fa-book,
                Installation, ###_PLACEHOLDER_WEB_CONTENT_ROOT_###/install.html, fas fa-download,
                Tutorials, ###_PLACEHOLDER_WEB_CONTENT_ROOT_###/tutorials/index.html, fas fa-external-link-alt,
                Github, https://github.com/awslabs/autogluon, fab fa-github,
-               Other Versions Documentation, https://autogluon.mxnet.io/dev/versions.html, fas fa-book
+               Other Versions Documentation, https://auto.gluon.ai/dev/versions.html, fas fa-book
 
 favicon = static/favicon.png
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-AutoGluon: AutoML Toolkit for Text, Image, and Tabular Data
+AutoGluon: AutoML Toolkit for Tabular, Text, and Image Data
 ===========================================================
 
 `AutoGluon` enables easy-to-use and easy-to-extend AutoML with a focus on automated stack ensembling, deep learning, and real-world applications spanning tabular, text, and image data. Intended for both ML beginners and experts, `AutoGluon` enables you to:

--- a/docs/install-warning.rst
+++ b/docs/install-warning.rst
@@ -1,4 +1,4 @@
 .. warning::
     This documentation is based off of the pre-release mainline branch which may have frequent API breaking changes.
 
-    Most users should instead reference the `stable v0.0.14 release documentation <https://autogluon.mxnet.io/v0.0.14/index.html>`_.
+    Most users should instead reference the `stable release documentation <https://auto.gluon.ai/stable/index.html>`_.

--- a/docs/root_index.html
+++ b/docs/root_index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<meta http-equiv="refresh" content="0; url=https://autogluon.mxnet.io/stable/index.html" />
+<meta http-equiv="refresh" content="0; url=https://auto.gluon.ai/stable/index.html" />
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
       <meta charset="utf-8"/>
@@ -33,7 +33,7 @@
       <link rel="index" title="Index" href="genindex.html"/>
       <link rel="search" title="Search" href="search.html"/>
       <link rel="next" title="Tabular Prediction" href="tutorials/tabular_prediction/index.html"/>
-      <link rel="canonical" href="https://autogluon.mxnet.io/stable/index.html" />
+      <link rel="canonical" href="https://auto.gluon.ai/stable/index.html" />
   </head>
 
 </html>

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -3,5 +3,5 @@ Available Documentation for AutoGluon
 
 Web-based documentation is available for versions listed below:
 
-- `AutoGluon 0.0.15 (dev) documentation <https://autogluon.mxnet.io/dev/index.html>`_
-- `AutoGluon 0.0.14 (stable) documentation <https://autogluon.mxnet.io/stable/index.html>`_
+- `AutoGluon 0.0.15 (dev) documentation <https://auto.gluon.ai/dev/index.html>`_
+- `AutoGluon 0.0.14 (stable) documentation <https://auto.gluon.ai/stable/index.html>`_


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updated autogluon.mxnet.io -> auto.gluon.ai
- Updated links to point to /dev/ or /stable/ appropriately, instead of root.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
