### PR TITLE
Added AG_ARGS_STACK functionality

### DIFF
--- a/core/src/autogluon/core/constants.py
+++ b/core/src/autogluon/core/constants.py
@@ -14,5 +14,6 @@ REFIT_FULL_SUFFIX = "_FULL"  # suffix appended to model name for refit_single_fu
 # AG_ARGS variables are key names in model hyperparameters to dictionaries of custom AutoGluon arguments.
 AG_ARGS = 'AG_args'  # Contains arguments to control model name, model priority, and the valid configurations which it can be used in.
 AG_ARGS_FIT = 'AG_args_fit'  # Contains arguments that impact model training, such as early stopping rounds, #cores, #gpus, max time limit, max memory usage  # TODO
+AG_ARGS_STACK = 'AG_args_stack'  # Contains arguments that impact model stacking, such as if the model is allowed to be a stacker, or if it is allowed to use the original features  # TODO: v0.1 add to documentation
 
 OBJECTIVES_TO_NORMALIZE = ['log_loss', 'pac_score', 'soft_log_loss']  # do not like predicted probabilities = 0

--- a/core/src/autogluon/core/constants.py
+++ b/core/src/autogluon/core/constants.py
@@ -12,8 +12,26 @@ REFIT_FULL_NAME = 'refit_single_full'  # stack-name used for refit_single_full (
 REFIT_FULL_SUFFIX = "_FULL"  # suffix appended to model name for refit_single_full (aka "compressed") models
 
 # AG_ARGS variables are key names in model hyperparameters to dictionaries of custom AutoGluon arguments.
+# TODO: Have documentation for all AG_ARGS values
 AG_ARGS = 'AG_args'  # Contains arguments to control model name, model priority, and the valid configurations which it can be used in.
 AG_ARGS_FIT = 'AG_args_fit'  # Contains arguments that impact model training, such as early stopping rounds, #cores, #gpus, max time limit, max memory usage  # TODO
-AG_ARGS_STACK = 'AG_args_stack'  # Contains arguments that impact model stacking, such as if the model is allowed to be a stacker, or if it is allowed to use the original features  # TODO: v0.1 add to documentation
+AG_ARGS_ENSEMBLE = 'AG_args_ensemble'  # Contains arguments that impact model ensembling, such as if an ensemble model is allowed to use the original features.  # TODO: v0.1 add to documentation
 
 OBJECTIVES_TO_NORMALIZE = ['log_loss', 'pac_score', 'soft_log_loss']  # do not like predicted probabilities = 0
+
+# TODO: Add docs to dedicated page, or should it live in AbstractModel?
+# TODO: How to reference correct version of docs?
+# TODO: Add error in AG_ARGS if unknown key present
+"""
+AG_ARGS: Dictionary of customization options related to meta properties of the model such as its name, the order it is trained, and the problem types it is valid for.
+    name: (str) The name of the model. This overrides AutoGluon's naming logic and all other name arguments if present.
+    name_main: (str) The main name of the model. In 'RandomForestClassifier', this is 'RandomForest'.
+    name_prefix: (str) Add a custom prefix to the model name. Unused by default.
+    name_type_suffix: (str) Override the type suffix of the model name. In 'RandomForestClassifier', this is 'Classifier'. This comes before 'name_suffix'.
+    name_suffix: (str) Add a custom suffix to the model name. Unused by default.
+    priority: (int) Determines the order in which the model is trained. Larger values result in the model being trained earlier. Default values range from 100 (RF) to 0 (custom), dictated by model type. If you want this model to be trained first, set priority = 999.
+    problem_types: (list) List of valid problem types for the model. `problem_types=['binary']` will result in the model only being trained if `problem_type` is 'binary'.
+    disable_in_hpo: (bool) If True, the model will only be trained if `hyperparameter_tune=False`.
+    valid_stacker: (bool) If False, the model will not be trained as a level 1 or higher stacker model.
+    valid_base: (bool) If False, the model will not be trained as a level 0 (base) model.
+"""

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -752,6 +752,15 @@ class AbstractModel:
         save_json.save(path=json_path, obj=info)
         return info
 
