### PR TITLE
Tabular: Fixed rare crash on leaderboard

### DIFF
--- a/core/src/autogluon/core/data/label_cleaner.py
+++ b/core/src/autogluon/core/data/label_cleaner.py
@@ -126,7 +126,7 @@ class LabelCleanerMulticlass(LabelCleaner):
         else:
             y_transformed = y
         if as_pred:
-            y_transformed = get_pred_from_proba(y_pred_proba=y_transformed, problem_type=self.problem_type_transform)
+            y_transformed = get_pred_from_proba(y_pred_proba=y_transformed, problem_type=MULTICLASS)
             y_transformed = self._convert_to_valid_series(y_transformed)
             y_transformed = y_transformed.map(self.cat_mappings_dependent_var_uncleaned)
             if y_index is not None:

--- a/core/src/autogluon/core/utils/savers/save_pd.py
+++ b/core/src/autogluon/core/utils/savers/save_pd.py
@@ -33,7 +33,10 @@ def save(path, df, index=False, verbose=True, type=None, sep=',', compression='g
     column_count = len(list(df.columns.values))
     row_count = df.shape[0]
     if is_local:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        path_abs = os.path.abspath(path)
+        path_abs_dirname = os.path.dirname(path_abs)
+        if path_abs_dirname:
+            os.makedirs(path_abs_dirname, exist_ok=True)
     if type == 'csv':
         if is_local:
             df.to_csv(path, index=index, sep=sep, header=header)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixes crash on leaderboard when multiclass problem is converted to binary internally, label cleaner was incorrectly using the internal problem type instead of the external problem type when converting internal pred_proba to external pred in leaderboard.
- Added support in save_pd to save without needing a directory. Aka: `save_pd.save('file.csv')` did not work before, but now does, because before it was trying to create a directory at `''`, which wasn't valid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
