### PR TITLE
[TextPrediction] Fix empty sentence handling

### DIFF
--- a/text/src/autogluon/text/text_prediction/column_property.py
+++ b/text/src/autogluon/text/text_prediction/column_property.py
@@ -275,7 +275,7 @@ class TextColumnProperty(ColumnProperty):
 
     def parse(self, column_data: pd.Series):
         super().parse(column_data)
-        lengths = column_data.apply(len)
+        lengths = column_data.apply(lambda x: len(x) if x else 0)
         self._min_length = lengths.min()
         self._avg_length = lengths.mean()
         self._max_length = lengths.max()

--- a/text/src/autogluon/text/text_prediction/preprocessing.py
+++ b/text/src/autogluon/text/text_prediction/preprocessing.py
@@ -153,11 +153,13 @@ def process_text_entity_features(
             slice_length = min(len(text_token_ids[col_name]), trim_length)
             sentence_start_in_merged[col_name] = shift
             sentence_slice_stat[col_name] = (0, slice_length)
-            encoded_token_ids.append(text_token_ids[col_name][:slice_length])
-            segment_ids.append(np.full((slice_length,), idx % 2))
+            if slice_length > 0:
+                encoded_token_ids.append(text_token_ids[col_name][:slice_length])
+                segment_ids.append(np.full((slice_length,), idx % 2))
             encoded_token_ids.append(np.array([tokenizer.vocab.sep_id]))
             segment_ids.append(np.array([idx % 2]))
-            encoded_token_offsets.append(text_token_offsets[col_name][:slice_length])
+            if slice_length > 0:
+                encoded_token_offsets.append(text_token_offsets[col_name][:slice_length])
             encoded_token_offsets.append(np.array([[-1, -1]]))
             shift += slice_length + 1
         encoded_token_ids = np.concatenate(encoded_token_ids).astype(np.int32)

--- a/text/tests/unittests/test_text_prediction.py
+++ b/text/tests/unittests/test_text_prediction.py
@@ -203,11 +203,11 @@ def test_empty_text_item():
     rng_state = np.random.RandomState(123)
     train_perm = rng_state.permutation(len(train_data))
     train_data = train_data.iloc[train_perm[:100]]
-    train_data['sentence1', 0] = None
-    train_data['sentence1', 10] = None
+    train_data.iat[0, 0] = None
+    train_data.iat[10, 0] = None
     predictor = task.fit(train_data, hyperparameters=test_hyperparameters,
-                         label='label', num_trials=1,
+                         label='score', num_trials=1,
                          ngpus_per_trial=0,
                          verbosity=4,
-                         output_directory='./sst_empty_text_item',
+                         output_directory='./sts_empty_text_item',
                          plot_results=False)

--- a/text/tests/unittests/test_text_prediction.py
+++ b/text/tests/unittests/test_text_prediction.py
@@ -195,3 +195,19 @@ def test_mixed_column_type():
                           plot_results=False)
     dev_rmse = predictor1.evaluate(dev_data, metrics=['rmse'])
     verify_predictor_save_load(predictor3, dev_data)
+
+
+def test_empty_text_item():
+    train_data = load_pd.load(
+        'https://autogluon-text.s3-accelerate.amazonaws.com/glue/sts/train.parquet')
+    rng_state = np.random.RandomState(123)
+    train_perm = rng_state.permutation(len(train_data))
+    train_data = train_data.iloc[train_perm[:100]]
+    train_data['sentence1', 0] = None
+    train_data['sentence1', 10] = None
+    predictor = task.fit(train_data, hyperparameters=test_hyperparameters,
+                         label='label', num_trials=1,
+                         ngpus_per_trial=0,
+                         verbosity=4,
+                         output_directory='./sst_empty_text_item',
+                         plot_results=False)


### PR DESCRIPTION
Fix the handling of empty sentences. In the old version, if the text column contains None, it will raise the following error:
```python
--> 185             column_properties[col_name].parse(df[col_name])
    186             continue
    187         # Raise error if we find an entity column

~/autogluon/text/src/autogluon/text/text_prediction/column_property.py in parse(self, column_data)
    276     def parse(self, column_data: pd.Series):
    277         super().parse(column_data)
--> 278         lengths = column_data.apply(len)
    279         self._min_length = lengths.min()
    280         self._avg_length = lengths.mean()

/usr/local/lib/python3.6/dist-packages/pandas/core/series.py in apply(self, func, convert_dtype, args, **kwds)
   4198             else:
   4199                 values = self.astype(object)._values
-> 4200                 mapped = lib.map_infer(values, f, convert=convert_dtype)
   4201 
   4202         if len(mapped) and isinstance(mapped[0], Series):

pandas/_libs/lib.pyx in pandas._libs.lib.map_infer()

TypeError: object of type 'NoneType' has no len()
```