+    # TODO: v0.1 Add reference link to all valid keys and their usage or keep full docs here and reference elsewhere?
+    @classmethod
+    def _get_default_ag_args(cls) -> dict:
+        """
+        Dictionary of customization options related to meta properties of the model such as its name, the order it is trained, and the problem types it is valid for.
+        """
+        return {}
+
+
 class AbstractNeuralNetworkModel(AbstractModel):
 
     def __init__(self, **kwargs):
@@ -820,4 +829,3 @@ class AbstractNeuralNetworkModel(AbstractModel):
                 types_of_features.append({"name": feature, "type": feature_type})
 
         return types_of_features, df
-

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -551,6 +551,24 @@ class AbstractModel:
         template.set_contexts(self.path_root + template.name + os.path.sep)
         return template
 
+    def _get_init_args(self):
+        hyperparameters = self.params.copy()
+        hyperparameters = {key: val for key, val in hyperparameters.items() if key in self.nondefault_params}
+        init_args = dict(
+            path=self.path_root,
+            name=self.name,
+            problem_type=self.problem_type,
+            eval_metric=self.eval_metric,
+            num_classes=self.num_classes,
+            stopping_metric=self.stopping_metric,
+            model=None,
+            hyperparameters=hyperparameters,
+            features=self.features,
+            feature_metadata=self.feature_metadata,
+            debug=self.debug
+        )
+        return init_args
+
     def hyperparameter_tune(self, X_train, y_train, X_val, y_val, scheduler_options, **kwargs):
         # verbosity = kwargs.get('verbosity', 2)
         time_start = time.time()

--- a/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 # TODO: Add metadata object with info like score on each model, train time on each model, etc.
 class BaggedEnsembleModel(AbstractModel):
     _oof_filename = 'oof.pkl'
+
     def __init__(self, model_base: AbstractModel, save_bagged_folds=True, random_state=0, **kwargs):
         self.model_base = model_base
         self._child_type = type(self.model_base)
@@ -316,13 +317,38 @@ class BaggedEnsembleModel(AbstractModel):
 
     # TODO: Multiply epochs/n_iterations by some value (such as 1.1) to account for having more training data than bagged models
     def convert_to_refitfull_template(self):
+        init_args = self._get_init_args()
+        init_args['save_bagged_folds'] = True  # refit full models must save folds
+        model_base_name_orig = init_args['model_base'].name
+        init_args['model_base'] = self.convert_to_refitfull_template_child()
+        model_base_name_new = init_args['model_base'].name
+        if model_base_name_orig in init_args['name'] and model_base_name_orig != model_base_name_new:
+            init_args['name'] = init_args['name'].replace(model_base_name_orig, model_base_name_new, 1)
+        else:
+            init_args['name'] = init_args['name'] + '_FULL'
+
+        model_full_template = self.__class__(**init_args)
+        return model_full_template
+
+    def convert_to_refitfull_template_child(self):
         compressed_params = self._get_compressed_params()
-        model_compressed = copy.deepcopy(self._get_model_base())
-        model_compressed.feature_metadata = self.feature_metadata  # TODO: Don't pass this here
-        model_compressed.params = compressed_params
-        model_compressed.name = model_compressed.name + REFIT_FULL_SUFFIX
-        model_compressed.set_contexts(self.path_root + model_compressed.name + os.path.sep)
-        return model_compressed
+        child_compressed = copy.deepcopy(self._get_model_base())
+        child_compressed.feature_metadata = self.feature_metadata  # TODO: Don't pass this here
+        child_compressed.params = compressed_params
+        child_compressed.name = child_compressed.name + REFIT_FULL_SUFFIX
+        child_compressed.set_contexts(self.path_root + child_compressed.name + os.path.sep)
+        return child_compressed
+
+    def _get_init_args(self):
+        init_args = dict(
+            model_base=self._get_model_base(),
+            save_bagged_folds=self.save_bagged_folds,
+            random_state=self._random_state,
+        )
+        init_args.update(super()._get_init_args())
+        init_args.pop('problem_type')
+        init_args.pop('feature_metadata')
+        return init_args
 
     def _get_compressed_params(self, model_params_list=None):
         if model_params_list is None:

