### PR TITLE
Tabular: Per model HPO control

### DIFF
--- a/core/src/autogluon/core/task/base/base_task.py
+++ b/core/src/autogluon/core/task/base/base_task.py
@@ -204,6 +204,7 @@ def compile_scheduler_options_v2(
         scheduler_options = dict()
     else:
         assert isinstance(scheduler_options, dict)
+    scheduler_options = copy.copy(scheduler_options)
     if dist_ip_addrs is None:
         dist_ip_addrs = []
     if search_strategy is None:
@@ -231,7 +232,13 @@ def compile_scheduler_options_v2(
         'visualizer': visualizer,
         'dist_ip_addrs': dist_ip_addrs,
     }
-    scheduler_params.update(copy.copy(scheduler_options))
+    resource = None
+    if 'resource' in scheduler_options:
+        scheduler_params['resource'].update(scheduler_options['resource'])
+        resource = scheduler_params['resource'].copy()
+    scheduler_params.update(scheduler_options)
+    if resource:
+        scheduler_params['resource'] = resource
 
     scheduler_params['resource']['num_cpus'], scheduler_params['resource']['num_gpus'] = setup_compute(
         nthreads_per_trial=scheduler_params['resource']['num_cpus'],

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -69,10 +69,9 @@ def setup_outputdir(path, warn_if_exist=True):
 
 
 def setup_compute(nthreads_per_trial, ngpus_per_trial):
-    if nthreads_per_trial is None or nthreads_per_trial == 'all' or nthreads_per_trial == 'auto':  # FIXME: Use 'auto' downstream
+    if nthreads_per_trial is None or nthreads_per_trial == 'all':
         nthreads_per_trial = get_cpu_count()  # Use all of processing power / trial by default. To use just half: # int(np.floor(multiprocessing.cpu_count()/2))
-
-    if ngpus_per_trial is None or ngpus_per_trial == 'auto':  # FIXME: Use 'auto' downstream
+    if ngpus_per_trial is None:
         ngpus_per_trial = 0  # do not use GPU by default
     elif ngpus_per_trial == 'all':
         ngpus_per_trial = get_gpu_count()

--- a/docs/tutorials/tabular_prediction/tabular-multimodal-text-others.md
+++ b/docs/tutorials/tabular_prediction/tabular-multimodal-text-others.md
@@ -234,7 +234,7 @@ tabular_multimodel_hparam_v2 = {
 }
 
 predictor_model6 = TabularPredictor(label=label, eval_metric='accuracy', path='model6').fit(
-    train_df, hyperparameters=tabular_multimodel_hparam_v2, num_gpus=1
+    train_df, hyperparameters=tabular_multimodel_hparam_v2
 )
 ```
 

--- a/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
+++ b/tabular/src/autogluon/tabular/models/abstract/abstract_model.py
@@ -272,10 +272,10 @@ class AbstractModel:
         elif time_limit is not None:
             time_limit = max(time_limit, min_time_limit)
         kwargs['time_limit'] = time_limit
-        kwargs = self._preprocess_fit_resources(kwargs)
+        kwargs = self._preprocess_fit_resources(**kwargs)
         return kwargs
 
-    def _preprocess_fit_resources(self, kwargs):
+    def _preprocess_fit_resources(self, **kwargs):
         default_num_cpus, default_num_gpus = self._get_default_resources()
         num_cpus = self.params_aux.get('num_cpus', 'auto')
         num_gpus = self.params_aux.get('num_gpus', 'auto')
@@ -508,6 +508,7 @@ class AbstractModel:
 
     def hyperparameter_tune(self, scheduler_options, time_limit=None, **kwargs):
         scheduler_options = copy.deepcopy(scheduler_options)
+        scheduler_options[1]['resource'] = self._preprocess_fit_resources(**scheduler_options[1]['resource'])
         if 'time_out' not in scheduler_options[1]:
             scheduler_options[1]['time_out'] = time_limit
         return self._hyperparameter_tune(scheduler_options=scheduler_options, **kwargs)

--- a/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
+++ b/tabular/src/autogluon/tabular/models/ensemble/bagged_ensemble_model.py
@@ -602,7 +602,7 @@ class BaggedEnsembleModel(AbstractModel):
         oof_pred_model_repeats = np.zeros(shape=len(X), dtype=np.uint8)
         return oof_pred_proba, oof_pred_model_repeats
 
-    def _preprocess_fit_resources(self, kwargs):
+    def _preprocess_fit_resources(self, **kwargs):
         """Pass along to child models to avoid altering up-front"""
         return kwargs
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -591,10 +591,13 @@ class TabularPredictor(TabularPredictorV1):
             if ag_args_ensemble is None:
                 ag_args_ensemble = {}
             ag_args_ensemble['save_bag_folds'] = kwargs['_save_bag_folds']
+        if scheduler_options is not None:
+            if ag_args is None:
+                ag_args = {}
+            ag_args['hyperparameter_tune_kwargs'] = scheduler_options
 
         core_kwargs = {'ag_args': ag_args, 'ag_args_ensemble': ag_args_ensemble, 'ag_args_fit': ag_args_fit, 'excluded_model_types': excluded_model_types}
         self._learner.fit(X=train_data, X_val=tuning_data, X_unlabeled=unlabeled_data,
-                          hyperparameter_tune_kwargs=scheduler_options,
                           holdout_frac=holdout_frac, num_bag_folds=num_bag_folds, num_bag_sets=num_bag_sets, num_stack_levels=num_stack_levels,
                           hyperparameters=hyperparameters, core_kwargs=core_kwargs,
                           time_limit=time_limit, verbosity=verbosity)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -813,7 +813,7 @@ class TabularPredictor(TabularPredictorV1):
         learner = predictor._learner_type.load(path)
         predictor._set_post_fit_vars(learner=learner)
         try:
-            from ...version import __version__
+            from ..version import __version__
             version_inference = __version__
         except:
             version_inference = None

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -813,7 +813,6 @@ class AbstractTrainer:
                 save_bag_folds = True
 
         weighted_ensemble_model = self.get_models(
-            stopping_metric=self.eval_metric,
             hyperparameters={
                 'default': {
                     'ENS_WEIGHTED': [child_hyperparameters],

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1,6 +1,6 @@
 import copy, time, traceback, logging
 import os
-from typing import List, Union
+from typing import List, Union, Tuple
 
 import networkx as nx
 import numpy as np
@@ -12,8 +12,9 @@ from autogluon.core.constants import AG_ARGS, AG_ARGS_FIT, BINARY, MULTICLASS, R
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_json, save_pkl
 from autogluon.core.utils.exceptions import TimeLimitExceeded, NotEnoughMemoryError, NoValidFeatures, NoGPUError
-from autogluon.core.utils import shuffle_df_rows, default_holdout_frac
-from autogluon.core.metrics import log_loss, scorer_expects_y_pred
+from autogluon.core.utils import default_holdout_frac
+from autogluon.core.metrics import scorer_expects_y_pred
+from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 
 from ..utils import get_pred_from_proba, generate_train_test_split, infer_eval_metric, compute_permutation_feature_importance
 from ..models.abstract.abstract_model import AbstractModel
@@ -176,7 +177,7 @@ class AbstractTrainer:
             return -1
 
     # TODO: Rename method for v0.1
-    def get_models(self, hyperparameters: dict, **kwargs) -> List[AbstractModel]:
+    def get_models(self, hyperparameters: dict, **kwargs) -> Tuple[List[AbstractModel], dict]:
         """Constructs a list of unfit models based on the hyperparameters dict."""
         raise NotImplementedError
 
@@ -208,7 +209,7 @@ class AbstractTrainer:
     # TODO: Enable feature prune on levels > 0
     # TODO: Enable easier re-mapping of trained models -> hyperparameters input (They don't share a key since name can change)
     def train_multi_levels(self, X_train, y_train, hyperparameters: dict, X_val=None, y_val=None, X_unlabeled=None, base_model_names: List[str] = None,
-                           hyperparameter_tune_kwargs=None, feature_prune=False, core_kwargs: dict = None, aux_kwargs: dict = None, level_start=0, level_end=0, time_limit=None, name_suffix: str = None, relative_stack=True) -> List[str]:
+                           feature_prune=False, core_kwargs: dict = None, aux_kwargs: dict = None, level_start=0, level_end=0, time_limit=None, name_suffix: str = None, relative_stack=True) -> List[str]:
         """
         Trains a multi-layer stack ensemble using the input data on the hyperparameters dict input.
             hyperparameters is used to determine the models used in each stack layer.
@@ -255,14 +256,11 @@ class AbstractTrainer:
                 core_kwargs_level['time_limit'] = core_kwargs_level.get('time_limit', time_limit_core)
                 aux_kwargs_level['time_limit'] = aux_kwargs_level.get('time_limit', time_limit_aux)
             if level != 0:
-                if hyperparameter_tune_kwargs:
-                    logger.log(15, 'Warning: Hyperparameter tuning is not implemented for stack levels > 0.')
-                hyperparameter_tune_kwargs = None  # TODO: Enable HPO on levels > 0
                 feature_prune = False  # TODO: Enable feature prune on levels > 0
             base_model_names, aux_models = self.stack_new_level(
                 X=X_train, y=y_train, X_val=X_val, y_val=y_val, X_unlabeled=X_unlabeled,
                 models=hyperparameters, level=level, base_model_names=base_model_names,
-                hyperparameter_tune_kwargs=hyperparameter_tune_kwargs, feature_prune=feature_prune,
+                feature_prune=feature_prune,
                 core_kwargs=core_kwargs_level, aux_kwargs=aux_kwargs_level, name_suffix=name_suffix,
             )
             model_names_fit += base_model_names + aux_models
@@ -271,7 +269,7 @@ class AbstractTrainer:
         return model_names_fit
 
     def stack_new_level(self, X, y, models: Union[List[AbstractModel], dict], X_val=None, y_val=None, X_unlabeled=None, level=0, base_model_names: List[str] = None,
-                        hyperparameter_tune_kwargs=None, feature_prune=False, core_kwargs: dict = None, aux_kwargs: dict = None, name_suffix: str = None) -> (List[str], List[str]):
+                        feature_prune=False, core_kwargs: dict = None, aux_kwargs: dict = None, name_suffix: str = None) -> (List[str], List[str]):
         """
         Similar to calling self.stack_new_level_core, except auxiliary models will also be trained via a call to self.stack_new_level_aux, with the models trained from self.stack_new_level_core used as base models.
         """
@@ -287,8 +285,7 @@ class AbstractTrainer:
             core_kwargs['name_suffix'] = core_kwargs.get('name_suffix', '') + name_suffix
             aux_kwargs['name_suffix'] = aux_kwargs.get('name_suffix', '') + name_suffix
         core_models = self.stack_new_level_core(X=X, y=y, X_val=X_val, y_val=y_val, X_unlabeled=X_unlabeled, models=models,
-                                                level=level, base_model_names=base_model_names,
-                                                hyperparameter_tune_kwargs=hyperparameter_tune_kwargs, feature_prune=feature_prune, **core_kwargs)
+                                                level=level, base_model_names=base_model_names, feature_prune=feature_prune, **core_kwargs)
         if self.bagged_mode:
             aux_models = self.stack_new_level_aux(X=X, y=y, base_model_names=core_models, level=level+1, **aux_kwargs)
         else:
@@ -310,32 +307,46 @@ class AbstractTrainer:
         if not self.bagged_mode and level != 0:
             raise ValueError('Stack Ensembling is not valid for non-bagged mode.')
 
-        hyperparameter_preprocess_kwargs = {'excluded_model_types': excluded_model_types}
+        if isinstance(models, dict):
+            get_models_kwargs = dict(
+                level=level,
+                name_suffix=name_suffix,
+                ag_args=ag_args,
+                ag_args_fit=ag_args_fit,
+                hyperparameter_preprocess_func=self._process_hyperparameters,
+                hyperparameter_preprocess_kwargs={'excluded_model_types': excluded_model_types},
+            )
 
-        if self.bagged_mode:
-            if level == 0:
-                (base_model_names, base_model_paths, base_model_types) = (None, None, None)
-            elif level > 0:
-                base_model_names, base_model_paths, base_model_types = self._get_models_load_info(model_names=base_model_names)
-                if len(base_model_names) == 0:
-                    logger.log(20, 'No base models to train on, skipping stack level...')
-                    return []
-            else:
-                raise AssertionError(f'Stack level cannot be negative! level = {level}')
+            if self.bagged_mode:
+                if level == 0:
+                    (base_model_names, base_model_paths, base_model_types) = (None, None, None)
+                elif level > 0:
+                    base_model_names, base_model_paths, base_model_types = self._get_models_load_info(model_names=base_model_names)
+                    if len(base_model_names) == 0:
+                        logger.log(20, 'No base models to train on, skipping stack level...')
+                        return []
+                else:
+                    raise AssertionError(f'Stack level cannot be negative! level = {level}')
 
-            if isinstance(models, dict):
                 ensemble_kwargs = {
                     'base_model_names': base_model_names,
                     'base_model_paths_dict': base_model_paths,
                     'base_model_types_dict': base_model_types,
                     'random_state': level + self.random_seed,
                 }
-                models = self.get_models(models, hyperparameter_tune_kwargs=kwargs.get('hyperparameter_tune_kwargs', None), level=level, name_suffix=name_suffix, ag_args=ag_args, ag_args_fit=ag_args_fit,
-                                         ensemble_type=ensemble_type, ensemble_kwargs=ensemble_kwargs, ag_args_ensemble=ag_args_ensemble,
-                                         hyperparameter_preprocess_func=self._process_hyperparameters, hyperparameter_preprocess_kwargs=hyperparameter_preprocess_kwargs)
-        elif isinstance(models, dict):
-            models = self.get_models(models, hyperparameter_tune_kwargs=kwargs.get('hyperparameter_tune_kwargs', None), level=level, name_suffix=name_suffix, ag_args=ag_args, ag_args_fit=ag_args_fit,
-                                     hyperparameter_preprocess_func=self._process_hyperparameters, hyperparameter_preprocess_kwargs=hyperparameter_preprocess_kwargs)
+                get_models_kwargs.update(dict(
+                    ag_args_ensemble=ag_args_ensemble,
+                    ensemble_type=ensemble_type,
+                    ensemble_kwargs=ensemble_kwargs,
+                ))
+
+            models, model_args_fit = self.get_models(hyperparameters=models, **get_models_kwargs)
+            if model_args_fit:
+                hyperparameter_tune_kwargs = {
+                    model_name: model_args_fit[model_name]['hyperparameter_tune_kwargs']
+                    for model_name in model_args_fit if 'hyperparameter_tune_kwargs' in model_args_fit[model_name]
+                }
+                kwargs['hyperparameter_tune_kwargs'] = hyperparameter_tune_kwargs
         X_train_init = self.get_inputs_to_stacker(X, base_models=base_model_names, fit=True)
         if X_val is not None:
             X_val = self.get_inputs_to_stacker(X_val, base_models=base_model_names, fit=False)
@@ -812,7 +823,7 @@ class AbstractTrainer:
             else:
                 save_bag_folds = True
 
-        weighted_ensemble_model = self.get_models(
+        weighted_ensemble_model, _ = self.get_models(
             hyperparameters={
                 'default': {
                     'ENS_WEIGHTED': [child_hyperparameters],
@@ -1010,6 +1021,9 @@ class AbstractTrainer:
                 raise ValueError(f'n_repeat_start must be 0 to hyperparameter_tune, value = {n_repeat_start}')
             elif k_fold_start != 0:
                 raise ValueError(f'k_fold_start must be 0 to hyperparameter_tune, value = {k_fold_start}')
+            if not isinstance(hyperparameter_tune_kwargs, tuple):
+                num_trials = 1 if time_limit is None else None
+                hyperparameter_tune_kwargs = scheduler_factory(hyperparameter_tune_kwargs, num_trials=num_trials)
             # hpo_models (dict): keys = model_names, values = model_paths
             logging.log(20, f'Hyperparameter tuning model: {model.name} ...')
             try:
@@ -1104,17 +1118,23 @@ class AbstractTrainer:
             k_fold=k_fold,
         )
         fit_args.update(kwargs)
-
+        hpo_enabled = False
         if hyperparameter_tune_kwargs:
+            for key in hyperparameter_tune_kwargs:
+                if hyperparameter_tune_kwargs[key] is not None:
+                    hpo_enabled = True
+                    break
+
+        if hpo_enabled:
             time_split = True
         else:
             time_split = False
         if k_fold == 0:
-            time_ratio = 0.9 if hyperparameter_tune_kwargs else 1
+            time_ratio = 0.9 if hpo_enabled else 1
             models = self._train_multi_fold(models=models, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs, feature_prune=feature_prune, time_limit=time_limit, time_split=time_split, time_ratio=time_ratio, **fit_args)
         else:
             k_fold_start = 0
-            if hyperparameter_tune_kwargs or feature_prune:
+            if hpo_enabled or feature_prune:
                 time_start = time.time()
                 time_ratio = (1 - (1 / k_fold)) * 0.9
                 models = self._train_multi_fold(models=models, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs, feature_prune=feature_prune,
@@ -1131,7 +1151,8 @@ class AbstractTrainer:
     # TODO: Robert dataset, LightGBM is super good but RF and KNN take all the time away from it on 1h despite being much worse
     # TODO: Add time_limit_per_model
     # TODO: Rename for v0.1
-    def _train_multi_fold(self, X_train, y_train, models: List[AbstractModel], time_limit=None, time_split=False, time_ratio=1, **kwargs) -> List[str]:
+    def _train_multi_fold(self, X_train, y_train, models: List[AbstractModel], time_limit=None, time_split=False,
+                          time_ratio=1, hyperparameter_tune_kwargs=None, **kwargs) -> List[str]:
         """
         Trains and saves a list of models sequentially.
         This method should only be called in self._train_multi_initial
@@ -1150,6 +1171,10 @@ class AbstractTrainer:
                 model = self.load_model(model)
             elif self.low_memory:
                 model = copy.deepcopy(model)
+            if hyperparameter_tune_kwargs is not None and isinstance(hyperparameter_tune_kwargs, dict):
+                hyperparameter_tune_kwargs_model = hyperparameter_tune_kwargs.get(model.name, None)
+            else:
+                hyperparameter_tune_kwargs_model = None
             # TODO: Only update scores when finished, only update model as part of final models if finished!
             if time_split:
                 time_left = time_limit_model_split
@@ -1159,7 +1184,8 @@ class AbstractTrainer:
                 else:
                     time_start_model = time.time()
                     time_left = time_limit - (time_start_model - time_start)
-            model_name_trained_lst = self._train_single_full(X_train, y_train, model, time_limit=time_left, **kwargs)
+            model_name_trained_lst = self._train_single_full(X_train, y_train, model, time_limit=time_left,
+                                                             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs_model, **kwargs)
 
             if self.low_memory:
                 del model
@@ -1935,9 +1961,9 @@ class AbstractTrainer:
             hyperparameters = {'GBM': {}, 'CAT': {}, 'NN': {}, 'RF': {}}
         hyperparameters = self._process_hyperparameters(hyperparameters=hyperparameters)  # TODO: consider exposing ag_args_fit, excluded_model_types as distill() arguments.
         if teacher_preds is None or teacher_preds == 'hard':
-            models_distill = self.get_models(hyperparameters=hyperparameters, name_suffix=student_suffix)
+            models_distill, _ = self.get_models(hyperparameters=hyperparameters, name_suffix=student_suffix)
         else:
-            models_distill = get_preset_models_distillation(path=self.path, problem_type=self.problem_type,
+            models_distill, _ = get_preset_models_distillation(path=self.path, problem_type=self.problem_type,
                                                             eval_metric=self.eval_metric, feature_metadata=self.feature_metadata,
                                                             num_classes=self.num_classes, hyperparameters=hyperparameters, name_suffix=student_suffix, invalid_model_names=self.get_model_names())
             if self.problem_type != REGRESSION:

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -1022,8 +1022,8 @@ class AbstractTrainer:
             elif k_fold_start != 0:
                 raise ValueError(f'k_fold_start must be 0 to hyperparameter_tune, value = {k_fold_start}')
             if not isinstance(hyperparameter_tune_kwargs, tuple):
-                num_trials = 1 if time_limit is None else None
-                hyperparameter_tune_kwargs = scheduler_factory(hyperparameter_tune_kwargs, num_trials=num_trials)
+                num_trials = 1 if time_limit is None else 1000
+                hyperparameter_tune_kwargs = scheduler_factory(hyperparameter_tune_kwargs, num_trials=num_trials, nthreads_per_trial='auto', ngpus_per_trial='auto')
             # hpo_models (dict): keys = model_names, values = model_paths
             logging.log(20, f'Hyperparameter tuning model: {model.name} ...')
             try:

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -20,7 +20,7 @@ class AutoTrainer(AbstractTrainer):
         return get_preset_models(path=path, problem_type=problem_type, eval_metric=eval_metric,
                                  num_classes=num_classes, hyperparameters=hyperparameters, invalid_model_names=invalid_model_names, feature_metadata=feature_metadata, **kwargs)
 
-    def fit(self, X_train, y_train, hyperparameters, X_val=None, y_val=None, X_unlabeled=None, hyperparameter_tune_kwargs=None, feature_prune=False, holdout_frac=0.1, num_stack_levels=0, core_kwargs: dict = None, time_limit=None, **kwargs):
+    def fit(self, X_train, y_train, hyperparameters, X_val=None, y_val=None, X_unlabeled=None, feature_prune=False, holdout_frac=0.1, num_stack_levels=0, core_kwargs: dict = None, time_limit=None, **kwargs):
         for key in kwargs:
             logger.warning(f'Warning: Unknown argument passed to `AutoTrainer.train()`. Argument: {key}')
 
@@ -38,5 +38,5 @@ class AutoTrainer(AbstractTrainer):
                 logger.log(20, f'Automatically generating train/validation split with holdout_frac={holdout_frac}, Train Rows: {len(X_train)}, Val Rows: {len(X_val)}')
 
         self._train_multi_and_ensemble(X_train, y_train, X_val, y_val, X_unlabeled=X_unlabeled, hyperparameters=hyperparameters,
-                                       hyperparameter_tune_kwargs=hyperparameter_tune_kwargs, feature_prune=feature_prune,
+                                       feature_prune=feature_prune,
                                        num_stack_levels=num_stack_levels, time_limit=time_limit, core_kwargs=core_kwargs)

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -17,8 +17,9 @@ class AutoTrainer(AbstractTrainer):
         num_classes = kwargs.pop('num_classes', self.num_classes)
         invalid_model_names = kwargs.pop('invalid_model_names', self.get_model_names())
         feature_metadata = kwargs.pop('feature_metadata', self.feature_metadata)
+        silent = kwargs.pop('silent', self.verbosity < 3)
         return get_preset_models(path=path, problem_type=problem_type, eval_metric=eval_metric,
-                                 num_classes=num_classes, hyperparameters=hyperparameters, invalid_model_names=invalid_model_names, feature_metadata=feature_metadata, **kwargs)
+                                 num_classes=num_classes, hyperparameters=hyperparameters, invalid_model_names=invalid_model_names, feature_metadata=feature_metadata, silent=silent, **kwargs)
 
     def fit(self, X_train, y_train, hyperparameters, X_val=None, y_val=None, X_unlabeled=None, feature_prune=False, holdout_frac=0.1, num_stack_levels=0, core_kwargs: dict = None, time_limit=None, **kwargs):
         for key in kwargs:

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -110,7 +110,7 @@ DEFAULT_MODEL_NAMES = {
 # DONE: Add banned_model_types arg
 # TODO: Add option to update hyperparameters with only added keys, so disabling CatBoost would just be {'CAT': []}, which keeps the other models as is.
 # TODO: special optional AG arg for only training model if eval_metric in list / not in list. Useful for F1 and 'is_unbalanced' arg in LGBM.
-def get_preset_models(path, problem_type, eval_metric, hyperparameters, feature_metadata=None, num_classes=None, hyperparameter_tune_kwargs=None,
+def get_preset_models(path, problem_type, eval_metric, hyperparameters, feature_metadata=None, num_classes=None,
                       level: int = 0, ensemble_type=StackerEnsembleModel, ensemble_kwargs: dict = None, ag_args_fit=None, ag_args=None, ag_args_ensemble=None,
                       name_suffix: str = None, default_priorities=None, invalid_model_names: list = None,
                       hyperparameter_preprocess_func=None, hyperparameter_preprocess_kwargs=None, silent=True):
@@ -129,15 +129,20 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, feature_
             default_priorities.update(PROBLEM_TYPE_MODEL_PRIORITY[problem_type])
 
     level_key = level if level in hyperparameters.keys() else 'default'
+    if level_key not in hyperparameters.keys() and level_key == 'default':
+        hyperparameters = {'default': hyperparameters}
     hp_level = hyperparameters[level_key]
     priority_dict = defaultdict(list)
     for model_type in hp_level:
-        for model in hp_level[model_type]:
+        models_of_type = hp_level[model_type]
+        if not isinstance(models_of_type, list):
+            models_of_type = [models_of_type]
+        for model in models_of_type:
             model = clean_model_config(model=model, model_type=model_type, ag_args=ag_args, ag_args_ensemble=ag_args_ensemble, ag_args_fit=ag_args_fit)
             model[AG_ARGS]['priority'] = model[AG_ARGS].get('priority', default_priorities.get(model_type, DEFAULT_CUSTOM_MODEL_PRIORITY))
             model_priority = model[AG_ARGS]['priority']
             # Check if model is valid
-            is_valid = is_model_valid(model, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs, level=level)
+            is_valid = is_model_valid(model, level=level)
             if is_valid:
                 priority_dict[model_priority].append(model)
 
@@ -146,16 +151,18 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters, feature_
     if not silent:
         logger.log(20, 'Model configs to train:')
     models = []
+    model_args_fit = {}
     for model in model_priority_list:
         model_init = model_factory(model, path=path, problem_type=problem_type, eval_metric=eval_metric,
                                    num_classes=num_classes, name_suffix=name_suffix, ensemble_type=ensemble_type, ensemble_kwargs=ensemble_kwargs,
                                    invalid_name_set=invalid_name_set, level=level, feature_metadata=feature_metadata)
         invalid_name_set.add(model_init.name)
+        if 'hyperparameter_tune_kwargs' in model[AG_ARGS]:
+            model_args_fit[model_init.name] = {'hyperparameter_tune_kwargs': model[AG_ARGS]['hyperparameter_tune_kwargs']}
         if not silent:
             logger.log(20, f'\t{model_init.name}: \t{model}')
         models.append(model_init)
-
-    return models
+    return models, model_args_fit
 
 
 def clean_model_config(model: dict, model_type=None, ag_args=None, ag_args_ensemble=None, ag_args_fit=None):
@@ -199,13 +206,13 @@ def clean_model_config(model: dict, model_type=None, ag_args=None, ag_args_ensem
 
 
 # Check if model is valid
-def is_model_valid(model, hyperparameter_tune_kwargs=None, level=0):
+def is_model_valid(model, level=0):
     is_valid = True
     if AG_ARGS not in model:
         is_valid = False  # AG_ARGS is required
     elif model[AG_ARGS].get('model_type', None) is None:
         is_valid = False  # model_type is required
-    elif hyperparameter_tune_kwargs and model[AG_ARGS].get('disable_in_hpo', False):
+    elif model[AG_ARGS].get('hyperparameter_tune_kwargs', None) and model[AG_ARGS].get('disable_in_hpo', False):
         is_valid = False
     elif not model[AG_ARGS].get('valid_stacker', True) and level > 0:
         is_valid = False  # Not valid as a stacker model
@@ -264,7 +271,7 @@ def model_factory(
 
 
 # TODO: v0.1 cleanup and avoid hardcoded logic with model names
-def get_preset_models_softclass(path, hyperparameters, feature_metadata, num_classes=None, hyperparameter_tune_kwargs=None, name_suffix='', ag_args=None, invalid_model_names: list = None):
+def get_preset_models_softclass(path, hyperparameters, feature_metadata, num_classes=None, name_suffix='', ag_args=None, invalid_model_names: list = None):
     model_types_standard = ['GBM', 'NN', 'CAT']
     hyperparameters = copy.deepcopy(hyperparameters)
     hyperparameters_standard = copy.deepcopy(hyperparameters)
@@ -277,8 +284,8 @@ def get_preset_models_softclass(path, hyperparameters, feature_metadata, num_cla
         hyperparameters_standard = {key: hyperparameters_standard[key] for key in hyperparameters_standard if key in model_types_standard}
         hyperparameters_rf = {key: hyperparameters_rf[key] for key in hyperparameters_rf if key == 'RF'}
         # TODO: add support for per-stack level hyperparameters
-    models = get_preset_models(path=path, problem_type=SOFTCLASS, feature_metadata=feature_metadata, eval_metric=soft_log_loss, ag_args_fit={'stopping_metric': soft_log_loss},
-                               hyperparameters=hyperparameters_standard, num_classes=num_classes, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+    models, model_args_fit = get_preset_models(path=path, problem_type=SOFTCLASS, feature_metadata=feature_metadata, eval_metric=soft_log_loss, ag_args_fit={'stopping_metric': soft_log_loss},
+                               hyperparameters=hyperparameters_standard, num_classes=num_classes,
                                ag_args=ag_args, name_suffix=name_suffix, default_priorities=DEFAULT_SOFTCLASS_PRIORITY, invalid_model_names=invalid_model_names)
     if invalid_model_names is None:
         invalid_model_names = []
@@ -303,9 +310,10 @@ def get_preset_models_softclass(path, hyperparameters, feature_metadata, num_cla
             hyperparameters_rf['RF'] = rf_params
         elif 'default' in hyperparameters_rf and 'RF' in hyperparameters_rf['default']:
             hyperparameters_rf['default']['RF'] = rf_params
-        rf_models = get_preset_models(path=path, problem_type=REGRESSION, feature_metadata=feature_metadata, eval_metric=mean_squared_error,
-                                      hyperparameters=hyperparameters_rf, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+        rf_models, model_args_fit_rf = get_preset_models(path=path, problem_type=REGRESSION, feature_metadata=feature_metadata, eval_metric=mean_squared_error,
+                                      hyperparameters=hyperparameters_rf,
                                       ag_args=ag_args, name_suffix=name_suffix, default_priorities=DEFAULT_SOFTCLASS_PRIORITY, invalid_model_names=invalid_model_names)
+        model_args_fit.update(model_args_fit_rf)
     models_cat = [model for model in models if isinstance(model, CatBoostModel)]
     models_noncat = [model for model in models if not isinstance(model, CatBoostModel)]
     models = models_noncat + rf_models + models_cat
@@ -316,4 +324,4 @@ def get_preset_models_softclass(path, hyperparameters, feature_metadata, num_cla
     for model in models:
         model.normalize_pred_probas = True
 
-    return models
+    return models, model_args_fit

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -94,6 +94,21 @@ DEFAULT_MODEL_NAMES = {
 }
 
 
+VALID_AG_ARGS_KEYS = {
+    'name',
+    'name_main',
+    'name_prefix',
+    'name_suffix',
+    'model_type',
+    'priority',
+    'problem_types',
+    'disable_in_hpo',
+    'valid_stacker',
+    'valid_base',
+    'hyperparameter_tune_kwargs',
+}
+
+
 # DONE: Add levels, including 'default'
 # DONE: Add lists
 # DONE: Add custom which can append to lists
@@ -210,6 +225,9 @@ def clean_model_cfg(model_cfg: dict, model_type=None, ag_args=None, ag_args_ense
 # Check if model is valid
 def is_model_cfg_valid(model_cfg, level=0):
     is_valid = True
+    for key in model_cfg.get(AG_ARGS, {}):
+        if key not in VALID_AG_ARGS_KEYS:
+            logger.warning(f'WARNING: Unknown ag_args key: {key}')
     if AG_ARGS not in model_cfg:
         is_valid = False  # AG_ARGS is required
     elif model_cfg[AG_ARGS].get('model_type', None) is None:

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets_custom.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets_custom.py
@@ -9,7 +9,7 @@ def get_preset_custom(name, problem_type, num_classes):
     # Custom model
     if name == 'GBM':
         model = get_param_baseline_custom(problem_type, num_classes=num_classes)
-        model[AG_ARGS] = dict(model_type='GBM', name_suffix='Custom', disable_in_hpo=True)
+        model[AG_ARGS] = dict(model_type='GBM', name_suffix='Custom', disable_in_hpo=True, hyperparameter_tune_kwargs=None)
         return [model]
     elif name == 'ELECTRA_BASE':
         return _get_preset_electra('google_electra_base', 'default_no_hpo', 'Base')

--- a/tabular/tests/unittests/models/test_text_prediction_v1_model.py
+++ b/tabular/tests/unittests/models/test_text_prediction_v1_model.py
@@ -3,7 +3,6 @@
 def test_text_prediction_v1_sts(fit_helper):
     fit_args = dict(
         hyperparameters={'TEXT_NN_V1': {}},
-        num_gpus=1,
     )
     dataset_name = 'sts'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args, sample_size=100)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Enables per model HPO control
- Now each model can specify its own scheduler (or lack of one) as an `ag_args` value.
- Enabled usage of 'custom' models when HPO is enabled. (custom models have HPO disabled so they just train normally)

Example:

```
hyperparameters = {
        'GBM': {'ag_args': {'hyperparameter_tune_kwargs': None}},
        'CAT': {'ag_args': {'hyperparameter_tune_kwargs': 'bayesopt'}},
        'NN': {},
    }
```

In this example:

1. GBM model will not perform any HPO because of `{'hyperparameter_tune_kwargs': None}`
2. CAT model will perform HPO with bayesopt
3. NN model will perform HPO based on the predictor.fit `hyperparameter_tune_kwargs` value (or not do HPO if not specified).
4. predictor.fit `hyperparameter_tune_kwargs` value acts as the value in predictor.fit `ag_args['hyperparameter_tune_kwargs']`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
