### PR TITLE
Avoid mkdir raising exception if path is empty string

### DIFF
--- a/core/src/autogluon/core/utils/files.py
+++ b/core/src/autogluon/core/utils/files.py
@@ -115,13 +115,14 @@ def check_sha1(filename, sha1_hash):
 def mkdir(path):
     """Make directory at the specified local path with special error handling.
     """
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
+    if len(path) > 0:
+        try:
+            os.makedirs(path)
+        except OSError as exc:  # Python >2.5
+            if exc.errno == errno.EEXIST and os.path.isdir(path):
+                pass
+            else:
+                raise
 
 def raise_num_file(nofile_atleast=4096):
     try:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In several scheduler code, lines like
   mkdir(os.path.dirname(checkpoint))
raise exceptions if checkpoint is a filename without a directory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
