### PR TITLE
Fixed Jenkinsfile typo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ max_time = 180
 
 stage("Unit Test") {
   node('linux-gpu') {
-    ws('workspace/autugluon-py3') {
+    ws('workspace/autogluon-py3') {
       timeout(time: max_time, unit: 'MINUTES') {
         checkout scm
         VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8

--- a/core/tests/test_check_style.py
+++ b/core/tests/test_check_style.py
@@ -1,19 +1,19 @@
-from subprocess import Popen, PIPE
 import logging
+import os
+import warnings
+from subprocess import Popen, PIPE
 
 
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    flake8_proc = Popen(['flake8', '--count'], stdout=PIPE)
+    wd = os.getcwd()
+    os.chdir("..")
+    flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
+    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())
     if count > 0:
-        logging.warn("%d PEP8 warnings remaining", count)
-    if count > 3438:
-        logging.warn("Additional PEP8 warnings were introducing, style check fails")
-        return 1
-    logging.info("Passed")
-    return 0
-
+        warnings.warn(f'{count} PEP8 warnings remaining')
+    assert count < 1000, 'Too many PEP8 warnings found, improve code quality to pass test.'

--- a/core/tests/test_check_style.py
+++ b/core/tests/test_check_style.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 from subprocess import Popen, PIPE
 
@@ -7,10 +6,7 @@ from subprocess import Popen, PIPE
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    wd = os.getcwd()
-    os.chdir("..")
     flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
-    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())

--- a/extra/tests/test_check_style.py
+++ b/extra/tests/test_check_style.py
@@ -1,19 +1,19 @@
-from subprocess import Popen, PIPE
 import logging
+import os
+import warnings
+from subprocess import Popen, PIPE
 
 
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    flake8_proc = Popen(['flake8', '--count'], stdout=PIPE)
+    wd = os.getcwd()
+    os.chdir("..")
+    flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
+    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())
     if count > 0:
-        logging.warn("%d PEP8 warnings remaining", count)
-    if count > 3438:
-        logging.warn("Additional PEP8 warnings were introducing, style check fails")
-        return 1
-    logging.info("Passed")
-    return 0
-
+        warnings.warn(f'{count} PEP8 warnings remaining')
+    assert count < 1000, 'Too many PEP8 warnings found, improve code quality to pass test.'

--- a/extra/tests/test_check_style.py
+++ b/extra/tests/test_check_style.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 from subprocess import Popen, PIPE
 
@@ -7,10 +6,7 @@ from subprocess import Popen, PIPE
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    wd = os.getcwd()
-    os.chdir("..")
     flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
-    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())

--- a/mxnet/tests/test_check_style.py
+++ b/mxnet/tests/test_check_style.py
@@ -1,19 +1,19 @@
-from subprocess import Popen, PIPE
 import logging
+import os
+import warnings
+from subprocess import Popen, PIPE
 
 
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    flake8_proc = Popen(['flake8', '--count'], stdout=PIPE)
+    wd = os.getcwd()
+    os.chdir("..")
+    flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
+    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())
     if count > 0:
-        logging.warn("%d PEP8 warnings remaining", count)
-    if count > 3438:
-        logging.warn("Additional PEP8 warnings were introducing, style check fails")
-        return 1
-    logging.info("Passed")
-    return 0
-
+        warnings.warn(f'{count} PEP8 warnings remaining')
+    assert count < 1000, 'Too many PEP8 warnings found, improve code quality to pass test.'

--- a/mxnet/tests/test_check_style.py
+++ b/mxnet/tests/test_check_style.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 from subprocess import Popen, PIPE
 
@@ -7,10 +6,7 @@ from subprocess import Popen, PIPE
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    wd = os.getcwd()
-    os.chdir("..")
     flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
-    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())

--- a/tabular/tests/test_check_style.py
+++ b/tabular/tests/test_check_style.py
@@ -1,19 +1,19 @@
-from subprocess import Popen, PIPE
 import logging
+import os
+import warnings
+from subprocess import Popen, PIPE
 
 
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    flake8_proc = Popen(['flake8', '--count'], stdout=PIPE)
+    wd = os.getcwd()
+    os.chdir("..")
+    flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
+    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())
     if count > 0:
-        logging.warn("%d PEP8 warnings remaining", count)
-    if count > 3438:
-        logging.warn("Additional PEP8 warnings were introducing, style check fails")
-        return 1
-    logging.info("Passed")
-    return 0
-
+        warnings.warn(f'{count} PEP8 warnings remaining')
+    assert count < 1000, 'Too many PEP8 warnings found, improve code quality to pass test.'

--- a/tabular/tests/test_check_style.py
+++ b/tabular/tests/test_check_style.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 from subprocess import Popen, PIPE
 
@@ -7,10 +6,7 @@ from subprocess import Popen, PIPE
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    wd = os.getcwd()
-    os.chdir("..")
     flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
-    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())

--- a/text/tests/test_check_style.py
+++ b/text/tests/test_check_style.py
@@ -1,19 +1,19 @@
-from subprocess import Popen, PIPE
 import logging
+import os
+import warnings
+from subprocess import Popen, PIPE
 
 
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    flake8_proc = Popen(['flake8', '--count'], stdout=PIPE)
+    wd = os.getcwd()
+    os.chdir("..")
+    flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
+    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())
     if count > 0:
-        logging.warn("%d PEP8 warnings remaining", count)
-    if count > 3438:
-        logging.warn("Additional PEP8 warnings were introducing, style check fails")
-        return 1
-    logging.info("Passed")
-    return 0
-
+        warnings.warn(f'{count} PEP8 warnings remaining')
+    assert count < 1000, 'Too many PEP8 warnings found, improve code quality to pass test.'

--- a/text/tests/test_check_style.py
+++ b/text/tests/test_check_style.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 from subprocess import Popen, PIPE
 
@@ -7,10 +6,7 @@ from subprocess import Popen, PIPE
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    wd = os.getcwd()
-    os.chdir("..")
     flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
-    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())

--- a/vision/tests/test_check_style.py
+++ b/vision/tests/test_check_style.py
@@ -1,19 +1,19 @@
-from subprocess import Popen, PIPE
 import logging
+import os
+import warnings
+from subprocess import Popen, PIPE
 
 
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    flake8_proc = Popen(['flake8', '--count'], stdout=PIPE)
+    wd = os.getcwd()
+    os.chdir("..")
+    flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
+    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())
     if count > 0:
-        logging.warn("%d PEP8 warnings remaining", count)
-    if count > 3438:
-        logging.warn("Additional PEP8 warnings were introducing, style check fails")
-        return 1
-    logging.info("Passed")
-    return 0
-
+        warnings.warn(f'{count} PEP8 warnings remaining')
+    assert count < 1000, 'Too many PEP8 warnings found, improve code quality to pass test.'

--- a/vision/tests/test_check_style.py
+++ b/vision/tests/test_check_style.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 from subprocess import Popen, PIPE
 
@@ -7,10 +6,7 @@ from subprocess import Popen, PIPE
 def test_check_style():
     logging.getLogger().setLevel(logging.INFO)
     logging.info("PEP8 Style check")
-    wd = os.getcwd()
-    os.chdir("..")
     flake8_proc = Popen(['flake8', '--count', '--max-line-length', '300'], stdout=PIPE)
-    os.chdir(wd)
     flake8_out = flake8_proc.communicate()[0]
     lines = flake8_out.splitlines()
     count = int(lines[-1].decode())


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed Jenkinsfile typo: aut**u**gluon-py3 -> aut**o**gluon-py3
- Updated test_check_style.py to correctly fail if PEP8 warnings exceeded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
