### PR TITLE
PR for hyperband-enabled decision trees

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,6 +275,198 @@ stage("Unit Test") {
   }
 }
 
+stage("Build Tutorials") {
+  parallel 'course': {
+    node('linux-gpu') {
+      ws('workspace/autogluon-tutorial-course') {
+        checkout scm
+        VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
+        sh """#!/bin/bash
+        set -ex
+        conda env update -n autogluon_tutorial_course -f docs/build_contrib.yml
+        conda activate autogluon_tutorial_course
+        conda list
+        export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
+        env
+        export LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+        export AG_DOCS=1
+        git clean -fx
+        bash docs/build_pip_install.sh
+
+        # only build for docs/course
+        shopt -s extglob
+        rm -rf ./docs/tutorials/!(course)
+        cd docs && rm -rf _build && d2lbook build rst && cd ..
+        """
+        pwd
+        stash includes: 'docs/_build/rst/tutorials/course/*', name: 'course'
+      }
+    }
+  },
+  'image_classification': {
+    node('linux-gpu') {
+      ws('workspace/autogluon-tutorial-image-classification') {
+        checkout scm
+        VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
+        sh """#!/bin/bash
+        set -ex
+        conda env update -n autogluon_tutorial_image_classification -f docs/build_contrib.yml
+        conda activate autogluon_tutorial_image_classification
+        conda list
+        export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
+        env
+        export LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+        export AG_DOCS=1
+        git clean -fx
+        bash docs/build_pip_install.sh
+
+        # only build for docs/image_classification
+        shopt -s extglob
+        rm -rf ./docs/tutorials/!(image_classification)
+        cd docs && rm -rf _build && d2lbook build rst && cd ..
+        cat docs/_build/rst/_static/d2l.js
+        cat docs/_build/rst/conf.py
+        tree -L 2 docs/_build/rst
+        """
+        stash includes: 'docs/_build/rst/tutorials/image_classification/*', name: 'image_classification'
+      }
+    }
+  },
+  'nas': {
+    node('linux-gpu') {
+      ws('workspace/autogluon-tutorial-nas') {
+        checkout scm
+        VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
+        sh """#!/bin/bash
+        set -ex
+        conda env update -n autogluon_tutorial_nas -f docs/build_contrib.yml
+        conda activate autogluon_tutorial_nas
+        conda list
+        export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
+        env
+        export LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+        export AG_DOCS=1
+        git clean -fx
+        bash docs/build_pip_install.sh
+
+        # only build for docs/nas
+        shopt -s extglob
+        rm -rf ./docs/tutorials/!(nas)
+        cd docs && rm -rf _build && d2lbook build rst && cd ..
+        """
+        stash includes: 'docs/_build/rst/tutorials/nas/*', name: 'nas'
+      }
+    }
+  },
+  'object_detection': {
+    node('linux-gpu') {
+      ws('workspace/autogluon-tutorial-object-detection') {
+        checkout scm
+        VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
+        sh """#!/bin/bash
+        set -ex
+        conda env update -n autogluon_tutorial_object_detection -f docs/build_contrib.yml
+        conda activate autogluon_tutorial_object_detection
+        conda list
+        export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
+        env
+        export LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+        export AG_DOCS=1
+        git clean -fx
+        bash docs/build_pip_install.sh
+
+        # only build for docs/object_detection
+        shopt -s extglob
+        rm -rf ./docs/tutorials/!(object_detection)
+        cd docs && rm -rf _build && d2lbook build rst && cd ..
+        tree -L 2 docs/_build/rst
+        pwd
+        """
+        echo pwd()
+        stash includes: 'docs/_build/rst/tutorials/object_detection/*', name: 'object_detection'
+      }
+    }
+  },
+  'tabular_prediction': {
+    node('linux-gpu') {
+      ws('workspace/autogluon-tutorial-tabular') {
+        checkout scm
+        VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
+        sh """#!/bin/bash
+        set -ex
+        conda env update -n autogluon_tutorial_tabular -f docs/build_contrib.yml
+        conda activate autogluon_tutorial_tabular
+        conda list
+        export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
+        env
+        export LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+        export AG_DOCS=1
+        git clean -fx
+        bash docs/build_pip_install.sh
+
+        # only build for docs/tabular
+        shopt -s extglob
+        rm -rf ./docs/tutorials/!(tabular_prediction)
+        cd docs && rm -rf _build && d2lbook build rst && cd ..
+        """
+        stash includes: 'docs/_build/rst/tutorials/tabular_prediction/*', name: 'tabular'
+      }
+    }
+  },
+  'text_prediction': {
+    node('linux-gpu') {
+      ws('workspace/autogluon-tutorial-text') {
+        checkout scm
+        VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
+        sh """#!/bin/bash
+        set -ex
+        conda env update -n autogluon_tutorial_text -f docs/build_contrib.yml
+        conda activate autogluon_tutorial_text
+        conda list
+        export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
+        env
+        export LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+        export AG_DOCS=1
+        git clean -fx
+        bash docs/build_pip_install.sh
+
+        # only build for docs/text
+        shopt -s extglob
+        rm -rf ./docs/tutorials/!(text_prediction)
+        cd docs && rm -rf _build && d2lbook build rst && cd ..
+        """
+        stash includes: 'docs/_build/rst/tutorials/text_prediction/*', name: 'text'
+      }
+    }
+  },
+  'torch': {
+    node('linux-gpu') {
+      ws('workspace/autogluon-tutorial-torch') {
+        checkout scm
+        VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
+        sh """#!/bin/bash
+        set -ex
+        conda env update -n autogluon_tutorial_torch -f docs/build_contrib.yml
+        conda activate autogluon_tutorial_torch
+        conda list
+        export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
+        env
+        export LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64
+        export AG_DOCS=1
+        git clean -fx
+        bash docs/build_pip_install.sh
+
+        # only build for docs/torch
+        shopt -s extglob
+        rm -rf ./docs/tutorials/!(torch)
+        cd docs && rm -rf _build && d2lbook build rst && cd ..
+        """
+        stash includes: 'docs/_build/rst/tutorials/torch/*', name: 'torch'
+      }
+    }
+  }
+}
+
 stage("Build Docs") {
   node('linux-gpu') {
     ws('workspace/autogluon-docs') {
@@ -313,6 +505,14 @@ stage("Build Docs") {
         }
 
         escaped_context_root = site.replaceAll('\\/', '\\\\/')
+
+        unstash 'course'
+        unstash 'image_classification'
+        unstash 'nas'
+        unstash 'object_detection'
+        unstash 'tabular'
+        unstash 'text'
+        unstash 'torch'
 
         sh """#!/bin/bash
         set -ex
@@ -374,7 +574,9 @@ stage("Build Docs") {
         sed -i -e 's/###_OTHER_VERSIONS_DOCUMENTATION_LABEL_###/${other_doc_version_text}/g' docs/config.ini
         sed -i -e 's/###_OTHER_VERSIONS_DOCUMENTATION_BRANCH_###/${other_doc_version_branch}/g' docs/config.ini
 
-        cd docs && bash build_doc.sh
+        shopt -s extglob
+        rm -rf ./docs/tutorials/!(index.rst)
+        cd docs && d2lbook build rst && d2lbook build html
         aws s3 sync ${flags} _build/html/ s3://${bucket}/${path} --acl public-read ${cacheControl}
         echo "Uploaded doc to http://${site}/index.html"
 

--- a/autogluon/setup.py
+++ b/autogluon/setup.py
@@ -9,16 +9,16 @@ from setuptools import setup, find_packages, find_namespace_packages
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join('..', 'VERSION')) as version_file:
+with open(os.path.join(os.path.dirname(__file__), '..', 'VERSION')) as version_file:
     version = version_file.read().strip()
 
 """
 This namespace package is added to enable `pip install autogluon` which will install the full AutoGluon package with all the dependencies included.
-For local installations, other modules must be built separately via the `full_install.sh` script. 
+For local installations, other modules must be built separately via the `full_install.sh` script.
 This `setup.py` file will NOT install the full autogluon package and all its dependencies.
 
-To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
-a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 
+To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
+a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
 You need to increase the version number after stable release, so that the nightly pypi can work properly.
 """
 try:

--- a/core/setup.py
+++ b/core/setup.py
@@ -9,12 +9,12 @@ from setuptools import setup, find_packages, find_namespace_packages
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join('..', 'VERSION')) as version_file:
+with open(os.path.join(os.path.dirname(__file__), '..', 'VERSION')) as version_file:
     version = version_file.read().strip()
 
 """
-To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
-a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 
+To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
+a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
 You need to increase the version number after stable release, so that the nightly pypi can work properly.
 """
 try:

--- a/core/src/autogluon/core/constants.py
+++ b/core/src/autogluon/core/constants.py
@@ -2,7 +2,7 @@
 BINARY = 'binary'
 MULTICLASS = 'multiclass'
 REGRESSION = 'regression'
-SOFTCLASS = 'softclass' # classification with soft-target (rather than classes, labels are probabilities of each class).
+SOFTCLASS = 'softclass'  # classification with soft-target (rather than classes, labels are probabilities of each class).
 
 PROBLEM_TYPES_CLASSIFICATION = [BINARY, MULTICLASS]
 PROBLEM_TYPES_REGRESSION = [REGRESSION]
@@ -25,9 +25,8 @@ OBJECTIVES_TO_NORMALIZE = ['log_loss', 'pac_score', 'soft_log_loss']  # do not l
 """
 AG_ARGS: Dictionary of customization options related to meta properties of the model such as its name, the order it is trained, and the problem types it is valid for.
     name: (str) The name of the model. This overrides AutoGluon's naming logic and all other name arguments if present.
-    name_main: (str) The main name of the model. In 'RandomForestClassifier', this is 'RandomForest'.
+    name_main: (str) The main name of the model. Example: 'RandomForest'.
     name_prefix: (str) Add a custom prefix to the model name. Unused by default.
-    name_type_suffix: (str) Override the type suffix of the model name. In 'RandomForestClassifier', this is 'Classifier'. This comes before 'name_suffix'.
     name_suffix: (str) Add a custom suffix to the model name. Unused by default.
     priority: (int) Determines the order in which the model is trained. Larger values result in the model being trained earlier. Default values range from 100 (RF) to 0 (custom), dictated by model type. If you want this model to be trained first, set priority = 999.
     problem_types: (list) List of valid problem types for the model. `problem_types=['binary']` will result in the model only being trained if `problem_type` is 'binary'.

--- a/core/src/autogluon/core/constants.py
+++ b/core/src/autogluon/core/constants.py
@@ -12,7 +12,26 @@ REFIT_FULL_NAME = 'refit_single_full'  # stack-name used for refit_single_full (
 REFIT_FULL_SUFFIX = "_FULL"  # suffix appended to model name for refit_single_full (aka "compressed") models
 
 # AG_ARGS variables are key names in model hyperparameters to dictionaries of custom AutoGluon arguments.
+# TODO: Have documentation for all AG_ARGS values
 AG_ARGS = 'AG_args'  # Contains arguments to control model name, model priority, and the valid configurations which it can be used in.
 AG_ARGS_FIT = 'AG_args_fit'  # Contains arguments that impact model training, such as early stopping rounds, #cores, #gpus, max time limit, max memory usage  # TODO
+AG_ARGS_ENSEMBLE = 'AG_args_ensemble'  # Contains arguments that impact model ensembling, such as if an ensemble model is allowed to use the original features.  # TODO: v0.1 add to documentation
 
 OBJECTIVES_TO_NORMALIZE = ['log_loss', 'pac_score', 'soft_log_loss']  # do not like predicted probabilities = 0
+
+# TODO: Add docs to dedicated page, or should it live in AbstractModel?
+# TODO: How to reference correct version of docs?
+# TODO: Add error in AG_ARGS if unknown key present
+"""
+AG_ARGS: Dictionary of customization options related to meta properties of the model such as its name, the order it is trained, and the problem types it is valid for.
+    name: (str) The name of the model. This overrides AutoGluon's naming logic and all other name arguments if present.
+    name_main: (str) The main name of the model. In 'RandomForestClassifier', this is 'RandomForest'.
+    name_prefix: (str) Add a custom prefix to the model name. Unused by default.
+    name_type_suffix: (str) Override the type suffix of the model name. In 'RandomForestClassifier', this is 'Classifier'. This comes before 'name_suffix'.
+    name_suffix: (str) Add a custom suffix to the model name. Unused by default.
+    priority: (int) Determines the order in which the model is trained. Larger values result in the model being trained earlier. Default values range from 100 (RF) to 0 (custom), dictated by model type. If you want this model to be trained first, set priority = 999.
+    problem_types: (list) List of valid problem types for the model. `problem_types=['binary']` will result in the model only being trained if `problem_type` is 'binary'.
+    disable_in_hpo: (bool) If True, the model will only be trained if `hyperparameter_tune=False`.
+    valid_stacker: (bool) If False, the model will not be trained as a level 1 or higher stacker model.
+    valid_base: (bool) If False, the model will not be trained as a level 0 (base) model.
+"""

--- a/core/src/autogluon/core/scheduler/reporter.py
+++ b/core/src/autogluon/core/scheduler/reporter.py
@@ -58,7 +58,7 @@ class DistStatusReporter(object):
             kwargs['time_this_iter'] = report_time - self._last_report_time
         self._last_report_time = report_time
 
-        # logger.debug('Reporting {}'.format(json.dumps(kwargs)))
+        logger.debug('Reporting {}'.format(json.dumps(kwargs)))
         try:
             self._queue.put(kwargs.copy())
         except RuntimeError:
@@ -131,7 +131,7 @@ class LocalStatusReporter(object):
         self._last_report_time = report_time
 
         self._queue.put(kwargs.copy(), block=True)
-        # logger.debug('StatusReporter reporting: {}'.format(json.dumps(kwargs)))
+        logger.debug('StatusReporter reporting: {}'.format(json.dumps(kwargs)))
 
         self._continue_semaphore.acquire()
         if self._stop.value:

--- a/core/src/autogluon/core/scheduler/reporter.py
+++ b/core/src/autogluon/core/scheduler/reporter.py
@@ -58,7 +58,7 @@ class DistStatusReporter(object):
             kwargs['time_this_iter'] = report_time - self._last_report_time
         self._last_report_time = report_time
 
-        logger.debug('Reporting {}'.format(json.dumps(kwargs)))
+        # logger.debug('Reporting {}'.format(json.dumps(kwargs)))
         try:
             self._queue.put(kwargs.copy())
         except RuntimeError:
@@ -131,11 +131,11 @@ class LocalStatusReporter(object):
         self._last_report_time = report_time
 
         self._queue.put(kwargs.copy(), block=True)
-        logger.debug('StatusReporter reporting: {}'.format(json.dumps(kwargs)))
+        # logger.debug('StatusReporter reporting: {}'.format(json.dumps(kwargs)))
 
         self._continue_semaphore.acquire()
         if self._stop.value:
-            raise AutoGluonEarlyStop
+            raise AutoGluonEarlyStop(kwargs)
 
     def fetch(self, block=True):
         kwargs = self._queue.get(block=block)

--- a/core/src/autogluon/core/task/base/base_task.py
+++ b/core/src/autogluon/core/task/base/base_task.py
@@ -99,7 +99,7 @@ searcher_for_hyperband_strategy = {
 def compile_scheduler_options(
         scheduler_options, search_strategy, search_options, nthreads_per_trial,
         ngpus_per_trial, checkpoint, num_trials, time_out, resume, visualizer,
-        time_attr, reward_attr, dist_ip_addrs, epochs=None):
+        time_attr, reward_attr, dist_ip_addrs, training_history_callback=None, epochs=None):
     """
     Updates a copy of scheduler_options (scheduler-specific options, can be
     empty) with general options. The result can be passed to __init__ of the
@@ -155,7 +155,9 @@ def compile_scheduler_options(
         'reward_attr': reward_attr,
         'time_attr': time_attr,
         'visualizer': visualizer,
-        'dist_ip_addrs': dist_ip_addrs})
+        'dist_ip_addrs': dist_ip_addrs,
+        'training_history_callback': training_history_callback,
+    })
     searcher = searcher_for_hyperband_strategy.get(search_strategy)
     if searcher is not None:
         scheduler_options['searcher'] = searcher

--- a/core/src/autogluon/core/utils/files.py
+++ b/core/src/autogluon/core/utils/files.py
@@ -115,13 +115,14 @@ def check_sha1(filename, sha1_hash):
 def mkdir(path):
     """Make directory at the specified local path with special error handling.
     """
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
+    if len(path) > 0:
+        try:
+            os.makedirs(path)
+        except OSError as exc:  # Python >2.5
+            if exc.errno == errno.EEXIST and os.path.isdir(path):
+                pass
+            else:
+                raise
 
 def raise_num_file(nofile_atleast=4096):
     try:

--- a/docs/build.yml
+++ b/docs/build.yml
@@ -6,6 +6,7 @@ dependencies:
   - jupyter-sphinx>=0.2.2
   - mxnet_cu101==1.7.0
   - portalocker
+  - scipy>=1.4.0
   - nose
   - docutils
   - mu-notedown

--- a/docs/build_contrib.yml
+++ b/docs/build_contrib.yml
@@ -6,6 +6,7 @@ dependencies:
   - jupyter-sphinx>=0.2.2
   - mxnet_cu101==1.7.0
   - portalocker
+  - scipy>=1.4.0
   - nose
   - docutils
   - mu-notedown

--- a/docs/build_pip_install.sh
+++ b/docs/build_pip_install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+python3 -m pip install git+https://github.com/zhanghang1989/d2l-book
+python3 -m pip install --force-reinstall ipython==7.16
+
+python3 -m pip uninstall -y autogluon
+python3 -m pip uninstall -y autogluon.vision
+python3 -m pip uninstall -y autogluon.text
+python3 -m pip uninstall -y autogluon.mxnet
+python3 -m pip uninstall -y autogluon.extra
+python3 -m pip uninstall -y autogluon.tabular
+python3 -m pip uninstall -y autogluon.core
+python3 -m pip uninstall -y autogluon-contrib-nlp
+python3 -m pip uninstall -y autogluon-core
+python3 -m pip uninstall -y autogluon-extra
+python3 -m pip uninstall -y autogluon-mxnet
+python3 -m pip uninstall -y autogluon-tabular
+python3 -m pip uninstall -y autogluon-text
+python3 -m pip uninstall -y autogluon-vision
+
+cd core/
+python3 -m pip install --upgrade -e .
+cd ..
+
+cd tabular/
+python3 -m pip install --upgrade -e .
+cd ..
+
+cd mxnet/
+python3 -m pip install --upgrade -e .
+cd ..
+
+cd extra/
+python3 -m pip install --upgrade -e .
+cd ..
+
+cd text/
+python3 -m pip install --upgrade -e .
+cd ..
+
+cd vision/
+python3 -m pip install --upgrade -e .
+cd ..
+
+cd autogluon/
+python3 -m pip install --upgrade -e .
+cd ..

--- a/docs/tutorials/tabular_prediction/tabular-faq.md
+++ b/docs/tutorials/tabular_prediction/tabular-faq.md
@@ -64,20 +64,21 @@ This should become obvious if you specify the `as_pandas` argument like this:
 predictor.predict_proba(test_data, as_pandas=True)
 ```
 
-Alternatively, you can see which class AutoGluon treats as the positive class in binary classification via:
-
-```
-positive_class = [label for label in predictor.class_labels if predictor.class_labels_internal_map[label]==1][0]
-```
-
-Or for multiclass classification:
+For multiclass classification:
 
 ```
 predictor.class_labels
 ```
 
-is a list of classes whose order corresponds to columns of `predict_proba()` output when it is a Numpy array.
+is a list of classes whose order corresponds to columns of `predict_proba()` output when it is a Numpy array. For binary classification, this is the order of classes when `predict_proba(as_multiclass=True)` is called.
 
+You can see which class AutoGluon treats as the positive class in binary classification via:
+
+```
+predictor.positive_class
+```
+
+The positive class can also be retrieved via `predictor.class_labels[-1]`. The output of `predict_proba()` for binary classification is the probability of the positive class.
 
 ### How can I use AutoGluon for interpretability?
 

--- a/docs/tutorials/tabular_prediction/tabular-quickstart.md
+++ b/docs/tutorials/tabular_prediction/tabular-quickstart.md
@@ -83,7 +83,7 @@ For tabular problems, `fit()` returns a `Predictor` object. For classification, 
 
 ```{.python .input}
 pred_probs = predictor.predict_proba(test_data_nolab)
-positive_class = [label for label in predictor.class_labels if predictor.class_labels_internal_map[label]==1][0]  # which label is considered 'positive' class
+positive_class = predictor.positive_class  # which label is considered 'positive' class
 print(f"Predicted probabilities of class '{positive_class}':", pred_probs)
 ```
 

--- a/docs/tutorials/text_prediction/beginner.md
+++ b/docs/tutorials/text_prediction/beginner.md
@@ -30,7 +30,7 @@ First, we consider the Stanford Sentiment Treebank ([SST](https://nlp.stanford.e
 from autogluon.core.utils.loaders.load_pd import load
 train_data = load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sst/train.parquet')
 dev_data = load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sst/dev.parquet')
-rand_idx = np.random.permutation(np.arange(len(train_data)))[:2000]
+rand_idx = np.random.permutation(np.arange(len(train_data)))[:1000]
 train_data = train_data.iloc[rand_idx]
 train_data.head(10)
 ```

--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -16,12 +16,16 @@ np.random.seed(123)
 ## Paraphrase Identification
 
 We consider a Paraphrase Identification task for illustration. Given a pair of sentences, the goal is to predict whether or not one sentence is a restatement of the other (a binary classification task). Here we train models on the [Microsoft Research Paraphrase Corpus](https://www.microsoft.com/en-us/download/details.aspx?id=52398) dataset.
+For quick demonstration, we will subsample the training data and only use 1000 samples.
 
 ```{.python .input}
 from autogluon.core.utils.loaders import load_pd
 
 train_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/mrpc/train.parquet')
 dev_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/mrpc/dev.parquet')
+rand_idx = np.random.permutation(np.arange(len(train_data)))[:1000]
+train_data = train_data.iloc[rand_idx]
+train_data.reset_index(inplace=True, drop=True)
 train_data.head(10)
 ```
 
@@ -85,8 +89,8 @@ Below `num_trials` controls the maximal number of different hyperparameter confi
 predictor_mrpc = task.fit(train_data,
                           label='label',
                           hyperparameters=hyperparameters,
-                          num_trials=5,  # increase this to achieve good performance in your applications
-                          time_limits=60 * 6,
+                          num_trials=2,  # increase this to achieve good performance in your applications
+                          time_limits=60 * 2,
                           ngpus_per_trial=1,
                           seed=123,
                           output_directory='./ag_mrpc_random_search')
@@ -136,8 +140,8 @@ hyperparameters['hpo_params'] = {
 
 predictor_mrpc_bo = task.fit(train_data, label='label',
                                 hyperparameters=hyperparameters,
-                                time_limits=60 * 6,
-                                num_trials=5,  # increase this to get good performance in your applications
+                                time_limits=60 * 2,
+                                num_trials=2,  # increase this to get good performance in your applications
                                 ngpus_per_trial=1, seed=123,
                                 output_directory='./ag_mrpc_custom_space_fifo_bo')
 ```
@@ -188,7 +192,7 @@ hyperparameters['hpo_params'] = {
 ```{.python .input}
 predictor_mrpc_hyperband = task.fit(train_data, label='label',
                                     hyperparameters=hyperparameters,
-                                    time_limits=60 * 6, ngpus_per_trial=1, seed=123,
+                                    time_limits=60 * 2, ngpus_per_trial=1, seed=123,
                                     output_directory='./ag_mrpc_custom_space_hyperband')
 ```
 
@@ -238,7 +242,7 @@ hyperparameters['hpo_params'] = {
 predictor_mrpc_bohb = task.fit(
     train_data, label='label',
     hyperparameters=hyperparameters,
-    time_limits=60 * 6, ngpus_per_trial=1, seed=123,
+    time_limits=60 * 2, ngpus_per_trial=1, seed=123,
     output_directory='./ag_mrpc_custom_space_bohb')
 ```
 

--- a/examples/tabular/distill/example_distill_binary.py
+++ b/examples/tabular/distill/example_distill_binary.py
@@ -8,7 +8,7 @@ time_limits = 60
 savedir = 'agModels/'
 # shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
 
-label_column = 'class' # specifies which column do we want to predict
+label_column = 'class'  # specifies which column do we want to predict
 train_file_path = 'https://autogluon.s3-us-west-2.amazonaws.com/datasets/Inc/train.csv'
 test_file_path = 'https://autogluon.s3-us-west-2.amazonaws.com/datasets/Inc/test.csv'
 
@@ -30,12 +30,12 @@ time_limits = 60  # set = None to fully train distilled models
 aug_data = task.Dataset(file_path=train_file_path)
 aug_data = aug_data.head(subsample_size)
 
-distilled_model_names = predictor.distill(time_limits=time_limits, augment_args={'num_augmented_samples':100})  # default distillation (time_limits & augment_args are also optional, here set to suboptimal values to ensure quick runtime)
+distilled_model_names = predictor.distill(time_limits=time_limits, augment_args={'num_augmented_samples': 100})  # default distillation (time_limits & augment_args are also optional, here set to suboptimal values to ensure quick runtime)
 
 # Other distillation variants demonstrating different usage options:
-predictor.distill(time_limits=time_limits, teacher_preds='soft', augment_method='spunge', augment_args={'size_factor':1}, verbosity=3, models_name_suffix='spunge')
+predictor.distill(time_limits=time_limits, teacher_preds='soft', augment_method='spunge', augment_args={'size_factor': 1}, verbosity=3, models_name_suffix='spunge')
 
-predictor.distill(time_limits=time_limits, hyperparameters={'GBM':{},'NN':{}}, teacher_preds='soft', augment_method='munge', augment_args={'size_factor':1,'max_size':100}, models_name_suffix='munge')
+predictor.distill(time_limits=time_limits, hyperparameters={'GBM': {},'NN': {}}, teacher_preds='soft', augment_method='munge', augment_args={'size_factor': 1,'max_size': 100}, models_name_suffix='munge')
 
 predictor.distill(augmentation_data=aug_data, time_limits=time_limits, teacher_preds='soft', models_name_suffix='extra')  # augmentation with "extra" unlabeled data.
 
@@ -43,7 +43,7 @@ predictor.distill(time_limits=time_limits, teacher_preds=None, models_name_suffi
 
 # Compare performance of different models on test data after distillation:
 ldr = predictor.leaderboard(test_data)
-model_todeploy = distilled_model_names[0]
+model_to_deploy = distilled_model_names[0]
 
-y_pred = predictor.predict_proba(test_data, model_todeploy)
+y_pred = predictor.predict_proba(test_data, model_to_deploy)
 print(y_pred[:5])

--- a/examples/tabular/distill/example_distill_multiclass.py
+++ b/examples/tabular/distill/example_distill_multiclass.py
@@ -8,11 +8,12 @@ import os
 from autogluon.tabular import TabularPrediction as task
 from autogluon.tabular.utils import MULTICLASS
 
+
 subsample_size = 500
 time_limits = 60
 
 multi_dataset = {'url': 'https://autogluon.s3-us-west-2.amazonaws.com/datasets/CoverTypeMulticlassClassification.zip',
-                  'name': 'CoverTypeMulticlassClassification', 'problem_type': MULTICLASS, 'label_column': 'Cover_Type'}
+                 'name': 'CoverTypeMulticlassClassification', 'problem_type': MULTICLASS, 'label_column': 'Cover_Type'}
 
 dataset = multi_dataset
 # directory_prefix = ""
@@ -47,12 +48,12 @@ time_limits = 60  # None
 aug_data = task.Dataset(file_path=train_file_path)
 aug_data = aug_data.head(subsample_size)  # subsample for faster demo
 
-distilled_model_names = predictor.distill(time_limits=time_limits, augment_args={'num_augmented_samples':100})  # default distillation (time_limits & augment_args are also optional, here set to suboptimal values to ensure quick runtime)
+distilled_model_names = predictor.distill(time_limits=time_limits, augment_args={'num_augmented_samples': 100})  # default distillation (time_limits & augment_args are also optional, here set to suboptimal values to ensure quick runtime)
 
 # Other variants demonstrating different usage options:
-predictor.distill(time_limits=time_limits, teacher_preds='soft', augment_method='spunge', augment_args={'size_factor':1}, verbosity=3, models_name_suffix='spunge')
+predictor.distill(time_limits=time_limits, teacher_preds='soft', augment_method='spunge', augment_args={'size_factor': 1}, verbosity=3, models_name_suffix='spunge')
 
-predictor.distill(time_limits=time_limits, hyperparameters={'GBM':{},'NN':{}}, teacher_preds='soft', augment_method='munge', augment_args={'size_factor':1,'max_size':100}, models_name_suffix='munge')
+predictor.distill(time_limits=time_limits, hyperparameters={'GBM': {},'NN': {}}, teacher_preds='soft', augment_method='munge', augment_args={'size_factor': 1,'max_size': 100}, models_name_suffix='munge')
 
 predictor.distill(augmentation_data=aug_data, time_limits=time_limits, teacher_preds='soft', models_name_suffix='extra')  # augmentation with "extra" unlabeled data.
 

--- a/examples/tabular/distill/example_distill_regression.py
+++ b/examples/tabular/distill/example_distill_regression.py
@@ -4,6 +4,7 @@ import os
 from autogluon.tabular import TabularPrediction as task
 from autogluon.tabular.utils import REGRESSION
 
+
 subsample_size = 500
 time_limits = 60
 savedir = 'agModels/'
@@ -27,8 +28,8 @@ if (not os.path.exists(train_file_path)) or (not os.path.exists(test_file_path))
 
 train_data = task.Dataset(file_path=train_file_path)
 test_data = task.Dataset(file_path=test_file_path)
-train_data = train_data.head(subsample_size) # subsample for faster demo
-test_data = test_data.head(subsample_size) # subsample for faster run
+train_data = train_data.head(subsample_size)  # subsample for faster demo
+test_data = test_data.head(subsample_size)  # subsample for faster run
 label_column = dataset['label_column']
 
 # Fit model ensemble:
@@ -42,12 +43,12 @@ time_limits = 60  # set = None to fully train distilled models
 aug_data = task.Dataset(file_path=train_file_path)
 aug_data = aug_data.head(subsample_size)  # subsample for faster demo
 
-distilled_model_names = predictor.distill(time_limits=time_limits, augment_args={'num_augmented_samples':100})  # default distillation (time_limits & augment_args are also optional, here set to suboptimal values to ensure quick runtime)
+distilled_model_names = predictor.distill(time_limits=time_limits, augment_args={'num_augmented_samples': 100})  # default distillation (time_limits & augment_args are also optional, here set to suboptimal values to ensure quick runtime)
 
 # Other variants demonstrating different usage options:
-predictor.distill(time_limits=time_limits, hyperparameters={'GBM':{},'NN':{}}, teacher_preds='soft', augment_method='spunge', augment_args={'size_factor':1}, verbosity=3, models_name_suffix='spunge')
+predictor.distill(time_limits=time_limits, hyperparameters={'GBM': {},'NN': {}}, teacher_preds='soft', augment_method='spunge', augment_args={'size_factor': 1}, verbosity=3, models_name_suffix='spunge')
 
-predictor.distill(time_limits=time_limits, teacher_preds='soft', augment_method='munge', augment_args={'size_factor':1,'max_size':100}, models_name_suffix='munge')
+predictor.distill(time_limits=time_limits, teacher_preds='soft', augment_method='munge', augment_args={'size_factor': 1,'max_size': 100}, models_name_suffix='munge')
 
 predictor.distill(augmentation_data=aug_data, time_limits=time_limits, teacher_preds='soft', models_name_suffix='extra')  # augmentation with "extra" unlabeled data.
 

--- a/examples/tabular/example_advanced_tabular.py
+++ b/examples/tabular/example_advanced_tabular.py
@@ -6,32 +6,33 @@
 import autogluon.core as ag
 from autogluon.tabular import TabularPrediction as task
 
-# Training time:
-train_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv') # can be local CSV file as well, returns Pandas DataFrame
-train_data = train_data.head(100) # subsample for faster demo
-print(train_data.head())
-label_column = 'class' # specifies which column do we want to predict
-savedir = 'ag_hpo_models/' # where to save trained models
 
-hyperparams = {'NN': {'num_epochs': 10, 'activation': 'relu', 'dropout_prob': ag.Real(0.0,0.5)},
-               'GBM': {'num_boost_round': 1000, 'learning_rate': ag.Real(0.01,0.1,log=True)},
-               'XGB': {'n_estimators': 1000, 'learning_rate': ag.Real(0.01,0.1,log=True)} }
+# Training time:
+train_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')  # can be local CSV file as well, returns Pandas DataFrame
+train_data = train_data.head(100)  # subsample for faster demo
+print(train_data.head())
+label_column = 'class'  # specifies which column do we want to predict
+savedir = 'ag_hpo_models/'  # where to save trained models
+
+hyperparams = {'NN': {'num_epochs': 10, 'activation': 'relu', 'dropout_prob': ag.Real(0.0, 0.5)},
+               'GBM': {'num_boost_round': 1000, 'learning_rate': ag.Real(0.01, 0.1,log=True)},
+               'XGB': {'n_estimators': 1000, 'learning_rate': ag.Real(0.01, 0.1,log=True)}}
 
 predictor = task.fit(train_data=train_data, label=label_column, output_directory=savedir,
                      hyperparameter_tune=True, hyperparameters=hyperparams,
-                     num_trials=5, time_limits=1*60, num_bagging_folds=0, stack_ensemble_levels=0) # since tuning_data = None, automatically determines train/validation split
+                     num_trials=5, time_limits=1*60, num_bagging_folds=0, stack_ensemble_levels=0)  # since tuning_data = None, automatically determines train/validation split
 
-results = predictor.fit_summary() # display detailed summary of fit() process
+results = predictor.fit_summary()  # display detailed summary of fit() process
 print(results)
 
 # Inference time:
-test_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv') # another Pandas DataFrame
+test_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')  # another Pandas DataFrame
 print(test_data.head())
 
-perf = predictor.evaluate(test_data) # shorthand way to evaluate our predictor if test-labels available
+perf = predictor.evaluate(test_data)  # shorthand way to evaluate our predictor if test-labels available
 
 # Otherwise we make predictions and can evaluate them later:
 y_test = test_data[label_column]
-test_data = test_data.drop(labels=[label_column],axis=1) # Delete labels from test data since we wouldn't have them in practice
+test_data = test_data.drop(labels=[label_column], axis=1)  # Delete labels from test data since we wouldn't have them in practice
 y_pred = predictor.predict(test_data)
 perf = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred, auxiliary_metrics=True)

--- a/examples/tabular/example_simple_tabular.py
+++ b/examples/tabular/example_simple_tabular.py
@@ -2,23 +2,24 @@
 
 from autogluon.tabular import TabularPrediction as task
 
+
 # Training time:
 train_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')  # can be local CSV file as well, returns Pandas DataFrame
-train_data = train_data.head(500) # subsample for faster demo
+train_data = train_data.head(500)  # subsample for faster demo
 print(train_data.head())
-label_column = 'class' # specifies which column do we want to predict
-savedir = 'ag_models/' # where to save trained models
+label_column = 'class'  # specifies which column do we want to predict
+savedir = 'ag_models/'  # where to save trained models
 
 predictor = task.fit(train_data=train_data, label=label_column, output_directory=savedir)
 # NOTE: Default settings above are intended to ensure reasonable runtime at the cost of accuracy. To maximize predictive accuracy, do this instead:  predictor = task.fit(train_data=train_data, label=label_column, output_directory=savedir, presets='best_quality', eval_metric=YOUR_METRIC_NAME)
 results = predictor.fit_summary()
 
 # Inference time:
-test_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv') # another Pandas DataFrame
+test_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')  # another Pandas DataFrame
 y_test = test_data[label_column]
-test_data = test_data.drop(labels=[label_column],axis=1) # delete labels from test data since we wouldn't have them in practice
+test_data = test_data.drop(labels=[label_column], axis=1)  # delete labels from test data since we wouldn't have them in practice
 print(test_data.head())
 
-predictor = task.load(savedir) # Unnecessary, we reload predictor just to demonstrate how to load previously-trained predictor from file
+predictor = task.load(savedir)  # Unnecessary, we reload predictor just to demonstrate how to load previously-trained predictor from file
 y_pred = predictor.predict(test_data)
 perf = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred, auxiliary_metrics=True)

--- a/extra/setup.py
+++ b/extra/setup.py
@@ -46,6 +46,7 @@ MIN_PYTHON_VERSION = '>=3.6.*'
 
 requirements = [
     'numpy>=1.16.0',
+    'scipy>=1.3.3',
     'gluoncv>=0.5.0,<1.0',
     'graphviz<0.9.0,>=0.8.1',
     'bokeh',

--- a/extra/setup.py
+++ b/extra/setup.py
@@ -9,12 +9,12 @@ from setuptools import setup, find_packages, find_namespace_packages
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join('..', 'VERSION')) as version_file:
+with open(os.path.join(os.path.dirname(__file__), '..', 'VERSION')) as version_file:
     version = version_file.read().strip()
 
 """
-To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
-a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 
+To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
+a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
 You need to increase the version number after stable release, so that the nightly pypi can work properly.
 """
 try:

--- a/mxnet/setup.py
+++ b/mxnet/setup.py
@@ -7,12 +7,12 @@ from setuptools import setup, find_packages
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join('..', 'VERSION')) as version_file:
+with open(os.path.join(os.path.dirname(__file__), '..', 'VERSION')) as version_file:
     version = version_file.read().strip()
 
 """
-To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
-a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 
+To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
+a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
 You need to increase the version number after stable release, so that the nightly pypi can work properly.
 """
 try:

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -7,12 +7,12 @@ from setuptools import setup, find_packages
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join('..', 'VERSION')) as version_file:
+with open(os.path.join(os.path.dirname(__file__), '..', 'VERSION')) as version_file:
     version = version_file.read().strip()
 
 """
-To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
-a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 
+To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
+a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
 You need to increase the version number after stable release, so that the nightly pypi can work properly.
 """
 try:

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -107,6 +107,10 @@ class AbstractModel:
             self.nondefault_params = list(hyperparameters.keys())[:]  # These are hyperparameters that user has specified.
         self.params_trained = dict()
 
+        #for warm-starting with hyperband scheduler
+        self._prev_model = None
+        self._early_stopped = False
+
     # Checks if model is capable of inference on new data (if normal model) or has produced out-of-fold predictions (if bagged model)
     def is_valid(self) -> bool:
         return self.is_fit()
@@ -598,6 +602,8 @@ class AbstractModel:
                 if isinstance(params_copy[hyperparam], Space):
                     logger.log(15, f"{hyperparam}:   {params_copy[hyperparam]}")
 
+        epochs = kwargs.get('epochs', 1)
+
         util_args = dict(
             dataset_train_filename=dataset_train_filename,
             dataset_val_filename=dataset_val_filename,
@@ -605,7 +611,14 @@ class AbstractModel:
             model=self,
             time_start=time_start,
             time_limit=scheduler_options['time_out'],
+            epochs=epochs,
+            report_probs=kwargs.get('report_probs', False)
         )
+
+        #epochs denotes number of times to invoke incremental training.
+        # This is to break up large (e.g. 300-tree model) into smaller chunks to enable hyperband scheduler
+        # for instance epochs=10, and num_iterations=30 lead to a total of 10x30 = 300 trees
+        params_copy["epochs"] = epochs
 
         model_trial.register_args(util_args=util_args, **params_copy)
         scheduler: FIFOScheduler = scheduler_func(model_trial, **scheduler_options)
@@ -620,7 +633,10 @@ class AbstractModel:
         scheduler.run()
         scheduler.join_jobs()
 
-        return self._get_hpo_results(scheduler=scheduler, scheduler_options=scheduler_options, time_start=time_start)
+        hpo_models, hpo_model_performances, hpo_results = self._get_hpo_results(scheduler=scheduler, scheduler_options=scheduler_options, time_start=time_start)
+        if 'report_probs' in kwargs:
+            hpo_results['ensemble'] = scheduler.ensemble
+        return hpo_models, hpo_model_performances, hpo_results
 
     def _get_hpo_results(self, scheduler, scheduler_options, time_start):
         # Store results / models from this HPO run:

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -551,6 +551,24 @@ class AbstractModel:
         template.set_contexts(self.path_root + template.name + os.path.sep)
         return template
 
+    def _get_init_args(self):
+        hyperparameters = self.params.copy()
+        hyperparameters = {key: val for key, val in hyperparameters.items() if key in self.nondefault_params}
+        init_args = dict(
+            path=self.path_root,
+            name=self.name,
+            problem_type=self.problem_type,
+            eval_metric=self.eval_metric,
+            num_classes=self.num_classes,
+            stopping_metric=self.stopping_metric,
+            model=None,
+            hyperparameters=hyperparameters,
+            features=self.features,
+            feature_metadata=self.feature_metadata,
+            debug=self.debug
+        )
+        return init_args
+
     def hyperparameter_tune(self, X_train, y_train, X_val, y_val, scheduler_options, **kwargs):
         # verbosity = kwargs.get('verbosity', 2)
         time_start = time.time()
@@ -734,6 +752,15 @@ class AbstractModel:
         save_json.save(path=json_path, obj=info)
         return info
 
+    # TODO: v0.1 Add reference link to all valid keys and their usage or keep full docs here and reference elsewhere?
+    @classmethod
+    def _get_default_ag_args(cls) -> dict:
+        """
+        Dictionary of customization options related to meta properties of the model such as its name, the order it is trained, and the problem types it is valid for.
+        """
+        return {}
+
+
 class AbstractNeuralNetworkModel(AbstractModel):
 
     def __init__(self, **kwargs):
@@ -802,4 +829,3 @@ class AbstractNeuralNetworkModel(AbstractModel):
                 types_of_features.append({"name": feature, "type": feature_type})
 
         return types_of_features, df
-

--- a/tabular/src/autogluon/tabular/models/abstract/model_trial.py
+++ b/tabular/src/autogluon/tabular/models/abstract/model_trial.py
@@ -7,6 +7,7 @@ from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.core import args
 from autogluon.core.scheduler.reporter import LocalStatusReporter
 
+from autogluon.core.utils import AutoGluonEarlyStop
 logger = logging.getLogger(__name__)
 
 
@@ -24,24 +25,29 @@ def model_trial(args, reporter: LocalStatusReporter):
     try:
         model, args, util_args = prepare_inputs(args=args)
 
+        epochs = util_args.pop("epochs")
+
+        report_probs = util_args.pop('report_probs')
+
         X_train, y_train = load_pkl.load(util_args.directory + util_args.dataset_train_filename)
         X_val, y_val = load_pkl.load(util_args.directory + util_args.dataset_val_filename)
 
         fit_model_args = dict(X_train=X_train, y_train=y_train, X_val=X_val, y_val=y_val)
         predict_proba_args = dict(X=X_val)
-        model = fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_val=y_val,
-                                   time_start=util_args.time_start, time_limit=util_args.get('time_limit', None), reporter=None)
+        model = fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args,
+                                   y_val=y_val, time_start=util_args.time_start, time_limit=util_args.get('time_limit', None),
+                                   epochs=epochs, reporter=reporter, report_probs=report_probs)
     except Exception as e:
-        if not isinstance(e, TimeLimitExceeded):
+        if not (isinstance(e, TimeLimitExceeded) or isinstance(e, AutoGluonEarlyStop)):
             logger.exception(e, exc_info=True)
         reporter.terminate()
-    else:
-        reporter(epoch=1, validation_performance=model.val_score)
-
+        model.save()
 
 def prepare_inputs(args):
     task_id = args.pop('task_id')
     util_args = args.pop('util_args')
+
+    args.pop("epochs")
 
     file_prefix = f"trial_{task_id}"  # append to all file names created during this trial. Do NOT change!
     model = util_args.model  # the model object must be passed into model_trial() here
@@ -50,7 +56,7 @@ def prepare_inputs(args):
     return model, args, util_args
 
 
-def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_start, time_limit=None, reporter=None):
+def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_start, time_limit=None, epochs=1, reporter=None, report_probs=False):
     time_current = time.time()
     time_elapsed = time_current - time_start
     if time_limit is not None:
@@ -62,13 +68,21 @@ def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_
 
     model.params.update(params)
     time_fit_start = time.time()
-    model.fit(**fit_args, time_limit=time_left, reporter=reporter)
-    time_fit_end = time.time()
-    y_pred_proba = model.predict_proba(**predict_proba_args)
-    time_pred_end = time.time()
-    model.val_score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba)
-    model.fit_time = time_fit_end - time_fit_start
-    model.predict_time = time_pred_end - time_fit_end
+    incremental = epochs > 1
+    for i in range(epochs):
+        model.fit(**fit_args, time_limit=time_left, reporter=reporter, warm_start=incremental)
+        time_fit_end = time.time()
+        y_pred_proba = model.predict_proba(**predict_proba_args)
+        time_pred_end = time.time()
+        val_score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba)
+        model.val_score = val_score
+        model.fit_time = time_fit_end - time_fit_start
+        model.predict_time = time_pred_end - time_fit_end
+        if report_probs:
+            #use model.path as a unique identifier. maybe change this later?
+            reporter(epoch=i+1, validation_performance=val_score, y_probs=y_pred_proba, y_val=y_val, model_path=model.path)
+        else:
+            reporter(epoch=i+1, validation_performance=val_score)
     model.save()
     return model
 

--- a/tabular/src/autogluon/tabular/models/abstract/model_trial.py
+++ b/tabular/src/autogluon/tabular/models/abstract/model_trial.py
@@ -7,6 +7,8 @@ from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.core import args
 from autogluon.core.scheduler.reporter import LocalStatusReporter
 
+from autogluon.core.utils.savers import save_pkl
+
 from autogluon.core.utils import AutoGluonEarlyStop
 logger = logging.getLogger(__name__)
 
@@ -22,26 +24,30 @@ def model_trial(args, reporter: LocalStatusReporter):
                 'num_threads', 'num_gpus' to set specific resources in model.fit()
             - model.save() must have return_filename, file_prefix, directory options
     """
+    model = None
     try:
         model, args, util_args = prepare_inputs(args=args)
 
         epochs = util_args.pop("epochs")
 
-        report_probs = util_args.pop('report_probs')
+        save_val_pred = util_args.pop('save_val_pred')
 
         X_train, y_train = load_pkl.load(util_args.directory + util_args.dataset_train_filename)
         X_val, y_val = load_pkl.load(util_args.directory + util_args.dataset_val_filename)
 
-        fit_model_args = dict(X_train=X_train, y_train=y_train, X_val=X_val, y_val=y_val)
+        fit_model_args = dict(X_train=X_train, y_train=y_train, X_val=X_val, y_val=y_val, save_val_pred=None)
         predict_proba_args = dict(X=X_val)
         model = fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args,
-                                   y_val=y_val, time_start=util_args.time_start, time_limit=util_args.get('time_limit', None),
-                                   epochs=epochs, reporter=reporter, report_probs=report_probs)
-    except Exception as e:
-        if not (isinstance(e, TimeLimitExceeded) or isinstance(e, AutoGluonEarlyStop)):
-            logger.exception(e, exc_info=True)
-        if isinstance(e, AutoGluonEarlyStop):
+                                   y_val=y_val, time_start=util_args.time_start, time_limit=util_args.get('time_limit'),
+                                   epochs=epochs, reporter=reporter, save_val_pred=save_val_pred)
+    except AutoGluonEarlyStop:
+        if model is not None:
             model.save()
+    except TimeLimitExceeded:
+        pass  # this is intended to be silent for model trials
+    except Exception as e:
+        logger.exception(e, exc_info=True)
+    finally:
         reporter.terminate()
 
 
@@ -58,7 +64,7 @@ def prepare_inputs(args):
     return model, args, util_args
 
 
-def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_start, time_limit=None, epochs=1, reporter=None, report_probs=False):
+def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_start, time_limit=None, epochs=None, reporter=None, save_val_pred=None):
     time_current = time.time()
     time_elapsed = time_current - time_start
     if time_limit is not None:
