### PR TITLE
Improved support for passing kwargs into feature generators fit_transform

### DIFF
--- a/features/src/autogluon/features/generators/pipeline.py
+++ b/features/src/autogluon/features/generators/pipeline.py
@@ -49,7 +49,7 @@ class PipelineFeatureGenerator(BulkFeatureGenerator):
         return X_out
 
     def _fit_transform(self, X: DataFrame, y=None, **kwargs):
-        X_out, type_group_map_special = super()._fit_transform(X=X, y=y)
+        X_out, type_group_map_special = super()._fit_transform(X=X, y=y, **kwargs)
         X_out, type_group_map_special = self._fit_transform_custom(X_out=X_out, type_group_map_special=type_group_map_special, y=y)
         return X_out, type_group_map_special
 

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -171,14 +171,14 @@ class AbstractLearner:
     def refit_ensemble_full(self, model='all'):
         return self.load_trainer().refit_ensemble_full(model=model)
 
-    def fit_transform_features(self, X, y=None):
+    def fit_transform_features(self, X, y=None, **kwargs):
         if self.label in X:
             X = X.drop(columns=[self.label])
         if self.ignored_columns:
             logger.log(20, f'Dropping user-specified ignored columns: {self.ignored_columns}')
             X = X.drop(columns=self.ignored_columns, errors='ignore')
         for feature_generator in self.feature_generators:
-            X = feature_generator.fit_transform(X, y)
+            X = feature_generator.fit_transform(X, y, **kwargs)
         return X
 
     def transform_features(self, X):

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -3,6 +3,7 @@ import logging
 import math
 import time
 
+import numpy as np
 import pandas as pd
 from pandas import DataFrame
 
@@ -155,7 +156,12 @@ class DefaultLearner(AbstractLearner):
                 X_super = self.feature_generator.transform(X_super)
                 self.feature_generator.print_feature_metadata_info()
             else:
-                X_super = self.fit_transform_features(X_super)
+                if X_unlabeled is None:
+                    y_super = pd.concat([y, y_val], ignore_index=True)
+                else:
+                    y_unlabeled = pd.Series(np.nan, index=X_unlabeled.index)
+                    y_super = pd.concat([y, y_val, y_unlabeled], ignore_index=True)  # TEST ME
+                X_super = self.fit_transform_features(X_super, y_super, problem_type=self.label_cleaner.problem_type_transform)
             X = X_super.head(len(X)).set_index(X.index)
 
             X_val = X_super.head(len(X)+len(X_val)).tail(len(X_val)).set_index(X_val.index)
@@ -170,7 +176,12 @@ class DefaultLearner(AbstractLearner):
                 X_super = self.feature_generator.transform(X_super)
                 self.feature_generator.print_feature_metadata_info()
             else:
-                X_super = self.fit_transform_features(X_super)
+                if X_unlabeled is None:
+                    y_super = y.reset_index(drop=True)
+                else:
+                    y_unlabeled = pd.Series(np.nan, index=X_unlabeled.index)
+                    y_super = pd.concat([y, y_unlabeled], ignore_index=True)  # TEST ME
+                X_super = self.fit_transform_features(X_super, y_super, problem_type=self.label_cleaner.problem_type_transform)
 
             X = X_super.head(len(X)).set_index(X.index)
             if X_unlabeled is not None:

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -160,7 +160,7 @@ class DefaultLearner(AbstractLearner):
                     y_super = pd.concat([y, y_val], ignore_index=True)
                 else:
                     y_unlabeled = pd.Series(np.nan, index=X_unlabeled.index)
-                    y_super = pd.concat([y, y_val, y_unlabeled], ignore_index=True)  # TEST ME
+                    y_super = pd.concat([y, y_val, y_unlabeled], ignore_index=True)
                 X_super = self.fit_transform_features(X_super, y_super, problem_type=self.label_cleaner.problem_type_transform)
             X = X_super.head(len(X)).set_index(X.index)
 
@@ -180,7 +180,7 @@ class DefaultLearner(AbstractLearner):
                     y_super = y.reset_index(drop=True)
                 else:
                     y_unlabeled = pd.Series(np.nan, index=X_unlabeled.index)
-                    y_super = pd.concat([y, y_unlabeled], ignore_index=True)  # TEST ME
+                    y_super = pd.concat([y, y_unlabeled], ignore_index=True)
                 X_super = self.fit_transform_features(X_super, y_super, problem_type=self.label_cleaner.problem_type_transform)
 
             X = X_super.head(len(X)).set_index(X.index)


### PR DESCRIPTION

*Issue #, if available:*

https://github.com/awslabs/autogluon/issues/899

*Description of changes:*

- Improved support for passing kwargs into feature generators fit_transform
- Added `y` and `problem_type` arguments to `.fit_transform` calls in `learner` to enable more advanced feature generation functionality.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
