### PR TITLE
Tabular: Optimized NN category embedding logic

### DIFF
--- a/tabular/src/autogluon/tabular/features/generators/category.py
+++ b/tabular/src/autogluon/tabular/features/generators/category.py
@@ -111,7 +111,8 @@ class CategoryFeatureGenerator(AbstractFeatureGenerator):
                     if len(category_list) > 1:
                         if self.cat_order == 'original':
                             original_cat_order = list(X_category[column].cat.categories)
-                            category_list = [cat for cat in original_cat_order if cat in category_list]
+                            set_category_list = set(category_list)
+                            category_list = [cat for cat in original_cat_order if cat in set_category_list]
                         elif self.cat_order == 'alphanumeric':
                             category_list.sort()
                     X_category[column] = X_category[column].astype(CategoricalDtype(categories=category_list))  # TODO: Remove columns if all NaN after this?

--- a/tabular/src/autogluon/tabular/models/tabular_nn/categorical_encoders.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/categorical_encoders.py
@@ -765,8 +765,13 @@ class OrdinalMergeRaresHandleUnknownEncoder(_BaseEncoder):
         self
         
         """
-        X = np.array(X).tolist() # converts all elements in X to the same type (i.e. cannot mix floats, ints, and str)
+        X = np.array(X).tolist()  # converts all elements in X to the same type (i.e. cannot mix floats, ints, and str)
         self._fit(X, handle_unknown='ignore')
+
+        self.categories_as_sets_ = [set(categories) for categories in self.categories_]
+        # new level introduced to account for unknown categories, always = 1 + total number of categories seen during training
+        self.categories_unknown_level_ = [min(len(categories), self.max_levels) for categories in self.categories_]
+        self.categories_len_ = [len(categories) for categories in self.categories_]
         return self
     
     def transform(self, X):
@@ -783,15 +788,16 @@ class OrdinalMergeRaresHandleUnknownEncoder(_BaseEncoder):
             Transformed input.
         
         """
-        X = np.array(X).tolist() # converts all elements in X to the same type (i.e. cannot mix floats, ints, and str)
+        X_og_array = np.array(X)  # original X array before transform
+        X = X_og_array.tolist()  # converts all elements in X to the same type (i.e. cannot mix floats, ints, and str)
         X_int, _ = self._transform(X, handle_unknown='ignore')  # will contain zeros for 0th category as well as unknown values.
-        X_og_array = np.array(X) # original X array before transform
+
         for i in range(X_int.shape[1]):
-            feature_i_categories = self.categories_[i]
-            feature_i_numlevels = min(len(feature_i_categories), self.max_levels)
-            unknown_level_i = feature_i_numlevels  # new level introduced to account for unknown categories, alway= 1 + total number of categories seen during training
-            unknown_elements = np.logical_not(np.isin(X_og_array[:,i], feature_i_categories))
-            X_int[unknown_elements,i] = unknown_level_i # replace entries with unknown categories with feature_i_numlevels + 1 value. Do NOT modify self.categories_
+            X_col_data = X_og_array[:, i]
+            cat_set = self.categories_as_sets_[i]
+            unknown_elements = np.array([cat not in cat_set for cat in X_col_data.tolist()])
+            X_int[unknown_elements, i] = self.categories_unknown_level_[i]  # replace entries with unknown categories with feature_i_numlevels + 1 value. Do NOT modify self.categories_
+
         return X_int.astype(self.dtype, copy=False)
     
     def inverse_transform(self, X):
@@ -831,5 +837,3 @@ class OrdinalMergeRaresHandleUnknownEncoder(_BaseEncoder):
             X_tr[:, i] = self.categories_[i][labels]
         
         return X_tr
-
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Optimized NN category embedding logic from O(n) -> O(1) where n is the number of categories.
- Added improved time limit control to NN.
- Optimized category handling for FeatureGenerator when minimum_cat_count is set from O(n) -> O(1).

This change results in a 4x speedup on small-medium category features between 5-15, and 100x+ speedup for extreme category count features during transformation.

The [albert](https://www.openml.org/d/41147) dataset had categorical features with 150,000 unique values:
Previously, NN took 1.5 hrs to transform the categorical features prior to fit. (ignoring time limits while doing so)
Now, NN takes only 30 seconds on the same data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
