### PR TITLE
Tabular: Updated LGB and CAT default learning rates from 0.1 to 0.05

### DIFF
--- a/tabular/src/autogluon/tabular/models/catboost/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/catboost/hyperparameters/parameters.py
@@ -17,7 +17,7 @@ def get_param_baseline(problem_type, num_classes=None):
 def get_param_binary_baseline():
     params = {
         'iterations': DEFAULT_ITERATIONS,
-        'learning_rate': 0.1,
+        'learning_rate': 0.05,
     }
     return params
 
@@ -25,7 +25,7 @@ def get_param_binary_baseline():
 def get_param_multiclass_baseline(num_classes):
     params = {
         'iterations': DEFAULT_ITERATIONS,
-        'learning_rate': 0.1,
+        'learning_rate': 0.05,
     }
     return params
 
@@ -33,6 +33,6 @@ def get_param_multiclass_baseline(num_classes):
 def get_param_regression_baseline():
     params = {
         'iterations': DEFAULT_ITERATIONS,
-        'learning_rate': 0.1,
+        'learning_rate': 0.05,
     }
     return params

--- a/tabular/src/autogluon/tabular/models/catboost/hyperparameters/searchspaces.py
+++ b/tabular/src/autogluon/tabular/models/catboost/hyperparameters/searchspaces.py
@@ -16,7 +16,7 @@ def get_default_searchspace(problem_type, num_classes=None):
 
 def get_searchspace_multiclass_baseline(num_classes):
     params = {
-        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.1, log=True),
+        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.05, log=True),
         'depth': Int(lower=5, upper=8, default=6),
         'l2_leaf_reg': Real(lower=1, upper=5, default=3),
     }
@@ -25,7 +25,7 @@ def get_searchspace_multiclass_baseline(num_classes):
 
 def get_searchspace_binary_baseline():
     params = {
-        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.1, log=True),
+        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.05, log=True),
         'depth': Int(lower=5, upper=8, default=6),
         'l2_leaf_reg': Real(lower=1, upper=5, default=3),
     }
@@ -34,7 +34,7 @@ def get_searchspace_binary_baseline():
 
 def get_searchspace_regression_baseline():
     params = {
-        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.1, log=True),
+        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.05, log=True),
         'depth': Int(lower=5, upper=8, default=6),
         'l2_leaf_reg': Real(lower=1, upper=5, default=3),
     }

--- a/tabular/src/autogluon/tabular/models/lgb/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/lgb/hyperparameters/parameters.py
@@ -55,6 +55,7 @@ def get_param_binary_baseline():
     params = {
         'num_boost_round': DEFAULT_NUM_BOOST_ROUND,
         'num_threads': -1,
+        'learning_rate': 0.05,
         'objective': 'binary',
         'verbose': -1,
         'boosting_type': 'gbdt',
@@ -67,6 +68,7 @@ def get_param_multiclass_baseline(num_classes):
     params = {
         'num_boost_round': DEFAULT_NUM_BOOST_ROUND,
         'num_threads': -1,
+        'learning_rate': 0.05,
         'objective': 'multiclass',
         'num_classes': num_classes,
         'verbose': -1,
@@ -80,6 +82,7 @@ def get_param_regression_baseline():
     params = {
         'num_boost_round': DEFAULT_NUM_BOOST_ROUND,
         'num_threads': -1,
+        'learning_rate': 0.05,
         'objective': 'regression',
         'verbose': -1,
         'boosting_type': 'gbdt',

--- a/tabular/src/autogluon/tabular/models/lgb/hyperparameters/searchspaces.py
+++ b/tabular/src/autogluon/tabular/models/lgb/hyperparameters/searchspaces.py
@@ -20,7 +20,7 @@ def get_searchspace_multiclass_baseline(num_classes):
     params = {
         'objective': 'multiclass',
         'num_classes': num_classes,
-        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.1, log=True),
+        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.05, log=True),
         'feature_fraction': Real(lower=0.75, upper=1.0, default=1.0),
         'min_data_in_leaf': Int(lower=2, upper=30, default=20),  # TODO: Use size of dataset to set upper, if row count is small upper should be small
         'num_leaves': Int(lower=16, upper=96, default=31),  # TODO: Use row count and feature count to set this, the higher feature count the higher num_leaves upper
@@ -38,7 +38,7 @@ def get_searchspace_multiclass_baseline(num_classes):
 def get_searchspace_binary_baseline():
     params = {
         'objective': 'binary',
-        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.1, log=True),
+        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.05, log=True),
         'feature_fraction': Real(lower=0.75, upper=1.0, default=1.0),
         'min_data_in_leaf': Int(lower=2, upper=30, default=20),
         'num_leaves': Int(lower=16, upper=96, default=31),
@@ -54,7 +54,7 @@ def get_searchspace_binary_baseline():
 def get_searchspace_regression_baseline():
     params = {
         'objective': 'regression',
-        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.1, log=True),
+        'learning_rate': Real(lower=5e-3, upper=0.2, default=0.05, log=True),
         'feature_fraction': Real(lower=0.75, upper=1.0, default=1.0),
         'min_data_in_leaf': Int(lower=2, upper=30, default=20),
         'num_leaves': Int(lower=16, upper=96, default=31),
@@ -65,5 +65,3 @@ def get_searchspace_regression_baseline():
         'seed_value': None,
     }
     return params
-
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Halved the learning rate of default LGB and CAT models.

This significantly improves medium-quality as seen below (and very slightly improves best-quality)

`AutoGluon_1h_2020_12_30_gbm` is this PR's medium-quality
`AutoGluon_1h_2020_12_25` is mainline's medium-quality

```
AutoGluon_1h_2020_12_25 VS all
                     framework  > AutoGluon_1h_2020_12_25  < AutoGluon_1h_2020_12_25  = AutoGluon_1h_2020_12_25  % Less Avg. Errors Than AutoGluon_1h_2020_12_25  time_train_s  metric_error  time_infer_s  loss_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0  AutoGluon_1h_2020_12_30_gbm                         59                         34                          8                                         0.975875    881.145545  75405.527674     24.488119       0.336634  1.376238            59            42             0             0            0
1      AutoGluon_1h_2020_12_25                          0                          0                        101                                         0.000000    835.735644  75569.594890     23.031683       0.584158  1.623762            34            67             0             0            0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
