### PR TITLE
Tabular: Added time_limit usage to KNN

### DIFF
--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -117,7 +117,7 @@ class KNNModel(AbstractModel):
 
         time_start_sample_loop = time.time()
         time_limit_left = time_limit - (time_start_sample_loop - time_start)
-        for samples in num_rows_samples:
+        for i, samples in enumerate(num_rows_samples):
             if samples != num_rows_max:
                 if self.problem_type == REGRESSION:
                     idx = np.random.choice(num_rows_max, size=samples, replace=False)
@@ -134,9 +134,9 @@ class KNNModel(AbstractModel):
             time_limit_left = time_limit - (time_fit_end_sample - time_start)
             time_fit_sample = time_limit_left_prior - time_limit_left
             time_required_for_next = time_fit_sample * sample_time_growth_factor
-            logger.log(15, f'\t{round(time_fit_sample, 2)}s \t= Train Time (Using {samples} of {num_rows_max} samples) ({round(time_limit_left, 2)}s remaining time)')
-            if time_required_for_next > time_limit_left and samples != num_rows_samples[-1]:
-                logger.log(20, f'\tNot enough time to train model on all training rows. Fit {samples}/{num_rows_max} rows. (Next model expected to take {round(time_required_for_next, 2)}s to train.)')
+            logger.log(15, f'\t{round(time_fit_sample, 2)}s \t= Train Time (Using {samples}/{num_rows_max} rows) ({round(time_limit_left, 2)}s remaining time)')
+            if time_required_for_next > time_limit_left and i != len(num_rows_samples) - 1:
+                logger.log(20, f'\tNot enough time to train KNN model on all training rows. Fit {samples}/{num_rows_max} rows. (Training KNN model on {num_rows_samples[i+1]} rows is expected to take {round(time_required_for_next, 2)}s)')
                 break
         return self.model
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added time_limit usage to KNN
- Fixed very rare crash when label column was category type and not all categories had rows and eval_metric was log_loss.

Previously on the KDDCup99 dataset, KNN would train for >10hrs regardless of time limit.
Now, it trains while respecting the time limit:

```
Fitting model: KNeighbors ... Training model for up to 561.84s of the 561.84s of remaining time.
	Dropped 9 of 40 features.
	0.56s 	= Train Time (Using 10000 of 4365529 samples) (559.12s remaining time)
	0.86s 	= Train Time (Using 20000 of 4365529 samples) (558.26s remaining time)
	1.55s 	= Train Time (Using 40000 of 4365529 samples) (556.71s remaining time)
	20.25s 	= Train Time (Using 80000 of 4365529 samples) (536.46s remaining time)
	62.91s 	= Train Time (Using 160000 of 4365529 samples) (473.55s remaining time)
	Not enough time to train model on all training rows. Fit 160000/4365529 rows. (Next model expected to take 503.29s to train.)
	-0.0141	 = Validation log_loss score
	88.34s	 = Training runtime
	55.95s	 = Validation runtime
```

One edge case to note is that refit_full will still use ALL rows during the refit. It is not clear the desired behavior refit_full should have in the scenario where KNN bags were not trained on all of their data, but it should be addressed prior to v0.1 release (added as FIXME).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
