### PR TITLE
[Bug][Fix] TextPrediction Metric Fix + Fix the default ELECTRA-base config

### DIFF
--- a/docs/tutorials/tabular_prediction/tabular-multimodal-text-others.md
+++ b/docs/tutorials/tabular_prediction/tabular-multimodal-text-others.md
@@ -257,12 +257,14 @@ from autogluon.text.text_prediction.text_prediction import ag_text_prediction_pa
 from autogluon.tabular.task.tabular_prediction.hyperparameter_configs import get_hyperparameter_config
 import copy
 
-text_nn_params = ag_text_prediction_params.create('default_no_hpo')
-text_nn_params['models']['BertForTextPredictionBasic']['search_space']['model.backbone.name'] = 'google_electra_base'
+text_nn_params = ag_text_prediction_params.create('default_electra_base_no_hpo')
 text_nn_params['AG_args'] = {'valid_stacker': False}
 
-tabular_multimodel_hparam_v2 = copy.deepcopy(tabular_multimodel_hparam_v1)
-tabular_multimodel_hparam_v2['TEXT_NN_V1'] = text_nn_params
+tabular_multimodel_hparam_v2 = {
+    'GBM': [{}, {'extra_trees': True, 'AG_args': {'name_suffix': 'XT'}}],
+    'CAT': {},
+    'TEXT_NN_V1': {'AG_args': {'valid_stacker': False}},
+}
 
 predictor_model6 = TabularPrediction.fit(train_df,
                                       label=label_column,

--- a/docs/tutorials/tabular_prediction/tabular-multimodal-text-others.md
+++ b/docs/tutorials/tabular_prediction/tabular-multimodal-text-others.md
@@ -263,7 +263,7 @@ text_nn_params['AG_args'] = {'valid_stacker': False}
 tabular_multimodel_hparam_v2 = {
     'GBM': [{}, {'extra_trees': True, 'AG_args': {'name_suffix': 'XT'}}],
     'CAT': {},
-    'TEXT_NN_V1': {'AG_args': {'valid_stacker': False}},
+    'TEXT_NN_V1': text_nn_params,
 }
 
 predictor_model6 = TabularPrediction.fit(train_df,

--- a/text/src/autogluon/text/text_prediction/models/basic_v1.py
+++ b/text/src/autogluon/text/text_prediction/models/basic_v1.py
@@ -416,7 +416,7 @@ def train_function(args, reporter, train_data, tuning_data,
             dev_score = calculate_metric(stopping_metric_scorer, gt_dev_labels, dev_predictions,
                                          problem_types[0])
             valid_time_spent = time.time() - valid_start_tick
-            # Metrics have ensured that greater --> better
+
             if best_performance_score is None or \
                     (greater_is_better and dev_score >= best_performance_score) or \
                     (not greater_is_better and dev_score <= best_performance_score):

--- a/text/src/autogluon/text/text_prediction/models/basic_v1.py
+++ b/text/src/autogluon/text/text_prediction/models/basic_v1.py
@@ -232,11 +232,12 @@ def _classification_regression_predict(net, dataloader, problem_type,
 def calculate_metric(scorer, ground_truth, predictions, problem_type):
     if problem_type == _C.CLASSIFICATION:
         if scorer.name == 'roc_auc':
-            return scorer(ground_truth, predictions[:, 1])
+            return scorer._sign * scorer(ground_truth, predictions[:, 1])
         else:
-            return scorer(ground_truth, predictions)
+            return scorer._sign * scorer(ground_truth, predictions)
     else:
-        return scorer(ground_truth, predictions)
+        return scorer._sign * scorer(ground_truth, predictions)
+
 
 @use_np
 def train_function(args, reporter, train_data, tuning_data,
@@ -249,6 +250,7 @@ def train_function(args, reporter, train_data, tuning_data,
     if isinstance(log_metrics, str):
         log_metrics = [log_metrics]
     log_metric_scorers = [get_metric(ele) for ele in log_metrics]
+    greater_is_better = log_metric_scorers[0].greater_is_better
     stopping_metric_scorer = get_metric(stopping_metric)
     os.environ['MKL_NUM_THREADS'] = '1'
     os.environ['OMP_NUM_THREADS'] = '1'
@@ -417,7 +419,9 @@ def train_function(args, reporter, train_data, tuning_data,
                                          problem_types[0])
             valid_time_spent = time.time() - valid_start_tick
             # Metrics have ensured that greater --> better
-            if best_performance_score is None or dev_score >= best_performance_score:
+            if best_performance_score is None or \
+                    (greater_is_better and dev_score >= best_performance_score) or \
+                    (not greater_is_better and dev_score <= best_performance_score):
                 find_better = True
                 no_better_rounds = 0
                 best_performance_score = dev_score
@@ -443,8 +447,7 @@ def train_function(args, reporter, train_data, tuning_data,
             if time_limits is not None and total_time_spent > time_limits:
                 break
             report_idx += 1
-            report_items.append((stopping_metric_scorer.reward_attr,
-                                 dev_score))
+            report_items.append((stopping_metric_scorer.name, dev_score))
             report_items.append(('exp_dir', exp_dir))
             if find_better:
                 best_report_items = report_items

--- a/text/src/autogluon/text/text_prediction/models/basic_v1.py
+++ b/text/src/autogluon/text/text_prediction/models/basic_v1.py
@@ -230,11 +230,9 @@ def _classification_regression_predict(net, dataloader, problem_type,
 
 
 def calculate_metric(scorer, ground_truth, predictions, problem_type):
-    if problem_type == _C.CLASSIFICATION:
-        if scorer.name == 'roc_auc':
-            return scorer._sign * scorer(ground_truth, predictions[:, 1])
-        else:
-            return scorer._sign * scorer(ground_truth, predictions)
+    if problem_type == _C.CLASSIFICATION and scorer.name == 'roc_auc':
+        # For ROC_AUC, we need to feed in the probability of positive class to the scorer.
+        return scorer._sign * scorer(ground_truth, predictions[:, 1])
     else:
         return scorer._sign * scorer(ground_truth, predictions)
 
@@ -606,7 +604,7 @@ class BertForTextPredictionBasic:
             resume=False,
             visualizer=scheduler_options.get('visualizer'),
             time_attr='report_idx',
-            reward_attr=stopping_metric_scorer.reward_attr,
+            reward_attr=stopping_metric_scorer.name,
             dist_ip_addrs=scheduler_options.get('dist_ip_addrs'))
         train_fn = search_space_reg(functools.partial(train_function,
                                                       train_data=train_data,

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -41,9 +41,9 @@ def default() -> dict:
         'models': {
             'BertForTextPredictionBasic': {
                 'search_space': {
-                    'model.backbone.name': 'google_electra_base',
+                    'model.backbone.name': 'google_electra_small',
                     'optimization.batch_size': 32,
-                    'optimization.per_device_batch_size': 8,
+                    'optimization.per_device_batch_size': 16,
                     'optimization.num_train_epochs': 4,
                     'optimization.lr': space.Real(1E-5, 1E-4, default=5E-5),
                     'optimization.layerwise_lr_decay': space.Real(0.8, 1.0, default=0.8)
@@ -86,6 +86,10 @@ def default_electra_small() -> dict:
 def default_electra_base_no_hpo() -> dict:
     """The default search space that uses ELECTRA Base as the backbone"""
     cfg = default_no_hpo()
+    cfg['models']['BertForTextPredictionBasic']['search_space']['model.backbone.name'] \
+        = 'google_electra_base'
+    cfg['models']['BertForTextPredictionBasic']['search_space'][
+        'optimization.per_device_batch_size'] = 8
     return cfg
 
 

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -65,23 +65,28 @@ def default() -> dict:
 
 @ag_text_prediction_params.register()
 def default_no_hpo() -> dict:
-    """The default hyperparameters without HPO
+    """The default hyperparameters without HPO"""
+    cfg = default()
+    cfg['hpo_params']['num_trials'] = 1
+    return cfg
 
-    It will have a version key and a list of candidate models.
-    Each model has its own search space inside.
-    """
-    ret = default()
-    ret['hpo_params']['num_trials'] = 1
-    return ret
+
+@ag_text_prediction_params.register()
+def default_electra_small() -> dict:
+    """The default search space that uses ELECTRA Small as the backbone."""
+    cfg = default()
+    cfg['models']['BertForTextPredictionBasic']['search_space']['model.backbone.name'] \
+        = 'google_electra_small'
+    cfg['models']['BertForTextPredictionBasic']['search_space'][
+        'optimization.per_device_batch_size'] = 16
+    return cfg
 
 
 @ag_text_prediction_params.register()
 def default_electra_base_no_hpo() -> dict:
-    ret = default_no_hpo()
-    ret['models']['BertForTextPredictionBasic']['search_space']['model.backbone.name']\
-        = 'google_electra_base'
-    ret['models']['BertForTextPredictionBasic']['search_space']['optimization.per_device_batch_size'] = 8
-    return ret
+    """The default search space that uses ELECTRA Base as the backbone"""
+    cfg = default_no_hpo()
+    return cfg
 
 
 def merge_params(base_params, partial_params=None):

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -232,6 +232,7 @@ class TextPrediction(BaseTask):
             hyperparameters=None,
             plot_results=None,
             seed=None,
+            visualizer=None,
             verbosity=2):
         """Fit models to make predictions based on text inputs.
 
@@ -292,7 +293,9 @@ class TextPrediction(BaseTask):
         plot_results : bool, default = None
             Whether or not to plot intermediate training results during `fit()`.
         seed : int, default = None
-            Seed value for random state used inside `fit()`. 
+            Seed value for random state used inside `fit()`.
+        visualizer : str, default = None
+            How to visualize the neural network training progress during `fit()`. Options: ['mxboard', 'tensorboard', None].
         verbosity : int, default = 2
             Verbosity levels range from 0 to 4 and control how much information is printed
             during fit().

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -41,10 +41,12 @@ def default() -> dict:
         'models': {
             'BertForTextPredictionBasic': {
                 'search_space': {
-                    'model.backbone.name': 'google_electra_small',
+                    'model.backbone.name': 'google_electra_base',
                     'optimization.batch_size': 32,
+                    'optimization.per_device_batch_size': 8,
                     'optimization.num_train_epochs': 4,
-                    'optimization.lr': space.Real(1E-5, 1E-4, default=5E-5)
+                    'optimization.lr': space.Real(1E-5, 1E-4, default=5E-5),
+                    'optimization.layerwise_lr_decay': space.Real(0.8, 1.0, default=0.8)
                 }
             },
         },
@@ -78,6 +80,7 @@ def default_electra_base_no_hpo() -> dict:
     ret = default_no_hpo()
     ret['models']['BertForTextPredictionBasic']['search_space']['model.backbone.name']\
         = 'google_electra_base'
+    ret['models']['BertForTextPredictionBasic']['search_space']['optimization.batch_size'] = 8
     return ret
 
 
@@ -470,7 +473,7 @@ class TextPrediction(BaseTask):
             scheduler_options['grace_period'] = scheduler_options.get(
                 'grace_period', 10)
             scheduler_options['max_t'] = scheduler_options.get(
-                'max_t', 50)
+                'max_t', 10)
 
         if recommended_resource['num_gpus'] == 0:
             warnings.warn('Recommend to use GPU to run the TextPrediction task!')

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -80,7 +80,7 @@ def default_electra_base_no_hpo() -> dict:
     ret = default_no_hpo()
     ret['models']['BertForTextPredictionBasic']['search_space']['model.backbone.name']\
         = 'google_electra_base'
-    ret['models']['BertForTextPredictionBasic']['search_space']['optimization.batch_size'] = 8
+    ret['models']['BertForTextPredictionBasic']['search_space']['optimization.per_device_batch_size'] = 8
     return ret
 
 


### PR DESCRIPTION
This bug was introduced in https://github.com/awslabs/autogluon/pull/770 when I switched to use the metric scorer in the core package. The root cause is that the metric scorer will multiply the sign in the calculation. Thus, the RMSE scorer will actually give you -RMSE.

I corrected the logic in this PR. The bug affects the evaluation code while the training was still correct. The evaluation result will be negative for RMSEs. For example:

```
score = predictor.evaluate(train_df, metric='rmse')
```
And the score can be `-0.7`. The training won't be affected.