--- a/tabular/src/autogluon/tabular/models/ensemble/greedy_weighted_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/greedy_weighted_ensemble_model.py
@@ -81,3 +81,10 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         info = super().get_info()
         info['model_weights'] = self._get_model_weights()
         return info
+
+    @classmethod
+    def _get_default_ag_args(cls) -> dict:
+        default_ag_args = super()._get_default_ag_args()
+        extra_ag_args = {'valid_base': False}
+        default_ag_args.update(extra_ag_args)
+        return default_ag_args

--- a/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
@@ -219,6 +219,17 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         # TODO: hpo_results likely not correct because no renames
         return stackers, stackers_performance, hpo_results
 
+    def _get_init_args(self):
+        init_args = dict(
+            base_model_names=self.base_model_names,
+            base_models_dict=self.base_models_dict,
+            base_model_paths_dict=self.base_model_paths_dict,
+            base_model_types_dict=self.base_model_types_dict,
+            use_orig_features=self.use_orig_features,
+        )
+        init_args.update(super()._get_init_args())
+        return init_args
+
     def load_base_model(self, model_name):
         if model_name in self.base_models_dict.keys():
             model = self.base_models_dict[model_name]

--- a/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 #  To solve this, this model must know full context of stacker, and only get preds once for each required model
 #  This is already done in trainer, but could be moved internally.
 class StackerEnsembleModel(BaggedEnsembleModel):
-    def __init__(self, base_model_names=None, base_models_dict=None, base_model_paths_dict=None, base_model_types_dict=None, base_model_types_inner_dict=None, base_model_performances_dict=None, use_orig_features=True, **kwargs):
+    def __init__(self, base_model_names=None, base_models_dict=None, base_model_paths_dict=None, base_model_types_dict=None, base_model_types_inner_dict=None, base_model_performances_dict=None, **kwargs):
         super().__init__(**kwargs)
         if base_model_names is None:
             base_model_names = []
@@ -33,7 +33,6 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         self.base_models_dict: Dict[str, AbstractModel] = base_models_dict  # String name -> Model objects
         self.base_model_paths_dict = base_model_paths_dict
         self.base_model_types_dict = base_model_types_dict
-        self.use_orig_features = use_orig_features
 
         if (base_model_performances_dict is not None) and (base_model_types_inner_dict is not None):
             if self.params['max_models_per_type'] > 0:
@@ -70,9 +69,10 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         return self.limit_models_per_type(models=models, model_types=model_types, model_scores=model_scores, max_models_per_type=max_models)
 
     def _set_default_params(self):
-        default_params = {'max_models': 25, 'max_models_per_type': 5}
+        default_params = {'max_models': 25, 'max_models_per_type': 5, 'use_orig_features': True}
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
+        super()._set_default_params()
 
     def preprocess(self, X, fit=False, compute_base_preds=True, infer=True, model_pred_proba_dict=None, **kwargs):
         if self.stack_column_prefix_lst:
@@ -94,11 +94,11 @@ class StackerEnsembleModel(BaggedEnsembleModel):
                         y_pred_proba = base_model.predict_proba(X)
                     X_stacker.append(y_pred_proba)  # TODO: This could get very large on a high class count problem. Consider capping to top N most frequent classes and merging least frequent
                 X_stacker = self.pred_probas_to_df(X_stacker, index=X.index)
-                if self.use_orig_features:
+                if self.params['use_orig_features']:
                     X = pd.concat([X_stacker, X], axis=1)
                 else:
                     X = X_stacker
-            elif not self.use_orig_features:
+            elif not self.params['use_orig_features']:
                 X = X[self.stack_columns]
         X = super().preprocess(X, **kwargs)
         return X
@@ -225,7 +225,6 @@ class StackerEnsembleModel(BaggedEnsembleModel):
             base_models_dict=self.base_models_dict,
             base_model_paths_dict=self.base_model_paths_dict,
             base_model_types_dict=self.base_model_types_dict,
-            use_orig_features=self.use_orig_features,
         )
         init_args.update(super()._get_init_args())
         return init_args
