### PR TITLE
Tabular: Optimize feature importance

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -2,15 +2,14 @@ import copy
 from abc import ABCMeta, abstractmethod
 from functools import partial
 
-import numpy as np
 import sklearn.metrics
-from sklearn.utils.multiclass import type_of_target
 
 from . import classification_metrics, softclass_metrics
 from .util import sanitize_array
 from ..constants import PROBLEM_TYPES, PROBLEM_TYPES_REGRESSION, PROBLEM_TYPES_CLASSIFICATION
 from autogluon.core.utils.miscs import warning_filter
 from .classification_metrics import *
+
 
 class Scorer(object, metaclass=ABCMeta):
     def __init__(self, name, score_func, optimum, sign, kwargs):
@@ -28,19 +27,24 @@ class Scorer(object, metaclass=ABCMeta):
         return self.name
 
     def sklearn_scorer(self):
-        if isinstance(self, _ProbaScorer):
-            needs_proba = True
-            needs_threshold = False
-        elif isinstance(self, _ThresholdScorer):
-            needs_proba = False
-            needs_threshold = True
-        else:
-            needs_proba = False
-            needs_threshold = False
-
         with warning_filter():
-            ret = sklearn.metrics.scorer.make_scorer(score_func=self, greater_is_better=True, needs_proba=needs_proba, needs_threshold=needs_threshold)
+            ret = sklearn.metrics.scorer.make_scorer(score_func=self, greater_is_better=True, needs_proba=self.needs_proba, needs_threshold=self.needs_threshold)
         return ret
+
+    @property
+    @abstractmethod
+    def needs_pred(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def needs_proba(self) -> bool:
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def needs_threshold(self) -> bool:
+        raise NotImplementedError
 
 
 class _PredictScorer(Scorer):
@@ -88,6 +92,18 @@ class _PredictScorer(Scorer):
             return self._sign * self._score_func(y_true, y_pred,
                                                  **self._kwargs)
 
+    @property
+    def needs_pred(self):
+        return True
+
+    @property
+    def needs_proba(self):
+        return False
+
+    @property
+    def needs_threshold(self):
+        return False
+
 
 class _ProbaScorer(Scorer):
     def __call__(self, y_true, y_pred, sample_weight=None):
@@ -115,6 +131,18 @@ class _ProbaScorer(Scorer):
                                                  **self._kwargs)
         else:
             return self._sign * self._score_func(y_true, y_pred, **self._kwargs)
+
+    @property
+    def needs_pred(self):
+        return False
+
+    @property
+    def needs_proba(self):
+        return True
+
+    @property
+    def needs_threshold(self):
+        return False
 
 
 class _ThresholdScorer(Scorer):
@@ -157,6 +185,18 @@ class _ThresholdScorer(Scorer):
                                                  **self._kwargs)
         else:
             return self._sign * self._score_func(y_true, y_pred, **self._kwargs)
+
+    @property
+    def needs_pred(self):
+        return False
+
+    @property
+    def needs_proba(self):
+        return False
+
+    @property
+    def needs_threshold(self):
+        return True
 
 
 def scorer_expects_y_pred(scorer: Scorer):

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -420,7 +420,7 @@ class AbstractLearner:
     # model: model (str) to get feature importances for, if None will choose best model.
     # features: list of feature names that feature importances are calculated for and returned, specify None to get all feature importances.
     # feature_stage: Whether to compute feature importance on raw original features ('original'), transformed features ('transformed') or on the features used by the particular model ('transformed_model').
-    def get_feature_importance(self, model=None, X=None, y=None, features: list = None, feature_stage='original', subsample_size=1000, silent=False, **kwargs) -> (Series, Series, Series):
+    def get_feature_importance(self, model=None, X=None, y=None, features: list = None, feature_stage='original', subsample_size=1000, silent=False, **kwargs) -> DataFrame:
         valid_feature_stages = ['original', 'transformed', 'transformed_model']
         if feature_stage not in valid_feature_stages:
             raise ValueError(f'feature_stage must be one of: {valid_feature_stages}, but was {feature_stage}.')

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -420,8 +420,8 @@ class AbstractLearner:
     # model: model (str) to get feature importances for, if None will choose best model.
     # features: list of feature names that feature importances are calculated for and returned, specify None to get all feature importances.
     # feature_stage: Whether to compute feature importance on raw original features ('original'), transformed features ('transformed') or on the features used by the particular model ('transformed_model').
-    def get_feature_importance(self, model=None, X=None, y=None, features: list = None, feature_stage='original', subsample_size=1000, silent=False) -> Series:
-        valid_feature_stages = ['original', 'original_legacy', 'transformed', 'transformed_model']
+    def get_feature_importance(self, model=None, X=None, y=None, features: list = None, feature_stage='original', subsample_size=1000, silent=False, **kwargs) -> (Series, Series, Series):
+        valid_feature_stages = ['original', 'transformed', 'transformed_model']
         if feature_stage not in valid_feature_stages:
             raise ValueError(f'feature_stage must be one of: {valid_feature_stages}, but was {feature_stage}.')
         trainer = self.load_trainer()
@@ -431,18 +431,15 @@ class AbstractLearner:
             y = self.label_cleaner.transform(y)
             X, y = self._remove_nan_label_rows(X, y)
 
-            # TODO: Remove original_legacy
-            if feature_stage == 'original_legacy':
-                return trainer._get_feature_importance_raw_legacy(model=model, X=X, y=y, features_to_use=features, subsample_size=subsample_size, transform_func=self.transform_features, silent=silent)
-            elif feature_stage == 'original':
-                return trainer._get_feature_importance_raw(model=model, X=X, y=y, features_to_use=features, subsample_size=subsample_size, transform_func=self.transform_features, silent=silent)
+            if feature_stage == 'original':
+                return trainer._get_feature_importance_raw(model=model, X=X, y=y, features=features, subsample_size=subsample_size, transform_func=self.transform_features, silent=silent, **kwargs)
             X = self.transform_features(X)
         else:
             if feature_stage == 'original':
                 raise AssertionError('Feature importance `dataset` cannot be None if `feature_stage==\'original\'`. A test dataset must be specified.')
             y = None
         raw = feature_stage == 'transformed'
