### PR TITLE
[CI] Fixing build version across modules to core version

### DIFF
--- a/autogluon/setup.py
+++ b/autogluon/setup.py
@@ -24,8 +24,13 @@ You need to increase the version number after stable release, so that the nightl
 try:
     if not os.getenv('RELEASE'):
         from datetime import date
-        today = date.today()
-        day = today.strftime("b%Y%m%d")
+        minor_version_file_path = os.path.join('..', 'VERSION.minor')
+        if os.path.isfile(minor_version_file_path):
+            with open(minor_version_file_path) as f:
+                day = f.read().strip()
+        else:
+            today = date.today()
+            day = today.strftime("b%Y%m%d")
         version += day
 except Exception:
     pass

--- a/core/setup.py
+++ b/core/setup.py
@@ -33,6 +33,8 @@ def create_version_file():
     with open(version_path, 'w') as f:
         f.write('"""This is autogluon version file."""\n')
         f.write("__version__ = '{}'\n".format(version))
+    with open(os.path.join('..', 'VERSION.minor'), 'w') as f:
+        f.write(day)
 
 
 long_description = open(os.path.join('..', 'README.md')).read()

--- a/extra/setup.py
+++ b/extra/setup.py
@@ -20,8 +20,13 @@ You need to increase the version number after stable release, so that the nightl
 try:
     if not os.getenv('RELEASE'):
         from datetime import date
-        today = date.today()
-        day = today.strftime("b%Y%m%d")
+        minor_version_file_path = os.path.join('..', 'VERSION.minor')
+        if os.path.isfile(minor_version_file_path):
+            with open(minor_version_file_path) as f:
+                day = f.read().strip()
+        else:
+            today = date.today()
+            day = today.strftime("b%Y%m%d")
         version += day
 except Exception:
     pass

--- a/mxnet/setup.py
+++ b/mxnet/setup.py
@@ -18,8 +18,13 @@ You need to increase the version number after stable release, so that the nightl
 try:
     if not os.getenv('RELEASE'):
         from datetime import date
-        today = date.today()
-        day = today.strftime("b%Y%m%d")
+        minor_version_file_path = os.path.join('..', 'VERSION.minor')
+        if os.path.isfile(minor_version_file_path):
+            with open(minor_version_file_path) as f:
+                day = f.read().strip()
+        else:
+            today = date.today()
+            day = today.strftime("b%Y%m%d")
         version += day
 except Exception:
     pass

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -18,8 +18,13 @@ You need to increase the version number after stable release, so that the nightl
 try:
     if not os.getenv('RELEASE'):
         from datetime import date
-        today = date.today()
-        day = today.strftime("b%Y%m%d")
+        minor_version_file_path = os.path.join('..', 'VERSION.minor')
+        if os.path.isfile(minor_version_file_path):
+            with open(minor_version_file_path) as f:
+                day = f.read().strip()
+        else:
+            today = date.today()
+            day = today.strftime("b%Y%m%d")
         version += day
 except Exception:
     pass

--- a/text/setup.py
+++ b/text/setup.py
@@ -20,8 +20,13 @@ You need to increase the version number after stable release, so that the nightl
 try:
     if not os.getenv('RELEASE'):
         from datetime import date
-        today = date.today()
-        day = today.strftime("b%Y%m%d")
+        minor_version_file_path = os.path.join('..', 'VERSION.minor')
+        if os.path.isfile(minor_version_file_path):
+            with open(minor_version_file_path) as f:
+                day = f.read().strip()
+        else:
+            today = date.today()
+            day = today.strftime("b%Y%m%d")
         version += day
 except Exception:
     pass

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -20,8 +20,13 @@ You need to increase the version number after stable release, so that the nightl
 try:
     if not os.getenv('RELEASE'):
         from datetime import date
-        today = date.today()
-        day = today.strftime("b%Y%m%d")
+        minor_version_file_path = os.path.join('..', 'VERSION.minor')
+        if os.path.isfile(minor_version_file_path):
+            with open(minor_version_file_path) as f:
+                day = f.read().strip()
+        else:
+            today = date.today()
+            day = today.strftime("b%Y%m%d")
         version += day
 except Exception:
     pass


### PR DESCRIPTION
*Description of changes:*
Builds happening near midnight have a chance of a date flip in build minor version as a result earlier built dependencies could not be found on a date change and the build fails. This change fixes the minor version across all namespace packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