@@ -244,7 +243,6 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         stacker_info = dict(
             num_base_models=len(self.base_model_names),
             base_model_names=self.base_model_names,
-            use_orig_features=self.use_orig_features,
         )
         children_info = info.pop('children_info')
         info['stacker_info'] = stacker_info

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -266,6 +266,8 @@ class TabularPrediction(BaseTask):
                             priority: (int) Determines the order in which the model is trained. Larger values result in the model being trained earlier. Default values range from 100 (RF) to 0 (custom), dictated by model type. If you want this model to be trained first, set priority = 999.
                             problem_types: (list) List of valid problem types for the model. `problem_types=['binary']` will result in the model only being trained if `problem_type` is 'binary'.
                             disable_in_hpo: (bool) If True, the model will only be trained if `hyperparameter_tune=False`.
+                            valid_stacker: (bool) If False, the model will not be trained as a level 1 or higher stacker model.
+                            valid_base: (bool) If False, the model will not be trained as a level 0 (base) model.
                         Reference the default hyperparameters for example usage of these options.
                     AG_args_fit: Dictionary of model fit customization options related to how and with what constraints the model is trained. These parameters affect stacker fold models, but not stacker models themselves.
                         Clarification: `time_limit` is the internal time in seconds given to a particular model to train, which is dictated in part by the `time_limits` argument given during `fit()` but is not the same.

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -118,7 +118,8 @@ DEFAULT_MODEL_TYPE_SUFFIX['regressor'].update({LinearModel: ''})
 # TODO: Add option to update hyperparameters with only added keys, so disabling CatBoost would just be {'CAT': []}, which keeps the other models as is.
 # TODO: special optional AG arg for only training model if eval_metric in list / not in list. Useful for F1 and 'is_unbalanced' arg in LGBM.
 def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None, hyperparameter_tune=False,
-                      level: int = 0, stacker_type=StackerEnsembleModel, stacker_kwargs: dict = None, extra_ag_args_fit=None, extra_ag_args=None, extra_ag_args_stack=None, name_suffix='', default_priorities=None, invalid_model_names: list = None):
+                      level: int = 0, stacker_type=StackerEnsembleModel, stacker_kwargs: dict = None, extra_ag_args_fit=None, extra_ag_args=None, extra_ag_args_stack=None,
+                      name_suffix: str = None, default_priorities=None, invalid_model_names: list = None):
     if problem_type not in [BINARY, MULTICLASS, REGRESSION, SOFTCLASS]:
         raise NotImplementedError
     if default_priorities is None:
@@ -175,7 +176,8 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
                 name_type_suffix = DEFAULT_MODEL_TYPE_SUFFIX[suffix_key][model_type]
             name_suff = model[AG_ARGS].get('name_suffix', '')
             name_orig = name_prefix + name_main + name_type_suffix + name_suff
-        name_orig = name_orig + name_suffix
+        if name_suffix is not None:
+            name_orig = name_orig + name_suffix
         name = name_orig
         name_stacker = None
         num_increment = 2

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from sklearn.linear_model import LogisticRegression, LinearRegression
 
 from autogluon.core.metrics import soft_log_loss, mean_squared_error
-from autogluon.core.constants import AG_ARGS, AG_ARGS_FIT, BINARY, MULTICLASS,\
+from autogluon.core.constants import AG_ARGS, AG_ARGS_FIT, AG_ARGS_STACK, BINARY, MULTICLASS,\
     REGRESSION, SOFTCLASS, PROBLEM_TYPES_CLASSIFICATION
 from ...models.abstract.abstract_model import AbstractModel
 from ...models.fastainn.tabular_nn_fastai import NNFastAiTabularModel
@@ -20,6 +20,7 @@ from ...models.catboost.catboost_model import CatboostModel
 from ...models.xgboost.xgboost_model import XGBoostModel
 from ...models.xt.xt_model import XTModel
 from ...models.tab_transformer.tab_transformer_model import TabTransformerModel