@@ -67,6 +73,9 @@ def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_
             raise TimeLimitExceeded
     else:
         time_left = None
+
+    if epochs is None:
+        epochs = 1
 
     model.params.update(params)
     time_fit_start = time.time()
@@ -80,11 +89,11 @@ def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_
         model.val_score = val_score
         model.fit_time = time_fit_end - time_fit_start
         model.predict_time = time_pred_end - time_fit_end
-        if report_probs:
-            #use model.path as a unique identifier. maybe change this later?
-            reporter(epoch=i+1, validation_performance=val_score, y_probs=y_pred_proba, y_val=y_val, model_path=model.path)
-        else:
-            reporter(epoch=i+1, validation_performance=val_score)
+        # save validation set prediction to disk
+        if save_val_pred:
+            save_pkl.save(path=os.path.join(model.path, "val_pred.save"), object=y_pred_proba)
+        reporter(epoch=i + 1, validation_performance=val_score, model_path=model.path)
+
     model.save()
     return model
 

--- a/tabular/src/autogluon/tabular/models/abstract/model_trial.py
+++ b/tabular/src/autogluon/tabular/models/abstract/model_trial.py
@@ -40,8 +40,10 @@ def model_trial(args, reporter: LocalStatusReporter):
     except Exception as e:
         if not (isinstance(e, TimeLimitExceeded) or isinstance(e, AutoGluonEarlyStop)):
             logger.exception(e, exc_info=True)
