### PR TITLE
Tabular: Optimized stopping metric

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -722,12 +722,7 @@ class AbstractModel:
         return {}
 
     def _get_default_stopping_metric(self):
-        if self.eval_metric.name == 'roc_auc':
-            stopping_metric = 'log_loss'
-        else:
-            stopping_metric = self.eval_metric
-        stopping_metric = metrics.get_metric(stopping_metric, self.problem_type, 'stopping_metric')
-        return stopping_metric
+        return metrics.get_metric(self.eval_metric, self.problem_type, 'stopping_metric')
 
 
 class AbstractNeuralNetworkModel(AbstractModel):

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -100,8 +100,5 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         default_ag_args.update(extra_ag_args)
         return default_ag_args
 
-    def _get_default_stopping_metric(self):
-        return self.eval_metric
-
     def _hyperparameter_tune(self, **kwargs):
         return skip_hpo(self, **kwargs)

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -761,9 +761,6 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         if remove_fit and requires_save:
             self.optimizer = None
 
-    def _get_default_stopping_metric(self):
-        return self.eval_metric
-
 
 def convert_df_dtype_to_str(df):
     return df.astype(str)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- AUC eval metric now directly uses AUC as stopping metric instead of log_loss

Next Steps:

- [ ] Benchmark

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