+from ...models.ensemble.stacker_ensemble_model import StackerEnsembleModel
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ DEFAULT_MODEL_TYPE_SUFFIX['regressor'].update({LinearModel: ''})
 # DONE: Add lists
 # DONE: Add custom which can append to lists
 # DONE: Add special optional AG args for things like name prefix, name suffix, name, etc.
-# TODO: Move creation of stack ensemble internally into this function? Requires passing base models in as well.
+# DONE: Move creation of stack ensemble internally into this function? Requires passing base models in as well.
 # DONE: Add special optional AG args for training order
 # TODO: Add special optional AG args for base models
 # TODO: Consider making hyperparameters arg in fit() accept lists, concatenate hyperparameter sets together.
@@ -117,7 +118,7 @@ DEFAULT_MODEL_TYPE_SUFFIX['regressor'].update({LinearModel: ''})
 # TODO: Add option to update hyperparameters with only added keys, so disabling CatBoost would just be {'CAT': []}, which keeps the other models as is.
 # TODO: special optional AG arg for only training model if eval_metric in list / not in list. Useful for F1 and 'is_unbalanced' arg in LGBM.
 def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None, hyperparameter_tune=False,
-                      level='default', extra_ag_args_fit=None, extra_ag_args=None, name_suffix='', default_priorities=None, invalid_model_names: list = None):
+                      level: int = 0, stacker_type=StackerEnsembleModel, stacker_kwargs: dict = None, extra_ag_args_fit=None, extra_ag_args=None, extra_ag_args_stack=None, name_suffix='', default_priorities=None, invalid_model_names: list = None):
     if problem_type not in [BINARY, MULTICLASS, REGRESSION, SOFTCLASS]:
         raise NotImplementedError
     if default_priorities is None:
@@ -136,14 +137,20 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
             model = copy.deepcopy(model)
             if AG_ARGS not in model:
                 model[AG_ARGS] = dict()
+            if AG_ARGS_STACK not in model:
+                model[AG_ARGS_STACK] = dict()
             if extra_ag_args is not None:
                 model[AG_ARGS].update(extra_ag_args.copy())
+            if extra_ag_args_stack is not None:
+                model[AG_ARGS_STACK].update(extra_ag_args_stack.copy())
             if 'model_type' not in model[AG_ARGS]:
                 model[AG_ARGS]['model_type'] = model_type
             model_priority = model[AG_ARGS].get('priority', default_priorities.get(model_type, DEFAULT_CUSTOM_MODEL_PRIORITY))
             # Check if model is valid
             if hyperparameter_tune and model[AG_ARGS].get('disable_in_hpo', False):
                 continue  # Not valid
+            elif stacker_kwargs is not None and not model[AG_ARGS_STACK].get('valid_stacker', True) and level > 0:
+                continue  # Not valid as a stacker
             priority_dict[model_priority].append(model)
     model_priority_list = [model for priority in sorted(priority_dict.keys(), reverse=True) for model in priority_dict[priority]]
     model_names_set = set()
@@ -170,18 +177,36 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
             name_orig = name_prefix + name_main + name_type_suffix + name_suff
         name_orig = name_orig + name_suffix
         name = name_orig
+        name_stacker = None
         num_increment = 2
-        while name in model_names_set:  # Ensure name is unique
-            name = f'{name_orig}_{num_increment}'
-            num_increment += 1
-        model_names_set.add(name)
+        if stacker_kwargs is None:
+            while name in model_names_set:  # Ensure name is unique
+                name = f'{name_orig}_{num_increment}'
+                num_increment += 1
+            model_names_set.add(name)
+        else:
+            name_stacker = f'{name}_STACKER_l{level}'
+            while name_stacker in model_names_set:  # Ensure name is unique
+                name = f'{name_orig}_{num_increment}'
+                name_stacker = f'{name}_STACKER_l{level}'
+                num_increment += 1
+            model_names_set.add(name_stacker)
         model_params = copy.deepcopy(model)
         model_params.pop(AG_ARGS)