+        if isinstance(e, AutoGluonEarlyStop):
+            model.save()
         reporter.terminate()
-        model.save()
+
 
 def prepare_inputs(args):
     task_id = args.pop('task_id')

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -21,8 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 # TODO: Consider having CatBoost variant that converts all categoricals to numerical as done in RFModel, was showing improved results in some problems.
-# TODO: v0.1 rename to CatBoostModel and rename model name default to CatBoost (instead of Catboost)
-class CatboostModel(AbstractModel):
+class CatBoostModel(AbstractModel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._category_features = None

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -53,9 +53,60 @@ class CatBoostModel(AbstractModel):
                     X[category] = X[category].cat.add_categories('__NaN__').fillna('__NaN__')
         return X
 
+    #TODO: could be useful if we could still exploit the early stopping feature during incremental training
+    #incremental training appears not compatible with early stopping for now
+    def _set_early_stopped(self, progress, iterations, early_stopping_rounds):
+        if progress:
+            self._early_stopped = iterations > (self.model.get_best_iteration() + early_stopping_rounds) \
+            if early_stopping_rounds else False
+        else:
+            self._early_stopped = True
+
+    def _merge_prev_model(self, init_model, metric_name, X_val=None, y_val=None):
+        progress = True #test if adding additional trees help with accuracy
+        if init_model is not None:
+            init_model_best_score = init_model.get_best_score()['validation'][metric_name]
+            final_model_best_score = self.model.get_best_score()['validation'][metric_name]
+            if self.stopping_metric._optimum > final_model_best_score:
+                if final_model_best_score > init_model_best_score:
+                    best_iteration = init_model.tree_count_ + self.model.get_best_iteration()
+                else:
+                    best_iteration = init_model.get_best_iteration()
+                    progress = False
+            else:
+                if final_model_best_score < init_model_best_score:
+                    best_iteration = init_model.tree_count_ + self.model.get_best_iteration()
+                else:
+                    best_iteration = init_model.get_best_iteration()
+                    progress = False
+        else:
+            best_iteration = self.model.get_best_iteration()
+        if best_iteration is not None:
+            self.model.shrink(ntree_start=0, ntree_end=best_iteration+1)
+        return progress
+
+    def trim_to_best(self):
+        if isinstance(self.params['eval_metric'], str):
+            metric_name = self.params['eval_metric']
+        else:
+            metric_name = type(self.params['eval_metric']).__name__
+        self._merge_prev_model(self._prev_model, metric_name, 0)
+
     # TODO: Use Pool in preprocess, optimize bagging to do Pool.split() to avoid re-computing pool for each fold! Requires stateful + y
     #  Pool is much more memory efficient, avoids copying data twice in memory
-    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_gpus=0, **kwargs):
+    # warm_start enables incremental training, if self.init_model is a learned model
+    # warm_iter specifies the number of additional trees to add for incremental training
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, warm_start=False, warm_iter=None, num_gpus=0, **kwargs):
+        """
+        Additional Parameters
+        warm_start: False
+            If warm_start is True, it allows the model to perform incremental training.
+            E.g. calling model.fit(X, y) multiple times would build upon the intermediate models and
+            increase the number of trees used. See also warm_iter
+        warm_iter: None
+            This sets the humber of additional trees to add for incremental training.
+            if warm_iter is None, the number of additional trees set by the model hyperparameter, such as "n_estimators"
+        """
         try_import_catboost()
         from catboost import CatBoostClassifier, CatBoostRegressor, Pool
         if self.problem_type == SOFTCLASS:
@@ -144,11 +195,6 @@ class CatBoostModel(AbstractModel):
         else:
             verbose = True
 
-        init_model = None
-        init_model_tree_count = None
-        init_model_best_iteration = None
-        init_model_best_score = None
-
         params = self.params.copy()
         num_features = len(self.features)
         if num_gpus != 0:
@@ -178,88 +224,96 @@ class CatBoostModel(AbstractModel):
                 params['colsample_bylevel'] = 1.0
                 logger.log(30, f'\t\'colsample_bylevel\' is not supported on GPU, using default value (Default = 1).')
 
-        if time_limit:
-            time_left_start = time_limit - (time.time() - start_time)
-            if time_left_start <= time_limit * 0.4:  # if 60% of time was spent preprocessing, likely not enough time to train model
-                raise TimeLimitExceeded
-            params_init = params.copy()
-            num_sample_iter = min(num_sample_iter_max, params_init['iterations'])
-            params_init['iterations'] = num_sample_iter
-            if train_dir is not None:
-                params_init['train_dir'] = train_dir
-            self.model = model_type(
-                **params_init,
-            )
-            self.model.fit(
-                X_train,
-                eval_set=eval_set,
-                use_best_model=True,
-                verbose=verbose,
-                # early_stopping_rounds=early_stopping_rounds,
-            )
+        if not warm_start:
+            if time_limit:
+                time_left_start = time_limit - (time.time() - start_time)
+                if time_left_start <= time_limit * 0.4:  # if 60% of time was spent preprocessing, likely not enough time to train model
+                    raise TimeLimitExceeded
+                params_init = params.copy()
+                num_sample_iter = min(num_sample_iter_max, params_init['iterations'])
+                params_init['iterations'] = num_sample_iter
+                if train_dir is not None:
+                    params_init['train_dir'] = train_dir
+                self.model = model_type(
+                    **params_init,
+                )
 
-            init_model_tree_count = self.model.tree_count_
-            init_model_best_iteration = self.model.get_best_iteration()
-            init_model_best_score = self.model.get_best_score()['validation'][metric_name]
+                #this is small-scall test fitting to determine time limit
+                self.model.fit(
+                    X_train,
+                    eval_set=eval_set,
+                    use_best_model=False,
+                    verbose=verbose,
+                    # early_stopping_rounds=early_stopping_rounds,
+                )
 
-            time_left_end = time_limit - (time.time() - start_time)
-            time_taken_per_iter = (time_left_start - time_left_end) / num_sample_iter
-            estimated_iters_in_time = round(time_left_end / time_taken_per_iter)
-            init_model = self.model
+                time_left_end = time_limit - (time.time() - start_time)
+                time_taken_per_iter = (time_left_start - time_left_end) / num_sample_iter
+                estimated_iters_in_time = round(time_left_end / time_taken_per_iter)
 
-            params_final = params.copy()
+                params_final = params.copy()
 
-            # TODO: This only handles memory with time_limits specified, but not with time_limits=None, handle when time_limits=None
-            available_mem = psutil.virtual_memory().available
-            if self.problem_type == SOFTCLASS:  # TODO: remove this once catboost-dev is no longer necessary and SOFTCLASS objectives can be pickled.
-                model_size_bytes = 1  # skip memory check
+                # TODO: This only handles memory with time_limits specified, but not with time_limits=None, handle when time_limits=None
+                available_mem = psutil.virtual_memory().available
+                if self.problem_type == SOFTCLASS:  # TODO: remove this once catboost-dev is no longer necessary and SOFTCLASS objectives can be pickled.
+                    model_size_bytes = 1  # skip memory check
+                else:
+                    model_size_bytes = sys.getsizeof(pickle.dumps(self.model))
+
+                max_memory_proportion = 0.3 * max_memory_usage_ratio
+                mem_usage_per_iter = model_size_bytes / num_sample_iter
+                max_memory_iters = math.floor(available_mem * max_memory_proportion / mem_usage_per_iter)
+
+                params_final['iterations'] = min(params['iterations'] - num_sample_iter, estimated_iters_in_time)
+                if params_final['iterations'] > max_memory_iters - num_sample_iter:
+                    if max_memory_iters - num_sample_iter <= 500:
+                        logger.warning('\tWarning: CatBoost will be early stopped due to lack of memory, increase memory to enable full quality models, max training iterations changed to %s from %s' % (max_memory_iters, params_final['iterations'] + num_sample_iter))
+                    params_final['iterations'] = max_memory_iters - num_sample_iter
             else:
