### PR TITLE
Tabular: Added AG_args and AG_args_ensemble arguments to task.fit

### DIFF
--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -32,8 +32,7 @@ class DefaultLearner(AbstractLearner):
         self._time_fit_training = None
         self._time_limit = None
 
-    # TODO: Add trainer_kwargs to simplify parameter count and extensibility
-
+    # TODO: v0.1 Document trainer_fit_kwargs
     def _fit(self, X: DataFrame, X_val: DataFrame = None, X_unlabeled: DataFrame = None, scheduler_options=None, holdout_frac=0.1,
              num_bagging_folds=0, num_bagging_sets=1, time_limit=None, save_data=False, save_bagged_folds=True, verbosity=2, **trainer_fit_kwargs):
         """ Arguments:

--- a/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
@@ -52,15 +52,10 @@ class StackerEnsembleModel(BaggedEnsembleModel):
     def limit_models_per_type(models, model_types, model_scores, max_base_models_per_type):
         model_type_groups = defaultdict(list)
         for model in models:
-            model_type = model_types[model]
-            model_type_groups[model_type].append((model, model_scores[model]))
-        for key in model_type_groups:
-            model_type_groups[key] = sorted(model_type_groups[key], key=lambda x: x[1], reverse=True)
-        for key in model_type_groups:
-            model_type_groups[key] = model_type_groups[key][:max_base_models_per_type]
+            model_type_groups[model_types[model]].append((model, model_scores[model]))
         models_remain = []
         for key in model_type_groups:
-            models_remain += model_type_groups[key]
+            models_remain += sorted(model_type_groups[key], key=lambda x: x[1], reverse=True)[:max_base_models_per_type]
         models_valid = [model for model, score in models_remain]
         return models_valid
 

--- a/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/stacker_ensemble_model.py
@@ -35,10 +35,10 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         self.base_model_types_dict = base_model_types_dict
 
         if (base_model_performances_dict is not None) and (base_model_types_inner_dict is not None):
-            if self.params['max_models_per_type'] > 0:
-                self.base_model_names = self.limit_models_per_type(models=self.base_model_names, model_types=base_model_types_inner_dict, model_scores=base_model_performances_dict, max_models_per_type=self.params['max_models_per_type'])
-            if self.params['max_models'] > 0:
-                self.base_model_names = self.limit_models(models=self.base_model_names, model_scores=base_model_performances_dict, max_models=self.params['max_models'])
+            if self.params['max_base_models_per_type'] > 0:
+                self.base_model_names = self.limit_models_per_type(models=self.base_model_names, model_types=base_model_types_inner_dict, model_scores=base_model_performances_dict, max_base_models_per_type=self.params['max_base_models_per_type'])
+            if self.params['max_base_models'] > 0:
+                self.base_model_names = self.limit_models(models=self.base_model_names, model_scores=base_model_performances_dict, max_base_models=self.params['max_base_models'])
 
         for model_name, model in self.base_models_dict.items():
             if model_name not in self.base_model_names:
@@ -49,7 +49,7 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         self.stack_column_prefix_to_model_map = {stack_column_prefix: self.base_model_names[i] for i, stack_column_prefix in enumerate(self.stack_column_prefix_lst)}
 
     @staticmethod
-    def limit_models_per_type(models, model_types, model_scores, max_models_per_type):
+    def limit_models_per_type(models, model_types, model_scores, max_base_models_per_type):
         model_type_groups = defaultdict(list)
         for model in models:
             model_type = model_types[model]
@@ -57,19 +57,19 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         for key in model_type_groups:
             model_type_groups[key] = sorted(model_type_groups[key], key=lambda x: x[1], reverse=True)
         for key in model_type_groups:
-            model_type_groups[key] = model_type_groups[key][:max_models_per_type]
+            model_type_groups[key] = model_type_groups[key][:max_base_models_per_type]
         models_remain = []
         for key in model_type_groups:
             models_remain += model_type_groups[key]
         models_valid = [model for model, score in models_remain]
         return models_valid
 
-    def limit_models(self, models, model_scores, max_models):
+    def limit_models(self, models, model_scores, max_base_models):
         model_types = {model: '' for model in models}
-        return self.limit_models_per_type(models=models, model_types=model_types, model_scores=model_scores, max_models_per_type=max_models)
+        return self.limit_models_per_type(models=models, model_types=model_types, model_scores=model_scores, max_base_models_per_type=max_base_models)
 
     def _set_default_params(self):
-        default_params = {'max_models': 25, 'max_models_per_type': 5, 'use_orig_features': True}
+        default_params = {'use_orig_features': True, 'max_base_models': 25, 'max_base_models_per_type': 5}
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
         super()._set_default_params()

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
@@ -354,7 +354,7 @@ class TabularPredictor(BasePredictor):
             'model_fit_times': self._trainer.get_models_attribute_dict('fit_time'),
             'model_pred_times': self._trainer.get_models_attribute_dict('predict_time'),
             'num_bagging_folds': self._trainer.k_fold,
-            'stack_ensemble_levels': self._trainer.stack_ensemble_levels,
+            'max_stack_level': self._trainer.get_max_level(),
             'feature_prune': self._trainer.feature_prune,
             'hyperparameter_tune': hpo_used,
             'hyperparameters_userspecified': self._trainer.hyperparameters,
@@ -386,10 +386,10 @@ class TabularPredictor(BasePredictor):
                 num_fold_str = f" (with {results['num_bagging_folds']} folds)"
             print("Bagging used: %s %s" % (bagging_used, num_fold_str))
             num_stack_str = ""
-            stacking_used = results['stack_ensemble_levels'] > 0
+            stacking_used = results['max_stack_level'] > 1  # TODO: v0.1 increment by 1 when refactoring level names
             if stacking_used:
-                num_stack_str = f" (with {results['stack_ensemble_levels']} levels)"
-            print("Stack-ensembling used: %s %s" % (stacking_used, num_stack_str))
+                num_stack_str = f" (with {results['max_stack_level']} levels)"
+            print("Multi-layer stack-ensembling used: %s %s" % (stacking_used, num_stack_str))
             hpo_str = ""
             if hpo_used and verbosity <= 2:
                 hpo_str = " (call fit_summary() with verbosity >= 3 to see detailed HPO info)"

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -278,10 +278,10 @@ class TabularPrediction(BaseTask):
                             min_time_limit: (float, default=0) Allow this model to train for at least this long (in sec), regardless of the time limit it would otherwise be granted.
                                 If `min_time_limit >= max_time_limit`, time_limit will be set to min_time_limit.
                                 If `min_time_limit=None`, time_limit will be set to None and the model will have no training time restriction.
-                    AG_args_ensemble: Dictionary of ensemble customization options. Only models in stack levels >=1 are impacted by these parameters.
+                    AG_args_ensemble: Dictionary of hyperparameters shared by all models that control how they are ensembled. Only models in stack levels >=1 are impacted by these parameters.
                         Valid keys:
                             use_orig_features: (bool) Whether a stack model will use the original features along with the stack features to train (akin to skip-connections). If the model has no stack features (no base models), this value is ignored and the stack model will use the original features.
-                            max_base_models: (int, default=25) Maximum number of base models to use when generating stack features. If more than `max_base_models` base models are available, only the top `max_base_models` models with highest validation score are used.
+                            max_base_models: (int, default=25) Maximum number of base models whose predictions form the features input to this stacker model. If more than `max_base_models` base models are available, only the top `max_base_models` models with highest validation score are used.
                             max_base_models_per_type: (int, default=5) Similar to `max_base_models`. If more than `max_base_models_per_type` of any particular model type are available, only the top `max_base_models_per_type` of that type are used. This occurs before the `max_base_models` filter.
 
         holdout_frac : float, default = None
@@ -318,15 +318,18 @@ class TabularPrediction(BaseTask):
 
         Kwargs can include additional arguments for advanced users:
             AG_args : dict, default={}
-                Keyword arguments to pass to all models. See the `AG_args` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
+                Keyword arguments to pass to all models (i.e. common hyperparameters shared by all AutoGluon models).
+                See the `AG_args` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
                 Identical to specifying `AG_args` parameter for all models in `hyperparameters`.
                 If a key in `AG_args` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
             AG_args_fit : dict, default={}
-                Keyword arguments to pass to all models. See the `AG_args_fit` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
+                Keyword arguments to pass to all models.
+                See the `AG_args_fit` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
                 Identical to specifying `AG_args_fit` parameter for all models in `hyperparameters`.
                 If a key in `AG_args_fit` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
             AG_args_ensemble : dict, default={}
-                Keyword arguments to pass to all models. See the `AG_args_ensemble` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
+                Keyword arguments to pass to all models.
+                See the `AG_args_ensemble` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
                 Identical to specifying `AG_args_ensemble` parameter for all models in `hyperparameters`.
                 If a key in `AG_args_ensemble` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
             excluded_model_types : list, default = []

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -69,9 +69,9 @@ class TabularPrediction(BaseTask):
             hyperparameter_tune=False,
             hyperparameters=None,
             holdout_frac=None,
-            num_bagging_folds=0,
+            num_bagging_folds=None,
             num_bagging_sets=None,
-            stack_ensemble_levels=0,
+            stack_ensemble_levels=None,
             num_trials=None,
             search_strategy='random',
             verbosity=2,
@@ -174,7 +174,8 @@ class TabularPrediction(BaseTask):
         auto_stack : bool, default = False
             Whether AutoGluon should automatically utilize bagging and multi-layer stack ensembling to boost predictive accuracy.
             Set this = True if you are willing to tolerate longer training times in order to maximize predictive accuracy!
-            Note: This overrides `num_bagging_folds` and `stack_ensemble_levels` arguments (selects optimal values for these parameters based on dataset properties).
+            Automatically sets `num_bagging_folds` and `stack_ensemble_levels` arguments based on dataset properties.
+            Note: Setting `num_bagging_folds` and `stack_ensemble_levels` arguments will override `auto_stack`.
             Note: This can increase training time (and inference time) by up to 20x, but can greatly improve predictive performance.
         hyperparameter_tune : bool, default = False
             Whether to tune hyperparameters or just use fixed hyperparameter values for each model. Setting as True will increase `fit()` runtimes.
@@ -236,13 +237,13 @@ class TabularPrediction(BaseTask):
                 }
 
             Details regarding the hyperparameters you can specify for each model are provided in the following files:
-                NN: `autogluon/utils/tabular/ml/models/tabular_nn/hyperparameters/parameters.py`
+                NN: `autogluon.tabular.models.tabular_nn.hyperparameters.parameters`
                     Note: certain hyperparameter settings may cause these neural networks to train much slower.
-                GBM: `autogluon/utils/tabular/ml/models/lgb/hyperparameters/parameters.py`
+                GBM: `autogluon.tabular.models.lgb.hyperparameters.parameters`
                      See also the lightGBM docs: https://lightgbm.readthedocs.io/en/latest/Parameters.html
-                CAT: `autogluon/utils/tabular/ml/models/catboost/hyperparameters/parameters.py`
+                CAT: `autogluon.tabular.models.catboost.hyperparameters.parameters`
                      See also the CatBoost docs: https://catboost.ai/docs/concepts/parameter-tuning.html
-                XGB: `autogluon/utils/tabular/ml/models/xgboost/hyperparameters/parameters.py`
+                XGB: `autogluon.tabular.models.xgboost.hyperparameters.parameters`
                      See also the XGBoost docs: https://xgboost.readthedocs.io/en/latest/parameter.html
                 RF: See sklearn documentation: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html
                     Note: Hyperparameter tuning is disabled for this model.
@@ -250,7 +251,7 @@ class TabularPrediction(BaseTask):
                     Note: Hyperparameter tuning is disabled for this model.
                 KNN: See sklearn documentation: https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html
                     Note: Hyperparameter tuning is disabled for this model.
-                LR: `autogluon/utils/tabular/ml/models/lr/hyperparameters/parameters.py`
+                LR: `autogluon.tabular.models.lr.hyperparameters.parameters`
                     Note: Hyperparameter tuning is disabled for this model.
                     Note: 'penalty' parameter can be used for regression to specify regularization method: 'L1' and 'L2' values are supported.
                 Advanced functionality: Custom AutoGluon model arguments
@@ -277,26 +278,32 @@ class TabularPrediction(BaseTask):
                             min_time_limit: (float, default=0) Allow this model to train for at least this long (in sec), regardless of the time limit it would otherwise be granted.
                                 If `min_time_limit >= max_time_limit`, time_limit will be set to min_time_limit.
                                 If `min_time_limit=None`, time_limit will be set to None and the model will have no training time restriction.
+                    AG_args_ensemble: Dictionary of ensemble customization options. Only models in stack levels >=1 are impacted by these parameters.
+                        Valid keys:
+                            use_orig_features: (bool) Whether a stack model will use the original features along with the stack features to train (akin to skip-connections). If the model has no stack features (no base models), this value is ignored and the stack model will use the original features.
+                            max_base_models: (int, default=25) Maximum number of base models to use when generating stack features. If more than `max_base_models` base models are available, only the top `max_base_models` models with highest validation score are used.
+                            max_base_models_per_type: (int, default=5) Similar to `max_base_models`. If more than `max_base_models_per_type` of any particular model type are available, only the top `max_base_models_per_type` of that type are used. This occurs before the `max_base_models` filter.
 
         holdout_frac : float, default = None
             Fraction of train_data to holdout as tuning data for optimizing hyperparameters (ignored unless `tuning_data = None`, ignored if `num_bagging_folds != 0`).
             Default value (if None) is selected based on the number of rows in the training data. Default values range from 0.2 at 2,500 rows to 0.01 at 250,000 rows.
             Default value is doubled if `hyperparameter_tune = True`, up to a maximum of 0.2.
             Disabled if `num_bagging_folds >= 2`.
-        num_bagging_folds : int, default = 0
+        num_bagging_folds : int, default = None
             Number of folds used for bagging of models. When `num_bagging_folds = k`, training time is roughly increased by a factor of `k` (set = 0 to disable bagging).
-            Disabled by default, but we recommend values between 5-10 to maximize predictive performance.
+            Disabled by default (0), but we recommend values between 5-10 to maximize predictive performance.
             Increasing num_bagging_folds will result in models with lower bias but that are more prone to overfitting.
+            `num_bagging_folds = 1` is an invalid value, and will raise a ValueError.
             Values > 10 may produce diminishing returns, and can even harm overall results due to overfitting.
             To further improve predictions, avoid increasing num_bagging_folds much beyond 10 and instead increase num_bagging_sets.
         num_bagging_sets : int, default = None
             Number of repeats of kfold bagging to perform (values must be >= 1). Total number of models trained during bagging = num_bagging_folds * num_bagging_sets.
             Defaults to 1 if time_limits is not specified, otherwise 20 (always disabled if num_bagging_folds is not specified).
             Values greater than 1 will result in superior predictive performance, especially on smaller problems and with stacking enabled (reduces overall variance).
-        stack_ensemble_levels : int, default = 0
+        stack_ensemble_levels : int, default = None
             Number of stacking levels to use in stack ensemble. Roughly increases model training time by factor of `stack_ensemble_levels+1` (set = 0 to disable stack ensembling).
-            Disabled by default, but we recommend values between 1-3 to maximize predictive performance.
-            To prevent overfitting, this argument is ignored unless you have also set `num_bagging_folds >= 2`.
+            Disabled by default (0), but we recommend values between 1-3 to maximize predictive performance.
+            To prevent overfitting, `num_bagging_folds >= 2` must also be set or else a ValueError will be raised.
         num_trials : int, default = None
             Maximal number of different hyperparameter settings of each model type to evaluate during HPO (only matters if `hyperparameter_tune = True`).
             If both `time_limits` and `num_trials` are specified, `time_limits` takes precedent.
@@ -310,10 +317,18 @@ class TabularPrediction(BaseTask):
             where `L` ranges from 0 to 50 (Note: higher values of `L` correspond to fewer print statements, opposite of verbosity levels)
 
         Kwargs can include additional arguments for advanced users:
+            AG_args : dict, default={}
+                Keyword arguments to pass to all models. See the `AG_args` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
+                Identical to specifying `AG_args` parameter for all models in `hyperparameters`.
+                If a key in `AG_args` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
             AG_args_fit : dict, default={}
                 Keyword arguments to pass to all models. See the `AG_args_fit` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
                 Identical to specifying `AG_args_fit` parameter for all models in `hyperparameters`.
                 If a key in `AG_args_fit` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
+            AG_args_ensemble : dict, default={}
+                Keyword arguments to pass to all models. See the `AG_args_ensemble` argument from "Advanced functionality: Custom AutoGluon model arguments" in the `hyperparameters` argument documentation for valid values.
+                Identical to specifying `AG_args_ensemble` parameter for all models in `hyperparameters`.
+                If a key in `AG_args_ensemble` is already specified for a model in `hyperparameters`, it will not be altered through this argument.
             excluded_model_types : list, default = []
                 Banned subset of model types to avoid training during `fit()`, even if present in `hyperparameters`.
                 Valid values: ['RF', 'XT', 'KNN', 'GBM', 'CAT', 'NN', 'LR', 'custom']. Reference `hyperparameters` documentation for what models correspond to each value.
@@ -479,7 +494,9 @@ class TabularPrediction(BaseTask):
         allowed_kwarg_names = {
             'feature_generator',
             'trainer_type',
+            'AG_args',
             'AG_args_fit',
+            'AG_args_ensemble',
             'excluded_model_types',
             'label_count_threshold',
             'id_columns',
@@ -584,7 +601,9 @@ class TabularPrediction(BaseTask):
         feature_generator = kwargs.get('feature_generator', AutoMLPipelineFeatureGenerator(**_feature_generator_kwargs))
         id_columns = kwargs.get('id_columns', [])
         trainer_type = kwargs.get('trainer_type', AutoTrainer)
-        ag_args_fit = kwargs.get('AG_args_fit', {})
+        ag_args = kwargs.get('AG_args', None)
+        ag_args_fit = kwargs.get('AG_args_fit', None)
+        ag_args_ensemble = kwargs.get('AG_args_ensemble', None)
         excluded_model_types = kwargs.get('excluded_model_types', [])
         random_seed = kwargs.get('random_seed', 0)
         nthreads_per_trial, ngpus_per_trial = setup_compute(nthreads_per_trial, ngpus_per_trial)
@@ -592,21 +611,36 @@ class TabularPrediction(BaseTask):
         if auto_stack:
             # TODO: What about datasets that are 100k+? At a certain point should we not bag?
             # TODO: What about time_limits? Metalearning can tell us expected runtime of each model, then we can select optimal folds + stack levels to fit time constraint
-            num_bagging_folds = min(10, max(5, math.floor(num_train_rows / 100)))
-            stack_ensemble_levels = min(1, max(0, math.floor(num_train_rows / 750)))
-
+            if num_bagging_folds is None:
+                num_bagging_folds = min(10, max(5, math.floor(num_train_rows / 100)))
+            if stack_ensemble_levels is None:
+                stack_ensemble_levels = min(1, max(0, math.floor(num_train_rows / 750)))
+        if num_bagging_folds is None:
+            num_bagging_folds = 0
+        if stack_ensemble_levels is None:
+            stack_ensemble_levels = 0
+        if not isinstance(num_bagging_folds, int):
+            raise ValueError(f'num_bagging_folds must be an integer. (num_bagging_folds={num_bagging_folds})')
+        if not isinstance(stack_ensemble_levels, int):
+            raise ValueError(f'stack_ensemble_levels must be an integer. (stack_ensemble_levels={stack_ensemble_levels})')
+        if num_bagging_folds < 2 and num_bagging_folds != 0:
+            raise ValueError(f'num_bagging_folds must be equal to 0 or >=2. (num_bagging_folds={num_bagging_folds})')
+        if stack_ensemble_levels != 0 and num_bagging_folds == 0:
+            raise ValueError(f'stack_ensemble_levels must be 0 if num_bagging_folds is 0. (stack_ensemble_levels={stack_ensemble_levels}, num_bagging_folds={num_bagging_folds})')
         if num_bagging_sets is None:
             if num_bagging_folds >= 2:
                 if time_limits is not None:
-                    num_bagging_sets = 20
+                    num_bagging_sets = 20  # TODO: v0.1 Reduce to 5 or 3 as 20 is unnecessarily extreme as a default.
                 else:
                     num_bagging_sets = 1
             else:
                 num_bagging_sets = 1
+        if not isinstance(num_bagging_sets, int):
+            raise ValueError(f'num_bagging_sets must be an integer. (num_bagging_sets={num_bagging_sets})')
 
         label_count_threshold = kwargs.get('label_count_threshold', 10)
-        if num_bagging_folds is not None:  # Ensure there exist sufficient labels for stratified splits across all bags
-            label_count_threshold = max(label_count_threshold, num_bagging_folds)
+        # Ensure there exist sufficient labels for stratified splits across all bags
+        label_count_threshold = max(label_count_threshold, num_bagging_folds)
 
         time_limits_orig = copy.deepcopy(time_limits)
         time_limits_hpo = copy.deepcopy(time_limits)
@@ -653,7 +687,8 @@ class TabularPrediction(BaseTask):
         learner.fit(X=train_data, X_val=tuning_data, X_unlabeled=unlabeled_data, scheduler_options=scheduler_options,
                     hyperparameter_tune=hyperparameter_tune, feature_prune=feature_prune,
                     holdout_frac=holdout_frac, num_bagging_folds=num_bagging_folds, num_bagging_sets=num_bagging_sets, stack_ensemble_levels=stack_ensemble_levels,
-                    hyperparameters=hyperparameters, ag_args_fit=ag_args_fit, excluded_model_types=excluded_model_types, time_limit=time_limits_orig, save_data=cache_data, save_bagged_folds=save_bagged_folds, verbosity=verbosity)
+                    hyperparameters=hyperparameters, ag_args=ag_args, ag_args_fit=ag_args_fit, ag_args_ensemble=ag_args_ensemble, excluded_model_types=excluded_model_types,
+                    time_limit=time_limits_orig, save_data=cache_data, save_bagged_folds=save_bagged_folds, verbosity=verbosity)
 
         predictor = TabularPredictor(learner=learner)
 

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -21,9 +21,13 @@ class AutoTrainer(AbstractTrainer):
                                  num_classes=num_classes, hyperparameters=hyperparameters, invalid_model_names=invalid_model_names, **kwargs)
 
     # TODO: rename to .fit for 0.1
-    def train(self, X_train, y_train, X_val=None, y_val=None, X_unlabeled=None, hyperparameter_tune=False, feature_prune=False, holdout_frac=0.1, hyperparameters=None, ag_args_fit=None, excluded_model_types=None, time_limit=None, **kwargs):
+    def train(self, X_train, y_train, X_val=None, y_val=None, X_unlabeled=None, hyperparameter_tune=False, feature_prune=False, holdout_frac=0.1, stack_ensemble_levels=0, hyperparameters=None, ag_args=None, ag_args_fit=None, ag_args_ensemble=None, excluded_model_types=None, time_limit=None, **kwargs):
+        for key in kwargs:
+            logger.warning(f'Warning: Unknown argument passed to `AutoTrainer.train()`. Argument: {key}')
+
         if hyperparameters is None:
             hyperparameters = {}
+        # TODO: v0.1 self.hyperparmeters is not consistent in repeated calls (re-uses ag_args_fit but not ag_args or ag_args_ensemble)
         self.hyperparameters = self._process_hyperparameters(hyperparameters=hyperparameters, ag_args_fit=ag_args_fit, excluded_model_types=excluded_model_types)
 
         if self.bagged_mode:
@@ -37,4 +41,8 @@ class AutoTrainer(AbstractTrainer):
         else:
             if (y_val is None) or (X_val is None):
                 X_train, X_val, y_train, y_val = generate_train_test_split(X_train, y_train, problem_type=self.problem_type, test_size=holdout_frac, random_state=self.random_seed)
-        self._train_multi_and_ensemble(X_train, y_train, X_val, y_val, X_unlabeled=X_unlabeled, hyperparameters=self.hyperparameters, hyperparameter_tune=hyperparameter_tune, feature_prune=feature_prune, time_limit=time_limit)
+
+        core_kwargs = {'extra_ag_args': ag_args, 'extra_ag_args_ensemble': ag_args_ensemble}
+        self._train_multi_and_ensemble(X_train, y_train, X_val, y_val, X_unlabeled=X_unlabeled, hyperparameters=self.hyperparameters,
+                                       hyperparameter_tune=hyperparameter_tune, feature_prune=feature_prune,
+                                       stack_ensemble_levels=stack_ensemble_levels, time_limit=time_limit, core_kwargs=core_kwargs)

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -138,6 +138,12 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
                 model_extra_ag_args_ensemble = extra_ag_args_ensemble.copy()
                 model_extra_ag_args_ensemble.update(model[AG_ARGS_ENSEMBLE])
                 model[AG_ARGS_ENSEMBLE] = model_extra_ag_args_ensemble
+            if extra_ag_args_fit is not None:
+                if AG_ARGS_FIT not in model:
+                    model[AG_ARGS_FIT] = dict()
+                model_extra_ag_args_fit = extra_ag_args_fit.copy()
+                model_extra_ag_args_fit.update(model[AG_ARGS_FIT])
+                model[AG_ARGS_FIT] = model_extra_ag_args_fit
             if default_ag_args is not None:
                 default_ag_args.update(model[AG_ARGS])
                 model[AG_ARGS] = default_ag_args
@@ -189,10 +195,6 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, stopping
         model_params = copy.deepcopy(model)
         model_params.pop(AG_ARGS)
         model_params.pop(AG_ARGS_ENSEMBLE)
-        if extra_ag_args_fit is not None:
-            if AG_ARGS_FIT not in model_params:
-                model_params[AG_ARGS_FIT] = {}
-            model_params[AG_ARGS_FIT].update(extra_ag_args_fit.copy())  # TODO: Consider case of overwriting user specified extra args.
         model_init = model_type(path=path, name=name, problem_type=problem_type, eval_metric=eval_metric, stopping_metric=stopping_metric, num_classes=num_classes, hyperparameters=model_params)
 
         if ensemble_kwargs is not None:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added `AG_args` and `AG_args_ensemble` arguments to task.fit, this allows users to do interesting things like disable stackers from using original features (only use stack features) via `AG_args_ensemble={'use_orig_features': False}`, or give all models a prefix in their name via `AG_args={'name_prefix': 'CustomPrefix_'}`.
- Fixed `unlabeled_data` error during stack ensembling.
- Enabled user overrides for `stack_ensemble_levels` and `num_bagging_folds` when `presets` or `auto_stack` are enabled (previously was confusing as user values were being silently ignored in these cases).
- Improved sanity checking for `stack_ensemble_levels` and `num_bagging_folds` values and compatibility (e.g. `stack_ensemble_levels` cannot be 1 if `num_bagging_folds` is 0).
- Fixed docstring file location hints to be aligned with post-modularization file locations.
- Cleaned Trainer by avoiding having a `self.stack_ensemble_levels` variable when it was not necessary (nor accurate after fit_extra is added).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