+        model_params.pop(AG_ARGS_STACK)
         if extra_ag_args_fit is not None:
             if AG_ARGS_FIT not in model_params:
                 model_params[AG_ARGS_FIT] = {}
             model_params[AG_ARGS_FIT].update(extra_ag_args_fit.copy())  # TODO: Consider case of overwriting user specified extra args.
         model_init = model_type(path=path, name=name, problem_type=problem_type, eval_metric=eval_metric, stopping_metric=stopping_metric, num_classes=num_classes, hyperparameters=model_params)
+
+        if stacker_kwargs is not None:
+            stacker_kwargs_model = copy.deepcopy(stacker_kwargs)
+            stacker_kwargs_model_extra = copy.deepcopy(model[AG_ARGS_STACK])
+            stacker_kwargs_model_extra.pop('valid_stacker', None)
+            stacker_kwargs_model.update(stacker_kwargs_model_extra)
+            model_init = stacker_type(path=path, name=name_stacker, model_base=model_init, num_classes=num_classes, **stacker_kwargs_model)
+
         models.append(model_init)
 
     return models

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from sklearn.linear_model import LogisticRegression, LinearRegression
 
 from autogluon.core.metrics import soft_log_loss, mean_squared_error
-from autogluon.core.constants import AG_ARGS, AG_ARGS_FIT, AG_ARGS_STACK, BINARY, MULTICLASS,\
+from autogluon.core.constants import AG_ARGS, AG_ARGS_FIT, AG_ARGS_ENSEMBLE, BINARY, MULTICLASS,\
     REGRESSION, SOFTCLASS, PROBLEM_TYPES_CLASSIFICATION
 from ...models.abstract.abstract_model import AbstractModel
 from ...models.fastainn.tabular_nn_fastai import NNFastAiTabularModel
@@ -118,7 +118,7 @@ DEFAULT_MODEL_TYPE_SUFFIX['regressor'].update({LinearModel: ''})
 # TODO: Add option to update hyperparameters with only added keys, so disabling CatBoost would just be {'CAT': []}, which keeps the other models as is.
 # TODO: special optional AG arg for only training model if eval_metric in list / not in list. Useful for F1 and 'is_unbalanced' arg in LGBM.
 def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping_metric=None, num_classes=None, hyperparameter_tune=False,
-                      level: int = 0, stacker_type=StackerEnsembleModel, stacker_kwargs: dict = None, extra_ag_args_fit=None, extra_ag_args=None, extra_ag_args_stack=None,
+                      level: int = 0, ensemble_type=StackerEnsembleModel, ensemble_kwargs: dict = None, extra_ag_args_fit=None, extra_ag_args=None, extra_ag_args_ensemble=None,
                       name_suffix: str = None, default_priorities=None, invalid_model_names: list = None):
     if problem_type not in [BINARY, MULTICLASS, REGRESSION, SOFTCLASS]:
         raise NotImplementedError
@@ -138,20 +138,33 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
             model = copy.deepcopy(model)
             if AG_ARGS not in model:
                 model[AG_ARGS] = dict()
-            if AG_ARGS_STACK not in model:
-                model[AG_ARGS_STACK] = dict()
-            if extra_ag_args is not None:
-                model[AG_ARGS].update(extra_ag_args.copy())
-            if extra_ag_args_stack is not None:
-                model[AG_ARGS_STACK].update(extra_ag_args_stack.copy())
+            if AG_ARGS_ENSEMBLE not in model:
+                model[AG_ARGS_ENSEMBLE] = dict()
             if 'model_type' not in model[AG_ARGS]:
                 model[AG_ARGS]['model_type'] = model_type
+            model_type_real = model[AG_ARGS]['model_type']
+            if not inspect.isclass(model_type_real):
+                model_type_real = MODEL_TYPES[model_type_real]
+            default_ag_args = model_type_real._get_default_ag_args()
+            if extra_ag_args is not None:
+                model_extra_ag_args = extra_ag_args.copy()
+                model_extra_ag_args.update(model[AG_ARGS])
+                model[AG_ARGS] = model_extra_ag_args
+            if extra_ag_args_ensemble is not None:
+                model_extra_ag_args_ensemble = extra_ag_args_ensemble.copy()
+                model_extra_ag_args_ensemble.update(model[AG_ARGS_ENSEMBLE])
+                model[AG_ARGS_ENSEMBLE] = model_extra_ag_args_ensemble
+            if default_ag_args is not None:
+                default_ag_args.update(model[AG_ARGS])
+                model[AG_ARGS] = default_ag_args
             model_priority = model[AG_ARGS].get('priority', default_priorities.get(model_type, DEFAULT_CUSTOM_MODEL_PRIORITY))
             # Check if model is valid
             if hyperparameter_tune and model[AG_ARGS].get('disable_in_hpo', False):
                 continue  # Not valid