-                model_size_bytes = sys.getsizeof(pickle.dumps(self.model))
+                params_final = params.copy()
 
-            max_memory_proportion = 0.3 * max_memory_usage_ratio
-            mem_usage_per_iter = model_size_bytes / num_sample_iter
-            max_memory_iters = math.floor(available_mem * max_memory_proportion / mem_usage_per_iter)
+            if train_dir is not None:
+                params_final['train_dir'] = train_dir
+            if params_final['iterations'] > 0:
+                init_model = self.model
 
-            params_final['iterations'] = min(params['iterations'] - num_sample_iter, estimated_iters_in_time)
-            if params_final['iterations'] > max_memory_iters - num_sample_iter:
-                if max_memory_iters - num_sample_iter <= 500:
-                    logger.warning('\tWarning: CatBoost will be early stopped due to lack of memory, increase memory to enable full quality models, max training iterations changed to %s from %s' % (max_memory_iters, params_final['iterations'] + num_sample_iter))
-                params_final['iterations'] = max_memory_iters - num_sample_iter
+                self.model = model_type(
+                    **params_final,
+                )
+
+                # TODO: Strangely, this performs different if clone init_model is sent in than if trained for same total number of iterations. May be able to optimize catboost models further with this
+                self.model.fit(
+                    X_train,
+                    eval_set=eval_set,
+                    verbose=verbose,
+                    early_stopping_rounds=early_stopping_rounds,
+                    # use_best_model=True,
+                    init_model=init_model,
+                )
+
+                self._merge_prev_model(init_model, metric_name)
         else:
+            #TODO: Time limit constraint is not considered in warm starting scenairo. May need to add it
+            self._prev_model = self.model
             params_final = params.copy()
 
-        if train_dir is not None:
-            params_final['train_dir'] = train_dir
-        if params_final['iterations'] > 0:
+            if warm_iter:
+                params_final["iterations"] = warm_iter
+
             self.model = model_type(
                 **params_final,
             )
 
-            # TODO: Strangely, this performs different if clone init_model is sent in than if trained for same total number of iterations. May be able to optimize catboost models further with this
             self.model.fit(
                 X_train,
                 eval_set=eval_set,
                 verbose=verbose,
-                early_stopping_rounds=early_stopping_rounds,
-                # use_best_model=True,
-                init_model=init_model,
+                #early_stopping_rounds=early_stopping_rounds,
+                use_best_model=False,
+                init_model=self._prev_model,
             )
 
-            if init_model is not None:
-                final_model_best_score = self.model.get_best_score()['validation'][metric_name]
-                if self.stopping_metric._optimum > final_model_best_score:
-                    if final_model_best_score > init_model_best_score:
-                        best_iteration = init_model_tree_count + self.model.get_best_iteration()
-                    else:
-                        best_iteration = init_model_best_iteration
-                else:
-                    if final_model_best_score < init_model_best_score:
-                        best_iteration = init_model_tree_count + self.model.get_best_iteration()
-                    else:
-                        best_iteration = init_model_best_iteration
-
-                self.model.shrink(ntree_start=0, ntree_end=best_iteration+1)
-
+            # progress = self._merge_prev_model(self.prev_model, metric_name, params_final["iterations"], X_val=X_val, y_val=y_val)
         self.params_trained['iterations'] = self.model.tree_count_
 
     def _predict_proba(self, X, **kwargs):

--- a/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
@@ -151,13 +151,7 @@ class BaggedEnsembleModel(AbstractModel):
         # TODO: Preprocess data here instead of repeatedly
         kfolds = generate_kfold(X=X, y=y, n_splits=k_fold, stratified=self.is_stratified(), random_state=self._random_state, n_repeats=n_repeats)
 
-        if self.problem_type == MULTICLASS:
-            oof_pred_proba = np.zeros(shape=(len(X), len(y.unique())), dtype=np.float32)
-        elif self.problem_type == SOFTCLASS:
-            oof_pred_proba = np.zeros(shape=y.shape, dtype=np.float32)
-        else:
-            oof_pred_proba = np.zeros(shape=len(X))
-        oof_pred_model_repeats = np.zeros(shape=len(X), dtype=np.uint8)
+        oof_pred_proba, oof_pred_model_repeats = self._construct_empty_oof(X=X, y=y)
 
         models = []
         folds_to_fit = fold_end - fold_start
@@ -563,3 +557,13 @@ class BaggedEnsembleModel(AbstractModel):
             else:
                 child_info_dict[model.name] = model.get_info()
         return child_info_dict
+
+    def _construct_empty_oof(self, X, y):
+        if self.problem_type == MULTICLASS:
+            oof_pred_proba = np.zeros(shape=(len(X), len(y.unique())), dtype=np.float32)
+        elif self.problem_type == SOFTCLASS:
+            oof_pred_proba = np.zeros(shape=y.shape, dtype=np.float32)
+        else:
+            oof_pred_proba = np.zeros(shape=len(X), dtype=np.float32)
+        oof_pred_model_repeats = np.zeros(shape=len(X), dtype=np.uint8)
+        return oof_pred_proba, oof_pred_model_repeats

--- a/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # TODO: Add metadata object with info like score on each model, train time on each model, etc.
 class BaggedEnsembleModel(AbstractModel):
     _oof_filename = 'oof.pkl'
+
     def __init__(self, model_base: AbstractModel, save_bagged_folds=True, random_state=0, **kwargs):
         self.model_base = model_base
         self._child_type = type(self.model_base)
@@ -316,13 +317,38 @@ class BaggedEnsembleModel(AbstractModel):
 
     # TODO: Multiply epochs/n_iterations by some value (such as 1.1) to account for having more training data than bagged models
     def convert_to_refitfull_template(self):
+        init_args = self._get_init_args()
+        init_args['save_bagged_folds'] = True  # refit full models must save folds
+        model_base_name_orig = init_args['model_base'].name
+        init_args['model_base'] = self.convert_to_refitfull_template_child()
+        model_base_name_new = init_args['model_base'].name
+        if model_base_name_orig in init_args['name'] and model_base_name_orig != model_base_name_new:
+            init_args['name'] = init_args['name'].replace(model_base_name_orig, model_base_name_new, 1)
+        else:
+            init_args['name'] = init_args['name'] + '_FULL'
+
+        model_full_template = self.__class__(**init_args)
+        return model_full_template
+
+    def convert_to_refitfull_template_child(self):
         compressed_params = self._get_compressed_params()
-        model_compressed = copy.deepcopy(self._get_model_base())
-        model_compressed.feature_metadata = self.feature_metadata  # TODO: Don't pass this here
-        model_compressed.params = compressed_params
-        model_compressed.name = model_compressed.name + REFIT_FULL_SUFFIX
-        model_compressed.set_contexts(self.path_root + model_compressed.name + os.path.sep)
-        return model_compressed
+        child_compressed = copy.deepcopy(self._get_model_base())
+        child_compressed.feature_metadata = self.feature_metadata  # TODO: Don't pass this here
+        child_compressed.params = compressed_params
+        child_compressed.name = child_compressed.name + REFIT_FULL_SUFFIX
+        child_compressed.set_contexts(self.path_root + child_compressed.name + os.path.sep)
+        return child_compressed
+
+    def _get_init_args(self):
+        init_args = dict(
+            model_base=self._get_model_base(),
+            save_bagged_folds=self.save_bagged_folds,
+            random_state=self._random_state,
+        )
+        init_args.update(super()._get_init_args())
+        init_args.pop('problem_type')
+        init_args.pop('feature_metadata')
+        return init_args
 
     def _get_compressed_params(self, model_params_list=None):
         if model_params_list is None:

--- a/tabular/src/autogluon/tabular/models/ensemble/greedy_weighted_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/greedy_weighted_ensemble_model.py
@@ -81,3 +81,10 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         info = super().get_info()
         info['model_weights'] = self._get_model_weights()
         return info
+
+    @classmethod
+    def _get_default_ag_args(cls) -> dict:
+        default_ag_args = super()._get_default_ag_args()
+        extra_ag_args = {'valid_base': False}
+        default_ag_args.update(extra_ag_args)
+        return default_ag_args

--- a/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 #  To solve this, this model must know full context of stacker, and only get preds once for each required model
 #  This is already done in trainer, but could be moved internally.
 class StackerEnsembleModel(BaggedEnsembleModel):
-    def __init__(self, base_model_names=None, base_models_dict=None, base_model_paths_dict=None, base_model_types_dict=None, base_model_types_inner_dict=None, base_model_performances_dict=None, use_orig_features=True, **kwargs):
+    def __init__(self, base_model_names=None, base_models_dict=None, base_model_paths_dict=None, base_model_types_dict=None, base_model_types_inner_dict=None, base_model_performances_dict=None, **kwargs):
         super().__init__(**kwargs)
         if base_model_names is None:
             base_model_names = []
@@ -33,7 +33,6 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         self.base_models_dict: Dict[str, AbstractModel] = base_models_dict  # String name -> Model objects
         self.base_model_paths_dict = base_model_paths_dict
         self.base_model_types_dict = base_model_types_dict
-        self.use_orig_features = use_orig_features
 
         if (base_model_performances_dict is not None) and (base_model_types_inner_dict is not None):
             if self.params['max_models_per_type'] > 0:
@@ -70,9 +69,10 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         return self.limit_models_per_type(models=models, model_types=model_types, model_scores=model_scores, max_models_per_type=max_models)
 
     def _set_default_params(self):
-        default_params = {'max_models': 25, 'max_models_per_type': 5}
+        default_params = {'max_models': 25, 'max_models_per_type': 5, 'use_orig_features': True}
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
+        super()._set_default_params()
 
     def preprocess(self, X, fit=False, compute_base_preds=True, infer=True, model_pred_proba_dict=None, **kwargs):
         if self.stack_column_prefix_lst:
@@ -94,11 +94,11 @@ class StackerEnsembleModel(BaggedEnsembleModel):
                         y_pred_proba = base_model.predict_proba(X)
                     X_stacker.append(y_pred_proba)  # TODO: This could get very large on a high class count problem. Consider capping to top N most frequent classes and merging least frequent
                 X_stacker = self.pred_probas_to_df(X_stacker, index=X.index)
-                if self.use_orig_features:
+                if self.params['use_orig_features']:
                     X = pd.concat([X_stacker, X], axis=1)
                 else:
                     X = X_stacker
-            elif not self.use_orig_features:
+            elif not self.params['use_orig_features']:
                 X = X[self.stack_columns]
         X = super().preprocess(X, **kwargs)
         return X
@@ -219,6 +219,16 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         # TODO: hpo_results likely not correct because no renames
         return stackers, stackers_performance, hpo_results
 
+    def _get_init_args(self):
+        init_args = dict(
+            base_model_names=self.base_model_names,
+            base_models_dict=self.base_models_dict,
+            base_model_paths_dict=self.base_model_paths_dict,
+            base_model_types_dict=self.base_model_types_dict,
+        )
+        init_args.update(super()._get_init_args())
+        return init_args
+
     def load_base_model(self, model_name):
         if model_name in self.base_models_dict.keys():
             model = self.base_models_dict[model_name]
@@ -233,7 +243,6 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         stacker_info = dict(
             num_base_models=len(self.base_model_names),
             base_model_names=self.base_model_names,
-            use_orig_features=self.use_orig_features,
         )
         children_info = info.pop('children_info')
         info['stacker_info'] = stacker_info

--- a/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
@@ -183,11 +183,7 @@ class StackerEnsembleModel(BaggedEnsembleModel):
             stacker.name = stacker.name + os.path.sep + str(i)
             stacker.set_contexts(self.path_root + stacker.name + os.path.sep)
 
-            if self.problem_type == MULTICLASS:
-                oof_pred_proba = np.zeros(shape=(len(X), len(y.unique())))
-            else:
-                oof_pred_proba = np.zeros(shape=len(X))
-            oof_pred_model_repeats = np.zeros(shape=len(X))
+            oof_pred_proba, oof_pred_model_repeats = self._construct_empty_oof(X=X, y=y)
             oof_pred_proba[test_index] += y_pred_proba
             oof_pred_model_repeats[test_index] += 1
 

--- a/tabular/src/autogluon/tabular/models/ensemble/weighted_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/weighted_ensemble_model.py
@@ -9,14 +9,18 @@ from .greedy_weighted_ensemble_model import GreedyWeightedEnsembleModel
 logger = logging.getLogger(__name__)
 
 
+# TODO: v0.1 see if this can be removed and logic moved to greedy weighted ensemble model -> Use StackerEnsembleModel as stacker instead
 # TODO: Optimize predict speed when fit on kfold, can simply sum weights
 class WeightedEnsembleModel(StackerEnsembleModel):
-    def __init__(self, base_model_names, base_model_paths_dict, base_model_types_dict, **kwargs):
-        model_0 = base_model_types_dict[base_model_names[0]].load(path=base_model_paths_dict[base_model_names[0]], verbose=False)
-        super().__init__(model_base=model_0, base_model_names=base_model_names, base_model_paths_dict=base_model_paths_dict, base_model_types_dict=base_model_types_dict, use_orig_features=False, **kwargs)
-        child_hyperparameters = kwargs.get('_tmp_greedy_hyperparameters', None)  # TODO: Rework to avoid this hack
-        self.model_base = GreedyWeightedEnsembleModel(path='', name='greedy_ensemble', num_classes=self.num_classes, base_model_names=self.stack_column_prefix_lst, problem_type=self.problem_type, eval_metric=self.eval_metric, stopping_metric=self.stopping_metric, hyperparameters=child_hyperparameters)
-        self._child_type = type(self.model_base)
+    def __init__(self, base_model_names, base_model_paths_dict, base_model_types_dict, model_base=None, **kwargs):
+        child_hyperparameters = kwargs.pop('_tmp_greedy_hyperparameters', None)  # TODO: Rework to avoid this hack
+        model_base_is_none = model_base is None
+        if model_base_is_none:
+            model_base = base_model_types_dict[base_model_names[0]].load(path=base_model_paths_dict[base_model_names[0]], verbose=False)
+        super().__init__(model_base=model_base, base_model_names=base_model_names, base_model_paths_dict=base_model_paths_dict, base_model_types_dict=base_model_types_dict, **kwargs)
+        if model_base_is_none:
+            self.model_base = GreedyWeightedEnsembleModel(path='', name='greedy_ensemble', num_classes=self.num_classes, base_model_names=self.stack_column_prefix_lst, problem_type=self.problem_type, eval_metric=self.eval_metric, stopping_metric=self.stopping_metric, hyperparameters=child_hyperparameters)
+            self._child_type = type(self.model_base)
         self.low_memory = False
 
     def _fit(self, X, y, k_fold=5, k_fold_start=0, k_fold_end=None, n_repeats=1, n_repeat_start=0, compute_base_preds=True, time_limit=None, **kwargs):
@@ -53,3 +57,9 @@ class WeightedEnsembleModel(StackerEnsembleModel):
             # TODO: Rewrite preprocess() in greedy_weighted_ensemble_model to enable
             # feature_importance = super().compute_feature_importance(X=X, y=y, features_to_use=features_to_use, preprocess=preprocess, is_oof=is_oof, **kwargs)
         return feature_importance
+
+    def _set_default_params(self):
+        default_params = {'use_orig_features': False}
+        for param, val in default_params.items():
+            self._set_default_param_value(param, val)
+        super()._set_default_params()

--- a/tabular/src/autogluon/tabular/models/lgb/hyperparameters/lgb_trial.py
+++ b/tabular/src/autogluon/tabular/models/lgb/hyperparameters/lgb_trial.py
@@ -6,6 +6,10 @@ from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.core.utils import try_import_lightgbm
 from autogluon.core import args
 
+from autogluon.core.utils import AutoGluonEarlyStop
+
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,21 +22,32 @@ def lgb_trial(args, reporter):
     try:
         model, args, util_args = model_trial.prepare_inputs(args=args)
 
+        epochs = util_args['epochs']
+
+        report_probs = util_args['report_probs']
+
         try_import_lightgbm()
         import lightgbm as lgb
 
-        dataset_train = lgb.Dataset(util_args.directory + util_args.dataset_train_filename)
-        dataset_val = lgb.Dataset(util_args.directory + util_args.dataset_val_filename)
-        X_val, y_val = load_pkl.load(util_args.directory + util_args.dataset_val_pkl_filename)
+        # dataset_train = lgb.Dataset(util_args.directory + util_args.dataset_train_filename)
+        # dataset_val = lgb.Dataset(util_args.directory + util_args.dataset_val_filename)
+        X_val, y_val = load_pkl.load(util_args.dataset_val_pkl_filename)
+        X_train, y_train = load_pkl.load(util_args.dataset_train_pkl_filename)
 
-        fit_model_args = dict(dataset_train=dataset_train, dataset_val=dataset_val)
+        # fit_model_args = dict(dataset_train=dataset_train,
+        #                       dataset_val=dataset_val)
+
+        fit_model_args = dict(X_train=X_train, y_train=y_train, X_val=X_val, y_val=y_val)
+
         predict_proba_args = dict(X=X_val)
         model_trial.fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_val=y_val,
-                                       time_start=util_args.time_start, time_limit=util_args.get('time_limit', None), reporter=reporter)
+                                       time_start=util_args.time_start, time_limit=util_args.get('time_limit', None),
+                                       epochs=epochs, reporter=reporter, report_probs=report_probs)
     except Exception as e:
-        if not isinstance(e, TimeLimitExceeded):
+        if not (isinstance(e, TimeLimitExceeded) or isinstance(e, AutoGluonEarlyStop)):
             logger.exception(e, exc_info=True)
         reporter.terminate()
+        model.save()
 
     # FIXME: If stopping metric and eval metric differ, the previous reported scores will not align as they will be evaluated with stopping_metric, whereas this is evaluated with eval_metric
     #  This should only impact if the reporter data is used

--- a/tabular/src/autogluon/tabular/models/lgb/hyperparameters/lgb_trial.py
+++ b/tabular/src/autogluon/tabular/models/lgb/hyperparameters/lgb_trial.py
@@ -47,7 +47,8 @@ def lgb_trial(args, reporter):
         if not (isinstance(e, TimeLimitExceeded) or isinstance(e, AutoGluonEarlyStop)):
             logger.exception(e, exc_info=True)
         reporter.terminate()
-        model.save()
+        if isinstance(e, AutoGluonEarlyStop):
+            model.save()
 
     # FIXME: If stopping metric and eval metric differ, the previous reported scores will not align as they will be evaluated with stopping_metric, whereas this is evaluated with eval_metric
     #  This should only impact if the reporter data is used

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -35,6 +35,7 @@ class LGBModel(AbstractModel):
         super().__init__(**kwargs)
 
         self._internal_feature_map = None
+        self.model = None
 
     def _set_default_params(self):
         default_params = get_param_baseline(problem_type=self.problem_type, num_classes=self.num_classes)