-        return trainer.get_feature_importance(X=X, y=y, model=model, features=features, raw=raw, subsample_size=subsample_size, silent=silent)
+        return trainer.get_feature_importance(X=X, y=y, model=model, features=features, raw=raw, subsample_size=subsample_size, silent=silent, **kwargs)
 
     @staticmethod
     def _remove_nan_label_rows(X, y):

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -421,7 +421,7 @@ class AbstractLearner:
     # features: list of feature names that feature importances are calculated for and returned, specify None to get all feature importances.
     # feature_stage: Whether to compute feature importance on raw original features ('original'), transformed features ('transformed') or on the features used by the particular model ('transformed_model').
     def get_feature_importance(self, model=None, X=None, y=None, features: list = None, feature_stage='original', subsample_size=1000, silent=False) -> Series:
-        valid_feature_stages = ['original', 'transformed', 'transformed_model']
+        valid_feature_stages = ['original', 'original_legacy', 'transformed', 'transformed_model']
         if feature_stage not in valid_feature_stages:
             raise ValueError(f'feature_stage must be one of: {valid_feature_stages}, but was {feature_stage}.')
         trainer = self.load_trainer()
@@ -431,7 +431,10 @@ class AbstractLearner:
             y = self.label_cleaner.transform(y)
             X, y = self._remove_nan_label_rows(X, y)
 
-            if feature_stage == 'original':
+            # TODO: Remove original_legacy
+            if feature_stage == 'original_legacy':
+                return trainer._get_feature_importance_raw_legacy(model=model, X=X, y=y, features_to_use=features, subsample_size=subsample_size, transform_func=self.transform_features, silent=silent)
+            elif feature_stage == 'original':
                 return trainer._get_feature_importance_raw(model=model, X=X, y=y, features_to_use=features, subsample_size=subsample_size, transform_func=self.transform_features, silent=silent)
             X = self.transform_features(X)
         else:

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -410,7 +410,7 @@ class AbstractModel:
         fi_df = self.compute_permutation_importance(X=X, y=y, features=features_to_check, silent=silent, **kwargs)
 
         results_banned = pd.Series(data=[0 for _ in range(len(banned_features))], index=banned_features, dtype='float64')
-        results_banned_z_score = pd.Series(data=[None for _ in range(len(banned_features))], index=banned_features, dtype='float64')
+        results_banned_z_score = pd.Series(data=[np.nan for _ in range(len(banned_features))], index=banned_features, dtype='float64')
         results_banned_df = results_banned.to_frame(name='importance')
         results_banned_df['stddev'] = results_banned
         results_banned_df['z_score'] = results_banned_z_score

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -34,7 +34,7 @@ class CatBoostModel(AbstractModel):
         # Set 'allow_writing_files' to True in order to keep log files created by catboost during training (these will be saved in the directory where AutoGluon stores this model)
         self._set_default_param_value('allow_writing_files', False)  # Disables creation of catboost logging files during training by default
         if self.problem_type != SOFTCLASS:  # TODO: remove this after catboost 0.24
-            self._set_default_param_value('eval_metric', construct_custom_catboost_metric(self.stopping_metric, True, not self.stopping_metric_needs_y_pred, self.problem_type))
+            self._set_default_param_value('eval_metric', construct_custom_catboost_metric(self.stopping_metric, True, not self.stopping_metric.needs_pred, self.problem_type))
 
     def _get_default_searchspace(self):
         return get_default_searchspace(self.problem_type, num_classes=self.num_classes)
@@ -62,7 +62,7 @@ class CatBoostModel(AbstractModel):
             try_import_catboostdev()  # Need to first import catboost then catboost_dev not vice-versa.
             from catboost_dev import CatBoostClassifier, CatBoostRegressor, Pool
             from .catboost_softclass_utils import SoftclassCustomMetric, SoftclassObjective
-            self._set_default_param_value('eval_metric', construct_custom_catboost_metric(self.stopping_metric, True, not self.stopping_metric_needs_y_pred, self.problem_type))
+            self._set_default_param_value('eval_metric', construct_custom_catboost_metric(self.stopping_metric, True, not self.stopping_metric.needs_pred, self.problem_type))
             self.params['loss_function'] = SoftclassObjective.SoftLogLossObjective()
             self.params['eval_metric'] = SoftclassCustomMetric.SoftLogLossMetric()
             self._set_default_param_value('early_stopping_rounds', 50)  # Speeds up training with custom (non-C++) losses

--- a/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
@@ -296,7 +296,8 @@ class BaggedEnsembleModel(AbstractModel):
             for i, fold in enumerate(cur_kfolds):
                 _, test_index = fold
                 model = self.load_child(self.models[model_index + i])
-                fi_fold = model.compute_feature_importance(X=X.iloc[test_index, :], y=y.iloc[test_index], features=features, time_limit=time_limit_per_child, silent=silent, log_prefix='\t', **kwargs)
+                fi_fold = model.compute_feature_importance(X=X.iloc[test_index, :], y=y.iloc[test_index], features=features, time_limit=time_limit_per_child,
+                                                           silent=silent, log_prefix='\t', importance_as_list=True, **kwargs)
                 fi_fold_list.append(fi_fold)
 
                 children_completed += 1
@@ -311,14 +312,14 @@ class BaggedEnsembleModel(AbstractModel):
             if early_stop:
                 break
             model_index += k
-
+        # TODO: DON'T THROW AWAY SAMPLES! USE LARGER N
         fi_list_dict = dict()
         for val in fi_fold_list:
             val = val['importance'].to_dict()  # TODO: Don't throw away stddev information of children
             for key in val:
                 if key not in fi_list_dict:
                     fi_list_dict[key] = []
-                fi_list_dict[key].append(val[key])
+                fi_list_dict[key] += val[key]
         fi_df = _compute_fi_with_stddev(fi_list_dict)
 
         if not silent:

--- a/tabular/src/autogluon/tabular/models/ensemble/weighted_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/weighted_ensemble_model.py
@@ -47,16 +47,18 @@ class WeightedEnsembleModel(StackerEnsembleModel):
             weights_dict[key] = weights_dict[key] / num_models
         return weights_dict
 
-    def compute_feature_importance(self, X, y, features_to_use=None, is_oof=True, **kwargs) -> pd.Series:
+    def compute_feature_importance(self, X, y, features=None, is_oof=True, **kwargs) -> (pd.Series, pd.Series, pd.Series):
         logger.warning('Warning: non-raw feature importance calculation is not valid for weighted ensemble since it does not have features, returning ensemble weights instead...')
         if is_oof:
             feature_importance = pd.Series(self._get_model_weights()).sort_values(ascending=False)
         else:
             logger.warning('Warning: Feature importance calculation is not yet implemented for WeightedEnsembleModel on unseen data, returning generic feature importance...')
             feature_importance = pd.Series(self._get_model_weights()).sort_values(ascending=False)
