### PR TITLE
Fix abstract_model HPO

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -22,7 +22,7 @@ from ...constants import AG_ARGS_FIT, BINARY, REGRESSION, REFIT_FULL_SUFFIX, OBJ
 from ...features.types import R_CATEGORY, R_OBJECT, R_FLOAT, R_INT
 from ...features.feature_metadata import FeatureMetadata
 from ...utils import get_pred_from_proba, normalize_pred_probas, infer_eval_metric, compute_permutation_feature_importance
-from . import model_trial
+from .model_trial import model_trial
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed bug causing models that use default HPO code to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
