### PR TITLE
Tabular: Ensure unique model names

### DIFF
--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -44,7 +44,7 @@ class AbstractModel:
                 hyperparameters (dict): various hyperparameters that will be used by model (can be search spaces instead of fixed values).
                 feature_metadata (autogluon.tabular.features.feature_metadata.FeatureMetadata): contains feature type information that can be used to identify special features such as text ngrams and datetime as well as which features are numerical vs categorical
         """
-        self.name = name
+        self.name = name  # TODO: v0.1 Consider setting to self._name and having self.name be a property so self.name can't be set outside of self.rename()
         self.path_root = path
         self.path_suffix = self.name + os.path.sep  # TODO: Make into function to avoid having to reassign on load?
         self.path = self.create_contexts(self.path_root + self.path_suffix)  # TODO: Make this path a function for consistency.

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -223,6 +223,7 @@ class AbstractTrainer:
     def train(self, X_train, y_train, X_val=None, y_val=None, **kwargs):
         raise NotImplementedError
 
+    # TODO: v0.1 add invalid_model_names argument
     # TODO: make models accept dictionary of level -> list of models for more control of future fit calls.
     # TODO: Enable HPO on levels > 0
     # TODO: Enable feature prune on levels > 0

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -914,10 +914,8 @@ class AbstractTrainer:
             logger.warning(f'\tNo valid features to train {model.name}... Skipping this model.')
             del model
         except Exception as err:
-            if self.verbosity >= 1:
-                traceback.print_tb(err.__traceback__)
-            logger.exception(f'Warning: Exception caused {model.name} to fail during training... Skipping this model.')
-            logger.log(20, err)
+            logger.exception(f'\tWarning: Exception caused {model.name} to fail during training... Skipping this model.')
+            logger.warning(err)
             del model
         else:
             self._add_model(model=model, stack_name=stack_name, level=level)

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -10,9 +10,15 @@ logger = logging.getLogger(__name__)
 
 # This Trainer handles model training details
 class AutoTrainer(AbstractTrainer):
-    def get_models(self, hyperparameters, hyperparameter_tune=False, level='default', extra_ag_args_fit=None, **kwargs):
-        return get_preset_models(path=self.path, problem_type=self.problem_type, eval_metric=self.eval_metric, stopping_metric=self.stopping_metric,
-                                 num_classes=self.num_classes, hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, level=level, extra_ag_args_fit=extra_ag_args_fit)
+    def get_models(self, hyperparameters, **kwargs):
+        path = kwargs.pop('path', self.path)
+        problem_type = kwargs.pop('problem_type', self.problem_type)
+        eval_metric = kwargs.pop('eval_metric', self.eval_metric)
+        stopping_metric = kwargs.pop('stopping_metric', self.stopping_metric)
+        num_classes = kwargs.pop('num_classes', self.num_classes)
+        invalid_model_names = kwargs.pop('invalid_model_names', self.get_model_names_all())
+        return get_preset_models(path=path, problem_type=problem_type, eval_metric=eval_metric, stopping_metric=stopping_metric,
+                                 num_classes=num_classes, hyperparameters=hyperparameters, invalid_model_names=invalid_model_names, **kwargs)
 
     # TODO: rename to .fit for 0.1
     def train(self, X_train, y_train, X_val=None, y_val=None, hyperparameter_tune=False, feature_prune=False, holdout_frac=0.1, hyperparameters=None, ag_args_fit=None, excluded_model_types=None, time_limit=None, **kwargs):

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets_distill.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets_distill.py
@@ -18,9 +18,14 @@ DEFAULT_DISTILL_PRIORITY = dict(
 
 def get_preset_models_distillation(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None,
                                    hyperparameter_tune=False, distill_level=0, name_suffix='_DSTL', invalid_model_names: list = None):
+    if problem_type != REGRESSION:
+        extra_ag_args = dict(name_type_suffix='Classifier')
+    else:
+        extra_ag_args = None
     if problem_type == MULTICLASS:
         models = get_preset_models_softclass(path=path, num_classes=num_classes, hyperparameters=hyperparameters,
-                                             hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix, invalid_model_names=invalid_model_names)
+                                             hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix,
+                                             extra_ag_args=extra_ag_args, invalid_model_names=invalid_model_names)
     elif problem_type == BINARY:  # convert to regression in distillation
         eval_metric = mean_squared_error
         stopping_metric = mean_squared_error
@@ -62,14 +67,12 @@ def get_preset_models_distillation(path, problem_type, eval_metric, hyperparamet
 
     if problem_type == REGRESSION or problem_type == BINARY:
         models = get_preset_models(path=path, problem_type=REGRESSION, eval_metric=eval_metric, stopping_metric=stopping_metric,
-                                   hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix, default_priorities=DEFAULT_DISTILL_PRIORITY, invalid_model_names=invalid_model_names)
+                                   hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix,
+                                   extra_ag_args=extra_ag_args, default_priorities=DEFAULT_DISTILL_PRIORITY, invalid_model_names=invalid_model_names)
 
     if problem_type in [MULTICLASS, BINARY]:
         for model in models:
             model.normalize_pred_probas = True
-            # TODO: v0.1 This is a hack and will allow for the possibility of duplicate model names
-            model.rename(model.name.replace('Regressor', 'Classifier'))  # conceal from user that model may actually be a regressor.
-            model.rename(model.name.replace('SoftClassifier', 'Classifier'))
 
     logger.log(20, f"Distilling with each of these student models: {[model.name for model in models]}")
     return models

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets_distill.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets_distill.py
@@ -17,10 +17,10 @@ DEFAULT_DISTILL_PRIORITY = dict(
 
 
 def get_preset_models_distillation(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None,
-                                   hyperparameter_tune=False, distill_level=0, name_suffix='_DSTL'):
+                                   hyperparameter_tune=False, distill_level=0, name_suffix='_DSTL', invalid_model_names: list = None):
     if problem_type == MULTICLASS:
         models = get_preset_models_softclass(path=path, num_classes=num_classes, hyperparameters=hyperparameters,
-                                             hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix)
+                                             hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix, invalid_model_names=invalid_model_names)
     elif problem_type == BINARY:  # convert to regression in distillation
         eval_metric = mean_squared_error
         stopping_metric = mean_squared_error
@@ -62,13 +62,14 @@ def get_preset_models_distillation(path, problem_type, eval_metric, hyperparamet
 
     if problem_type == REGRESSION or problem_type == BINARY:
         models = get_preset_models(path=path, problem_type=REGRESSION, eval_metric=eval_metric, stopping_metric=stopping_metric,
-                                   hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix, default_priorities=DEFAULT_DISTILL_PRIORITY)
+                                   hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix, default_priorities=DEFAULT_DISTILL_PRIORITY, invalid_model_names=invalid_model_names)
 
     if problem_type in [MULTICLASS, BINARY]:
         for model in models:
             model.normalize_pred_probas = True
-            model.name = model.name.replace('Regressor', 'Classifier')  # conceal from user that model may actually be a regressor.
-            model.name = model.name.replace('SoftClassifier', 'Classifier')
+            # TODO: v0.1 This is a hack and will allow for the possibility of duplicate model names
+            model.rename(model.name.replace('Regressor', 'Classifier'))  # conceal from user that model may actually be a regressor.
+            model.rename(model.name.replace('SoftClassifier', 'Classifier'))
 
     logger.log(20, f"Distilling with each of these student models: {[model.name for model in models]}")
     return models


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Addressed duplicate model name issue, now when models share the same name, one will have a unique suffix appended to it. This is a pre-req for repeated fit functionality to work smoothly. Prior, the model would overwrite the earlier model it shared a name with, leading to major bugs with stackers having their base models overwritten. This bug did not happen in current usage, but could start to happen if users were allowed to call fit repeatedly.
- Removed duplicate stack trace print on model exception, before the stack trace was being printed twice.
- Simplified hyperparameters argument in `Trainer.train_multi_levels` to handle the same input format as users provide in task.fit(hyperparameters), in preparation for repeated fit functionality.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
