### PR TITLE
[Scheduler][Bugfix] Added resources availability check before time limit is checked

### DIFF
--- a/core/src/autogluon/core/scheduler/managers.py
+++ b/core/src/autogluon/core/scheduler/managers.py
@@ -49,3 +49,6 @@ class TaskManagers(object):
 
     def release_resources(self, resources):
         self.resource_manager._release(resources)
+
+    def check_availability(self, resources):
+        return self.resource_manager.check_availability(resources)


### PR DESCRIPTION
*Description of changes:*

Added  a quick check if resources are available before we check the time limit. This is required to prevent booking of the next job while we are waiting for a resource, which results in going over the time limit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