@@ -54,7 +55,19 @@ class LGBModel(AbstractModel):
             eval_metric_name = eval_metric
         return eval_metric, eval_metric_name
 
-    def _fit(self, X_train=None, y_train=None, X_val=None, y_val=None, dataset_train=None, dataset_val=None, time_limit=None, num_gpus=0, **kwargs):
+    # warm_start enables incremental training, if self.init_model is a learned model
+    # warm_iter specifies the number of additional trees to add for incremental training.
+    def _fit(self, X_train=None, y_train=None, X_val=None, y_val=None, dataset_train=None, dataset_val=None, time_limit=None, warm_start=False, warm_iter=None, num_gpus=0, **kwargs):
+        """
+            Additional Parameters
+            warm_start: False
+                If warm_start is True, it allows the model to perform incremental training.
+                E.g. calling model.fit(X, y) multiple times would build upon the intermediate models and
+                increase the number of trees used. See also warm_iter
+            warm_iter: None
+                This sets the humber of additional trees to add for incremental training.
+                if warm_iter is None, the number of additional trees set by the model hyperparameter, such as "n_estimators"
+       """
         start_time = time.time()
         params = self.params.copy()
 
@@ -89,6 +102,7 @@ class LGBModel(AbstractModel):
         logger.log(15, "with the following hyperparameter settings:")
         logger.log(15, params)
 
+        #len(data) can't be repeatedly called in warm start, since dataset.construct() destroy the raw data
         num_rows_train = len(dataset_train.data)
         if 'min_data_in_leaf' in params:
             if params['min_data_in_leaf'] > num_rows_train:  # TODO: may not be necessary
@@ -112,11 +126,12 @@ class LGBModel(AbstractModel):
                     params['metric'] = train_loss_name
                 elif train_loss_name not in params['metric']:
                     params['metric'] = f'{params["metric"]},{train_loss_name}'
-            callbacks += [
-                # Note: Don't use self.params_aux['max_memory_usage_ratio'] here as LightGBM handles memory per iteration optimally.  # TODO: Consider using when ratio < 1.
-                early_stopping_custom(early_stopping_rounds, metrics_to_use=[('valid_set', eval_metric_name)], max_diff=None, start_time=start_time, time_limit=time_limit,
-                                      ignore_dart_warning=True, verbose=False, manual_stop_file=False, reporter=reporter, train_loss_name=train_loss_name),
-            ]
+            if not warm_start:
+                callbacks += [
+                    # Note: Don't use self.params_aux['max_memory_usage_ratio'] here as LightGBM handles memory per iteration optimally.  # TODO: Consider using when ratio < 1.
+                    early_stopping_custom(early_stopping_rounds, metrics_to_use=[('valid_set', eval_metric_name)], max_diff=None, start_time=start_time, time_limit=time_limit,
+                                          ignore_dart_warning=True, verbose=False, manual_stop_file=False, reporter=reporter, train_loss_name=train_loss_name),
+                ]
             valid_names = ['valid_set'] + valid_names
             valid_sets = [dataset_val] + valid_sets
 
@@ -147,31 +162,73 @@ class LGBModel(AbstractModel):
         # Train LightGBM model:
         try_import_lightgbm()
         import lightgbm as lgb
-        with warnings.catch_warnings():
-            # Filter harmless warnings introduced in lightgbm 3.0, future versions plan to remove: https://github.com/microsoft/LightGBM/issues/3379
-            warnings.filterwarnings('ignore', message='Overriding the parameters from Reference Dataset.')
-            warnings.filterwarnings('ignore', message='categorical_column in param dict is overridden.')
-            self.model = lgb.train(**train_params)
-            retrain = False
-            if train_params['params'].get('boosting_type', '') == 'dart':
-                if dataset_val is not None and dart_retrain and (self.model.best_iteration != num_boost_round):
-                    retrain = True
-                    if time_limit is not None:
-                        time_left = time_limit + start_time - time.time()
-                        if time_left < 0.5 * time_limit:
-                            retrain = False
-                    if retrain:
-                        logger.log(15, f"Retraining LGB model to optimal iterations ('dart' mode).")
-                        train_params.pop('callbacks')
-                        train_params['num_boost_round'] = self.model.best_iteration
-                        self.model = lgb.train(**train_params)
-                    else:
-                        logger.log(15, f"Not enough time to retrain LGB model ('dart' mode)...")
 
-        if dataset_val is not None and not retrain:
-            self.params_trained['num_boost_round'] = self.model.best_iteration
+
+        if warm_start:
+            self._prev_model = self.model
+            train_params["init_model"] = self.model
+            if warm_iter:
+                train_params["num_boost_round"] = warm_iter
+            with warnings.catch_warnings():
+                # Filter harmless warnings introduced in lightgbm 3.0, future versions plan to remove: https://github.com/microsoft/LightGBM/issues/3379
+                warnings.filterwarnings('ignore', message='Overriding the parameters from Reference Dataset.')
+                warnings.filterwarnings('ignore', message='categorical_column in param dict is overridden.')
+                self.model = lgb.train(**train_params)
         else:
-            self.params_trained['num_boost_round'] = self.model.current_iteration()
+            with warnings.catch_warnings():
+                # Filter harmless warnings introduced in lightgbm 3.0, future versions plan to remove: https://github.com/microsoft/LightGBM/issues/3379
+                warnings.filterwarnings('ignore', message='Overriding the parameters from Reference Dataset.')
+                warnings.filterwarnings('ignore', message='categorical_column in param dict is overridden.')
+                self.model = lgb.train(**train_params)
+                retrain = False
+                if train_params['params'].get('boosting_type', '') == 'dart':
+                    if dataset_val is not None and dart_retrain and (self.model.best_iteration != num_boost_round):
+                        retrain = True
+                        if time_limit is not None:
+                            time_left = time_limit + start_time - time.time()
+                            if time_left < 0.5 * time_limit:
+                                retrain = False
+                        if retrain:
+                            logger.log(15, f"Retraining LGB model to optimal iterations ('dart' mode).")
+                            train_params.pop('callbacks')
+                            train_params['num_boost_round'] = self.model.best_iteration
+                            self.model = lgb.train(**train_params)
+                        else:
+                            logger.log(15, f"Not enough time to retrain LGB model ('dart' mode)...")
+
+                if dataset_val is not None and not retrain:
+                    self.params_trained['num_boost_round'] = self.model.best_iteration
+                else:
+                    self.params_trained['num_boost_round'] = self.model.current_iteration()
+
+
+    def _set_early_stopped(self, progress, iterations, early_stopping_rounds):
+        if progress:
+            self._early_stopped = iterations > (self.model.best_iteration + early_stopping_rounds) \
+                if early_stopping_rounds else False
+        else:
+            self._early_stopped = True
+
+
+    def _merge_prev_model(self, init_model, metric_name):
+        progress = True
+        if init_model:
+            prev_perf = init_model.best_score["valid_set"][metric_name]
+            curr_perf = self.model.best_score["valid_set"][metric_name]
+
+            if self.stopping_metric._optimum > curr_perf:
+                if curr_perf < prev_perf:
+                    self.model = init_model
+                    progress = False
+            elif curr_perf > prev_perf:
+                self.model = init_model
+                progress = False
+        return progress
+
+    def trim_to_best(self):
+        if self._prev_model:
+            _, eval_metric_name = self.get_eval_metric()
+            self._merge_prev_model(self._prev_model, eval_metric_name)
 
     def _predict_proba(self, X, **kwargs):
         X = self.preprocess(X, **kwargs)
@@ -300,20 +357,12 @@ class LGBModel(AbstractModel):
         params_copy['num_threads'] = num_threads
         # num_gpus = scheduler_options['resource']['num_gpus'] # TODO: unused
 
-        dataset_train, dataset_val = self.generate_datasets(X_train=X_train, y_train=y_train, params=params_copy, X_val=X_val, y_val=y_val)
-        dataset_train_filename = "dataset_train.bin"
-        train_file = self.path + dataset_train_filename
-        if os.path.exists(train_file):  # clean up old files first
-            os.remove(train_file)
-        dataset_train.save_binary(train_file)
-        dataset_val_filename = "dataset_val.bin"  # names without directory info
-        val_file = self.path + dataset_val_filename
-        if os.path.exists(val_file):  # clean up old files first
-            os.remove(val_file)
-        dataset_val.save_binary(val_file)
         dataset_val_pkl_filename = 'dataset_val.pkl'
         val_pkl_path = directory + dataset_val_pkl_filename
         save_pkl.save(path=val_pkl_path, object=(X_val, y_val))
+
+        train_pkl_path = directory + 'dataset_train.pkl'
+        save_pkl.save(path=train_pkl_path, object=(X_train, y_train))
 
         if not np.any([isinstance(params_copy[hyperparam], Space) for hyperparam in params_copy]):
             logger.warning("Attempting to do hyperparameter optimization without any search space (all hyperparameters are already fixed values)")
@@ -323,21 +372,26 @@ class LGBModel(AbstractModel):
                 if isinstance(params_copy[hyperparam], Space):
                     logger.log(15, f'{hyperparam}:   {params_copy[hyperparam]}')
 
+        epochs = kwargs.get("epochs", 1)
+
         util_args = dict(
-            dataset_train_filename=dataset_train_filename,
-            dataset_val_filename=dataset_val_filename,
-            dataset_val_pkl_filename=dataset_val_pkl_filename,
+            dataset_train_pkl_filename=train_pkl_path,
+            dataset_val_pkl_filename=val_pkl_path,
             directory=directory,
             model=self,
             time_start=time_start,
-            time_limit=scheduler_options['time_out']
+            time_limit=scheduler_options['time_out'],
+            epochs=epochs,
+            report_probs = kwargs.get("report_probs", False)
         )
+        params_copy['epochs'] = epochs
+
         lgb_trial.register_args(util_args=util_args, **params_copy)
         scheduler = scheduler_func(lgb_trial, **scheduler_options)
         if ('dist_ip_addrs' in scheduler_options) and (len(scheduler_options['dist_ip_addrs']) > 0):
             # This is multi-machine setting, so need to copy dataset to workers:
             logger.log(15, "Uploading data to remote workers...")
-            scheduler.upload_files([train_file, val_file, val_pkl_path])  # TODO: currently does not work.
+            scheduler.upload_files([train_pkl_path, val_pkl_path])  # TODO: currently does not work.
             directory = self.path  # TODO: need to change to path to working directory used on every remote machine
             lgb_trial.update(directory=directory)
             logger.log(15, "uploaded")
@@ -345,7 +399,10 @@ class LGBModel(AbstractModel):
         scheduler.run()
         scheduler.join_jobs()
 
-        return self._get_hpo_results(scheduler=scheduler, scheduler_options=scheduler_options, time_start=time_start)
+        hpo_models, hpo_model_performances, hpo_results = self._get_hpo_results(scheduler=scheduler, scheduler_options=scheduler_options, time_start=time_start)
+        if 'report_probs' in kwargs:
+            hpo_results['ensemble'] = scheduler.ensemble
+        return hpo_models, hpo_model_performances, hpo_results
 
     # TODO: Consider adding _internal_feature_map functionality to abstract_model
     def compute_feature_importance(self, **kwargs) -> pd.Series:

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -12,9 +12,10 @@ from autogluon.core.constants import MULTICLASS, REGRESSION
 from autogluon.core.utils.exceptions import NotEnoughMemoryError, TimeLimitExceeded
 
 from ...features.feature_metadata import R_OBJECT
-from ..abstract.model_trial import skip_hpo
 from ..abstract.abstract_model import AbstractModel
 from ...features.generators import LabelEncoderFeatureGenerator
+
+from autogluon.core import Categorical, Int
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +48,7 @@ class RFModel(AbstractModel):
         default_params = {
             'n_estimators': 300,
             'n_jobs': -1,
+            'bootstrap': True,
             'random_state': 0,
         }
         for param, val in default_params.items():
@@ -56,62 +58,85 @@ class RFModel(AbstractModel):
     # TODO: enable HPO for RF models
     def _get_default_searchspace(self):
         spaces = {
-            # 'n_estimators': Int(lower=10, upper=1000, default=300),
-            # 'max_features': Categorical(['auto', 0.5, 0.25]),
-            # 'criterion': Categorical(['gini', 'entropy']),
+            'max_features': Categorical('auto', 0.5, 0.25),
+            'max_samples': Categorical(None, 0.6, 0.4),
+            'criterion': Categorical('mse') if self.problem_type == REGRESSION
+                else Categorical('gini', 'entropy'),
+            'min_samples_leaf': Int(lower=1, upper=10, default=1),
         }
         return spaces
 
-    def _fit(self, X_train, y_train, time_limit=None, **kwargs):
+    def _fit(self, X_train, y_train, time_limit=None, warm_start=True, warm_iter=None, **kwargs):
+        """
+            Additional Parameters
+            warm_start: False
+                If warm_start is True, it allows the model to perform incremental training.
+                E.g. calling model.fit(X, y) multiple times would build upon the intermediate models and
+                increase the number of trees used. See also warm_iter
+            warm_iter: None
+                This sets the humber of additional trees to add for incremental training.
+                if warm_iter is None, the number of additional trees set by the model hyperparameter, such as "n_estimators"
+       """
+        #for warm start, simply allow more trees to form
         time_start = time.time()
         max_memory_usage_ratio = self.params_aux['max_memory_usage_ratio']
         hyperparams = self.params.copy()
         n_estimators_final = hyperparams['n_estimators']
 
-        n_estimators_minimum = min(40, n_estimators_final)
-        if n_estimators_minimum < 40:
-            n_estimators_test = max(1, math.floor(n_estimators_minimum/5))
-        else:
-            n_estimators_test = 8
+        if warm_start:
+            hyperparams["warm_start"] = True
 
         X_train = self.preprocess(X_train)
-        n_estimator_increments = [n_estimators_final]
 
-        # Very rough guess to size of a single tree before training
-        if self.problem_type == MULTICLASS:
-            if self.num_classes is None:
-                num_trees_per_estimator = 10  # Guess since it wasn't passed in, could also check y_train for a better value
+        if not (self.model and warm_start):
+            n_estimators_minimum = min(40, n_estimators_final)
+            if n_estimators_minimum < 40:
+                n_estimators_test = max(1, math.floor(n_estimators_minimum/5))
             else:
-                num_trees_per_estimator = self.num_classes
-        else:
-            num_trees_per_estimator = 1
-        bytes_per_estimator = num_trees_per_estimator * len(X_train) / 60000 * 1e6  # Underestimates by 3x on ExtraTrees
-        available_mem = psutil.virtual_memory().available
-        expected_memory_usage = bytes_per_estimator * n_estimators_final / available_mem
-        expected_min_memory_usage = bytes_per_estimator * n_estimators_minimum / available_mem
-        if expected_min_memory_usage > (0.5 * max_memory_usage_ratio):  # if minimum estimated size is greater than 50% memory
-            logger.warning(f'\tWarning: Model is expected to require {round(expected_min_memory_usage * 100, 2)}% of available memory (Estimated before training)...')
-            raise NotEnoughMemoryError
+                n_estimators_test = 8
 
-        if n_estimators_final > n_estimators_test * 2:
+            n_estimator_increments = [n_estimators_final]
+
+            # Very rough guess to size of a single tree before training
             if self.problem_type == MULTICLASS:
-                n_estimator_increments = [n_estimators_test, n_estimators_final]
-                hyperparams['warm_start'] = True
+                if self.num_classes is None:
+                    num_trees_per_estimator = 10  # Guess since it wasn't passed in, could also check y_train for a better value
+                else:
+                    num_trees_per_estimator = self.num_classes
             else:
-                if expected_memory_usage > (0.05 * max_memory_usage_ratio):  # Somewhat arbitrary, consider finding a better value, should it scale by cores?
-                    # Causes ~10% training slowdown, so try to avoid if memory is not an issue
+                num_trees_per_estimator = 1
+            bytes_per_estimator = num_trees_per_estimator * len(X_train) / 60000 * 1e6  # Underestimates by 3x on ExtraTrees
+            available_mem = psutil.virtual_memory().available
+            expected_memory_usage = bytes_per_estimator * n_estimators_final / available_mem
+            expected_min_memory_usage = bytes_per_estimator * n_estimators_minimum / available_mem
+            if expected_min_memory_usage > (0.5 * max_memory_usage_ratio):  # if minimum estimated size is greater than 50% memory
+                logger.warning(f'\tWarning: Model is expected to require {round(expected_min_memory_usage * 100, 2)}% of available memory (Estimated before training)...')
+                raise NotEnoughMemoryError
+
+            if n_estimators_final > n_estimators_test * 2:
+                if self.problem_type == MULTICLASS:
                     n_estimator_increments = [n_estimators_test, n_estimators_final]
                     hyperparams['warm_start'] = True
+                else:
+                    if expected_memory_usage > (0.05 * max_memory_usage_ratio):  # Somewhat arbitrary, consider finding a better value, should it scale by cores?
+                        # Causes ~10% training slowdown, so try to avoid if memory is not an issue
+                        n_estimator_increments = [n_estimators_test, n_estimators_final]
+                        hyperparams['warm_start'] = True
 
-        hyperparams['n_estimators'] = n_estimator_increments[0]
-        self.model = self._model_type(**hyperparams)
+            if not warm_start:
+                hyperparams['n_estimators'] = n_estimator_increments[0]
 
-        time_train_start = time.time()
-        for i, n_estimators in enumerate(n_estimator_increments):
-            if i != 0:
-                self.model.n_estimators = n_estimators
-            self.model = self.model.fit(X_train, y_train)
-            if (i == 0) and (len(n_estimator_increments) > 1):
+            if 'num_threads' in hyperparams: #for hpo, this is an unwanted arg to be removed.
+                del hyperparams['num_threads']
+                del hyperparams['num_gpus']
+
+            self.model = self._model_type(**hyperparams)
+
+        n_estimators_ideal = n_estimators_final
+        if not warm_start:
+            time_train_start = time.time()
+            if len(n_estimator_increments) > 1:
+                self.model = self.model.fit(X_train, y_train)
                 time_elapsed = time.time() - time_train_start
 
                 model_size_bytes = sys.getsizeof(pickle.dumps(self.model))
@@ -120,17 +145,19 @@ class RFModel(AbstractModel):
                 model_memory_ratio = expected_final_model_size_bytes / available_mem
 
                 ideal_memory_ratio = 0.15 * max_memory_usage_ratio
-                n_estimators_ideal = min(n_estimators_final, math.floor(ideal_memory_ratio / model_memory_ratio * n_estimators_final))
+                n_estimators_ideal = min(n_estimators_final,
+                                         math.floor(ideal_memory_ratio / model_memory_ratio * n_estimators_final))
 
                 if n_estimators_final > n_estimators_ideal:
                     if n_estimators_ideal < n_estimators_minimum:
-                        logger.warning(f'\tWarning: Model is expected to require {round(model_memory_ratio*100, 2)}% of available memory...')
+                        logger.warning(f'\tWarning: Model is expected to require {round(model_memory_ratio * 100, 2)}% of available memory...')
                         raise NotEnoughMemoryError  # don't train full model to avoid OOM error
