### PR TITLE
Tabular: HPO bag fix

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -609,7 +609,7 @@ class AbstractModel:
         hpo_model_performances = {}
         for trial in sorted(hpo_results['trial_info'].keys()):
             # TODO: ignore models which were killed early by scheduler (eg. in Hyperband). How to ID these?
-            file_id = "trial_" + str(trial)  # unique identifier to files from this trial
+            file_id = f"T{trial}"  # unique identifier to files from this trial
             trial_model_name = self.name + os.path.sep + file_id
             trial_model_path = self.path_root + trial_model_name + os.path.sep
             hpo_models[trial_model_name] = trial_model_path

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -192,6 +192,7 @@ class AbstractModel:
         if self.params is not None:
             self.params.update(def_search_space)
 
+    # TODO: v0.1 Change this to update path_root only, path change to property
     def set_contexts(self, path_context):
         self.path = self.create_contexts(path_context)
         self.path_root = self.path.rsplit(self.path_suffix, 1)[0]

--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -29,8 +29,16 @@ def model_trial(args, reporter: LocalStatusReporter):
 
         fit_model_args = dict(X_train=X_train, y_train=y_train, X_val=X_val, y_val=y_val, **util_args.get('fit_kwargs', dict()))
         predict_proba_args = dict(X=X_val)
-        model = fit_and_save_model(model=model, params=args, fit_args=fit_model_args, predict_proba_args=predict_proba_args, y_val=y_val,
-                                   time_start=util_args.time_start, time_limit=util_args.get('time_limit', None), reporter=None)
+        model = fit_and_save_model(
+            model=model,
+            params=args,
+            fit_args=fit_model_args,
+            predict_proba_args=predict_proba_args,
+            y_val=y_val,
+            time_start=util_args.time_start,
+            time_limit=util_args.get('time_limit', None),
+            reporter=None,
+        )
     except Exception as e:
         if not isinstance(e, TimeLimitExceeded):
             logger.exception(e, exc_info=True)
@@ -43,7 +51,7 @@ def prepare_inputs(args):
     task_id = args.pop('task_id')
     util_args = args.pop('util_args')
 
-    file_prefix = f"trial_{task_id}"  # append to all file names created during this trial. Do NOT change!
+    file_prefix = f"T{task_id}"  # append to all file names created during this trial. Do NOT change!
     model = util_args.model  # the model object must be passed into model_trial() here
     model.name = model.name + os.path.sep + file_prefix
     model.set_contexts(path_context=model.path_root + model.name + os.path.sep)

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -125,6 +125,7 @@ class BaggedEnsembleModel(AbstractModel):
         time_start = time.time()
 
         model_base = self._get_model_base()
+        model_base.rename(name='')
         if self.features is not None:
             model_base.features = self.features
         model_base.feature_metadata = self.feature_metadata  # TODO: Don't pass this here
@@ -136,6 +137,7 @@ class BaggedEnsembleModel(AbstractModel):
         if k_fold == 1:
             if self._n_repeats != 0:
                 raise ValueError(f'n_repeats must equal 0 when fitting a single model with k_fold < 2, values: ({self._n_repeats}, {k_fold})')
+            model_base.name = f'{model_base.name}S1F1'
             model_base.set_contexts(path_context=self.path + model_base.name + os.path.sep)
             time_start_fit = time.time()
             model_base.fit(X_train=X_train, y_train=y_train, time_limit=time_limit, **kwargs)
@@ -171,6 +173,7 @@ class BaggedEnsembleModel(AbstractModel):
             fold_end_n_repeat = min(fold_start_n_repeat + k_fold, fold_end)
             # TODO: Consider moving model fit inner for loop to a function to simply this code
             for i in range(fold_start_n_repeat, fold_end_n_repeat):  # For each fold
+                fold_num_in_repeat = i - (j * k_fold)  # The fold in the current repeat set (first fold in set = 0)
                 folds_finished = i - fold_start
                 folds_left = fold_end - i
                 fold = kfolds[i]
@@ -194,7 +197,7 @@ class BaggedEnsembleModel(AbstractModel):
                 X_train_fold, X_val_fold = X_train.iloc[train_index, :], X_train.iloc[val_index, :]
                 y_train_fold, y_val_fold = y_train.iloc[train_index], y_train.iloc[val_index]
                 fold_model = copy.deepcopy(model_base)
