### PR TITLE
[Fix] Disable TextPrediction when GPU is not available + Fix Tensorboard Integration

### DIFF
--- a/core/src/autogluon/core/scheduler/fifo.py
+++ b/core/src/autogluon/core/scheduler/fifo.py
@@ -475,6 +475,7 @@ class FIFOScheduler(TaskScheduler):
 
     def _add_training_result(self, task_id, reported_result, config=None):
         if self.visualizer == 'mxboard' or self.visualizer == 'tensorboard':
+            print(reported_result)
             if 'loss' in reported_result:
                 self.mxboard.add_scalar(
                     tag='loss',

--- a/core/src/autogluon/core/scheduler/fifo.py
+++ b/core/src/autogluon/core/scheduler/fifo.py
@@ -475,7 +475,6 @@ class FIFOScheduler(TaskScheduler):
 
     def _add_training_result(self, task_id, reported_result, config=None):
         if self.visualizer == 'mxboard' or self.visualizer == 'tensorboard':
-            print(reported_result)
             if 'loss' in reported_result:
                 self.mxboard.add_scalar(
                     tag='loss',
@@ -483,7 +482,7 @@ class FIFOScheduler(TaskScheduler):
                         f'task {task_id} valid_loss',
                         reported_result['loss']
                     ),
-                    global_step=reported_result[self._reward_attr]
+                    global_step=reported_result[self._time_attr]
                 )
             self.mxboard.add_scalar(
                 tag=self._reward_attr,
@@ -491,7 +490,7 @@ class FIFOScheduler(TaskScheduler):
                     f'task {task_id} {self._reward_attr}',
                     reported_result[self._reward_attr]
                 ),
-                global_step=reported_result[self._reward_attr]
+                global_step=reported_result[self._time_attr]
             )
         with self._fifo_lock:
             # Note: We store all of reported_result in training_history[task_id],

--- a/text/src/autogluon/text/text_prediction/models/basic_v1.py
+++ b/text/src/autogluon/text/text_prediction/models/basic_v1.py
@@ -587,8 +587,6 @@ class BertForTextPredictionBasic:
         os.makedirs(self._output_directory, exist_ok=True)
         search_space_reg = args(search_space=space.Dict(**self.search_space))
         # Scheduler and searcher for HPO
-        if search_strategy.endswith('hyperband') and time_limits is None:
-            time_limits = 5 * 60 * 60  # 5 hours
         if scheduler_options is None:
             scheduler_options = dict()
         stopping_metric_scorer = get_metric(self._stopping_metric)

--- a/text/src/autogluon/text/text_prediction/models/basic_v1.py
+++ b/text/src/autogluon/text/text_prediction/models/basic_v1.py
@@ -598,7 +598,7 @@ class BertForTextPredictionBasic:
             search_options=search_options,
             nthreads_per_trial=resource['num_cpus'],
             ngpus_per_trial=resource['num_gpus'],
-            checkpoint=None,
+            checkpoint=os.path.join(self._output_directory, 'checkpoint.ag'),
             num_trials=num_trials,
             time_out=scheduler_options.get('time_out'),
             resume=False,

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -488,7 +488,7 @@ class TextPrediction(BaseTask):
 
         if recommended_resource['num_gpus'] == 0:
             if 'AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU' in os.environ:
-                use_warning = os.environ['AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU']
+                use_warning = bool(os.environ['AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU'])
             else:
                 use_warning = False
             if use_warning:

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -488,7 +488,7 @@ class TextPrediction(BaseTask):
 
         if recommended_resource['num_gpus'] == 0:
             if 'AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU' in os.environ:
-                use_warning = bool(os.environ['AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU'])
+                use_warning = int(os.environ['AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU'])
             else:
                 use_warning = False
             if use_warning:

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -46,7 +46,7 @@ def default() -> dict:
                     'optimization.per_device_batch_size': 16,
                     'optimization.num_train_epochs': 4,
                     'optimization.lr': space.Real(1E-5, 1E-4, default=5E-5),
-                    'optimization.layerwise_lr_decay': space.Real(0.8, 1.0, default=0.8)
+                    'optimization.layerwise_lr_decay': 0.8
                 }
             },
         },
@@ -475,6 +475,7 @@ class TextPrediction(BaseTask):
             scheduler_options = hyperparameters['hpo_params']['scheduler_options']
             if scheduler_options is None:
                 scheduler_options = dict()