-                    logger.warning(f'\tWarning: Reducing model \'n_estimators\' from {n_estimators_final} -> {n_estimators_ideal} due to low memory. Expected memory usage reduced from {round(model_memory_ratio*100, 2)}% -> {round(ideal_memory_ratio*100, 2)}% of available memory...')
+                    logger.warning(f'\tWarning: Reducing model \'n_estimators\' from {n_estimators_final} -> {n_estimators_ideal} due to low memory. Expected memory usage reduced from {round(model_memory_ratio * 100, 2)}% -> {round(ideal_memory_ratio * 100, 2)}% of available memory...')
 
                 if time_limit is not None:
-                    time_expected = time_train_start - time_start + (time_elapsed * n_estimators_ideal / n_estimators)
-                    n_estimators_time = math.floor((time_limit - time_train_start + time_start) * n_estimators / time_elapsed)
+                    time_expected = time_train_start - time_start + (time_elapsed * n_estimators_ideal / n_estimators_test)
+                    n_estimators_time = math.floor(
+                        (time_limit - time_train_start + time_start) * n_estimators_test / time_elapsed)
                     if n_estimators_time < n_estimators_ideal:
                         if n_estimators_time < n_estimators_minimum:
                             logger.warning(f'\tWarning: Model is expected to require {round(time_expected, 1)}s to train, which exceeds the maximum time limit of {round(time_limit, 1)}s, skipping model...')
@@ -138,15 +165,20 @@ class RFModel(AbstractModel):
                         logger.warning(f'\tWarning: Reducing model \'n_estimators\' from {n_estimators_ideal} -> {n_estimators_time} due to low time. Expected time usage reduced from {round(time_expected, 1)}s -> {round(time_limit, 1)}s...')
                         n_estimators_ideal = n_estimators_time
 
-                for j in range(len(n_estimator_increments)):
-                    if n_estimator_increments[j] > n_estimators_ideal:
-                        n_estimator_increments[j] = n_estimators_ideal
-
+            self.model.n_estimators = n_estimators_ideal
+        else:
+            self.model.n_estimators += warm_iter if warm_iter else n_estimators_ideal
+        self.model = self.model.fit(X_train, y_train)
         self.params_trained['n_estimators'] = self.model.n_estimators
 
-    # TODO: Add HPO
-    def hyperparameter_tune(self, **kwargs):
-        return skip_hpo(self, **kwargs)
+    # def hyperparameter_tune(self, X_train, y_train, X_val, y_val, scheduler_options=None, **kwargs):
+    #     fit_model_args = dict(X_train=X_train, y_train=y_train, **kwargs)
+    #     predict_proba_args = dict(X=X_val)
+    #     model_trial.fit_and_save_model(model=self, params=dict(), fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_val=y_val, time_start=time.time(), time_limit=None)
+    #     hpo_results = {'total_time': self.fit_time}
+    #     hpo_model_performances = {self.name: self.val_score}
+    #     hpo_models = {self.name: self.path}
+    #     return hpo_models, hpo_model_performances, hpo_results
 
     def get_model_feature_importance(self):
         if self.features is None:

--- a/tabular/src/autogluon/tabular/models/tab_transformer/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/hyperparameters/parameters.py
@@ -35,13 +35,13 @@ def get_fixed_params():
 def get_hyper_params():
     """ Parameters that currently can be tuned during HPO """
     hyper_params = {
-        'lr': 1e-3, # Learning rate
+        'lr': 3.6e-3, # Learning rate
         # Options: Real(5e-5, 5e-3)
         'weight_decay': 1e-6, # Rate of linear weight decay for learning rate
         # Options: Real(1e-6, 5e-2)
-        'p_dropout': 0.1, # dropout probability, 0 turns off Dropout.
+        'p_dropout': 0, # dropout probability, 0 turns off Dropout.
         # Options: Categorical(0, 0.1, 0.2, 0.3, 0.4, 0.5)
-        'n_heads': 8, # Number of attention heads
+        'n_heads': 4, # Number of attention heads
         # Options: Categorical(2, 4, 8)
         'hidden_dim': 128, # hidden dimension size
         # Options: Categorical(32, 64, 128, 256)

--- a/tabular/src/autogluon/tabular/models/tab_transformer/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/hyperparameters/parameters.py
@@ -18,7 +18,7 @@ def get_fixed_params():
                                   'SCALAR'     : 'ScalarQuantileOrdinalEnc',
                                   'TEXT'       : 'TextSummaryScalarEnc'},
                     'aug_mask_prob' : 0.4, # What percentage of values to apply augmentation to.
-                    'num_augs' : 1, # Number of augmentations to add.
+                    'num_augs' : 0, # Number of augmentations to add.
                     'pretext': 'BERTPretext', # What pretext to use when performing pretraining/semi-supervised learning.
                     'n_cont_features': 8, # How many continuous features to concatenate onto the categorical features
                     'fix_attention': False, # If True, use the categorical embeddings in the transformer architecture.
@@ -27,6 +27,7 @@ def get_fixed_params():
                     'epochs_wo_improve': 30, # How many epochs to continue running without improving on metric. aka "Early Stopping Patience"
                     'num_workers': 16, # How many workers to use for torch DataLoader.
                     'max_columns': 500, # Maximum number of columns TabTransformer will accept as input. This is to combat huge memory requirements/errors.
+                    'tab_readout': 'none', # What sort of readout from the transformer. Options: ['readout_emb', 'mean', 'concat_pool', 'concat_pool_all', 'concat_pool_add', 'all_feat_embs', 'mean_feat_embs', 'none']
                     }
 
     return fixed_params
@@ -44,12 +45,10 @@ def get_hyper_params():
         # Options: Categorical(2, 4, 8)
         'hidden_dim': 128, # hidden dimension size
         # Options: Categorical(32, 64, 128, 256)
-        'n_layers': 1, # Number of Tab Transformer encoder layers,
+        'n_layers': 2, # Number of Tab Transformer encoder layers,
         # Options: Categorical(1, 2, 3, 4, 5)
         'feature_dim': 64, # Size of fully connected layer in TabNet.
         # Options: Int(8, 128)
-        'tab_readout': 'none', # What sort of readout from the transformer.
-        # Options: ['readout_emb', 'mean', 'concat_pool', 'concat_pool_all', 'concat_pool_add', 'all_feat_embs', 'mean_feat_embs', 'none']
         'num_output_layers': 1 # How many fully-connected layers on top of transformer to produce predictions. Minimum 1 layer.
         # Options: Categorical(1, 2, 3)
     }

--- a/tabular/src/autogluon/tabular/models/tab_transformer/hyperparameters/searchspaces.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/hyperparameters/searchspaces.py
@@ -5,13 +5,12 @@ def get_default_searchspace():
     params = {
         'lr': Real(5e-5, 5e-3, default=1e-3, log=True),
         'weight_decay': Real(1e-6, 5e-2, default=1e-6, log=True),
-        'p_dropout': Categorical(0.1, 0, 0.2, 0.3, 0.4, 0.5),
-        'n_heads': Categorical(8, 2, 4),
+        'p_dropout': Categorical(0.1, 0, 0.5),
+        'n_heads': Categorical(8, 4),
         'hidden_dim': Categorical(128, 32, 64, 256),
-        'n_layers': Categorical(1, 2, 3, 4, 5),
+        'n_layers': Categorical(2, 1, 3, 4, 5),
         'feature_dim': Int(8, 128, default=64),
-        'tab_readout': Categorical('none', 'readout_emb', 'mean', 'concat_pool', 'concat_pool_all', 'concat_pool_add', 'all_feat_embs', 'mean_feat_embs'),
-        'num_output_layers': Categorical(2, 1, 3),
+        'num_output_layers': Categorical(1, 2),
     }
 
     return params.copy()

--- a/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
@@ -5,16 +5,15 @@ import time
 
 import numpy as np
 import pandas as pd
-from tqdm import tqdm
-
 from autogluon.core.utils.loaders import load_pkl
-from autogluon.core.constants import BINARY, REGRESSION, MULTICLASS
-from autogluon.core.utils import try_import_torch
+from tqdm import tqdm
 
 from .hyperparameters.parameters import get_default_param
 from .hyperparameters.searchspaces import get_default_searchspace
 from ..abstract.abstract_model import AbstractNeuralNetworkModel
+from autogluon.core.utils import try_import_torch
 from ...features.feature_metadata import R_OBJECT, S_TEXT_NGRAM, S_TEXT_AS_CATEGORY
+from autogluon.core.constants import BINARY, REGRESSION, MULTICLASS
 
 
 logger = logging.getLogger(__name__)
@@ -196,7 +195,8 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
                     pretext = pretext.cuda()
 
                 if state in [None, 'finetune']:
-                    data, target = augmentation(data, target, **params)
+                    if self.params['num_augs'] > 0:
+                        data, target = augmentation(data, target, **params)
                     out, _ = net(data)
                 elif state == 'pretrain':
                     _, out = net(data)
@@ -225,7 +225,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
                     val_metric = self.score(X=loader_val, y=y_val, eval_metric=self.stopping_metric,
                                             metric_needs_y_pred=self.stopping_metric_needs_y_pred)
                     data_bar.set_description('{} Epoch: [{}/{}] Train Loss: {:.4f} Validation {}: {:.2f}'.format(
-                        train_test, epoch, epochs, total_loss / total_num, self.eval_metric.name, val_metric))
+                        train_test, epoch, epochs, total_loss / total_num, self.stopping_metric.name, val_metric))
 
                     if reporter is not None:
                         reporter(epoch=epoch+1, validation_performance=val_metric, train_loss=total_loss)
@@ -385,8 +385,12 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
         self.model = self._get_model()
 
         if X_unlabeled is not None:
-            self.tt_fit(loader_unlab, loader_val, y_val, state='pretrain', time_limit=time_limit, reporter=reporter)
-            self.tt_fit(loader_train, loader_val, y_val, state='finetune', time_limit=time_limit, reporter=reporter)
+            # Can't spend all the time in pretraining, have to split it up.
+            pretrain_time_limit = time_limit / 2 if time_limit is not None else time_limit
+            pretrain_before_time = time.time()
+            self.tt_fit(loader_unlab, loader_val, y_val, state='pretrain', time_limit=pretrain_time_limit, reporter=reporter)
+            finetune_time_limit = time_limit - (time.time() - pretrain_before_time) if time_limit is not None else time_limit
+            self.tt_fit(loader_train, loader_val, y_val, state='finetune', time_limit=finetune_time_limit, reporter=reporter)
         else:
             self.tt_fit(loader_train, loader_val, y_val, time_limit=time_limit, reporter=reporter)
 
@@ -475,7 +479,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
         scheduler = scheduler_func(tt_trial, **scheduler_options)
         scheduler.run()
         scheduler.join_jobs()
-        self.model = self.model.to(torch.device("cpu"))
+
         scheduler.get_training_curves(plot=False, use_legend=False)
 
         return self._get_hpo_results(scheduler=scheduler, scheduler_options=scheduler_options, time_start=time_start)

--- a/tabular/src/autogluon/tabular/models/tab_transformer/utils.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/utils.py
@@ -7,7 +7,6 @@ from .tab_transformer_encoder import WontEncodeError, NullEnc
 import logging
 from autogluon.core import args
 from ..abstract import model_trial
-from ... import REGRESSION
 
 logger = logging.getLogger(__name__)
 
@@ -19,12 +18,14 @@ def tt_trial(args, reporter):
 
         fit_model_args = dict(X_train=util_args.X_train, y_train=util_args.y_train, X_val=util_args.X_val, y_val=util_args.y_val)
         predict_proba_args = dict(X=util_args.X_val)
-        model_trial.fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_val=util_args.y_val,
+        model = model_trial.fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_val=util_args.y_val,
                                        time_start=util_args.time_start, time_limit=util_args.get('time_limit', None), reporter=reporter)
     except Exception as e:
         if not isinstance(e, TimeLimitExceeded):
             logger.exception(e, exc_info=True)
         reporter.terminate()
+    else:
+        reporter(epoch = model.params['epochs'] + 1, validation_performance=model.val_score)
     pass
 
 def augmentation(data, target, **params):

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_utils.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_utils.py
@@ -122,10 +122,7 @@ class OheFeatureGenerator(BaseEstimator, TransformerMixin):
 
         if self.other_cols:
             for c in self.other_cols:
-                if X[c].dtypes == int:
-                    self._feature_map[c] = 'int'
-                else:
-                    self._feature_map[c] = 'float'
+                self._feature_map[c] = 'int' if X[c].dtypes == int else 'float'
         return self
 
     def transform(self, X, y=None):

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from typing import Union
 
 import pandas as pd
 
@@ -7,9 +8,10 @@ from .dataset import TabularDataset
 from .hyperparameter_configs import get_hyperparameter_config
 from autogluon.core.task.base import BasePredictor
 from autogluon.core.utils import plot_performance_vs_trials, plot_summary_of_models, plot_tabular_models, verbosity2loglevel
-from ...utils import REGRESSION
+from ...utils import BINARY, MULTICLASS, REGRESSION, get_pred_from_proba
 from ...learner import AbstractLearner as Learner  # TODO: Keep track of true type of learner for loading
 from ...trainer import AbstractTrainer  # TODO: Keep track of true type of trainer for loading
+from ...data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.utils.utils import setup_outputdir
 
 __all__ = ['TabularPredictor']
@@ -92,6 +94,7 @@ class TabularPredictor(BasePredictor):
         self.class_labels_internal = self._learner.label_cleaner.ordered_class_labels_transformed
         self.class_labels_internal_map = self._learner.label_cleaner.inv_map
 
+    # TODO: v0.1 as_pandas=True by default to avoid user confusion and errors with mismatching indices?
     def predict(self, dataset, model=None, as_pandas=False):
         """ Use trained models to produce predicted labels (in classification) or response values (in regression).
 
@@ -115,6 +118,7 @@ class TabularPredictor(BasePredictor):
         dataset = self.__get_dataset(dataset)
         return self._learner.predict(X=dataset, model=model, as_pandas=as_pandas)
 
+    # TODO: v0.1 as_pandas=True by default to avoid user confusion on class names and errors with mismatching indices?
     def predict_proba(self, dataset, model=None, as_pandas=False, as_multiclass=False):
         """ Use trained models to produce predicted class probabilities rather than class-labels (if task is classification).
             If `predictor.problem_type` is regression, this functions identically to `predict`, returning the same output.
@@ -500,9 +504,6 @@ class TabularPredictor(BasePredictor):
         dataset = self.__get_dataset(dataset) if dataset is not None else dataset
         return self._learner.get_inputs_to_stacker(dataset=dataset, model=model, base_models=base_models, use_orig_features=return_original_features)
 
-    # TODO: Add support for DataFrame input and support for DataFrame output
-    #  Add support for retaining DataFrame/Series indices in output
-    #  Add as_pandas parameter
     def transform_labels(self, labels, inverse=False, proba=False):
         """
         Transforms dataset labels to the internal label representation.
@@ -520,7 +521,7 @@ class TabularPredictor(BasePredictor):
             When `True`, the input labels are treated as being in the internal representation and the original representation is outputted.
         proba : boolean, default = False
             When `True`, the input labels are treated as probabilities and the output will be the internal representation of probabilities.
-                In this case, it is expected that `labels` be a `numpy.ndarray`.
+                In this case, it is expected that `labels` be a `pandas.DataFrame` or `numpy.ndarray`.
                 If the `problem_type` is multiclass:
                     The input column order must be equal to `predictor.class_labels`.
                     The output column order will be equal to `predictor.class_labels_internal`.
@@ -530,17 +531,17 @@ class TabularPredictor(BasePredictor):
 
         Returns
         -------
-        Pandas `pandas.Series` of labels if `proba=False` or Numpy `numpy.ndarray` of label probabilities if `proba=True`
+        Pandas `pandas.Series` of labels if `proba=False` or Pandas `pandas.DataFrame` of label probabilities if `proba=True`
 
         """
         if inverse:
             if proba:
-                labels_transformed = self._learner.label_cleaner.inverse_transform_proba(y=labels)
+                labels_transformed = self._learner.label_cleaner.inverse_transform_proba(y=labels, as_pandas=True)
             else:
                 labels_transformed = self._learner.label_cleaner.inverse_transform(y=labels)
         else:
             if proba:
-                labels_transformed = self._learner.label_cleaner.transform_proba(y=labels)
+                labels_transformed = self._learner.label_cleaner.transform_proba(y=labels, as_pandas=True)
             else:
                 labels_transformed = self._learner.label_cleaner.transform(y=labels)
         return labels_transformed
@@ -815,6 +816,115 @@ class TabularPredictor(BasePredictor):
         models += trainer.generate_weighted_ensemble(X=X_train_stack_preds, y=y, level=weighted_ensemble_level, stack_name=stack_name, base_model_names=base_models, name_suffix=name_suffix, time_limit=time_limits)
 
         return models
