### PR TITLE
Tabular: Added FastAI NN to default models

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,9 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
+
           cd core/
           python3 -m pip install --upgrade -e .
           python3 -m pytest --junitxml=results.xml --runslow tests
@@ -60,6 +63,9 @@ stage("Unit Test") {
           pip uninstall -y autogluon.tabular
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
+
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
 
           cd core/
           python3 -m pip install --upgrade -e .
@@ -101,6 +107,9 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
+
           cd core/
           python3 -m pip install --upgrade -e .
           cd ../extra/
@@ -139,6 +148,9 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
+
           cd core/
           python3 -m pip install --upgrade -e .
           cd ../mxnet/
@@ -176,6 +188,9 @@ stage("Unit Test") {
           pip uninstall -y autogluon.tabular
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
+
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
 
           cd core/
           python3 -m pip install --upgrade -e .
@@ -217,6 +232,9 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
+
           cd core/
           python3 -m pip install --upgrade -e .
           cd ../mxnet/
@@ -256,6 +274,9 @@ stage("Unit Test") {
           pip uninstall -y autogluon.tabular
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
+
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
 
           cd core/
           python3 -m pip install --upgrade -e .

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,6 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
-          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-          pip uninstall -y typing
-
           cd core/
           python3 -m pip install --upgrade -e .
           python3 -m pytest --junitxml=results.xml --runslow tests
@@ -64,12 +61,11 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
-          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-          pip uninstall -y typing
-
           cd core/
           python3 -m pip install --upgrade -e .
           cd ../tabular/
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
           python3 -m pip install --upgrade -e .
           cd ../mxnet/
           python3 -m pip install --upgrade -e .
@@ -106,9 +102,6 @@ stage("Unit Test") {
           pip uninstall -y autogluon.tabular
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
-
-          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-          pip uninstall -y typing
 
           cd core/
           python3 -m pip install --upgrade -e .
@@ -148,9 +141,6 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
-          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-          pip uninstall -y typing
-
           cd core/
           python3 -m pip install --upgrade -e .
           cd ../mxnet/
@@ -189,12 +179,11 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
-          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-          pip uninstall -y typing
-
           cd core/
           python3 -m pip install --upgrade -e .
           cd ../tabular/
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
           python3 -m pip install --upgrade -e .
           cd ../mxnet/
           python3 -m pip install --upgrade -e .
@@ -231,9 +220,6 @@ stage("Unit Test") {
           pip uninstall -y autogluon.tabular
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
-
-          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-          pip uninstall -y typing
 
           cd core/
           python3 -m pip install --upgrade -e .
@@ -275,12 +261,11 @@ stage("Unit Test") {
           pip uninstall -y autogluon.core
           pip uninstall -y autogluon-contrib-nlp
 
-          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-          pip uninstall -y typing
-
           cd core/
           python3 -m pip install --upgrade -e .
           cd ../tabular/
+          # Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+          pip uninstall -y typing
           python3 -m pip install --upgrade -e .
           cd ../mxnet/
           python3 -m pip install --upgrade -e .

--- a/docs/build_pip_install.sh
+++ b/docs/build_pip_install.sh
@@ -11,12 +11,9 @@ python3 -m pip uninstall -y autogluon.extra
 python3 -m pip uninstall -y autogluon.tabular
 python3 -m pip uninstall -y autogluon.core
 python3 -m pip uninstall -y autogluon-contrib-nlp
-python3 -m pip uninstall -y autogluon-core
-python3 -m pip uninstall -y autogluon-extra
-python3 -m pip uninstall -y autogluon-mxnet
-python3 -m pip uninstall -y autogluon-tabular
-python3 -m pip uninstall -y autogluon-text
-python3 -m pip uninstall -y autogluon-vision
+
+# Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+python3 -m pip uninstall -y typing
 
 cd core/
 python3 -m pip install --upgrade -e .

--- a/docs/build_pip_install.sh
+++ b/docs/build_pip_install.sh
@@ -12,14 +12,13 @@ python3 -m pip uninstall -y autogluon.tabular
 python3 -m pip uninstall -y autogluon.core
 python3 -m pip uninstall -y autogluon-contrib-nlp
 
-# Python 3.7 bug workaround: https://github.com/python/typing/issues/573
-python3 -m pip uninstall -y typing
-
 cd core/
 python3 -m pip install --upgrade -e .
 cd ..
 
 cd tabular/
+# Python 3.7 bug workaround: https://github.com/python/typing/issues/573
+python3 -m pip uninstall -y typing
 python3 -m pip install --upgrade -e .
 cd ..
 

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -53,13 +53,13 @@ requirements = [
     'scikit-learn>=0.22.0,<0.24',
     'networkx>=2.3,<3.0',
     'gluoncv==0.9.0',  # TODO: v0.1 consider using only minimum required code from gluoncv and drop dependency
-    'torch<2.0',  # TODO: v0.1 make optional
-    'fastai<2.0',  # TODO: v0.1 make optional
+    'torch>=1.0,<2.0',  # TODO: v0.1 make optional
+    'fastai>=1.0,<2.0',  # TODO: v0.1 make optional
     f'autogluon.core=={version}',
 ]
 
 test_requirements = [
-    'pytest'
+    'pytest',
 ]
 
 if __name__ == '__main__':

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -52,8 +52,10 @@ requirements = [
     'psutil>=5.0.0,<=5.7.0',  # TODO: psutil 5.7.1/5.7.2 has non-deterministic error on CI doc build -  ImportError: cannot import name '_psutil_linux' from 'psutil'
     'scikit-learn>=0.22.0,<0.24',
     'networkx>=2.3,<3.0',
-    'gluoncv==0.9.0',
-    f'autogluon.core=={version}'
+    'gluoncv==0.9.0',  # TODO: v0.1 consider using only minimum required code from gluoncv and drop dependency
+    'torch<2.0',  # TODO: v0.1 make optional
+    'fastai<2.0',  # TODO: v0.1 make optional
+    f'autogluon.core=={version}',
 ]
 
 test_requirements = [

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/hyperparameter_configs.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/hyperparameter_configs.py
@@ -13,6 +13,7 @@ hyperparameter_config_dict = dict(
         ],
         'CAT': {},
         'XGB': {},
+        'FASTAI': {},
         'RF': [
             {'criterion': 'gini', 'AG_args': {'name_suffix': 'Gini', 'problem_types': ['binary', 'multiclass']}},
             {'criterion': 'entropy', 'AG_args': {'name_suffix': 'Entr', 'problem_types': ['binary', 'multiclass']}},
@@ -38,6 +39,7 @@ hyperparameter_config_dict = dict(
         ],
         'CAT': {},
         'XGB': {},
+        'FASTAI': {},
         'RF': [
             {'criterion': 'gini', 'max_depth': 15, 'AG_args': {'name_suffix': 'Gini', 'problem_types': ['binary', 'multiclass']}},
             {'criterion': 'entropy', 'max_depth': 15, 'AG_args': {'name_suffix': 'Entr', 'problem_types': ['binary', 'multiclass']}},
@@ -59,6 +61,7 @@ hyperparameter_config_dict = dict(
         ],
         'CAT': {},
         'XGB': {},
+        'FASTAI': {},
     },
     # Results in extremely quick to train models. Only use this when prototyping, as the model accuracy will be severely reduced.
     toy={

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/tabular_prediction.py
@@ -219,6 +219,7 @@ class TabularPrediction(BaseTask):
                     ],
                     'CAT': {},
                     'XGB': {},
+                    'FASTAI': {},
                     'RF': [
                         {'criterion': 'gini', 'AG_args': {'name_suffix': 'Gini', 'problem_types': ['binary', 'multiclass']}},
                         {'criterion': 'entropy', 'AG_args': {'name_suffix': 'Entr', 'problem_types': ['binary', 'multiclass']}},
@@ -245,6 +246,8 @@ class TabularPrediction(BaseTask):
                      See also the CatBoost docs: https://catboost.ai/docs/concepts/parameter-tuning.html
                 XGB: `autogluon.tabular.models.xgboost.hyperparameters.parameters`
                      See also the XGBoost docs: https://xgboost.readthedocs.io/en/latest/parameter.html
+                FASTAI: `autogluon.tabular.models.fastainn.hyperparameters.parameters`
+                     See also the FastAI docs: https://docs.fast.ai/tabular.models.html
                 RF: See sklearn documentation: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html
                     Note: Hyperparameter tuning is disabled for this model.
                 XT: See sklearn documentation: https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.ExtraTreesClassifier.html

--- a/tabular/tests/unittests/models/test_tabular_nn_fastai.py
+++ b/tabular/tests/unittests/models/test_tabular_nn_fastai.py
@@ -1,11 +1,7 @@
 
-import pytest
-
 from autogluon.tabular.models.fastainn.tabular_nn_fastai import NNFastAiTabularModel
 
 
-# TODO: Add torch and fastai to CI to enable tests
-@pytest.mark.skip(reason="torch and fastai are not installed during tests.")
 def test_tabular_nn_fastai_binary(fit_helper):
     fit_args = dict(
         hyperparameters={NNFastAiTabularModel: {}},
@@ -14,7 +10,6 @@ def test_tabular_nn_fastai_binary(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
-@pytest.mark.skip(reason="torch and fastai are not installed during tests.")
 def test_tabular_nn_fastai_multiclass(fit_helper):
     fit_args = dict(
         hyperparameters={NNFastAiTabularModel: {}},
@@ -23,7 +18,6 @@ def test_tabular_nn_fastai_multiclass(fit_helper):
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
 
 
-@pytest.mark.skip(reason="torch and fastai are not installed during tests.")
 def test_tabular_nn_fastai_regression(fit_helper):
     fit_args = dict(
         hyperparameters={NNFastAiTabularModel: {}},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds FastAI NN to default models. Also adds `torch` and `fastai` dependencies to Tabular. Plan is to move these into optional dependencies prior to v0.1 release.

Benchmark results:

`AutoGluon_bestquality_1h_2020_12_25` : Mainline
`AutoGluon_bestquality_fastai_1h_2020_12_30_fai` : This PR

```
AutoGluon_bestquality_1h_2020_12_25 VS all
                                        framework  > AutoGluon_bestquality_1h_2020_12_25  < AutoGluon_bestquality_1h_2020_12_25  = AutoGluon_bestquality_1h_2020_12_25  % Less Avg. Errors Than AutoGluon_bestquality_1h_2020_12_25  time_train_s  metric_error  time_infer_s  loss_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0  AutoGluon_bestquality_fastai_1h_2020_12_30_fai                                     53                                     35                                      6                                          -0.545924             3334.171915  75266.267894     99.742766       0.393617  1.404255            58            41             0             0            1
1             AutoGluon_bestquality_1h_2020_12_25                                      0                                      0                                     95                                           0.000000             3362.935319  75201.088629    116.126489       0.563830  1.595745            36            59             0             0            5

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
