### PR TITLE
Enable forkserver as a default forking mode for HPO

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -58,7 +58,8 @@ requirements = [
     'boto3',
     'pandas>=1.0.0,<2.0',
     'scikit-learn>=0.22.0,<0.24',
-    'autograd>=1.3'
+    'autograd>=1.3',
+    'dill==0.3.3',
 ]
 
 test_requirements = [

--- a/core/src/autogluon/core/scheduler/remote/cli.py
+++ b/core/src/autogluon/core/scheduler/remote/cli.py
@@ -1,6 +1,9 @@
+import multiprocessing as mp
+
 import click
 
 from .remote import DaskRemoteService
+
 
 @click.command(
     help="""Launch an AutoGluon Remote from terminal, example:
@@ -21,4 +24,12 @@ from .remote import DaskRemoteService
     help="Specify the port number.",
 )
 def main(address, port):
+    # Dask requirement - add support for when a program which uses multiprocessing has been frozen to produce a Windows executable.
+    mp.freeze_support()
+    if ('forkserver' in mp.get_all_start_methods()) & (mp.get_start_method(allow_none=True) != 'forkserver'):
+        # The CUDA runtime does not support the fork start method;
+        # either the spawn or forkserver start method are required to use CUDA in subprocesses.
+        # forkserver is used because spawn is still affected by locking issues
+        mp.set_start_method('forkserver', force=True)
+
     service = DaskRemoteService(address, port)

--- a/core/src/autogluon/core/scheduler/remote/remote.py
+++ b/core/src/autogluon/core/scheduler/remote/remote.py
@@ -61,7 +61,7 @@ class Remote(Client):
     LOCK = mp.Lock()
     REMOTE_ID = mp.Value('i', 0)
     def __init__(self, remote_ip=None, port=None, local=False, ssh_username=None,
-            ssh_port=22, ssh_private_key=None, remote_python=None):
+            ssh_port=22, ssh_private_key=None, remote_python=None, timeout=30):
         self.service = None
         if local:
             super().__init__(processes=False)
@@ -69,9 +69,7 @@ class Remote(Client):
             remote_addr = (remote_ip + ':{}'.format(port))
             self.service = start_service(remote_ip, port)
             _set_global_remote_service(self.service)
-            import time
-            time.sleep(10)
-            super().__init__(remote_addr)
+            super().__init__(remote_addr, timeout=timeout)
         with Remote.LOCK:
             self.remote_id = Remote.REMOTE_ID.value
             Remote.REMOTE_ID.value += 1

--- a/core/src/autogluon/core/scheduler/scheduler.py
+++ b/core/src/autogluon/core/scheduler/scheduler.py
@@ -1,8 +1,14 @@
 """Distributed Task Scheduler"""
+import contextlib
 import os
 import pickle
 import logging
+import shutil
 import sys
+import tempfile
+from functools import partial
+
+import dill
 import distributed
 from warnings import warn
 import multiprocessing as mp
@@ -13,11 +19,23 @@ from .resource import DistributedResourceManager
 from .. import Task
 from .reporter import *
 from ..utils import AutoGluonWarning, AutoGluonEarlyStop, CustomProcess
+from ..utils.multiprocessing_utils import is_fork_enabled
+
+SYS_ERR_OUT_FILE = 'sys_err.out'
+SYS_STD_OUT_FILE = 'sys_std.out'
 
 logger = logging.getLogger(__name__)
 
 __all__ = ['TaskScheduler']
 
+
+@contextlib.contextmanager
+def make_temp_directory():
+    temp_dir = tempfile.mkdtemp()
+    try:
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir)
 
 class ClassProperty(object):
 
@@ -130,6 +148,43 @@ class TaskScheduler(object):
         job.add_done_callback(_release_resource_callback)
         return job
 
+
+    @staticmethod
+    def _wrapper(tempdir, task, *args, **kwargs):
+        with open(os.path.join(tempdir, SYS_STD_OUT_FILE), 'w') as std_out:
+            with open(os.path.join(tempdir, SYS_ERR_OUT_FILE), 'w') as err_out:
+                sys.stdout = std_out
+                sys.stderr = err_out
+                task(*args, **kwargs)
+
+    @staticmethod
+    def _wrap(tempdir, task):
+        return partial(TaskScheduler._wrapper, tempdir, task)
+
+    @staticmethod
+    def _worker(pickled_fn, pickled_args, return_list, gpu_ids, args):
+        """Worker function in the client
+        """
+
+        # Only fork mode allows passing non-picklable objects
+        fn = pickled_fn if is_fork_enabled() else dill.loads(pickled_fn)
+        args = {**pickled_args, **args} if is_fork_enabled() else {**dill.loads(pickled_args), **args}
+
+        if len(gpu_ids) > 0:
+            # handle GPU devices
+            os.environ['CUDA_VISIBLE_DEVICES'] = ",".join(map(str, gpu_ids))
+            os.environ['MXNET_CUDNN_AUTOTUNE_DEFAULT'] = "0"
+        else:
+            os.environ['CUDA_VISIBLE_DEVICES'] = "-1"
+
+        # running
+        try:
+            ret = fn(**args)
+        except AutoGluonEarlyStop:
+            ret = None
+        return_list.append(ret)
+
+
     @staticmethod
     def _run_dist_job(fn, args, gpu_ids):
         """Remote function Executing the task
@@ -144,28 +199,38 @@ class TaskScheduler(object):
 
         manager = mp.Manager()
         return_list = manager.list()
-        def _worker(return_list, gpu_ids, args):
-            """Worker function in thec client
-            """
-            if len(gpu_ids) > 0:
-                # handle GPU devices
-                os.environ['CUDA_VISIBLE_DEVICES'] = ",".join(map(str, gpu_ids))
-                os.environ['MXNET_CUDNN_AUTOTUNE_DEFAULT'] = "0"
-
-            # running
-            try:
-                ret = fn(**args)
-            except AutoGluonEarlyStop:
-                ret = None
-            return_list.append(ret)
 
         try:
-            # start local progress
-            p = CustomProcess(target=_worker, args=(return_list, gpu_ids, args))
-            p.start()
-            if 'reporter' in args:
-                cp = Communicator.Create(p, local_reporter, dist_reporter)
-            p.join()
+            # Starting local process
+            # Note: we have to use dill here because every argument passed to a child process over spawn or forkserver
+            # has to be pickled. fork mode does not require this because memory sharing, but it is unusable for CUDA
+            # applications (CUDA does not support fork) and multithreading issues (hanged threads).
+            # Usage of decorators makes standard pickling unusable (https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled)
+            # Dill enables sending of decorated classes. Please note if some classes are used in the training function,
+            # those classes are best be defined inside the function - this way those can be constructed 'on-the-other-side'
+            # after deserialization.
+            pickled_fn = fn if is_fork_enabled() else dill.dumps(fn)
+
+            # Reporter has to be separated since it's used for cross-process communication and has to be passed as-is
+            args_ = {k: v for (k, v) in args.items() if k not in ['reporter']}
+            pickled_args = args_ if is_fork_enabled() else dill.dumps(args_)
+
+            cross_process_args = {k: v for (k, v) in args.items() if k not in ['fn', 'args']}
+
+            with make_temp_directory() as tempdir:
+                p = CustomProcess(
+                    target=TaskScheduler._wrap(tempdir, partial(TaskScheduler._worker, pickled_fn, pickled_args)),
+                    args=(return_list, gpu_ids, cross_process_args)
+                )
+                p.start()
+                if 'reporter' in args:
+                    cp = Communicator.Create(p, local_reporter, dist_reporter)
+                p.join()
+                # Get processes outputs
+                with open(os.path.join(tempdir, SYS_STD_OUT_FILE)) as f:
+                    print(f.read(), file=sys.stdout, end = '')
+                with open(os.path.join(tempdir, SYS_ERR_OUT_FILE)) as f:
+                    print(f.read(), file=sys.stderr, end = '')
         except Exception as e:
             logger.error('Exception in worker process: {}'.format(e))
         ret = return_list[0] if len(return_list) > 0 else None

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,8 +95,8 @@ Advanced Topics
    tutorials/course/index
    tutorials/nas/index
    tutorials/torch/index
-   api/autogluon.core
    api/autogluon.task
+   api/autogluon.core
    api/autogluon.core.space
    api/autogluon.core.scheduler
    api/autogluon.core.searcher

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 import psutil
 
+from autogluon.core.utils.multiprocessing_utils import force_forkserver
 from autogluon.core.utils import shuffle_df_rows
 from autogluon.core.utils.exceptions import TimeLimitExceeded, NoValidFeatures
 from autogluon.core.utils.loaders import load_pkl
@@ -572,6 +573,7 @@ class AbstractModel:
     def hyperparameter_tune(self, X_train, y_train, X_val, y_val, scheduler_options, **kwargs):
         # verbosity = kwargs.get('verbosity', 2)
         time_start = time.time()
+        force_forkserver()
         logger.log(15, "Starting generic AbstractModel hyperparameter tuning for %s model..." % self.name)
         self._set_default_searchspace()
         params_copy = self.params.copy()

--- a/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 from collections import defaultdict
 
+from autogluon.core.utils.multiprocessing_utils import force_forkserver
 from autogluon.core.utils.utils import generate_kfold
 from autogluon.core.constants import MULTICLASS
 
@@ -147,6 +148,7 @@ class StackerEnsembleModel(BaggedEnsembleModel):
 
     # TODO: Currently double disk usage, saving model in HPO and also saving model in stacker
     def hyperparameter_tune(self, X, y, k_fold, scheduler_options=None, compute_base_preds=True, **kwargs):
+        force_forkserver()
         if len(self.models) != 0:
             raise ValueError('self.models must be empty to call hyperparameter_tune, value: %s' % self.models)
 

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-from fastai.core import defaults
 
 from autogluon.core.utils import try_import_fastai_v1
 from autogluon.core.utils.loaders import load_pkl
@@ -105,6 +104,7 @@ class NNFastAiTabularModel(AbstractModel):
         from fastai.data_block import FloatList
         from fastai.tabular import TabularList
         from fastai.tabular import FillMissing, Categorify, Normalize
+        from fastai.core import defaults
 
         self.cat_columns = X_train.select_dtypes([
             'category', 'object', 'bool', 'bool_'

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -363,6 +363,7 @@ class NNFastAiTabularModel(AbstractModel):
     # TODO: add warning regarding dataloader leak: https://github.com/pytorch/pytorch/issues/31867
     # TODO: Add HPO
     def hyperparameter_tune(self, **kwargs):
+        # force_forkserver()
         return skip_hpo(self, **kwargs)
 
     def _get_default_auxiliary_params(self) -> dict:

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -73,6 +73,7 @@ class KNNModel(AbstractModel):
 
     # TODO: Add HPO
     def hyperparameter_tune(self, **kwargs):
+        # force_forkserver()
         return skip_hpo(self, **kwargs)
 
 

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 
+from autogluon.core.utils.multiprocessing_utils import force_forkserver
 from autogluon.core.utils.savers import save_pkl
 from autogluon.core.utils import try_import_lightgbm
 from autogluon.core import Int, Space

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -141,6 +141,7 @@ class LinearModel(AbstractModel):
 
     # TODO: Add HPO
     def hyperparameter_tune(self, **kwargs):
+        # force_forkserver()
         return skip_hpo(self, **kwargs)
 
     def _select_features_handle_text_include(self, df, types_of_features, categorical_featnames, language_featnames, continuous_featnames):

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -146,6 +146,7 @@ class RFModel(AbstractModel):
 
     # TODO: Add HPO
     def hyperparameter_tune(self, **kwargs):
+        # force_forkserver()
         return skip_hpo(self, **kwargs)
 
     def get_model_feature_importance(self):

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_dataset.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_dataset.py
@@ -5,6 +5,7 @@ import pandas as pd
 import mxnet as mx
 
 from autogluon.core.utils.loaders import load_pkl
+from autogluon.core.utils.multiprocessing_utils import is_fork_enabled, is_forkserver_enabled
 from autogluon.core.utils.savers import save_pkl
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS
 
@@ -153,9 +154,17 @@ class TabularNNDataset:
 
     def generate_dataset_and_dataloader(self, data_list):
         self.dataset = mx.gluon.data.dataset.ArrayDataset(*data_list)  # Access ith embedding-feature via: self.dataset._data[self.data_desc.index('embed_'+str(i))].asnumpy()
-        self.dataloader = mx.gluon.data.DataLoader(self.dataset, self.batch_size, shuffle=not self.is_test,
-                                                   last_batch='keep' if self.is_test else 'rollover',
-                                                   num_workers=self.num_dataloading_workers)  # no need to shuffle test data
+        self.dataloader = mx.gluon.data.DataLoader(
+            self.dataset, self.batch_size, shuffle=not self.is_test,
+            last_batch='keep' if self.is_test else 'rollover',
+
+           # local thread version is faster unless fork is enabled
+           num_workers=self.num_dataloading_workers if is_fork_enabled() else 0,
+
+           # need to use threadpool if forkserver is enabled, otherwise GIL will be locked
+            # please note: this will make training slower
+           thread_pool=is_forkserver_enabled(),
+        )  # no need to shuffle test data
 
     def has_vector_features(self):
         """ Returns boolean indicating whether this dataset contains vector features """

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -24,6 +24,7 @@ from autogluon.core import Space
 from autogluon.core.utils import try_import_mxboard
 from autogluon.core.metrics import log_loss, roc_auc
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS
+from autogluon.core.utils.multiprocessing_utils import force_forkserver
 
 
 from .categorical_encoders import OneHotMergeRaresHandleUnknownEncoder, OrdinalMergeRaresHandleUnknownEncoder

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -557,10 +557,6 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
             raise ValueError("Unknown optimizer specified: %s" % params['optimizer'])
         return optimizer
 
-    @staticmethod
-    def convert_df_dtype_to_str(df):
-        return df.astype(str)
-
     def _get_feature_arraycol_map(self, max_category_levels):
         """ Returns OrderedDict of feature-name -> list of column-indices in processed data array corresponding to this feature """
         feature_preserving_transforms = set(['continuous','skewed', 'ordinal', 'language'])  # these transforms do not alter dimensionality of feature
@@ -628,13 +624,13 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         if onehot_features:
             onehot_transformer = Pipeline(steps=[
                 # TODO: Consider avoiding converting to string for improved memory efficiency
-                ('to_str', FunctionTransformer(self.convert_df_dtype_to_str)),
+                ('to_str', FunctionTransformer(convert_df_dtype_to_str)),
                 ('imputer', SimpleImputer(strategy='constant', fill_value=self.unique_category_str)),
                 ('onehot', OneHotMergeRaresHandleUnknownEncoder(max_levels=max_category_levels, sparse=False))])  # test-time unknown values will be encoded as all zeros vector
             transformers.append( ('onehot', onehot_transformer, onehot_features) )
         if embed_features:  # Ordinal transformer applied to convert to-be-embedded categorical features to integer levels
             ordinal_transformer = Pipeline(steps=[
-                ('to_str', FunctionTransformer(self.convert_df_dtype_to_str)),
+                ('to_str', FunctionTransformer(convert_df_dtype_to_str)),
                 ('imputer', SimpleImputer(strategy='constant', fill_value=self.unique_category_str)),
                 ('ordinal', OrdinalMergeRaresHandleUnknownEncoder(max_levels=max_category_levels))])  # returns 0-n when max_category_levels = n-1. category n is reserved for unknown test-time categories.
             transformers.append( ('ordinal', ordinal_transformer, embed_features) )
@@ -674,8 +670,9 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         return model
 
     def hyperparameter_tune(self, X_train, y_train, X_val, y_val, scheduler_options, **kwargs):
-        time_start = time.time()
         """ Performs HPO and sets self.params to best hyperparameter values """
+        time_start = time.time()
+        force_forkserver()
         self.verbosity = kwargs.get('verbosity', 2)
         logger.log(15, "Beginning hyperparameter tuning for Neural Network...")
         self._set_default_searchspace()  # changes non-specified default hyperparams from fixed values to search-spaces.
@@ -740,6 +737,10 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         super().reduce_memory_size(remove_fit=remove_fit, requires_save=requires_save, **kwargs)
         if remove_fit and requires_save:
             self.optimizer = None
+
+
+def convert_df_dtype_to_str(df):
+    return df.astype(str)
 
 
 """ General TODOs:

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 import math
-import multiprocessing as mp
 
 import numpy as np
 

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -1,12 +1,14 @@
 import copy
 import logging
 import math
+import multiprocessing as mp
 
 import numpy as np
 
 from autogluon.core.task.base import BaseTask, compile_scheduler_options
 from autogluon.core.task.base.base_task import schedulers
 from autogluon.core.utils import verbosity2loglevel
+from autogluon.core.utils.multiprocessing_utils import force_forkserver
 from autogluon.core.utils.utils import setup_outputdir, setup_compute, setup_trial_limits, default_holdout_frac
 from autogluon.core.metrics import get_metric
 
@@ -562,6 +564,7 @@ class TabularPrediction(BaseTask):
 
         if hyperparameter_tune:
             logger.log(30, 'Warning: `hyperparameter_tune=True` is currently experimental and may cause the process to hang. Setting `auto_stack=True` instead is recommended to achieve maximum quality models.')
+            force_forkserver()
 
         if dist_ip_addrs is None:
             dist_ip_addrs = []


### PR DESCRIPTION
*Description of changes:*
- fixes issues with threads locking
- fixes issues with CUDA - [#620](https://github.com/awslabs/autogluon/issues/602)
- fixes to scheduler tests to enable pickling
- use forkserver only for HPO; dataloader updates
- force thread_pool usage for forkserver to prevent GIL locks
- Added GPU control options; added docs
- Added stdout/stderr capture

Updated version of #767 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