+
+    # TODO: v0.1 This can cause very strange issues related to index mismatches with original training data on extreme edge cases (multiclass where autogluon duplicated rows in data due to rare classes and eval_metric was log_loss)
+    #  This is a very rare case but needs to be fixed by v0.1 release
+    #  It might be good enough to do an inner join on training data, but it needs to be tested
+    def get_oof_pred(self, model: str = None, transformed=False) -> pd.Series:
+        """
+        Note: This is advanced functionality not intended for normal usage.
+
+        Returns the out-of-fold (OOF) predictions for every row in the training data.
+
+        For more information, refer to `get_oof_pred_proba()` documentation.
+
+        Parameters
+        ----------
+        model : str (optional)
+            Refer to `get_oof_pred_proba()` documentation.
+        transformed : bool, default = False
+            Refer to `get_oof_pred_proba()` documentation.
+
+        Returns
+        -------
+        :class:`pd.Series` object of the out-of-fold training predictions of the model.
+        """
+        y_pred_proba_oof_transformed = self.get_oof_pred_proba(model=model, transformed=True)
+        y_index = y_pred_proba_oof_transformed.index
+        y_pred_oof_transformed = get_pred_from_proba(y_pred_proba=y_pred_proba_oof_transformed.to_numpy(), problem_type=self._trainer.problem_type)
+        y_pred_oof_transformed = pd.Series(data=y_pred_oof_transformed, index=y_index, name=self.label_column)
+        if transformed:
+            return y_pred_oof_transformed
+        else:
+            return self.transform_labels(labels=y_pred_oof_transformed, inverse=True, proba=False)
+
+    # TODO: Improve error messages when trying to get oof from refit_full and distilled models.
+    # TODO: v0.1 add tutorial related to this method, as it is very powerful.
+    # TODO: v0.1 This can cause very strange issues related to index mismatches with original training data on extreme edge cases (multiclass where autogluon duplicated rows in data due to rare classes and eval_metric was logloss)
+    #  This is a very rare case but needs to be fixed by v0.1 release
+    #  It might be good enough to do an inner join on training data, but it needs to be tested
+    def get_oof_pred_proba(self, model: str = None, transformed=False, as_multiclass=False) -> Union[pd.DataFrame, pd.Series]:
+        """
+        Note: This is advanced functionality not intended for normal usage.
+
+        Returns the out-of-fold (OOF) predicted class probabilities for every row in the training data.
+        OOF prediction probabilities may provide unbiased estimates of generalization accuracy (reflecting how predictions will behave on new data)
+        Predictions for each row are only made using models that were fit to a subset of data where this row was held-out.
+
+        Warning: This method will raise an exception if called on a model that is not a bagged ensemble. Only bagged models (such a stacker models) can produce OOF predictions.
+            This also means that refit_full models and distilled models will raise an exception.
+        Warning: If intending to join the output of this method with the original training data, be aware that a rare edge-case issue exists:
+            Multiclass problems with rare classes combined with the use of the 'log_loss' eval_metric may have forced AutoGluon to duplicate rows in the training data to satisfy minimum class counts in the data.
+            If this has occurred, then the indices and row counts of the returned pandas Series in this method may not align with the training data.
+            In this case, consider fetching the processed training data using `predictor.load_data_internal()` instead of using the original training data.
+            A more benign version of this issue occurs when 'log_loss' wasn't specified as the eval_metric but rare classes were dropped by AutoGluon.
+            In this case, not all of the original training data rows will have an OOF prediction. It is recommended to either drop these rows during the join or to get direct predictions on the missing rows via `predictor.predict`.
+
+        Parameters
+        ----------
+        model : str (optional)
+            The name of the model to get out-of-fold predictions from. Defaults to None, which uses the highest scoring model on the validation set.
+            Valid models are listed in this `predictor` by calling `predictor.get_model_names()`
+        transformed : bool, default = False
+            Whether the output values should be of the original label representation (False) or the internal label representation (True).
+            The internal representation for binary and multiclass classification are integers numbering the k possible classes from 0 to k-1, while the original representation is identical to the label classes provided during fit.
+            Generally, most users will want the original representation and keep `transformed=False`.
+        as_multiclass : bool, default = False
+            Whether to return binary classification probabilities as if they were for multiclass classification.
+                Output will contain two columns, and if `transformed=False`, the column names will correspond to the binary class labels.
+                The columns will be the same order as `predictor.class_labels`.
+            Only impacts output for binary classification problems.
+
+        Returns
+        -------
+        :class:`pd.Series` or :class:`pd.DataFrame` object of the out-of-fold training prediction probabilities of the model.
+        """
+        if not self._trainer.bagged_mode:
+            raise AssertionError('Predictor must be in bagged mode to get out-of-fold predictions.')
+        if model is None:
+            model = self.get_model_best()
+        y_pred_proba_oof_transformed = self.transform_features(base_models=[model], return_original_features=False)
+        if self.problem_type == MULTICLASS:
+            y_pred_proba_oof_transformed.columns = copy.deepcopy(self._learner.label_cleaner.ordered_class_labels_transformed)
+        else:
+            y_pred_proba_oof_transformed.columns = [self.label_column]
+            y_pred_proba_oof_transformed = y_pred_proba_oof_transformed[self.label_column]
+            if as_multiclass and self.problem_type == BINARY:
+                y_pred_proba_oof_transformed = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_pred_proba_oof_transformed, as_pandas=True)
+                if not transformed:
+                    y_pred_proba_oof_transformed.columns = copy.deepcopy(self._learner.label_cleaner.ordered_class_labels)
+        if transformed:
+            return y_pred_proba_oof_transformed
+        else:
+            return self.transform_labels(labels=y_pred_proba_oof_transformed, inverse=True, proba=True)
+
+    # TODO: v0.1 Properly error/return None if label_cleaner hasn't been fit yet. (After API refactor)
+    # TODO: v0.1 Add positive_class parameter to task.fit
+    @property
+    def positive_class(self):
+        """
+        Returns the positive class name in binary classification. Useful for computing metrics such as F1 which require a positive and negative class.
+        In binary classification, `predictor.predict_proba()` returns the estimated probability that each row belongs to the positive class.
+        Will print a warning and return None if called when `predictor.problem_type != 'binary'`.
+
+        Returns
+        -------
+        The positive class name in binary classification or None if the problem is not binary classification.
+        """
+        if self.problem_type != BINARY:
+            logger.warning(f"Warning: Attempted to retrieve positive class label in a non-binary problem. Positive class labels only exist in binary classification. Returning None instead. self.problem_type is '{self.problem_type}' but positive_class only exists for '{BINARY}'.")
+            return None
+        return self._learner.label_cleaner.cat_mappings_dependent_var[1]
 
     @classmethod
     def load(cls, output_directory, verbosity=2):

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
@@ -2,7 +2,11 @@ import copy
 import logging
 from typing import Union
 
+import os
 import pandas as pd
+from PIL import Image
+
+import networkx as nx
 
 from .dataset import TabularDataset
 from .hyperparameter_configs import get_hyperparameter_config
@@ -1196,6 +1200,72 @@ class TabularPredictor(BasePredictor):
         return self._learner.distill(X=train_data, X_val=tuning_data, time_limits=time_limits, hyperparameters=hyperparameters, holdout_frac=holdout_frac,
                                      verbosity=verbosity, models_name_suffix=models_name_suffix, teacher_preds=teacher_preds,
                                      augmentation_data=augmentation_data, augment_method=augment_method, augment_args=augment_args)
+
+    def plot_ensemble_model(self, prune_unused_nodes=True):
+        """
+            Output the visualized stack ensemble architecture of a model trained by `fit()`. 
+            The plot is stored to a file, `ensemble_model.png` in folder `Predictor.output_directory` 
+
+            This function requires `graphviz` and `pygraphviz` to be installed because this visualization depends on those package.
+            Unless this function will raise `ImportError` without being able to generate the visual of the ensemble model.
+
+            To install the required package, run the below commands (for Ubuntu linux):
+
+            $ sudo apt-get install graphviz
+            $ pip install graphviz
+
+            For other platforms, refer to https://graphviz.org/ for Graphviz install, and https://pygraphviz.github.io/documentation.html for PyGraphviz.
+
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        The file name with the full path to the saved graphic
+        """
+        try:
+            import pygraphviz
+        except:
+            raise ImportError('Visualizing ensemble network architecture requires pygraphviz library')
+            
+        G = self._trainer.model_graph.copy()
+
+        if prune_unused_nodes == True:
+            nodes_without_outedge = [node for node,degree in dict(G.degree()).items() if degree < 1]
+        else:
+            nodes_without_outedge = []
+
+        nodes_no_val_score = [node for node in G if G.nodes[node]['val_score'] == None]
+        
+        G.remove_nodes_from(nodes_without_outedge)
+        G.remove_nodes_from(nodes_no_val_score)
+
+        root_node = [n for n,d in G.out_degree() if d == 0]
+        best_model_node = self.get_model_best()
+
+        A = nx.nx_agraph.to_agraph(G)
+        
+        A.graph_attr.update(rankdir='BT')
+        A.node_attr.update(fontsize=10)
+        A.node_attr.update(shape='rectangle')
+
+        for node in A.iternodes():
+            node.attr['label'] = f"{node.name}\nVal score: {float(node.attr['val_score']):.4f}"
+
+            if node.name == best_model_node:
+                node.attr['style'] = 'filled'
+                node.attr['fillcolor'] = '#ff9900'
+                node.attr['shape'] = 'box3d'
+            elif nx.has_path(G, node.name, best_model_node):
+                node.attr['style'] = 'filled'
+                node.attr['fillcolor'] = '#ffcc00'
+
+        model_image_fname = os.path.join(self.output_directory, 'ensemble_model.png')
+
+        A.draw(model_image_fname, format='png', prog='dot')
+
+        return model_image_fname
 
     @staticmethod
     def _summarize(key, msg, results):

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -266,6 +266,8 @@ class TabularPrediction(BaseTask):
                             priority: (int) Determines the order in which the model is trained. Larger values result in the model being trained earlier. Default values range from 100 (RF) to 0 (custom), dictated by model type. If you want this model to be trained first, set priority = 999.
                             problem_types: (list) List of valid problem types for the model. `problem_types=['binary']` will result in the model only being trained if `problem_type` is 'binary'.
                             disable_in_hpo: (bool) If True, the model will only be trained if `hyperparameter_tune=False`.
+                            valid_stacker: (bool) If False, the model will not be trained as a level 1 or higher stacker model.
+                            valid_base: (bool) If False, the model will not be trained as a level 0 (base) model.
                         Reference the default hyperparameters for example usage of these options.
                     AG_args_fit: Dictionary of model fit customization options related to how and with what constraints the model is trained. These parameters affect stacker fold models, but not stacker models themselves.
                         Clarification: `time_limit` is the internal time in seconds given to a particular model to train, which is dictated in part by the `time_limits` argument given during `fit()` but is not the same.

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -259,9 +259,8 @@ class TabularPrediction(BaseTask):
                     AG_args: Dictionary of customization options related to meta properties of the model such as its name, the order it is trained, and the problem types it is valid for.
                         Valid keys:
                             name: (str) The name of the model. This overrides AutoGluon's naming logic and all other name arguments if present.
-                            name_main: (str) The main name of the model. In 'RandomForestClassifier', this is 'RandomForest'.
+                            name_main: (str) The main name of the model. Example: 'RandomForest'.
                             name_prefix: (str) Add a custom prefix to the model name. Unused by default.
-                            name_type_suffix: (str) Override the type suffix of the model name. In 'RandomForestClassifier', this is 'Classifier'. This comes before 'name_suffix'.
                             name_suffix: (str) Add a custom suffix to the model name. Unused by default.
                             priority: (int) Determines the order in which the model is trained. Larger values result in the model being trained earlier. Default values range from 100 (RF) to 0 (custom), dictated by model type. If you want this model to be trained first, set priority = 999.
                             problem_types: (list) List of valid problem types for the model. `problem_types=['binary']` will result in the model only being trained if `problem_type` is 'binary'.

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -279,7 +279,7 @@ class TabularPrediction(BaseTask):
 
         holdout_frac : float, default = None
             Fraction of train_data to holdout as tuning data for optimizing hyperparameters (ignored unless `tuning_data = None`, ignored if `num_bagging_folds != 0`).
-            Default value (if None) is selected based on the number of rows in the training data. Default values range from 0.2 at 2,500 rows to 0.01 at 250,000 rows.
+            Default value (if None) is selected based on the number of rows in the training data. Default values range from 0.2 at 2,500 rows to 0.01 at 250,000 rows.
             Default value is doubled if `hyperparameter_tune = True`, up to a maximum of 0.2.
             Disabled if `num_bagging_folds >= 2`.
         num_bagging_folds : int, default = 0
@@ -295,7 +295,7 @@ class TabularPrediction(BaseTask):
         stack_ensemble_levels : int, default = 0
             Number of stacking levels to use in stack ensemble. Roughly increases model training time by factor of `stack_ensemble_levels+1` (set = 0 to disable stack ensembling).
             Disabled by default, but we recommend values between 1-3 to maximize predictive performance.
-            To prevent overfitting, this argument is ignored unless you have also set `num_bagging_folds >= 2`.
+            To prevent overfitting, this argument is ignored unless you have also set `num_bagging_folds >= 2`.
         num_trials : int, default = None
             Maximal number of different hyperparameter settings of each model type to evaluate during HPO (only matters if `hyperparameter_tune = True`).
             If both `time_limits` and `num_trials` are specified, `time_limits` takes precedent.
@@ -532,8 +532,8 @@ class TabularPrediction(BaseTask):
             if np.any(train_features != tuning_features):
                 raise ValueError("Column names must match between training and tuning data")
         if unlabeled_data is not None:
-            train_features = np.array([column for column in train_data.columns if column != label])
-            unlabeled_features = np.array([column for column in unlabeled_data.columns])
+            train_features = sorted(np.array([column for column in train_data.columns if column != label]))
+            unlabeled_features = sorted(np.array([column for column in unlabeled_data.columns]))
             if np.any(train_features != unlabeled_features):
                 raise ValueError("Column names must match between training and unlabeled data.\n"
                                  "Unlabeled data must have not the label column specified in it.\n")

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -795,10 +795,10 @@ class AbstractTrainer:
 
         invalid_model_names = set(self.get_model_names())
         # Ensure name is unique
-        model_stack_name = f'weighted_ensemble{name_suffix}_k{k_fold}_l{level}'
+        model_stack_name = f'WeightedEnsemble{name_suffix}_L{level}'
         num_increment = 2
         while model_stack_name in invalid_model_names:  # Ensure name is unique
-            model_stack_name = f'weighted_ensemble{name_suffix}_{num_increment}_k{k_fold}_l{level}'
+            model_stack_name = f'WeightedEnsemble{name_suffix}_{num_increment}_L{level}'
             num_increment += 1
 
         weighted_ensemble_model = WeightedEnsembleModel(

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from sklearn.linear_model import LogisticRegression, LinearRegression
 
 from autogluon.core.metrics import soft_log_loss, mean_squared_error
-from autogluon.core.constants import AG_ARGS, AG_ARGS_FIT, BINARY, MULTICLASS,\
+from autogluon.core.constants import AG_ARGS, AG_ARGS_FIT, AG_ARGS_ENSEMBLE, BINARY, MULTICLASS,\
     REGRESSION, SOFTCLASS, PROBLEM_TYPES_CLASSIFICATION
 from ...models.abstract.abstract_model import AbstractModel
 from ...models.fastainn.tabular_nn_fastai import NNFastAiTabularModel
@@ -20,6 +20,7 @@ from ...models.catboost.catboost_model import CatboostModel
 from ...models.xgboost.xgboost_model import XGBoostModel
 from ...models.xt.xt_model import XTModel
 from ...models.tab_transformer.tab_transformer_model import TabTransformerModel
+from ...models.ensemble.stacker_ensemble_model import StackerEnsembleModel
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ DEFAULT_MODEL_TYPE_SUFFIX['regressor'].update({LinearModel: ''})
 # DONE: Add lists
 # DONE: Add custom which can append to lists
 # DONE: Add special optional AG args for things like name prefix, name suffix, name, etc.
-# TODO: Move creation of stack ensemble internally into this function? Requires passing base models in as well.
+# DONE: Move creation of stack ensemble internally into this function? Requires passing base models in as well.
 # DONE: Add special optional AG args for training order
 # TODO: Add special optional AG args for base models
 # TODO: Consider making hyperparameters arg in fit() accept lists, concatenate hyperparameter sets together.
@@ -117,7 +118,8 @@ DEFAULT_MODEL_TYPE_SUFFIX['regressor'].update({LinearModel: ''})
 # TODO: Add option to update hyperparameters with only added keys, so disabling CatBoost would just be {'CAT': []}, which keeps the other models as is.
 # TODO: special optional AG arg for only training model if eval_metric in list / not in list. Useful for F1 and 'is_unbalanced' arg in LGBM.
 def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None, hyperparameter_tune=False,
-                      level='default', extra_ag_args_fit=None, extra_ag_args=None, name_suffix='', default_priorities=None, invalid_model_names: list = None):
+                      level: int = 0, ensemble_type=StackerEnsembleModel, ensemble_kwargs: dict = None, extra_ag_args_fit=None, extra_ag_args=None, extra_ag_args_ensemble=None,
+                      name_suffix: str = None, default_priorities=None, invalid_model_names: list = None):
     if problem_type not in [BINARY, MULTICLASS, REGRESSION, SOFTCLASS]:
         raise NotImplementedError
     if default_priorities is None:
@@ -136,14 +138,33 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
             model = copy.deepcopy(model)
             if AG_ARGS not in model:
                 model[AG_ARGS] = dict()
-            if extra_ag_args is not None:
-                model[AG_ARGS].update(extra_ag_args.copy())
+            if AG_ARGS_ENSEMBLE not in model:
+                model[AG_ARGS_ENSEMBLE] = dict()
             if 'model_type' not in model[AG_ARGS]:
                 model[AG_ARGS]['model_type'] = model_type
+            model_type_real = model[AG_ARGS]['model_type']
+            if not inspect.isclass(model_type_real):
+                model_type_real = MODEL_TYPES[model_type_real]
+            default_ag_args = model_type_real._get_default_ag_args()
+            if extra_ag_args is not None:
+                model_extra_ag_args = extra_ag_args.copy()
+                model_extra_ag_args.update(model[AG_ARGS])
+                model[AG_ARGS] = model_extra_ag_args
+            if extra_ag_args_ensemble is not None:
+                model_extra_ag_args_ensemble = extra_ag_args_ensemble.copy()
+                model_extra_ag_args_ensemble.update(model[AG_ARGS_ENSEMBLE])
+                model[AG_ARGS_ENSEMBLE] = model_extra_ag_args_ensemble
+            if default_ag_args is not None:
+                default_ag_args.update(model[AG_ARGS])
+                model[AG_ARGS] = default_ag_args
             model_priority = model[AG_ARGS].get('priority', default_priorities.get(model_type, DEFAULT_CUSTOM_MODEL_PRIORITY))
             # Check if model is valid
             if hyperparameter_tune and model[AG_ARGS].get('disable_in_hpo', False):
                 continue  # Not valid
+            elif not model[AG_ARGS].get('valid_stacker', True) and level > 0:
+                continue  # Not valid as a stacker model
+            elif not model[AG_ARGS].get('valid_base', True) and level == 0:
+                continue  # Not valid as a base model
             priority_dict[model_priority].append(model)
     model_priority_list = [model for priority in sorted(priority_dict.keys(), reverse=True) for model in priority_dict[priority]]
     model_names_set = set()
@@ -168,20 +189,39 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
                 name_type_suffix = DEFAULT_MODEL_TYPE_SUFFIX[suffix_key][model_type]
             name_suff = model[AG_ARGS].get('name_suffix', '')
             name_orig = name_prefix + name_main + name_type_suffix + name_suff
-        name_orig = name_orig + name_suffix
+        if name_suffix is not None:
+            name_orig = name_orig + name_suffix
         name = name_orig
+        name_stacker = None
         num_increment = 2
-        while name in model_names_set:  # Ensure name is unique
-            name = f'{name_orig}_{num_increment}'
-            num_increment += 1
-        model_names_set.add(name)
+        if ensemble_kwargs is None:
+            while name in model_names_set:  # Ensure name is unique
+                name = f'{name_orig}_{num_increment}'
+                num_increment += 1
+            model_names_set.add(name)
+        else:
+            name_stacker = f'{name}_STACKER_l{level}'
+            while name_stacker in model_names_set:  # Ensure name is unique
+                name = f'{name_orig}_{num_increment}'
+                name_stacker = f'{name}_STACKER_l{level}'
+                num_increment += 1
+            model_names_set.add(name_stacker)
         model_params = copy.deepcopy(model)
         model_params.pop(AG_ARGS)
+        model_params.pop(AG_ARGS_ENSEMBLE)
         if extra_ag_args_fit is not None:
             if AG_ARGS_FIT not in model_params:
                 model_params[AG_ARGS_FIT] = {}
             model_params[AG_ARGS_FIT].update(extra_ag_args_fit.copy())  # TODO: Consider case of overwriting user specified extra args.
         model_init = model_type(path=path, name=name, problem_type=problem_type, eval_metric=eval_metric, stopping_metric=stopping_metric, num_classes=num_classes, hyperparameters=model_params)