-                fold_model.name = f'{fold_model.name}_F{i+1}'
+                fold_model.name = f'{fold_model.name}S{j+1}F{fold_num_in_repeat+1}'  # S5F3 = 3rd fold of the 5th repeat set
                 fold_model.set_contexts(self.path + fold_model.name + os.path.sep)
                 fold_model.fit(X_train=X_train_fold, y_train=y_train_fold, X_val=X_val_fold, y_val=y_val_fold, time_limit=time_limit_fold, **kwargs)
                 time_train_end_fold = time.time()
@@ -350,14 +353,8 @@ class BaggedEnsembleModel(AbstractModel):
     def convert_to_refit_full_template(self):
         init_args = self._get_init_args()
         init_args['hyperparameters']['save_bag_folds'] = True  # refit full models must save folds
-        model_base_name_orig = init_args['model_base'].name
         init_args['model_base'] = self.convert_to_refitfull_template_child()
-        model_base_name_new = init_args['model_base'].name
-        if model_base_name_orig in init_args['name'] and model_base_name_orig != model_base_name_new:
-            init_args['name'] = init_args['name'].replace(model_base_name_orig, model_base_name_new, 1)
-        else:
-            init_args['name'] = init_args['name'] + '_FULL'
-
+        init_args['name'] = init_args['name'] + REFIT_FULL_SUFFIX
         model_full_template = self.__class__(**init_args)
         return model_full_template
 
@@ -366,8 +363,6 @@ class BaggedEnsembleModel(AbstractModel):
         child_compressed = copy.deepcopy(self._get_model_base())
         child_compressed.feature_metadata = self.feature_metadata  # TODO: Don't pass this here
         child_compressed.params = compressed_params
-        child_compressed.name = child_compressed.name + REFIT_FULL_SUFFIX
-        child_compressed.set_contexts(self.path_root + child_compressed.name + os.path.sep)
         return child_compressed
 
     def _get_init_args(self):
@@ -637,7 +632,7 @@ class BaggedEnsembleModel(AbstractModel):
 
             # TODO: Create new Ensemble Here
             bag = copy.deepcopy(self)
-            bag.name = bag.name + os.path.sep + str(i)
+            bag.name = f"{bag.name}{os.path.sep}T{i}"
             bag.set_contexts(self.path_root + bag.name + os.path.sep)
 
             oof_pred_proba, oof_pred_model_repeats = self._construct_empty_oof(X=X_train, y=y_train)
@@ -645,6 +640,7 @@ class BaggedEnsembleModel(AbstractModel):
             oof_pred_model_repeats[test_index] += 1
 
             bag.model_base = None
+            child.rename(name='')
             child.set_contexts(bag.path + child.name + os.path.sep)
             bag.save_model_base(child.convert_to_template())
 
@@ -653,7 +649,7 @@ class BaggedEnsembleModel(AbstractModel):
             bag._n_repeats = 1
             bag._oof_pred_proba = oof_pred_proba
             bag._oof_pred_model_repeats = oof_pred_model_repeats
-            child.name = child.name + '_fold_0'
+            child.rename(name='S1F1')
             child.set_contexts(bag.path + child.name + os.path.sep)
             if not self.params.get('save_bag_folds', True):
                 child.model = None

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -632,7 +632,7 @@ class BaggedEnsembleModel(AbstractModel):
 
             # TODO: Create new Ensemble Here
             bag = copy.deepcopy(self)
-            bag.name = f"{bag.name}{os.path.sep}T{i}"
+            bag.rename(f"{bag.name}{os.path.sep}T{i}")
             bag.set_contexts(self.path_root + bag.name + os.path.sep)
 
             oof_pred_proba, oof_pred_model_repeats = self._construct_empty_oof(X=X_train, y=y_train)
@@ -640,7 +640,7 @@ class BaggedEnsembleModel(AbstractModel):
             oof_pred_model_repeats[test_index] += 1
 
             bag.model_base = None
-            child.rename(name='')
+            child.rename('')
             child.set_contexts(bag.path + child.name + os.path.sep)
             bag.save_model_base(child.convert_to_template())
 
@@ -649,7 +649,7 @@ class BaggedEnsembleModel(AbstractModel):
             bag._n_repeats = 1
             bag._oof_pred_proba = oof_pred_proba
             bag._oof_pred_model_repeats = oof_pred_model_repeats
-            child.rename(name='S1F1')
+            child.rename('S1F1')
             child.set_contexts(bag.path + child.name + os.path.sep)
             if not self.params.get('save_bag_folds', True):
                 child.model = None

