### PR TITLE
NLP token prefilter

### DIFF
--- a/features/src/autogluon/features/generators/auto_ml_pipeline.py
+++ b/features/src/autogluon/features/generators/auto_ml_pipeline.py
@@ -38,7 +38,7 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
         Appends TextSpecialFeatureGenerator() to the generator group.
     enable_text_ngram_features : bool, default True
         Whether to use 'object' features identified as 'text' features to generate 'text_ngram' features.
-        Appends TextNgramFeatureGenerator(vectorizer=vectorizer) to the generator group.
+        Appends TextNgramFeatureGenerator(vectorizer=vectorizer, text_ngram_params) to the generator group. See text_ngram.py for valid parameters.
     enable_raw_text_features : bool, default False
         Whether to use the raw text features. The generated raw text features will end up with '_raw_text' suffix.
         For example, 'sentence' --> 'sentence_raw_text'
@@ -102,6 +102,6 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
         if self.enable_text_special_features:
             generator_group.append(TextSpecialFeatureGenerator())
         if self.enable_text_ngram_features:
-            generator_group.append(TextNgramFeatureGenerator(**self.text_ngram_params))
+            generator_group.append(TextNgramFeatureGenerator(vectorizer=vectorizer, **self.text_ngram_params))
         generators = [generator_group]
         return generators

--- a/features/src/autogluon/features/generators/auto_ml_pipeline.py
+++ b/features/src/autogluon/features/generators/auto_ml_pipeline.py
@@ -69,7 +69,7 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
     def __init__(self, enable_numeric_features=True, enable_categorical_features=True,
                  enable_datetime_features=True,
                  enable_text_special_features=True, enable_text_ngram_features=True,
-                 enable_raw_text_features=False, vectorizer=None, **kwargs):
+                 enable_raw_text_features=False, vectorizer=None, prefilter_tokens=False, prefilter_token_count=10, **kwargs):
         if 'generators' in kwargs:
             raise KeyError(f'generators is not a valid parameter to {self.__class__.__name__}. Use {PipelineFeatureGenerator.__name__} to specify custom generators.')
         if 'enable_raw_features' in kwargs:
@@ -82,6 +82,8 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
         self.enable_text_special_features = enable_text_special_features
         self.enable_text_ngram_features = enable_text_ngram_features
         self.enable_raw_text_features = enable_raw_text_features
+        self.prefilter_tokens = prefilter_tokens
+        self.prefilter_token_count = prefilter_token_count
 
         generators = self._get_default_generators(vectorizer=vectorizer)
         super().__init__(generators=generators, **kwargs)
@@ -101,6 +103,8 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
         if self.enable_text_special_features:
             generator_group.append(TextSpecialFeatureGenerator())
         if self.enable_text_ngram_features:
-            generator_group.append(TextNgramFeatureGenerator(vectorizer=vectorizer))
+            generator_group.append(TextNgramFeatureGenerator(vectorizer=vectorizer, 
+                prefilter_tokens=self.prefilter_tokens, 
+                prefilter_token_count=self.prefilter_token_count))
         generators = [generator_group]
         return generators

--- a/features/src/autogluon/features/generators/auto_ml_pipeline.py
+++ b/features/src/autogluon/features/generators/auto_ml_pipeline.py
@@ -69,7 +69,7 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
     def __init__(self, enable_numeric_features=True, enable_categorical_features=True,
                  enable_datetime_features=True,
                  enable_text_special_features=True, enable_text_ngram_features=True,
-                 enable_raw_text_features=False, vectorizer=None, prefilter_tokens=False, prefilter_token_count=10, **kwargs):
+                 enable_raw_text_features=False, vectorizer=None, text_ngram_params=None, **kwargs):
         if 'generators' in kwargs:
             raise KeyError(f'generators is not a valid parameter to {self.__class__.__name__}. Use {PipelineFeatureGenerator.__name__} to specify custom generators.')
         if 'enable_raw_features' in kwargs:
@@ -82,8 +82,7 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
         self.enable_text_special_features = enable_text_special_features
         self.enable_text_ngram_features = enable_text_ngram_features
         self.enable_raw_text_features = enable_raw_text_features
-        self.prefilter_tokens = prefilter_tokens
-        self.prefilter_token_count = prefilter_token_count
+        self.text_ngram_params = text_ngram_params if text_ngram_params else {}
 
         generators = self._get_default_generators(vectorizer=vectorizer)
         super().__init__(generators=generators, **kwargs)
@@ -103,8 +102,6 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
         if self.enable_text_special_features:
             generator_group.append(TextSpecialFeatureGenerator())
         if self.enable_text_ngram_features:
-            generator_group.append(TextNgramFeatureGenerator(vectorizer=vectorizer, 
-                prefilter_tokens=self.prefilter_tokens, 
-                prefilter_token_count=self.prefilter_token_count))
+            generator_group.append(TextNgramFeatureGenerator(**self.text_ngram_params))
         generators = [generator_group]
         return generators