-            # TODO: Rewrite preprocess() in greedy_weighted_ensemble_model to enable
-            # feature_importance = super().compute_feature_importance(X=X, y=y, features_to_use=features_to_use, preprocess=preprocess, is_oof=is_oof, **kwargs)
-        return feature_importance
+        feature_importance_stddev = pd.Series(data=[None for _ in range(len(feature_importance))], index=feature_importance.index, dtype='float64')
+        feature_importance_z_score = pd.Series(data=[None for _ in range(len(feature_importance))], index=feature_importance.index, dtype='float64')
+        # TODO: Rewrite preprocess() in greedy_weighted_ensemble_model to enable
+        # feature_importance = super().compute_feature_importance(X=X, y=y, features_to_use=features_to_use, preprocess=preprocess, is_oof=is_oof, **kwargs)
+        return feature_importance, feature_importance_stddev, feature_importance_z_score
 
     def _set_default_params(self):
         default_params = {'use_orig_features': False}

--- a/tabular/src/autogluon/tabular/models/ensemble/weighted_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/weighted_ensemble_model.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 
+import numpy as np
 import pandas as pd
 
 from .stacker_ensemble_model import StackerEnsembleModel
@@ -54,12 +55,12 @@ class WeightedEnsembleModel(StackerEnsembleModel):
         else:
             logger.warning('Warning: Feature importance calculation is not yet implemented for WeightedEnsembleModel on unseen data, returning generic feature importance...')
             fi = pd.Series(self._get_model_weights()).sort_values(ascending=False)
-        fi_stddev = pd.Series(data=[None for _ in range(len(fi))], index=fi.index, dtype='float64')
-        fi_z_score = pd.Series(data=[None for _ in range(len(fi))], index=fi.index, dtype='float64')
 
         fi_df = fi.to_frame(name='importance')
-        fi_df['stddev'] = fi_stddev
-        fi_df['z_score'] = fi_z_score
+        fi_df['stddev'] = np.nan
+        fi_df['p_score'] = np.nan
+        fi_df['n'] = np.nan
+
         # TODO: Rewrite preprocess() in greedy_weighted_ensemble_model to enable
         # fi_df = super().compute_feature_importance(X=X, y=y, features_to_use=features_to_use, preprocess=preprocess, is_oof=is_oof, **kwargs)
         return fi_df

--- a/tabular/src/autogluon/tabular/models/ensemble/weighted_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/weighted_ensemble_model.py
@@ -47,18 +47,22 @@ class WeightedEnsembleModel(StackerEnsembleModel):
             weights_dict[key] = weights_dict[key] / num_models
         return weights_dict
 
-    def compute_feature_importance(self, X, y, features=None, is_oof=True, **kwargs) -> (pd.Series, pd.Series, pd.Series):
+    def compute_feature_importance(self, X, y, features=None, is_oof=True, **kwargs) -> pd.DataFrame:
         logger.warning('Warning: non-raw feature importance calculation is not valid for weighted ensemble since it does not have features, returning ensemble weights instead...')
         if is_oof:
-            feature_importance = pd.Series(self._get_model_weights()).sort_values(ascending=False)
+            fi = pd.Series(self._get_model_weights()).sort_values(ascending=False)
         else:
             logger.warning('Warning: Feature importance calculation is not yet implemented for WeightedEnsembleModel on unseen data, returning generic feature importance...')
-            feature_importance = pd.Series(self._get_model_weights()).sort_values(ascending=False)
-        feature_importance_stddev = pd.Series(data=[None for _ in range(len(feature_importance))], index=feature_importance.index, dtype='float64')
-        feature_importance_z_score = pd.Series(data=[None for _ in range(len(feature_importance))], index=feature_importance.index, dtype='float64')
+            fi = pd.Series(self._get_model_weights()).sort_values(ascending=False)
+        fi_stddev = pd.Series(data=[None for _ in range(len(fi))], index=fi.index, dtype='float64')
+        fi_z_score = pd.Series(data=[None for _ in range(len(fi))], index=fi.index, dtype='float64')
+
+        fi_df = fi.to_frame(name='importance')
+        fi_df['stddev'] = fi_stddev
+        fi_df['z_score'] = fi_z_score
         # TODO: Rewrite preprocess() in greedy_weighted_ensemble_model to enable
-        # feature_importance = super().compute_feature_importance(X=X, y=y, features_to_use=features_to_use, preprocess=preprocess, is_oof=is_oof, **kwargs)
-        return feature_importance, feature_importance_stddev, feature_importance_z_score
+        # fi_df = super().compute_feature_importance(X=X, y=y, features_to_use=features_to_use, preprocess=preprocess, is_oof=is_oof, **kwargs)
+        return fi_df
 
     def _set_default_params(self):
         default_params = {'use_orig_features': False}

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -348,14 +348,17 @@ class LGBModel(AbstractModel):
         return self._get_hpo_results(scheduler=scheduler, scheduler_options=scheduler_options, time_start=time_start)
 
     # TODO: Consider adding _internal_feature_map functionality to abstract_model
-    def compute_feature_importance(self, **kwargs) -> pd.Series:
-        feature_importances = super().compute_feature_importance(**kwargs)
+    def compute_feature_importance(self, **kwargs) -> (pd.Series, pd.Series, pd.Series):
+        feature_importances, feature_importances_stddev, feature_importances_z_score = super().compute_feature_importance(**kwargs)
         if self._internal_feature_map is not None:
             inverse_internal_feature_map = {i: feature for feature, i in self._internal_feature_map.items()}
             feature_importances = {inverse_internal_feature_map[i]: importance for i, importance in feature_importances.items()}
-            feature_importances = pd.Series(data=feature_importances)
-            feature_importances = feature_importances.sort_values(ascending=False)
-        return feature_importances
+            feature_importances = pd.Series(data=feature_importances).sort_values(ascending=False)
+            feature_importances_stddev = {inverse_internal_feature_map[i]: importance for i, importance in feature_importances_stddev.items()}
+            feature_importances_stddev = pd.Series(data=feature_importances_stddev).sort_values(ascending=False)
+            feature_importances_z_score = {inverse_internal_feature_map[i]: importance for i, importance in feature_importances_z_score.items()}
+            feature_importances_z_score = pd.Series(data=feature_importances_z_score).sort_values(ascending=False)
+        return feature_importances, feature_importances_stddev, feature_importances_z_score
 
     def _get_train_loss_name(self):
         if self.problem_type == BINARY:

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -347,19 +347,6 @@ class LGBModel(AbstractModel):
 
         return self._get_hpo_results(scheduler=scheduler, scheduler_options=scheduler_options, time_start=time_start)
 