+        scheduler_options['visualizer'] = visualizer
         if search_strategy.endswith('hyperband'):
             # Specific defaults for hyperband scheduling
             scheduler_options['reduction_factor'] = scheduler_options.get(
@@ -482,10 +483,12 @@ class TextPrediction(BaseTask):
             scheduler_options['grace_period'] = scheduler_options.get(
                 'grace_period', 10)
             scheduler_options['max_t'] = scheduler_options.get(
-                'max_t', 10)
+                'max_t', 50)
 
         if recommended_resource['num_gpus'] == 0:
-            warnings.warn('Recommend to use GPU to run the TextPrediction task!')
+            raise RuntimeError('Only CPU is detected and we will not proceed to run TextPrediction.'
+                               ' GPU is required to run the model! You may set '
+                               '`ngpus_per_trial` to enable GPU.')
         model = model_candidates[0]
         if plot_results is None:
             if in_ipynb():

--- a/text/src/autogluon/text/text_prediction/text_prediction.py
+++ b/text/src/autogluon/text/text_prediction/text_prediction.py
@@ -1,6 +1,7 @@
 import logging
 import copy
 import warnings
+import os
 from packaging import version
 
 import numpy as np
@@ -486,9 +487,22 @@ class TextPrediction(BaseTask):
                 'max_t', 50)
 
         if recommended_resource['num_gpus'] == 0:
-            raise RuntimeError('Only CPU is detected and we will not proceed to run TextPrediction.'
-                               ' GPU is required to run the model! You may set '
-                               '`ngpus_per_trial` to enable GPU.')
+            if 'AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU' in os.environ:
+                use_warning = os.environ['AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU']
+            else:
+                use_warning = False
+            if use_warning:
+                warnings.warn('No GPU is detected in the machine and we will recommend you to '
+                              'use TextPrediction on a GPU-enabled instance. Currently, '
+                              'training on CPU is slow.')
+            else:
+                raise RuntimeError('No GPU is detected in the machine and we will '
+                                   'not proceed to run TexPrediction because they will train '
+                                   'too slowly with only CPU. You may try to set `ngpus_per_trial` '
+                                   'to a number larger than 0 when calling `.fit()`. '
+                                   'Also, you can set the environment variable '
+                                   '"AUTOGLUON_TEXT_TRAIN_WITHOUT_GPU=1" to force the model to '
+                                   'use CPU for training.')
         model = model_candidates[0]
         if plot_results is None:
             if in_ipynb():

--- a/text/tests/unittests/test_text_prediction.py
+++ b/text/tests/unittests/test_text_prediction.py
@@ -46,7 +46,7 @@ def test_sst():
     dev_data = dev_data.iloc[valid_perm[:10]]
     predictor = task.fit(train_data, hyperparameters=test_hyperparameters,
                          label='label', num_trials=1,
-                         ngpus_per_trial=0,
+                         ngpus_per_trial=1,
                          verbosity=4,
                          output_directory='./sst',
                          plot_results=False)
@@ -129,7 +129,7 @@ def test_no_job_finished_raise():
         # Setting a very small time limits to trigger the bug
         predictor = task.fit(train_data, hyperparameters=test_hyperparameters,
                              label='label', num_trials=1,
-                             ngpus_per_trial=0,
+                             ngpus_per_trial=1,
                              verbosity=4,
                              time_limits=10,
                              output_directory='./sst_raise',
@@ -207,7 +207,7 @@ def test_empty_text_item():
     train_data.iat[10, 0] = None
     predictor = task.fit(train_data, hyperparameters=test_hyperparameters,
                          label='score', num_trials=1,
-                         ngpus_per_trial=0,
+                         ngpus_per_trial=1,
                          verbosity=4,
                          output_directory='./sts_empty_text_item',
                          plot_results=False)


### PR DESCRIPTION
- [x] Disable TextPrediction when GPU is not available
- [x] Add the `visualizer` option to TextPrediction
- [x] Fix Tensorboard. After the fix, we can use the following code to log to tensorboard.

```
predictor = TextPrediction.fit(train_data, label='Sentiment', visualizer='tensorboard')
```

<img width="1028" alt="Screen Shot 2021-01-05 at 10 06 39 PM" src="https://user-images.githubusercontent.com/5178350/103735340-b7178400-4fa2-11eb-99a8-9d5213f9144f.png">