--- a/features/src/autogluon/features/generators/text_ngram.py
+++ b/features/src/autogluon/features/generators/text_ngram.py
@@ -44,14 +44,14 @@ class TextNgramFeatureGenerator(AbstractFeatureGenerator):
     **kwargs :
         Refer to :class:`AbstractFeatureGenerator` documentation for details on valid key word arguments.
     """
-    def __init__(self, vectorizer=None, vectorizer_strategy='combined', max_memory_ratio=0.15, prefilter_tokens=False, prefilter_token_count=10, **kwargs):
+    def __init__(self, vectorizer=None, vectorizer_strategy='combined', max_memory_ratio=0.15, prefilter_tokens=False, prefilter_token_count=100, **kwargs):
         super().__init__(**kwargs)
-
         self.vectorizers = []
         # TODO: 0.20 causes OOM error with 64 GB ram on NN with several datasets. LightGBM and CatBoost succeed
         # TODO: Finetune this, or find a better way to ensure stability
+        # TODO: adjust max_memory_ratio correspondingly if prefilter_tokens==True
         self.max_memory_ratio = max_memory_ratio  # Ratio of maximum memory the output ngram features are allowed to use in dense int32 form.
-
+        
         if vectorizer is None:
             self.vectorizer_default_raw = vectorizer_auto_ml_default()
         else:
@@ -61,8 +61,8 @@ class TextNgramFeatureGenerator(AbstractFeatureGenerator):
             raise ValueError(f"vectorizer_strategy must be one of {['combined', 'separate', 'both']}, but value is: {vectorizer_strategy}")
         self.vectorizer_strategy = vectorizer_strategy
         self.vectorizer_features = None
-        self.prefilter_tokens = prefilter_tokens
-        self.prefilter_token_count = prefilter_token_count
+        self.prefilter_tokens = prefilter_tokens 
+        self.prefilter_token_count = prefilter_token_count 
         self.token_mask = None
 
     def _fit_transform(self, X: DataFrame, y: Series = None, problem_type: str = None, **kwargs) -> (DataFrame, dict):

--- a/features/src/autogluon/features/generators/text_ngram.py
+++ b/features/src/autogluon/features/generators/text_ngram.py
@@ -67,16 +67,12 @@ class TextNgramFeatureGenerator(AbstractFeatureGenerator):
 
     def _fit_transform(self, X: DataFrame, y: Series, **kwargs) -> (DataFrame, dict):
         
-        print(kwargs)
         X_out = self._fit_transform_ngrams(X)
         if self.prefilter_tokens:
-            print('shape before: ', X_out.shape)
             selector = SelectKBest(f_classif, k=self.prefilter_token_count) # hard-code f-score for now
             selector.fit(X_out, y)
             self.token_mask = selector.get_support() # create token mask
             X_out = X_out[ X_out.columns[self.token_mask] ] # select the most informative columns
-            print('shape after: ', X_out.shape)
-            print(X_out.head())
 
         type_family_groups_special = {
             S_TEXT_NGRAM: list(X_out.columns)

--- a/features/src/autogluon/features/generators/text_ngram.py
+++ b/features/src/autogluon/features/generators/text_ngram.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import psutil
 from pandas import DataFrame, Series
-from sklearn.feature_selection import SelectKBest, f_classif
+from sklearn.feature_selection import SelectKBest, f_classif, f_regression
 
 from autogluon.core.features.types import S_TEXT, S_TEXT_NGRAM
 
@@ -65,14 +65,28 @@ class TextNgramFeatureGenerator(AbstractFeatureGenerator):
         self.prefilter_token_count = prefilter_token_count
         self.token_mask = None
 
-    def _fit_transform(self, X: DataFrame, y: Series, **kwargs) -> (DataFrame, dict):
+    def _fit_transform(self, X: DataFrame, y: Series = None, problem_type: str = None, **kwargs) -> (DataFrame, dict):
         
         X_out = self._fit_transform_ngrams(X)
+        
+        if (self.prefilter_tokens and self.prefilter_token_count>=X_out.shape[1]):
+            logger.warning('`prefilter_tokens` was enabled but `prefilter_token_count` larger than the vocabulary. Disabling `prefilter_tokens`.')
+            self.prefilter_tokens=False
+
+        if self.prefilter_tokens and problem_type not in ['binary','regression']:
+           logger.warning('`prefilter_tokens` was enabled but invalid `problem_type`. Disabling `prefilter_tokens`.')
+           self.prefilter_tokens = False
+
+        if self.prefilter_tokens and y is None:
+           logger.warning('`prefilter_tokens` was enabled but `y` values were not provided to fit_transform. Disabling `prefilter_tokens`.')
+           self.prefilter_tokens = False
+
         if self.prefilter_tokens:
-            selector = SelectKBest(f_classif, k=self.prefilter_token_count) # hard-code f-score for now
+            scoring_function = f_classif if problem_type=='binary' else f_regression
+            selector = SelectKBest(scoring_function, k=self.prefilter_token_count)
             selector.fit(X_out, y)
-            self.token_mask = selector.get_support() # create token mask
-            X_out = X_out[ X_out.columns[self.token_mask] ] # select the most informative columns
+            self.token_mask = selector.get_support()
+            X_out = X_out[ X_out.columns[self.token_mask] ] # select the columns that are most correlated with y
 
         type_family_groups_special = {
             S_TEXT_NGRAM: list(X_out.columns)
@@ -80,6 +94,7 @@ class TextNgramFeatureGenerator(AbstractFeatureGenerator):
         return X_out, type_family_groups_special
 
     def _transform(self, X: DataFrame) -> DataFrame:
+        # TODO: Optimize for inference
         if not self.features_in:
             return DataFrame(index=X.index)
         try:


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/awslabs/autogluon/issues/899

*Description of changes:*
add option to pre-filter tokens according to correlation with the label: if `prefilter_tokens=True`, then only keep the `prefilter_token_count` most correlated tokens.

Use this option by parsing `AutoMLPipelineFeatureGenerator(prefilter_tokens=True, prefilter_token_count=10)`
into .fit().

Note that in the current form this will not work for multi-class classification problems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