-    # TODO: Consider adding _internal_feature_map functionality to abstract_model
-    def compute_feature_importance(self, **kwargs) -> (pd.Series, pd.Series, pd.Series):
-        feature_importances, feature_importances_stddev, feature_importances_z_score = super().compute_feature_importance(**kwargs)
-        if self._internal_feature_map is not None:
-            inverse_internal_feature_map = {i: feature for feature, i in self._internal_feature_map.items()}
-            feature_importances = {inverse_internal_feature_map[i]: importance for i, importance in feature_importances.items()}
-            feature_importances = pd.Series(data=feature_importances).sort_values(ascending=False)
-            feature_importances_stddev = {inverse_internal_feature_map[i]: importance for i, importance in feature_importances_stddev.items()}
-            feature_importances_stddev = pd.Series(data=feature_importances_stddev).sort_values(ascending=False)
-            feature_importances_z_score = {inverse_internal_feature_map[i]: importance for i, importance in feature_importances_z_score.items()}
-            feature_importances_z_score = pd.Series(data=feature_importances_z_score).sort_values(ascending=False)
-        return feature_importances, feature_importances_stddev, feature_importances_z_score
-
     def _get_train_loss_name(self):
         if self.problem_type == BINARY:
             train_loss_name = 'binary_logloss'

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -48,7 +48,7 @@ class LGBModel(AbstractModel):
     def get_eval_metric(self):
         eval_metric = lgb_utils.convert_ag_metric_to_lgbm(ag_metric_name=self.stopping_metric.name, problem_type=self.problem_type)
         if eval_metric is None:
-            eval_metric = lgb_utils.func_generator(metric=self.stopping_metric, is_higher_better=True, needs_pred_proba=not self.stopping_metric_needs_y_pred, problem_type=self.problem_type)
+            eval_metric = lgb_utils.func_generator(metric=self.stopping_metric, is_higher_better=True, needs_pred_proba=not self.stopping_metric.needs_pred, problem_type=self.problem_type)
             eval_metric_name = self.stopping_metric.name
         else:
             eval_metric_name = eval_metric

--- a/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
@@ -217,7 +217,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
                 val_metric = None
                 if loader_val is not None and state != 'pretrain':
                     val_metric = self.score(X=loader_val, y=y_val, eval_metric=self.stopping_metric,
-                                            metric_needs_y_pred=self.stopping_metric_needs_y_pred)
+                                            metric_needs_y_pred=self.stopping_metric.needs_pred)
                     data_bar.set_description('{} Epoch: [{}/{}] Train Loss: {:.4f} Validation {}: {:.2f}'.format(
                         train_test, epoch, epochs, total_loss / total_num, self.stopping_metric.name, val_metric))
 

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -333,7 +333,7 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
                 cumulative_loss += loss.sum()
             train_loss = cumulative_loss/float(train_dataset.num_examples)  # training loss this epoch
             if val_dataset is not None:
-                val_metric = self.score(X=val_dataset, y=y_val, eval_metric=self.stopping_metric, metric_needs_y_pred=self.stopping_metric_needs_y_pred)
+                val_metric = self.score(X=val_dataset, y=y_val, eval_metric=self.stopping_metric, metric_needs_y_pred=self.stopping_metric.needs_pred)
             if (val_dataset is None) or (val_metric >= best_val_metric) or (e == 0):  # keep training if score has improved
                 if val_dataset is not None:
                     if not np.isnan(val_metric):
@@ -379,7 +379,7 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         if val_dataset is None:
             logger.log(15, "Best model found in epoch %d" % best_val_epoch)
         else:  # evaluate one final time:
-            final_val_metric = self.score(X=val_dataset, y=y_val, eval_metric=self.stopping_metric, metric_needs_y_pred=self.stopping_metric_needs_y_pred)
+            final_val_metric = self.score(X=val_dataset, y=y_val, eval_metric=self.stopping_metric, metric_needs_y_pred=self.stopping_metric.needs_pred)
             if np.isnan(final_val_metric):
                 final_val_metric = -np.inf
             logger.log(15, "Best model found in epoch %d. Val %s: %s" %

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -38,7 +38,7 @@ class XGBoostModel(AbstractModel):
     def get_eval_metric(self):
         eval_metric = xgboost_utils.convert_ag_metric_to_xgbm(ag_metric_name=self.stopping_metric.name, problem_type=self.problem_type)
         if eval_metric is None:
-            eval_metric = xgboost_utils.func_generator(metric=self.stopping_metric, is_higher_better=True, needs_pred_proba=not self.stopping_metric_needs_y_pred, problem_type=self.problem_type)
+            eval_metric = xgboost_utils.func_generator(metric=self.stopping_metric, is_higher_better=True, needs_pred_proba=not self.stopping_metric.needs_pred, problem_type=self.problem_type)
         return eval_metric
 
     def _preprocess(self, X, is_train=False, max_category_levels=None, **kwargs):

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -131,21 +131,3 @@ class XGBoostModel(AbstractModel):
             return y_pred_proba
         else:
             return y_pred_proba[:, 1]
-
-    def get_model_feature_importance(self):
-        original_feature_names: list = self._ohe_generator.get_original_feature_names()
-        feature_names = self._ohe_generator.get_feature_names()
-        importances = self.model.feature_importances_.tolist()
-
-        importance_dict = {}
-        for original_feature in original_feature_names:
-            importance_dict[original_feature] = 0
-            for feature, value in zip(feature_names, importances):
-                if feature in self._ohe_generator.othercols:
-                    importance_dict[feature] = value
-                else:
-                    feature = '_'.join(feature.split('_')[:-1])
-                    if feature == original_feature:
-                        importance_dict[feature] += value
-
-        return importance_dict

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
@@ -617,12 +617,12 @@ class TabularPredictor(BasePredictor):
         Pandas `pandas.DataFrame` of feature importance scores with 3 columns:
             index: The feature name.
             'importance': The feature importance score.
-            'stddev': The standard deviation of the feature importance score. If None, then not enough num_shuffle_sets were used to calculate a variance.
+            'stddev': The standard deviation of the feature importance score. If NaN, then not enough num_shuffle_sets were used to calculate a variance.
             'z_score': The z-score of the feature importance score. Equivalent to 'importance' / 'stddev'.
                 A z-score of +4 or higher indicates that the feature is almost certainly useful and should be kept.
                 A z-score of +2 indicates that the feature has a 97.5% chance of improving model quality when present.
                 A z-score that is 0 or negative indicates that the feature can likely be dropped without negative impact to model quality.
-                A z-score of None indicates that the feature's stddev was None or that the model predictions were never impacted by the feature (importance 0 and stddev 0). This indicates that the feature can safely be dropped.
+                A z-score of NaN indicates that the feature's stddev was NaN or that the model predictions were never impacted by the feature (importance 0 and stddev 0). This indicates that the feature can safely be dropped.
                 A z-score of +inf or -inf indicates that `subsample_size` and/or `num_shuffle_sets` were too small to calculate variance for the feature (non-zero importance with zero stddev).
         """
         dataset = self.__get_dataset(dataset) if dataset is not None else dataset

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/predictor.py
@@ -552,7 +552,7 @@ class TabularPredictor(BasePredictor):
 
     # TODO: Consider adding time_limit option to early stop the feature importance process
     # TODO: Add option to specify list of features within features list, to check importances of groups of features. Make tuple to specify new feature name associated with group.
-    def feature_importance(self, dataset=None, model=None, features=None, feature_stage='original', subsample_size=1000, silent=False, **kwargs):
+    def feature_importance(self, dataset=None, model=None, features=None, feature_stage='original', subsample_size=1000, silent=False):
         """
         Calculates feature importance scores for the given model.
         A feature's importance score represents the performance drop that results when the model makes predictions on a perturbed copy of the dataset where this feature's values have been randomly shuffled across rows.
@@ -606,21 +606,6 @@ class TabularPredictor(BasePredictor):
         Pandas `pandas.Series` of feature importance scores.
 
         """
-        allowed_kwarg_names = {'raw'}
-        for kwarg_name in kwargs.keys():
-            if kwarg_name not in allowed_kwarg_names:
-                raise ValueError("Unknown keyword argument specified: %s" % kwarg_name)
-        if 'raw' in kwargs.keys():
-            logger.log(30, 'Warning: `raw` is a deprecated parameter. Use `feature_stage` instead. Starting from AutoGluon 0.1.0, specifying `raw` as a parameter will cause an exception.')
-            logger.log(30, 'Overriding `feature_stage` value with `raw` value.')
-            raw = kwargs['raw']
-            if raw is True:
-                feature_stage = 'transformed'
-            elif raw is False:
-                feature_stage = 'transformed_model'
-            else:
-                raise ValueError(f'`raw` must be one of [True, False], but was {raw}.')
-
         dataset = self.__get_dataset(dataset) if dataset is not None else dataset
         if (dataset is None) and (not self._trainer.is_data_saved):
             raise AssertionError('No dataset was provided and there is no cached data to load for feature importance calculation. `cache_data=True` must be set in the `TabularPrediction.fit()` call to enable this functionality when dataset is not specified.')

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -33,7 +33,7 @@ class TabularPrediction(BaseTask):
     Predictor = TabularPredictor
 
     @staticmethod
-    def load(output_directory, verbosity=2):
+    def load(output_directory, verbosity=2) -> TabularPredictor:
         """
         Load a predictor object previously produced by `fit()` from file and returns this object.
         It is highly recommended the predictor be loaded with the exact AutoGluon version it was fit with.

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -313,8 +313,8 @@ class AbstractTrainer:
             if isinstance(models, dict):
                 ensemble_kwargs = {
                     'base_model_names': base_model_names,
-                    'base_model_paths': base_model_paths,
-                    'base_model_types': base_model_types,
+                    'base_model_paths_dict': base_model_paths,
+                    'base_model_types_dict': base_model_types,
                     'save_bagged_folds': save_bagged_folds,
                     'random_state': level + self.random_seed,
                 }

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1240,7 +1240,7 @@ class AbstractTrainer:
     # TODO: Enable raw=True for bagged models when X=None
     #  This is non-trivial to implement for multi-layer stacking ensembles on the OOF data.
     # TODO: Consider limiting X to 10k rows here instead of inside the model call
-    def get_feature_importance(self, model=None, X=None, y=None, raw=True, **kwargs):
+    def get_feature_importance(self, model=None, X=None, y=None, raw=True, **kwargs) -> pd.DataFrame:
         if model is None:
             model = self.model_best
         model: AbstractModel = self.load_model(model)
@@ -1296,7 +1296,7 @@ class AbstractTrainer:
     #  This is different from raw, where the predictions of the folds are averaged and then feature importance is computed.
     #  Consider aligning these methods so they produce the same result.
     # The output of this function is identical to non-raw when model is level 0 and non-bagged
-    def _get_feature_importance_raw(self, X, y, model, eval_metric=None, **kwargs) -> (pd.Series, pd.Series, pd.Series):
+    def _get_feature_importance_raw(self, X, y, model, eval_metric=None, **kwargs) -> pd.DataFrame:
         if eval_metric is None:
             eval_metric = self.eval_metric
         if model is None:

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1,9 +1,6 @@
 import copy, time, traceback, logging
 import os
 from typing import List, Union
-import sys
-import pickle
-import math
 
 import networkx as nx
 import numpy as np

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -18,7 +18,7 @@ from autogluon.core.utils.exceptions import TimeLimitExceeded, NotEnoughMemoryEr
 from autogluon.core.utils import shuffle_df_rows, default_holdout_frac
 from autogluon.core.metrics import log_loss, scorer_expects_y_pred
 
-from ..utils import get_pred_from_proba, generate_train_test_split, infer_eval_metric
+from ..utils import get_pred_from_proba, generate_train_test_split, infer_eval_metric, compute_permutation_feature_importance
 from ..models.abstract.abstract_model import AbstractModel
 from ..models.ensemble.bagged_ensemble_model import BaggedEnsembleModel
 from ..trainer.model_presets.presets_custom import get_preset_custom
@@ -571,7 +571,7 @@ class AbstractTrainer:
             for model in models_level:
                 model = self.load_model(model)
                 model_name = model.name
-                model_full = model.convert_to_refitfull_template()
+                model_full = model.convert_to_refit_full_template()
                 # Mitigates situation where bagged models barely had enough memory and refit requires more. Worst case results in OOM, but this lowers chance of failure.
                 model_full.params_aux['max_memory_usage_ratio'] = model_full.params_aux['max_memory_usage_ratio'] * 1.15
                 # TODO: Do it for all models in the level at once to avoid repeated processing of data?
@@ -1243,7 +1243,7 @@ class AbstractTrainer:
     # TODO: Enable raw=True for bagged models when X=None
     #  This is non-trivial to implement for multi-layer stacking ensembles on the OOF data.
     # TODO: Consider limiting X to 10k rows here instead of inside the model call
-    def get_feature_importance(self, model=None, X=None, y=None, features=None, raw=True, subsample_size=1000, silent=False):
+    def get_feature_importance(self, model=None, X=None, y=None, raw=True, **kwargs):
         if model is None:
             model = self.model_best
         model: AbstractModel = self.load_model(model)
@@ -1286,10 +1286,9 @@ class AbstractTrainer:
                 y = self.load_y_val()
 
         if raw:
-            feature_importance = self._get_feature_importance_raw(model=model, X=X, y=y, features_to_use=features, subsample_size=subsample_size, silent=silent)
+            return self._get_feature_importance_raw(X=X, y=y, model=model, **kwargs)
         else:
-            feature_importance = model.compute_feature_importance(X=X, y=y, features_to_use=features, subsample_size=subsample_size, is_oof=is_oof, silent=silent)
-        return feature_importance
+            return model.compute_feature_importance(X=X, y=y, is_oof=is_oof, **kwargs)
 
     # TODO: Can get feature importances of all children of model at no extra cost, requires scoring the values after predict_proba on each model
     #  Could solve by adding a self.score_all() function which takes model as input and also returns scores of all children models.
@@ -1300,8 +1299,7 @@ class AbstractTrainer:
     #  This is different from raw, where the predictions of the folds are averaged and then feature importance is computed.
     #  Consider aligning these methods so they produce the same result.
     # The output of this function is identical to non-raw when model is level 0 and non-bagged
-    def _get_feature_importance_raw(self, model, X, y, features_to_use=None, eval_metric=None, subsample_size=1000, transform_func=None, silent=False):
-        time_start = time.time()
+    def _get_feature_importance_raw(self, X, y, model, eval_metric=None, **kwargs) -> (pd.Series, pd.Series, pd.Series):
         if eval_metric is None:
             eval_metric = self.eval_metric
         if model is None:
@@ -1312,151 +1310,9 @@ class AbstractTrainer:
             predict_func = self.predict_proba
         model: AbstractModel = self.load_model(model)
         predict_func_kwargs = dict(model=model)
-        if features_to_use is None:
-            features_to_use = list(X.columns)
-        feature_count = len(features_to_use)
-
-        if not silent:
-            logger.log(20, f'Computing raw permutation importance for {feature_count} features on {model.name} ...')
-
-        if (subsample_size is not None) and (len(X) > subsample_size):
-            # Reset index to avoid error if duplicated indices.
-            X = X.reset_index(drop=True)
-            y = y.reset_index(drop=True)
-
-            X = X.sample(subsample_size, random_state=0)
-            y = y.loc[X.index]
-
-        time_start_score = time.time()
-
-        X_transformed = X if transform_func is None else transform_func(X)
-        y_pred = predict_func(X_transformed, **predict_func_kwargs)
-        score_baseline = eval_metric(y, y_pred)
-        time_score = time.time() - time_start_score
-
-        if not silent:
-            time_estimated = (feature_count + 1) * time_score + time_start_score - time_start
-            logger.log(20, f'\t{round(time_estimated, 2)}s\t= Expected runtime')
-
-        X_shuffled = shuffle_df_rows(X=X, seed=0)
-
-        row_count = X.shape[0]
-
-        # calculating maximum number of features, which is safe to process parallel
-        X_memory_ratio_max = 0.2
-        compute_count_max = 200
-
-        X_size_bytes = sys.getsizeof(pickle.dumps(X, protocol=4))
-        if transform_func is not None:
-            X_size_bytes += sys.getsizeof(pickle.dumps(X_transformed, protocol=4))
-        available_mem = psutil.virtual_memory().available
-        X_memory_ratio = X_size_bytes / available_mem
-
-        compute_count_safe = math.floor(X_memory_ratio_max / X_memory_ratio)
-        compute_count = max(1, min(compute_count_max, compute_count_safe))
-        compute_count = min(compute_count, feature_count)
-
-        # creating copy of original data N=compute_count times for parallel processing
-        X_raw = pd.concat([X.copy() for _ in range(compute_count)], ignore_index=True, sort=False).reset_index(drop=True)
-
-        permutation_importance_dict = dict()
-        for i in range(0, feature_count, compute_count):
-            parallel_computed_features = features_to_use[i:i + compute_count]
-
-            # if final iteration, leaving only necessary part of X_raw
-            num_features_processing = len(parallel_computed_features)
-            final_iteration = i + num_features_processing == feature_count
-            if (num_features_processing < compute_count) and final_iteration:
-                X_raw = X_raw.loc[:row_count * num_features_processing - 1]
-
-            row_index = 0
-            for feature in parallel_computed_features:
-                row_index_end = row_index + row_count
-                X_raw.loc[row_index:row_index_end - 1, feature] = X_shuffled[feature].values
-                row_index = row_index_end
-
-            X_raw_transformed = X_raw if transform_func is None else transform_func(X_raw)
-            y_pred = predict_func(X_raw_transformed, **predict_func_kwargs)
-
-            row_index = 0
-            for feature in parallel_computed_features:
-                # calculating importance score for given feature
-                row_index_end = row_index + row_count
-                y_pred_cur = y_pred[row_index:row_index_end]
-                score = eval_metric(y, y_pred_cur)
-                permutation_importance_dict[feature] = score_baseline - score
-
-                if not final_iteration:
-                    # resetting to original values for processed feature
-                    X_raw.loc[row_index:row_index_end - 1, feature] = X[feature].values
-
-                row_index = row_index_end
-
-        feature_importances = pd.Series(permutation_importance_dict).sort_values(ascending=False)
-
-        if not silent:
-            logger.log(20, f'\t{round(time.time() - time_start, 2)}s\t= Actual runtime')
-
-        return feature_importances
-
-    # TODO: v0.1 Remove this
-    def _get_feature_importance_raw_legacy(self, model, X, y, features_to_use=None, subsample_size=1000, transform_func=None, silent=False):
-        time_start = time.time()
-        if model is None:
-            model = self.model_best
-        model: AbstractModel = self.load_model(model)
-        if features_to_use is None:
-            features_to_use = list(X.columns)
-        feature_count = len(features_to_use)
-
-        if not silent:
-            logger.log(20, f'Computing raw permutation importance for {feature_count} features on {model.name} ...')
-
-        if (subsample_size is not None) and (len(X) > subsample_size):
-            # Reset index to avoid error if duplicated indices.
-            X = X.reset_index(drop=True)
-            y = y.reset_index(drop=True)
-
-            X = X.sample(subsample_size, random_state=0)
-            y = y.loc[X.index]
-
-        time_start_score = time.time()
-        if transform_func is None:
-            score_baseline = self.score(X=X, y=y, model=model)
-        else:
-            X_transformed = transform_func(X)
-            score_baseline = self.score(X=X_transformed, y=y, model=model)
-        time_score = time.time() - time_start_score
-
-        if not silent:
-            time_estimated = (feature_count + 1) * time_score + time_start_score - time_start
-            logger.log(20, f'\t{round(time_estimated, 2)}s\t= Expected runtime')
-
-        X_shuffled = shuffle_df_rows(X=X, seed=0)
-
-        # Assuming X_test or X_val
-        # TODO: Can check multiple features at a time only if non-OOF
-        permutation_importance_dict = dict()
-        X_to_check = X.copy()
-        last_processed = None
-        for feature in features_to_use:
-            if last_processed is not None:  # resetting original values
-                X_to_check[last_processed] = X[last_processed].values
-            X_to_check[feature] = X_shuffled[feature].values
-            if transform_func is None:
-                score_feature = self.score(X=X_to_check, y=y, model=model)
-            else:
-                X_to_check_transformed = transform_func(X_to_check)
-                score_feature = self.score(X=X_to_check_transformed, y=y, model=model)
-            score_diff = score_baseline - score_feature
-            permutation_importance_dict[feature] = score_diff
-            last_processed = feature
-        feature_importances = pd.Series(permutation_importance_dict).sort_values(ascending=False)
-
-        if not silent:
-            logger.log(20, f'\t{round(time.time() - time_start, 2)}s\t= Actual runtime')
-
-        return feature_importances
+        return compute_permutation_feature_importance(
+            X=X, y=y, predict_func=predict_func, predict_func_kwargs=predict_func_kwargs, eval_metric=eval_metric, **kwargs
+        )
 
     def _get_models_load_info(self, model_names):
         model_names = copy.deepcopy(model_names)

--- a/tabular/src/autogluon/tabular/tuning/feature_pruner.py
+++ b/tabular/src/autogluon/tabular/tuning/feature_pruner.py
@@ -114,7 +114,7 @@ class FeaturePruner:
                 self.tuned = True
                 break
 
-            gain_df = model_iter.compute_feature_importance(X=X_val_subset, y=y_val, features_to_use=features_to_use)
+            gain_df = model_iter.compute_feature_importance(X=X_val_subset, y=y_val, features=features_to_use)
             if not objective_goal_is_negative:
                 gain_df = -gain_df
 

--- a/tabular/src/autogluon/tabular/utils.py
+++ b/tabular/src/autogluon/tabular/utils.py
@@ -225,12 +225,12 @@ def compute_permutation_feature_importance(X: pd.DataFrame, y: pd.Series, predic
     Pandas `pandas.DataFrame` of feature importance scores with 3 columns:
         index: The feature name.
         'importance': The feature importance score.
-        'stddev': The standard deviation of the feature importance score. If None, then not enough num_shuffle_sets were used to calculate a variance.
+        'stddev': The standard deviation of the feature importance score. If NaN, then not enough num_shuffle_sets were used to calculate a variance.
         'z_score': The z-score of the feature importance score. Equivalent to 'importance' / 'stddev'.
             A z-score of +4 or higher indicates that the feature is almost certainly useful and should be kept.
             A z-score of +2 indicates that the feature has a 97.5% chance of improving model quality when present.
             A z-score that is 0 or negative indicates that the feature can likely be dropped without negative impact to model quality.
-            A z-score of None indicates that the feature's stddev was None or that the model predictions were never impacted by the feature (importance 0 and stddev 0). This indicates that the feature can safely be dropped.
+            A z-score of NaN indicates that the feature's stddev was NaN or that the model predictions were never impacted by the feature (importance 0 and stddev 0). This indicates that the feature can safely be dropped.
             A z-score of +inf or -inf indicates that `subsample_size` and/or `num_shuffle_sets` were too small to calculate variance for the feature (non-zero importance with zero stddev).
     """
     if num_shuffle_sets is None:
@@ -294,11 +294,11 @@ def compute_permutation_feature_importance(X: pd.DataFrame, y: pd.Series, predic
     X_raw = pd.concat([X.copy() for _ in range(compute_count)], ignore_index=True, sort=False).reset_index(drop=True)
 
     time_permutation_start = time.time()
-    permutation_importance_dict_list = []
+    fi_dict_list = []
     # TODO: Can speedup shuffle_repeats by incorporating into X_raw (do multiple repeats in a single predict call)
     shuffle_repeats_completed = 0
     for shuffle_repeat in range(num_shuffle_sets):
-        permutation_importance_dict = dict()
+        fi = dict()
         X_shuffled = shuffle_df_rows(X=X, seed=shuffle_repeat)
         for i in range(0, feature_count, compute_count):
             parallel_computed_features = features[i:i + compute_count]
@@ -324,14 +324,14 @@ def compute_permutation_feature_importance(X: pd.DataFrame, y: pd.Series, predic
                 row_index_end = row_index + row_count
                 y_pred_cur = y_pred[row_index:row_index_end]
                 score = eval_metric(y, y_pred_cur)
-                permutation_importance_dict[feature] = score_baseline - score
+                fi[feature] = score_baseline - score
 
                 if not final_iteration:
                     # resetting to original values for processed feature
                     X_raw.loc[row_index:row_index_end - 1, feature] = X[feature].values
 
                 row_index = row_index_end
-        permutation_importance_dict_list.append(permutation_importance_dict)
+        fi_dict_list.append(fi)
         shuffle_repeats_completed = shuffle_repeat + 1
         if time_limit is not None and shuffle_repeat != (num_shuffle_sets - 1):
             time_now = time.time()
@@ -341,35 +341,35 @@ def compute_permutation_feature_importance(X: pd.DataFrame, y: pd.Series, predic
                 if not silent:
                     logger.log(20, f'\tEarly stopping feature importance calculation before all shuffle sets have completed due to lack of time...')
                 break
-    permutation_importance_dict = dict()
-    permutation_importance_stddev_dict = dict()
-    permutation_importance_z_score_dict = dict()
+    fi = dict()
+    fi_stddev_dict = dict()
+    fi_z_score_dict = dict()
     for feature in features:
-        feature_shuffle_scores = [permutation_importance_dict_repeat[feature] for permutation_importance_dict_repeat in permutation_importance_dict_list]
-        permutation_importance_dict[feature] = np.mean(feature_shuffle_scores)
-        if len(feature_shuffle_scores) > 1:
-            permutation_importance_stddev_dict[feature] = np.std(feature_shuffle_scores, ddof=1)
+        fi_fold_feature_list = [permutation_importance_dict_repeat[feature] for permutation_importance_dict_repeat in fi_dict_list]
+        fi[feature] = np.mean(fi_fold_feature_list)
+        if len(fi_fold_feature_list) > 1:
+            fi_stddev_dict[feature] = np.std(fi_fold_feature_list, ddof=1)
         else:
-            permutation_importance_stddev_dict[feature] = None
-        if permutation_importance_stddev_dict[feature] is not None and permutation_importance_stddev_dict[feature] != 0:
-            permutation_importance_z_score_dict[feature] = permutation_importance_dict[feature] / permutation_importance_stddev_dict[feature]
-        elif permutation_importance_stddev_dict[feature] is not None:  # stddev = 0
-            if permutation_importance_dict[feature] == 0:
-                permutation_importance_z_score_dict[feature] = None
-            elif permutation_importance_dict[feature] > 0:
-                permutation_importance_z_score_dict[feature] = np.inf
+            fi_stddev_dict[feature] = np.nan
+        if fi_stddev_dict[feature] != np.nan and fi_stddev_dict[feature] != 0:
+            fi_z_score_dict[feature] = fi[feature] / fi_stddev_dict[feature]
+        elif fi_stddev_dict[feature] != np.nan:  # stddev = 0
+            if fi[feature] == 0:
+                fi_z_score_dict[feature] = np.nan
+            elif fi[feature] > 0:
+                fi_z_score_dict[feature] = np.inf
             else:  # < 0
-                permutation_importance_z_score_dict[feature] = -np.inf
+                fi_z_score_dict[feature] = -np.inf
         else:
-            permutation_importance_z_score_dict[feature] = None
+            fi_z_score_dict[feature] = np.nan
 
-    feature_importances = pd.Series(permutation_importance_dict).sort_values(ascending=False)
-    feature_importances_stddev = pd.Series(permutation_importance_stddev_dict).sort_values(ascending=False)
-    feature_importances_z_score = pd.Series(permutation_importance_z_score_dict).sort_values(ascending=False)
+    fi = pd.Series(fi).sort_values(ascending=False)
+    fi_stddev = pd.Series(fi_stddev_dict).sort_values(ascending=False)
+    fi_z_score = pd.Series(fi_z_score_dict).sort_values(ascending=False)
 
-    fi_df = feature_importances.to_frame(name='importance')
-    fi_df['stddev'] = feature_importances_stddev
-    fi_df['z_score'] = feature_importances_z_score
+    fi_df = fi.to_frame(name='importance')
+    fi_df['stddev'] = fi_stddev
+    fi_df['z_score'] = fi_z_score
 
     if not silent:
         logger.log(20, f'\t{round(time.time() - time_start, 2)}s\t= Actual runtime (Completed {shuffle_repeats_completed} of {num_shuffle_sets} shuffle sets)')

--- a/tabular/src/autogluon/tabular/utils.py
+++ b/tabular/src/autogluon/tabular/utils.py
@@ -231,8 +231,11 @@ def compute_permutation_feature_importance(X: pd.DataFrame, y: pd.Series, predic
         index: The feature name.
         'importance': The estimated feature importance score.
         'stddev': The standard deviation of the feature importance score. If NaN, then not enough num_shuffle_sets were used to calculate a variance.
-        'p_value': The probability that the feature's true importance score is less than or equal to 0. Feature with p_values > 0.9 are likely harmful.
-        'n': The number of shuffles (samples) performed.
+        'p_value': P-value for a statistical t-test of the null hypothesis: importance = 0, vs the (one-sided) alternative: importance > 0.
+            Features with low p-value appear confidently useful to the predictor, while the other features may be useless to the predictor (or even harmful to include in its training data).
+            A p-value of 0.01 indicates that there is a 1% chance that the feature is useless or harmful, and a 99% chance that the feature is useful.
+            A p-value of 0.99 indicates that there is a 99% chance that the feature is useless or harmful, and a 1% chance that the feature is useful.
+        'n': The number of shuffles performed to estimate importance score (corresponds to sample-size used to determine confidence interval for true score).
     """
     if num_shuffle_sets is None:
         num_shuffle_sets = 1 if time_limit is None else 10

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -95,7 +95,8 @@ def test_advanced_functionality():
     feature_importances = predictor.feature_importance(dataset=test_data)
     original_features = set(train_data.columns)
     original_features.remove(label)
-    assert(set(feature_importances.keys()) == original_features)
+    assert set(feature_importances.index) == original_features
+    assert set(feature_importances.columns) == {'importance', 'stddev', 'z_score'}
     predictor.transform_features()
     predictor.transform_features(dataset=test_data)
     predictor.info()

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -96,7 +96,7 @@ def test_advanced_functionality():
     original_features = set(train_data.columns)
     original_features.remove(label)
     assert set(feature_importances.index) == original_features
-    assert set(feature_importances.columns) == {'importance', 'stddev', 'z_score'}
+    assert set(feature_importances.columns) == {'importance', 'stddev', 'p_value', 'n', 'p99_high', 'p99_low'}
     predictor.transform_features()
     predictor.transform_features(dataset=test_data)
     predictor.info()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Optimized feature importance calculation speed by 10x+ in expensive situations involving many features (3000s -> 250s on dual-core mac laptop with identical final result, likely larger gains with more CPU cores).
- Refactored and standardized feature importance calculations to stem from a single function.
- Added `time_limit` and `num_shuffle_sets` functionality to feature importance.
- Fixed XGBoost `transformed_model` feature importance causing exceptions.
- Added stddev and z-score calculations and outputs to feature importance.

TODO:

- [x] Add documentation to generic compute_permutation_feature_importance() function
- [x] Add option to return stddev and z-score information (need to update tutorials)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