-            elif stacker_kwargs is not None and not model[AG_ARGS_STACK].get('valid_stacker', True) and level > 0:
-                continue  # Not valid as a stacker
+            elif not model[AG_ARGS].get('valid_stacker', True) and level > 0:
+                continue  # Not valid as a stacker model
+            elif not model[AG_ARGS].get('valid_base', True) and level == 0:
+                continue  # Not valid as a base model
             priority_dict[model_priority].append(model)
     model_priority_list = [model for priority in sorted(priority_dict.keys(), reverse=True) for model in priority_dict[priority]]
     model_names_set = set()
@@ -181,7 +194,7 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
         name = name_orig
         name_stacker = None
         num_increment = 2
-        if stacker_kwargs is None:
+        if ensemble_kwargs is None:
             while name in model_names_set:  # Ensure name is unique
                 name = f'{name_orig}_{num_increment}'
                 num_increment += 1
@@ -195,19 +208,19 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
             model_names_set.add(name_stacker)
         model_params = copy.deepcopy(model)
         model_params.pop(AG_ARGS)
-        model_params.pop(AG_ARGS_STACK)
+        model_params.pop(AG_ARGS_ENSEMBLE)
         if extra_ag_args_fit is not None:
             if AG_ARGS_FIT not in model_params:
                 model_params[AG_ARGS_FIT] = {}
             model_params[AG_ARGS_FIT].update(extra_ag_args_fit.copy())  # TODO: Consider case of overwriting user specified extra args.
         model_init = model_type(path=path, name=name, problem_type=problem_type, eval_metric=eval_metric, stopping_metric=stopping_metric, num_classes=num_classes, hyperparameters=model_params)
 
-        if stacker_kwargs is not None:
-            stacker_kwargs_model = copy.deepcopy(stacker_kwargs)
-            stacker_kwargs_model_extra = copy.deepcopy(model[AG_ARGS_STACK])
-            stacker_kwargs_model_extra.pop('valid_stacker', None)
-            stacker_kwargs_model.update(stacker_kwargs_model_extra)
-            model_init = stacker_type(path=path, name=name_stacker, model_base=model_init, num_classes=num_classes, **stacker_kwargs_model)
+        if ensemble_kwargs is not None:
+            ensemble_kwargs_model = copy.deepcopy(ensemble_kwargs)
+            extra_ensemble_hyperparameters = copy.deepcopy(model[AG_ARGS_ENSEMBLE])
+            ensemble_kwargs_model['hyperparameters'] = ensemble_kwargs_model.get('hyperparameters', {})
+            ensemble_kwargs_model['hyperparameters'].update(extra_ensemble_hyperparameters)
+            model_init = ensemble_type(path=path, name=name_stacker, model_base=model_init, num_classes=num_classes, **ensemble_kwargs_model)
 
         models.append(model_init)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added functionality to specify that a model should not be used as a stacker and that a model should not use the original features.

Example:

```
hyperparameters = {
    'GBM': [
        # Normal model
        {},

        # Will train in the first level but will not train in stack levels (level > 0)
        {'AG_args': {'valid_stacker': False}},

        # Will not train in the first level but will train in stack levels (level > 0)
        {'AG_args': {'valid_base': False}},

        # Will use original features in the first level but will not use original features in stack levels (level > 0) and instead only use OOF features.
        {'AG_args_ensemble': {'use_orig_features': False}}
    ],
}
```

TODO:

- [ ] Add unit test
- [ ] Add documentation + argument to task.fit
- [x] Add ability for models to have default AG_ARGS values without specifying in hyperparameters dict (such as BERT defaulting to `'valid_stacker'=False`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
