### PR TITLE
[Scheduler][Stability] Adding random jitter to address duplicate task ids occurrence

### DIFF
--- a/core/src/autogluon/core/task/task.py
+++ b/core/src/autogluon/core/task/task.py
@@ -4,6 +4,8 @@ import argparse
 import multiprocessing as mp
 
 logger = logging.getLogger(__name__)
+import time
+import random
 
 __all__ = ['Task']
 
@@ -30,6 +32,9 @@ class Task(object):
         self.args = copy.deepcopy(args)
         self.resources = resources
         with Task.LOCK:
+            # Adding random jitter to reduce likelihood of tasks starting at the same time
+            # This should significantly reduce generation of duplicate values (observed earlier)
+            time.sleep(0.1 + random.random())
             self.task_id = Task.TASK_ID.value
             if 'args' in self.args:
                 if isinstance(self.args['args'], (argparse.Namespace, argparse.ArgumentParser)):


### PR DESCRIPTION
*Description of changes:*
Added random jitter delay for task id generation - this naturally makes simultaneous state updates/requests less likely.

*Tasks start logs*

Task with id 4 was scheduled multiple times. The problem relatively easy to reproduce without this change on ubuntu, 8-core machine.
``` plain
Scheduling Task (task_id: 0,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 1.0, 'learning_rate': 0.1, 'min_data_in_leaf': 20, 'num_leaves': 31}, reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[0]}))


Scheduling Task (task_id: 1,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 0.9247339772148495, 'learning_rate': 0.06592805898944631, 'min_data_in_leaf': 2.., reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[1]}))


Scheduling Task (task_id: 2,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 0.8695569099758053, 'learning_rate': 0.08051659770615258, 'min_data_in_leaf': 2.., reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[2]}))


Scheduling Task (task_id: 3,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 0.8507991265255086, 'learning_rate': 0.07345453930070389, 'min_data_in_leaf': 2.., reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[3]}))


Scheduling Task (task_id: 4,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 0.9516841572012867, 'learning_rate': 0.0699298010777774, 'min_data_in_leaf': 10.., reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[4]}))


Scheduling Task (task_id: 5,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 0.8320992088927449, 'learning_rate': 0.009188210797555645, 'min_data_in_leaf': .., reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[5]}))


Scheduling Task (task_id: 6,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 0.9774783624448347, 'learning_rate': 0.1255406602615921, 'min_data_in_leaf': 14.., reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[6]}))


Scheduling Task (task_id: 7,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 0.9323156247870876, 'learning_rate': 0.05933944114295586, 'min_data_in_leaf': 1.., reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[7]}))


Scheduling Task (task_id: 4,
	fn: <function lgb_trial at 0x7fa83ace9b00>,
	args: {args: {'util_args': {'dataset_train_filename': 'dataset_train.bin', 'dataset_val_filename': 'dataset_val.b.., config: {'feature_fraction': 0.9516841572012867, 'learning_rate': 0.0699298010777774, 'min_data_in_leaf': 10.., reporter: DistStatusReporter, },
	resource: DistributedResource(
	Node = Remote REMOTE_ID: 0,
	<Remote: 'inproc://<ip_here>/18386/1' processes=1 threads=8, memory=33.19 GB>
	nCPUs = 1, CPU_IDs = {[4]}))


```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