+
+        if ensemble_kwargs is not None:
+            ensemble_kwargs_model = copy.deepcopy(ensemble_kwargs)
+            extra_ensemble_hyperparameters = copy.deepcopy(model[AG_ARGS_ENSEMBLE])
+            ensemble_kwargs_model['hyperparameters'] = ensemble_kwargs_model.get('hyperparameters', {})
+            ensemble_kwargs_model['hyperparameters'].update(extra_ensemble_hyperparameters)
+            model_init = ensemble_type(path=path, name=name_stacker, model_base=model_init, num_classes=num_classes, **ensemble_kwargs_model)
+
         models.append(model_init)
 
     return models

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets_distill.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets_distill.py
@@ -18,14 +18,9 @@ DEFAULT_DISTILL_PRIORITY = dict(
 
 def get_preset_models_distillation(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None,
                                    hyperparameter_tune=False, distill_level=0, name_suffix='_DSTL', invalid_model_names: list = None):
-    if problem_type != REGRESSION:
-        extra_ag_args = dict(name_type_suffix='Classifier')
-    else:
-        extra_ag_args = None
     if problem_type == MULTICLASS:
         models = get_preset_models_softclass(path=path, num_classes=num_classes, hyperparameters=hyperparameters,
-                                             hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix,
-                                             extra_ag_args=extra_ag_args, invalid_model_names=invalid_model_names)
+                                             hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix, invalid_model_names=invalid_model_names)
     elif problem_type == BINARY:  # convert to regression in distillation
         eval_metric = mean_squared_error
         stopping_metric = mean_squared_error
@@ -68,7 +63,7 @@ def get_preset_models_distillation(path, problem_type, eval_metric, hyperparamet
     if problem_type == REGRESSION or problem_type == BINARY:
         models = get_preset_models(path=path, problem_type=REGRESSION, eval_metric=eval_metric, stopping_metric=stopping_metric,
                                    hyperparameters=hyperparameters, hyperparameter_tune=hyperparameter_tune, name_suffix=name_suffix,
-                                   extra_ag_args=extra_ag_args, default_priorities=DEFAULT_DISTILL_PRIORITY, invalid_model_names=invalid_model_names)
+                                   default_priorities=DEFAULT_DISTILL_PRIORITY, invalid_model_names=invalid_model_names)
 
     if problem_type in [MULTICLASS, BINARY]:
         for model in models:

--- a/tabular/tests/unittests/data/test_label_cleaner.py
+++ b/tabular/tests/unittests/data/test_label_cleaner.py
@@ -117,7 +117,7 @@ def test_label_cleaner_multiclass_to_binary():
             [0, 0.3, 0.7, 0, 0],
             [0, 0.8, 0.2, 0, 0],
             [0, 0.5, 0.5, 0, 0]
-        ], index=[5, 2, 8], columns=['l0', 'l1', 'l2', 'l3', 'l4'], dtype=np.float64
+        ], index=[5, 2, 8], columns=['l0', 'l1', 'l2', 'l3', 'l4'], dtype=np.float32
     )
 
     # When

--- a/tabular/tests/unittests/models/test_catboost.py
+++ b/tabular/tests/unittests/models/test_catboost.py
@@ -1,10 +1,10 @@
 
-from autogluon.tabular.models.catboost.catboost_model import CatboostModel
+from autogluon.tabular.models.catboost.catboost_model import CatBoostModel
 
 
 def test_catboost_binary(fit_helper):
     fit_args = dict(
-        hyperparameters={CatboostModel: {}},
+        hyperparameters={CatBoostModel: {}},
     )
     dataset_name = 'adult'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
@@ -12,7 +12,7 @@ def test_catboost_binary(fit_helper):
 
 def test_catboost_multiclass(fit_helper):
     fit_args = dict(
-        hyperparameters={CatboostModel: {}},
+        hyperparameters={CatBoostModel: {}},
     )
     dataset_name = 'covertype'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
@@ -20,7 +20,7 @@ def test_catboost_multiclass(fit_helper):
 
 def test_catboost_regression(fit_helper):
     fit_args = dict(
-        hyperparameters={CatboostModel: {}},
+        hyperparameters={CatBoostModel: {}},
     )
     dataset_name = 'ames'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)

--- a/tabular/tests/unittests/test_hyperband_for_decision_trees.py
+++ b/tabular/tests/unittests/test_hyperband_for_decision_trees.py
@@ -10,7 +10,7 @@ from autogluon.tabular.models.xt.xt_model import XTModel
 
 
 from autogluon.core.space import Int
-from autogluon.tabular.metrics import accuracy
+from autogluon.core.metrics import accuracy
 
 from autogluon.core.scheduler.hyperband import HyperbandScheduler
 from autogluon.core.task.base.base_task import compile_scheduler_options
@@ -98,3 +98,4 @@ def test_xt():
 
 def test_rf():
     hyperband_hpo("rf")
+

--- a/tabular/tests/unittests/test_hyperband_for_decision_trees.py
+++ b/tabular/tests/unittests/test_hyperband_for_decision_trees.py
@@ -3,7 +3,7 @@ from autogluon.tabular import TabularPrediction as task
 from autogluon.tabular.learner.default_learner import DefaultLearner as Learner
 from autogluon.tabular.features.generators.auto_ml_pipeline import AutoMLPipelineFeatureGenerator
 
-from autogluon.tabular.models.catboost.catboost_model import CatboostModel
+from autogluon.tabular.models.catboost.catboost_model import CatBoostModel
 from autogluon.tabular.models.lgb.lgb_model import LGBModel
 from autogluon.tabular.models.rf.rf_model import RFModel
 from autogluon.tabular.models.xt.xt_model import XTModel

--- a/tabular/tests/unittests/test_hyperband_for_decision_trees.py
+++ b/tabular/tests/unittests/test_hyperband_for_decision_trees.py
@@ -10,7 +10,7 @@ from autogluon.tabular.models.xt.xt_model import XTModel
 
 
 from autogluon.core.space import Int
-from autogluon.tabular.metrics import accuracy
+from autogluon.core.metrics import accuracy
 
 from autogluon.core.scheduler.hyperband import HyperbandScheduler
 from autogluon.core.task.base.base_task import compile_scheduler_options

--- a/tabular/tests/unittests/test_hyperband_for_decision_trees.py
+++ b/tabular/tests/unittests/test_hyperband_for_decision_trees.py
@@ -10,7 +10,7 @@ from autogluon.tabular.models.xt.xt_model import XTModel
 
 
 from autogluon.core.space import Int
-from autogluon.core.metrics import accuracy
+from autogluon.tabular.metrics import accuracy
 
 from autogluon.core.scheduler.hyperband import HyperbandScheduler
 from autogluon.core.task.base.base_task import compile_scheduler_options
@@ -71,7 +71,7 @@ def hyperband_hpo(model_name, label_column='class', strategy="bayesopt",
         ngpus_per_trial=0,
         checkpoint=None,
         num_trials=num_trials,
-        time_out=timeout, #1 hours timeout
+        time_out=timeout,
         resume=False,
         visualizer=None,
         time_attr='epoch',
@@ -98,4 +98,3 @@ def test_xt():
 
 def test_rf():
     hyperband_hpo("rf")
-

--- a/tabular/tests/unittests/test_hyperband_for_decision_trees.py
+++ b/tabular/tests/unittests/test_hyperband_for_decision_trees.py
@@ -46,7 +46,7 @@ def hyperband_hpo(model_name, label_column='class', strategy="bayesopt",
     hyper = {}
     if model_name == "cat":
         hyper = {'iterations': Int(lower=2, upper=25, default=10)}
-        model_cls = CatboostModel
+        model_cls = CatBoostModel
     elif model_name == "gbm":
         hyper ={'num_boost_round': Int(lower=2, upper=25, default=20)}
         model_cls = LGBModel

--- a/tabular/tests/unittests/test_hyperband_for_decision_trees.py
+++ b/tabular/tests/unittests/test_hyperband_for_decision_trees.py
@@ -1,0 +1,100 @@
+from autogluon.tabular import TabularPrediction as task
+
+from autogluon.tabular.learner.default_learner import DefaultLearner as Learner
+from autogluon.tabular.features.generators.auto_ml_pipeline import AutoMLPipelineFeatureGenerator
+
+from autogluon.tabular.models.catboost.catboost_model import CatboostModel
+from autogluon.tabular.models.lgb.lgb_model import LGBModel
+from autogluon.tabular.models.rf.rf_model import RFModel
+from autogluon.tabular.models.xt.xt_model import XTModel
+
+
+from autogluon.core.space import Int
+from autogluon.tabular.metrics import accuracy
+
+from autogluon.core.scheduler.hyperband import HyperbandScheduler
+from autogluon.core.task.base.base_task import compile_scheduler_options
+
+from autogluon.tabular.utils import infer_problem_type
+
+def hyperband_hpo(model_name, label_column='class', strategy="bayesopt",
+        num_trials=5, epochs=5, timeout=60*60, thread_per_trial=1):
+
+    eval_metric = accuracy
+
+    train_data = task.Dataset(file_path='https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
+
+    train_data = train_data.head(500)
+
+    train_size = int(round(len(train_data) * 0.8))
+    valid_size = len(train_data) - train_size
+
+    X_train = train_data.head(train_size)
+    X_val = train_data.tail(valid_size)
+
+    feat_generator = AutoMLPipelineFeatureGenerator()
+    learner = Learner(path_context="/tmp", label=label_column, id_columns=[],
+                      feature_generator=feat_generator)
+    X, y, X_val, y_val, _, holdout_frac, num_bagging_folds = learner.general_data_processing(X=X_train, X_val=X_val, X_unlabeled=None,
+                                                                                holdout_frac=0.1, num_bagging_folds=0)
+
+    prob_type = infer_problem_type(y=train_data[label_column])
+
+    sch_cls = HyperbandScheduler
+    model_cls = None
+
+    hyper = {}
+    if model_name == "cat":
+        hyper = {'iterations': Int(lower=2, upper=25, default=10)}
+        model_cls = CatboostModel
+    elif model_name == "gbm":
+        hyper ={'num_boost_round': Int(lower=2, upper=25, default=20)}
+        model_cls = LGBModel
+    elif model_name == "xt":
+        hyper = {'n_estimators': Int(lower=2, upper=25, default=10)}
+        model_cls = XTModel
+    elif model_name == "rf":
+        hyper = {'n_estimators': Int(lower=2, upper=25, default=10)}
+        model_cls = RFModel
+
+    model = model_cls(path="tmp", name=f"{model_name}", problem_type=prob_type,
+                              eval_metric=eval_metric, feature_metadata=learner.feature_generator.feature_metadata,
+                              hyperparameters=hyper, num_classes=learner.label_cleaner.num_classes)
+
+    scheduler_options = None
+
+    scheduler_options = compile_scheduler_options(
+        scheduler_options=scheduler_options,
+        search_strategy=strategy,
+        search_options=None,
+        nthreads_per_trial=thread_per_trial,
+        ngpus_per_trial=0,
+        checkpoint=None,
+        num_trials=num_trials,
+        time_out=timeout, #1 hours timeout
+        resume=False,
+        visualizer=None,
+        time_attr='epoch',
+        reward_attr='validation_performance',
+        dist_ip_addrs=[],
+        )
+
+    hpo_models, hpo_model_performances, hpo_results = model.hyperparameter_tune(X_train=X, y_train=y, X_val=X_val,
+                                y_val=y_val, scheduler_options=(sch_cls, scheduler_options), epochs=epochs)
+
+    assert(len(hpo_models)==num_trials)
+    for name, res in hpo_model_performances.items():
+        assert(res>0)
+
+
+def test_cat():
+    hyperband_hpo("cat")
+
+def test_gbm():
+    hyperband_hpo("gbm")
+
+def test_xt():
+    hyperband_hpo("xt")
+
+def test_rf():
+    hyperband_hpo("rf")

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -25,6 +25,7 @@ import mxnet as mx
 from random import seed
 
 from networkx.exception import NetworkXError
+import pandas as pd
 import pytest
 
 import autogluon.core as ag
@@ -268,8 +269,10 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
             if fast_benchmark:
                 if subsample_size is None:
                     raise ValueError("fast_benchmark specified without subsample_size")
-                train_data = train_data.head(subsample_size) # subsample for fast_benchmark
-            predictor = task.fit(train_data=train_data, label=label_column, output_directory=savedir, **fit_args)
+                if subsample_size < len(train_data):
+                    # .sample instead of .head to increase diversity and test cases where data index is not monotonically increasing.
+                    train_data = train_data.sample(n=subsample_size, random_state=seed_val)  # subsample for fast_benchmark
+            predictor: TabularPredictor = task.fit(train_data=train_data, label=label_column, output_directory=savedir, **fit_args)
             results = predictor.fit_summary(verbosity=4)
             if predictor.problem_type != dataset['problem_type']:
                 warnings.warn("For dataset %s: Autogluon inferred problem_type = %s, but should = %s" % (dataset['name'], predictor.problem_type, dataset['problem_type']))
@@ -285,8 +288,59 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
             if (not fast_benchmark) and (performance_vals[idx] > dataset['performance_val'] * perf_threshold):
                 warnings.warn("Performance on dataset %s is %s times worse than previous performance." %
                               (dataset['name'], performance_vals[idx]/(EPS+dataset['performance_val'])))
+            if predictor._trainer.bagged_mode:
+                # TODO: Test index alignment with original training data (first handle duplicated rows / dropped rows edge cases)
+                y_train_pred_oof = predictor.get_oof_pred()
+                y_train_pred_proba_oof = predictor.get_oof_pred_proba()
+                y_train_pred_oof_transformed = predictor.get_oof_pred(transformed=True)
+                y_train_pred_proba_oof_transformed = predictor.get_oof_pred_proba(transformed=True)
+
+                # Assert expected type output
+                assert isinstance(y_train_pred_oof, pd.Series)
+                assert isinstance(y_train_pred_oof_transformed, pd.Series)
+                if predictor.problem_type == MULTICLASS:
+                    assert isinstance(y_train_pred_proba_oof, pd.DataFrame)
+                    assert isinstance(y_train_pred_proba_oof_transformed, pd.DataFrame)
+                else:
+                    if predictor.problem_type == BINARY:
+                        assert isinstance(predictor.get_oof_pred_proba(as_multiclass=True), pd.DataFrame)
+                    assert isinstance(y_train_pred_proba_oof, pd.Series)
+                    assert isinstance(y_train_pred_proba_oof_transformed, pd.Series)
+
+                assert y_train_pred_oof_transformed.equals(predictor.transform_labels(y_train_pred_oof, proba=False))
+
+                # Test that the transform_labels method is capable of reproducing the same output when converting back and forth, and test that oof 'transform' parameter works properly.
+                y_train_pred_proba_oof_inverse = predictor.transform_labels(y_train_pred_proba_oof, proba=True)
+                y_train_pred_proba_oof_inverse_inverse = predictor.transform_labels(y_train_pred_proba_oof_inverse, proba=True, inverse=True)
+                y_train_pred_oof_inverse = predictor.transform_labels(y_train_pred_oof)
+                y_train_pred_oof_inverse_inverse = predictor.transform_labels(y_train_pred_oof_inverse, inverse=True)
+
+                if isinstance(y_train_pred_proba_oof_transformed, pd.DataFrame):
+                    pd.testing.assert_frame_equal(y_train_pred_proba_oof_transformed, y_train_pred_proba_oof_inverse)
+                    pd.testing.assert_frame_equal(y_train_pred_proba_oof, y_train_pred_proba_oof_inverse_inverse)
+                else:
+                    pd.testing.assert_series_equal(y_train_pred_proba_oof_transformed, y_train_pred_proba_oof_inverse)
+                    pd.testing.assert_series_equal(y_train_pred_proba_oof, y_train_pred_proba_oof_inverse_inverse)
+                pd.testing.assert_series_equal(y_train_pred_oof_transformed, y_train_pred_oof_inverse)
+                pd.testing.assert_series_equal(y_train_pred_oof, y_train_pred_oof_inverse_inverse)
+
+                # Test that index of both the internal training data and the oof outputs are consistent in their index values.
+                X_internal, y_internal = predictor.load_data_internal()
+                y_internal_index = list(y_internal.index)
+                assert list(X_internal.index) == y_internal_index
+                assert list(y_train_pred_oof.index) == y_internal_index
+                assert list(y_train_pred_proba_oof.index) == y_internal_index
+                assert list(y_train_pred_oof_transformed.index) == y_internal_index
+                assert list(y_train_pred_proba_oof_transformed.index) == y_internal_index
+            else:
+                # Raise exception
+                with pytest.raises(AssertionError):
+                    predictor.get_oof_pred()
+                with pytest.raises(AssertionError):
+                    predictor.get_oof_pred_proba()
             if run_distill:
                 predictor.distill(time_limits=60, augment_args={'size_factor':0.5})
+
     # Summarize:
     avg_perf = np.mean(performance_vals)
     median_perf = np.median(performance_vals)

--- a/text/setup.py
+++ b/text/setup.py
@@ -9,12 +9,12 @@ from setuptools import setup, find_packages, find_namespace_packages
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join('..', 'VERSION')) as version_file:
+with open(os.path.join(os.path.dirname(__file__), '..', 'VERSION')) as version_file:
     version = version_file.read().strip()
 
 """
-To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
-a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 
+To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
+a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
 You need to increase the version number after stable release, so that the nightly pypi can work properly.
 """
 try:

--- a/text/src/autogluon/text/text_prediction/models/basic_v1.py
+++ b/text/src/autogluon/text/text_prediction/models/basic_v1.py
@@ -529,11 +529,15 @@ def train_function(args, reporter, train_data, tuning_data,
             else:
                 report_items.append(('reward', performance_score))
             report_items.append(('exp_dir', exp_dir))
+            if find_better:
+                best_report_items = report_items
             reporter(**dict(report_items))
             if no_better_rounds >= cfg.learning.early_stopping_patience:
                 logger.info('Early stopping patience reached!')
                 break
-
+    best_report_items_dict = dict(best_report_items)
+    best_report_items_dict['report_idx'] = report_idx + 1
+    reporter(**best_report_items_dict)
 
 @use_np
 class BertForTextPredictionBasic:

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -9,12 +9,12 @@ from setuptools import setup, find_packages, find_namespace_packages
 
 cwd = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join('..', 'VERSION')) as version_file:
+with open(os.path.join(os.path.dirname(__file__), '..', 'VERSION')) as version_file:
     version = version_file.read().strip()
 
 """
-To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish 
-a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml . 
+To release a new stable version on PyPi, simply tag the release on github, and the Github CI will automatically publish
+a new stable version to PyPi using the configurations in .github/workflows/pypi_release.yml .
 You need to increase the version number after stable release, so that the nightly pypi can work properly.
 """
 try:


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
This change enables multi-fidelity scheduler (HyperbandScheduler) to be used with decision tree-based methods (Catboost, lightGBM, Random Forests, and Extreme Trees), during hyperparameter optimization.

With the change, the decision tree-based methods is now able to perform incremental training, similar to those found in scikit-learn. By specifying warm_start=True in fit() function, the training would continue from the model trained over previous calls to fit().


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