--- a/core/src/autogluon/core/utils/plots.py
+++ b/core/src/autogluon/core/utils/plots.py
@@ -37,6 +37,7 @@ def plot_performance_vs_trials(results, output_directory, save_file="Performance
         print("Plot of HPO performance saved to file: %s" % outputfile)
     plt.show()
 
+
 def plot_summary_of_models(results, output_directory, save_file='SummaryOfModels.html', plot_title="Models produced during fit()"):
     """ Plot dynamic scatterplot summary of each model encountered during fit(), based on the returned Results object. 
     """
@@ -71,6 +72,7 @@ def plot_summary_of_models(results, output_directory, save_file='SummaryOfModels
     if save_path is not None:
         print("Plot summary of models saved to file: %s" % save_file)
 
+
 def plot_tabular_models(results, output_directory=None, save_file="SummaryOfModels.html", plot_title="Models produced during fit()"):
     """ Plot dynamic scatterplot of every single model trained during tabular_prediction.fit()
         Args:
@@ -87,19 +89,15 @@ def plot_tabular_models(results, output_directory=None, save_file="SummaryOfMode
     hidden_keys.append(model_types)
     model_hyperparams = [_formatDict(results['model_hyperparams'][key]) for key in model_names]
     datadict = {'performance': val_perfs, 'model': model_names, 'model_type': model_types, 'hyperparameters': model_hyperparams}
-    hpo_used = results['hyperparameter_tune']
-    if not hpo_used:  # currently, times are only stored without HPO
-        leaderboard = results['leaderboard'].copy()
-        leaderboard['fit_time'] = leaderboard['fit_time'].fillna(0)
-        leaderboard['pred_time_val'] = leaderboard['pred_time_val'].fillna(0)
+    leaderboard = results['leaderboard'].copy()
+    leaderboard['fit_time'] = leaderboard['fit_time'].fillna(0)
+    leaderboard['pred_time_val'] = leaderboard['pred_time_val'].fillna(0)
 
-        datadict['inference_latency'] = [leaderboard['pred_time_val'][leaderboard['model'] == m].values[0] for m in model_names]
-        datadict['training_time'] = [leaderboard['fit_time'][leaderboard['model'] == m].values[0] for m in model_names]
-        mousover_plot(datadict, attr_x='inference_latency', attr_y='performance', attr_color='model_type', 
-                      save_file=save_path, plot_title=plot_title, hidden_keys=hidden_keys)
-    else:
-        mousover_plot(datadict, attr_x='model_type', attr_y='performance',
-                      save_file=save_path, plot_title=plot_title, hidden_keys=hidden_keys)
+    datadict['inference_latency'] = [leaderboard['pred_time_val'][leaderboard['model'] == m].values[0] for m in model_names]
+    datadict['training_time'] = [leaderboard['fit_time'][leaderboard['model'] == m].values[0] for m in model_names]
+    mousover_plot(datadict, attr_x='inference_latency', attr_y='performance', attr_color='model_type',
+                  save_file=save_path, plot_title=plot_title, hidden_keys=hidden_keys)
+
 
 def _formatDict(d):
     """ Returns dict as string with HTML new-line tags <br> between key-value pairs. """
@@ -108,6 +106,7 @@ def _formatDict(d):
         new_s = str(key) + ": " + str(d[key]) + "<br>"
         s += new_s
     return s[:-4]
+
 
 def mousover_plot(datadict, attr_x, attr_y, attr_color=None, attr_size=None, save_file=None, plot_title="",
                   point_transparency = 0.5, point_size=20, default_color="#2222aa", hidden_keys = []):
@@ -216,4 +215,3 @@ def mousover_plot(datadict, attr_x, attr_y, attr_color=None, attr_size=None, sav
         p.add_layout(Legend(items=[LegendItem(label='Size of points based on "'+attr_size + '"')]), 'below')
     
     show(p)
-    

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -265,7 +265,6 @@ class CatBoostModel(AbstractModel):
                     self.model = init_model
                 else:
                     if (init_model_best_score > self.stopping_metric._optimum) or (final_model_best_score > self.stopping_metric._optimum):
-                        logger.warning(f'Warning: Sign differs between AG metric and CatBoost metric variants: {self.stopping_metric.name}, flipping signs.')
                         init_model_best_score = -init_model_best_score
                         final_model_best_score = -final_model_best_score
 

--- a/tabular/src/autogluon/tabular/task/tabular_prediction/predictor_legacy.py
+++ b/tabular/src/autogluon/tabular/task/tabular_prediction/predictor_legacy.py
@@ -316,7 +316,8 @@ class TabularPredictorV1:
         -------
         Dict containing various detailed information. We do not recommend directly printing this dict as it may be very large.
         """
-        hpo_used = len(self._trainer.hpo_results) > 0
+        # hpo_used = len(self._trainer.hpo_results) > 0
+        hpo_used = False  # Disabled until a more memory efficient hpo_results object is implemented.
         model_types = self._trainer.get_models_attribute_dict(attribute='type')
         model_inner_types = self._trainer.get_models_attribute_dict(attribute='type_inner')
         model_typenames = {key: model_types[key].__name__ for key in model_types}
@@ -341,13 +342,11 @@ class TabularPredictorV1:
             'model_pred_times': self._trainer.get_models_attribute_dict('predict_time'),
             'num_bag_folds': self._trainer.k_fold,
             'max_stack_level': self._trainer.get_max_level(),
-            'feature_prune': self._trainer.feature_prune,
-            'hyperparameter_tune': hpo_used,
         }
         if self.problem_type != REGRESSION:
             results['num_classes'] = self._trainer.num_classes
-        if hpo_used:
-            results['hpo_results'] = self._trainer.hpo_results
+        # if hpo_used:
+        #     results['hpo_results'] = self._trainer.hpo_results
         # get dict mapping model name to final hyperparameter values for each model:
         model_hyperparams = {}
         for model_name in self._trainer.get_model_names():
@@ -376,9 +375,9 @@ class TabularPredictorV1:
                 num_stack_str = f" (with {results['max_stack_level']} levels)"
             print("Multi-layer stack-ensembling used: %s %s" % (stacking_used, num_stack_str))
             hpo_str = ""
-            if hpo_used and verbosity <= 2:
-                hpo_str = " (call fit_summary() with verbosity >= 3 to see detailed HPO info)"
-            print("Hyperparameter-tuning used: %s %s" % (hpo_used, hpo_str))
+            # if hpo_used and verbosity <= 2:
+            #     hpo_str = " (call fit_summary() with verbosity >= 3 to see detailed HPO info)"
+            # print("Hyperparameter-tuning used: %s %s" % (hpo_used, hpo_str))
             # TODO: uncomment once feature_prune is functional:  self._summarize('feature_prune', 'feature-selection used', results)
             print("Feature Metadata (Processed):")
             print("(raw dtype, special dtypes):")

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -264,21 +264,22 @@ def model_factory(
         name_prefix = model[AG_ARGS].get('name_prefix', '')
         name_suff = model[AG_ARGS].get('name_suffix', '')
         name_orig = name_prefix + name_main + name_suff
-    if name_suffix is not None:
-        name_orig = name_orig + name_suffix
-    name = name_orig
     name_stacker = None
     num_increment = 2
+    if name_suffix is None:
+        name_suffix = ''
     if ensemble_kwargs is None:
+        name = f'{name_orig}{name_suffix}'
         while name in invalid_name_set:  # Ensure name is unique
-            name = f'{name_orig}_{num_increment}'
+            name = f'{name_orig}_{num_increment}{name_suffix}'
             num_increment += 1
     else:
+        name = name_orig
         name_bag_suffix = model[AG_ARGS].get('name_bag_suffix', '_BAG')
-        name_stacker = f'{name}{name_bag_suffix}_L{level}'
+        name_stacker = f'{name}{name_bag_suffix}_L{level}{name_suffix}'
         while name_stacker in invalid_name_set:  # Ensure name is unique
             name = f'{name_orig}_{num_increment}'
-            name_stacker = f'{name}{name_bag_suffix}_L{level}'
+            name_stacker = f'{name}{name_bag_suffix}_L{level}{name_suffix}'
             num_increment += 1
     model_params = copy.deepcopy(model)
     model_params.pop(AG_ARGS, None)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [x] During bagging, first fold of model is called `trial*_fold_0/` while other folds are called `trial*_F2/` etc. This has been fixed.
- [x] AutoGluon was giving far too much time to HPO when bagging due to a bug (9x longer than intended). This has been fixed.
- [x] Trainer became very large during HPO sometimes, such as >5GB. This caused memory errors. Trainer should never be >1 MB in general. This was caused by `trainer.hpo_results` being extremely large after many HPO trials (>>5 GB). I have removed this object for now, fixing the issue.
- [x] Simplified model name logic such that `_FULL` is always at the end of a model name, rather than inserted before the model level. This makes the model name construction logic much easier to understand.
- [x] Improved naming of fold models. Now they are simply `SxFy`, where x is the repeat set, and y is the fold in the repeat set. This reduces redundant naming and separates the naming logic of the child models from the naming logic of the BaggedEnsemble.
- [x] Other minor fixes and improvements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
