### PR TITLE
Tabular: Added dropping of object type features in tabular models

### DIFF
--- a/tabular/src/autogluon/tabular/features/feature_metadata.py
+++ b/tabular/src/autogluon/tabular/features/feature_metadata.py
@@ -94,7 +94,7 @@ class FeatureMetadata:
         """
         Returns a list of features held within the feature metadata object after being pruned through the available parameters.
 
-         Parameters
+        Parameters
         ----------
         valid_raw_types : list, default None
             If a feature's raw type is not in this list, it is pruned.
@@ -121,7 +121,7 @@ class FeatureMetadata:
             If special_types is None, then any feature will satisfy the special type requirement (including those with no special types).
         required_exact : bool, default False
             If True, then if a feature does not have the exact same special types (with no extra special types) as required_special_types, it is pruned.
-            This also applied to required_raw_special_pairs if specified.
+            This is also applied to required_raw_special_pairs if specified.
             Has no effect if required_special_types and required_raw_special_pairs are None.
         required_at_least_one_special : bool, default False
             If True, then if a feature has zero special types, it is pruned.

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -132,10 +132,14 @@ class AbstractModel:
         for key, value in default_auxiliary_params.items():
             self._set_default_param_value(key, value, params=self.params_aux)
 
+    # TODO: v0.1 consider adding documentation to each model highlighting which feature dtypes are valid
     def _get_default_auxiliary_params(self) -> dict:
-        """Dictionary of auxiliary parameters that dictate various model-agnostic logic."""
+        """
+        Dictionary of auxiliary parameters that dictate various model-agnostic logic, such as:
+            Which column dtypes are filtered out of the input data, or how much memory the model is allowed to use.
+        """
         default_auxiliary_params = dict(
-            max_memory_usage_ratio=1.0,  # Ratio of memory usage allowed by the model. Values > 1.0 have an increased risk of causing OOM errors.
+            max_memory_usage_ratio=1.0,  # Ratio of memory usage allowed by the model. Values > 1.0 have an increased risk of causing OOM errors. Used in memory checks during model training to avoid OOM errors.
             # TODO: Add more params
             # max_memory_usage=None,
             # max_disk_usage=None,

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -12,15 +12,15 @@ from .hyperparameters.parameters import get_param_baseline
 from .hyperparameters.searchspaces import get_default_searchspace
 from ..abstract.abstract_model import AbstractModel
 from ...constants import PROBLEM_TYPES_CLASSIFICATION, MULTICLASS, SOFTCLASS
+from ...features.feature_metadata import R_OBJECT
 from autogluon.core.utils.exceptions import NotEnoughMemoryError, TimeLimitExceeded
 from autogluon.core.utils import try_import_catboost, try_import_catboostdev
 
 logger = logging.getLogger(__name__)
 
 
-# TODO: Catboost crashes on multiclass problems where only two classes have significant member count.
-#  Question: Do we turn these into binary classification and then convert to multiclass output in Learner? This would make the most sense.
-# TODO: Consider having Catboost variant that converts all categoricals to numerical as done in RFModel, was showing improved results in some problems.
+# TODO: Consider having CatBoost variant that converts all categoricals to numerical as done in RFModel, was showing improved results in some problems.
+# TODO: v0.1 rename to CatBoostModel and rename model name default to CatBoost (instead of Catboost)
 class CatboostModel(AbstractModel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -280,3 +280,11 @@ class CatboostModel(AbstractModel):
         importance_series = importance_df.set_index('Feature Id')['Importances']
         importance_dict = importance_series.to_dict()
         return importance_dict
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
+            ignored_type_group_raw=[R_OBJECT],
+        )
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -18,6 +18,7 @@ from .hyperparameters.searchspaces import get_default_searchspace
 from ..abstract.model_trial import skip_hpo
 from ..abstract.abstract_model import AbstractModel
 from ...constants import REGRESSION, BINARY, MULTICLASS
+from ...features.feature_metadata import R_OBJECT
 
 # FIXME: Has a leak somewhere, training additional models in a single python script will slow down training for each additional model. Gets very slow after 20+ models (10x+ slowdown)
 #  Slowdown does not appear to impact Mac OS
@@ -362,3 +363,11 @@ class NNFastAiTabularModel(AbstractModel):
     # TODO: Add HPO
     def hyperparameter_tune(self, **kwargs):
         return skip_hpo(self, **kwargs)
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
+            ignored_type_group_raw=[R_OBJECT],
+        )
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -39,14 +39,14 @@ class KNNModel(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
-    def _set_default_auxiliary_params(self):
-        default_auxiliary_params = dict(
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
             ignored_type_group_raw=[R_CATEGORY, R_OBJECT],  # TODO: Eventually use category features
             ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_SPECIAL, S_DATETIME_AS_INT],
         )
-        for key, value in default_auxiliary_params.items():
-            self._set_default_param_value(key, value, params=self.params_aux)
-        super()._set_default_auxiliary_params()
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params
 
     # TODO: Enable HPO for KNN
     def _get_default_searchspace(self):

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -19,6 +19,7 @@ from .lgb_utils import construct_dataset
 from ..abstract.abstract_model import AbstractModel
 from ..utils import fixedvals_from_searchspaces
 from ...constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS
+from ...features.feature_metadata import R_OBJECT
 from autogluon.core.utils.savers import save_pkl
 from autogluon.core.utils import try_import_lightgbm
 from autogluon.core import Int, Space
@@ -374,3 +375,11 @@ class LGBModel(AbstractModel):
             inverse_internal_feature_map = {i: feature for feature, i in self._internal_feature_map.items()}
             importance_dict = {inverse_internal_feature_map[i]: importance for i, importance in importance_dict.items()}
         return importance_dict
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
+            ignored_type_group_raw=[R_OBJECT],
+        )
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -183,3 +183,11 @@ class LinearModel(AbstractModel):
             elif (feature in categorical_featnames) and (num_unique_vals <= one_hot_threshold):
                 types_of_features['onehot'].append(feature)
         return types_of_features
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
+            ignored_type_group_raw=[R_OBJECT],
+        )
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -8,6 +8,7 @@ import numpy as np
 import psutil
 from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
+from ...features.feature_metadata import R_OBJECT
 from ..abstract.model_trial import skip_hpo
 from ..abstract.abstract_model import AbstractModel
 from ...constants import MULTICLASS, REGRESSION
@@ -152,3 +153,11 @@ class RFModel(AbstractModel):
             logger.warning('Warning: get_model_feature_importance called when self.features is None!')
             return dict()
         return dict(zip(self.features, self.model.feature_importances_))
+
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
+            ignored_type_group_raw=[R_OBJECT],
+        )
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -29,7 +29,7 @@ from .tabular_nn_trial import tabular_nn_trial
 from ..abstract.abstract_model import AbstractModel
 from ..utils import fixedvals_from_searchspaces
 from ...constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS
-from ...features.feature_metadata import R_INT, R_FLOAT, R_CATEGORY, R_OBJECT
+from ...features.feature_metadata import R_INT, R_FLOAT, R_CATEGORY, R_OBJECT, S_TEXT_NGRAM, S_TEXT_AS_CATEGORY
 from ...metrics import log_loss, roc_auc
 from autogluon.core import Space
 from autogluon.core.utils import try_import_mxboard
@@ -102,13 +102,14 @@ class TabularNeuralNetModel(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
-    def _set_default_auxiliary_params(self):
-        default_auxiliary_params = dict(
-            ignored_type_group_special=['text_ngram', 'text_as_category'],
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
+            ignored_type_group_raw=[R_OBJECT],
+            ignored_type_group_special=[S_TEXT_NGRAM, S_TEXT_AS_CATEGORY],
         )
-        for key, value in default_auxiliary_params.items():
-            self._set_default_param_value(key, value, params=self.params_aux)
-        super()._set_default_auxiliary_params()
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params
 
     def _get_default_searchspace(self):
         return get_default_searchspace(self.problem_type, num_classes=None)


### PR DESCRIPTION
*Issue #, if available:*
#580 

*Description of changes:*

- Added object dtype to the ignored type list of all tabular models, as they should be converted to category first.
- This enables text features in object type form to not crash tabular models, they will be dropped instead.
- Added get_features_kwargs and get_features_kwargs_extra aux model params to enable full flexibility of which feature types a model accepts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
