### PR TITLE
[Dependencies] Constraining numpy to <1.20.0 due to pyarrow compatibility issues

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -43,7 +43,7 @@ long_description = open(os.path.join('..', 'README.md')).read()
 MIN_PYTHON_VERSION = '>=3.6.*'  # TODO v0.1: Also specify max version? (We don't support 3.8)
 
 requirements = [
-    'numpy>=1.16.0',
+    'numpy>=1.16.0,<1.20.0',
     'scipy>=1.3.3,<1.5.0',  # TODO v0.1: Upgrade?
     'cython',  # TODO: Do we need cython here?
     'tornado>=5.0.1',

--- a/extra/setup.py
+++ b/extra/setup.py
@@ -45,7 +45,7 @@ long_description = open(os.path.join('..', 'README.md')).read()
 MIN_PYTHON_VERSION = '>=3.6.*'
 
 requirements = [
-    'numpy>=1.16.0',
+    'numpy>=1.16.0,<1.20.0',
     'gluoncv>=0.9.1,<1.0',
     'scipy>=1.3.3,<1.5.0',
     'graphviz<0.9.0,>=0.8.1',

--- a/features/setup.py
+++ b/features/setup.py
@@ -43,7 +43,7 @@ long_description = open(os.path.join('..', 'README.md')).read()
 MIN_PYTHON_VERSION = '>=3.6.*'
 
 requirements = [
-    'numpy>=1.16.0',
+    'numpy>=1.16.0,<1.20.0',
     'pandas>=1.0.0,<2.0',
     'scikit-learn>=0.22.0,<0.24',
     f'autogluon.core=={version}'

--- a/mxnet/setup.py
+++ b/mxnet/setup.py
@@ -44,7 +44,7 @@ MIN_PYTHON_VERSION = '>=3.6.*'
 
 requirements = [
     'Pillow<=6.2.1',
-    'numpy>=1.16.0',
+    'numpy>=1.16.0,<1.20.0',
     'matplotlib',
     'pandas>=1.0.0,<2.0',
     'scikit-learn>=0.22.0,<0.24',

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -43,7 +43,7 @@ long_description = open(os.path.join('..', 'README.md')).read()
 MIN_PYTHON_VERSION = '>=3.6.*'
 
 requirements = [
-    'numpy>=1.16.0',
+    'numpy>=1.16.0,<1.20.0',
     'scipy>=1.3.3,<1.5.0',
     'catboost>=0.23.0,<0.25',
     'xgboost>=1.2,<1.3',

--- a/text/setup.py
+++ b/text/setup.py
@@ -45,7 +45,7 @@ long_description = open(os.path.join('..', 'README.md')).read()
 MIN_PYTHON_VERSION = '>=3.6.*'
 
 requirements = [
-    'numpy>=1.16.0',
+    'numpy>=1.16.0,<1.20.0',
     'scipy>=1.3.3,<1.5.0',
     'tqdm>=4.38.0',
     'pandas>=1.0.0,<2.0',

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -46,7 +46,7 @@ MIN_PYTHON_VERSION = '>=3.6.*'
 
 requirements = [
     'Pillow<=6.2.1',
-    'numpy>=1.16.0',
+    'numpy>=1.16.0,<1.20.0',
     'matplotlib',
     'gluoncv>=0.9.1,<1.0',
     'graphviz<0.9.0,>=0.8.1',


### PR DESCRIPTION
*Description of changes:*
A new version of numpy (1.20.0) was released on Jan 30th. It is causing compatibility issues with pyarrow.
```
tests/unittests/test_text_prediction.py:248: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/mxnet/util.py:297: in _with_np_shape
    return func(*args, **kwargs)
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/mxnet/util.py:481: in _with_np_array
    return func(*args, **kwargs)
src/autogluon/text/text_prediction/text_prediction.py:533: in fit
    ignore_warning=verbosity <= 2)
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/mxnet/util.py:297: in _with_np_shape
    return func(*args, **kwargs)
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/mxnet/util.py:481: in _with_np_array
    return func(*args, **kwargs)
src/autogluon/text/text_prediction/models/basic_v1.py:634: in train
    train_data.table.to_parquet(train_df_path)
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/pandas/util/_decorators.py:199: in wrapper
    return func(*args, **kwargs)
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/pandas/core/frame.py:2463: in to_parquet
    **kwargs,
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/pandas/io/parquet.py:397: in to_parquet
    **kwargs,
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/pandas/io/parquet.py:152: in write
    table = self.api.Table.from_pandas(df, **from_pandas_kwargs)
pyarrow/table.pxi:1376: in pyarrow.lib.Table.from_pandas
    ???
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/pyarrow/pandas_compat.py:579: in dataframe_to_arrays
    for c, f in zip(columns_to_convert, convert_fields)]
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/pyarrow/pandas_compat.py:579: in <listcomp>
    for c, f in zip(columns_to_convert, convert_fields)]
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/pyarrow/pandas_compat.py:565: in convert_column
    raise e
../../../../miniconda3/envs/autogluon-text-py3-v2/lib/python3.7/site-packages/pyarrow/pandas_compat.py:559: in convert_column
    result = pa.array(col, type=type_, from_pandas=True, safe=safe)
pyarrow/array.pxi:265: in pyarrow.lib.array
    ???
pyarrow/array.pxi:76: in pyarrow.lib._ndarray_to_array
    ???
pyarrow/array.pxi:64: in pyarrow.lib._ndarray_to_type
    ???
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
