### PR TITLE
[CI] ConfigSpace stability on CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,9 +124,11 @@ tutorials/checkpoint/*
 tutorials/train/*
 examples/image_classification/*.csv
 tests/unittests/*.zip
+tabular/tests/unittests/datasets
 
 autogluon/src/autogluon/version.py
 core/src/autogluon/core/version.py
+features/src/autogluon/features/version.py
 mxnet/src/autogluon/mxnet/version.py
 extra/src/autogluon/extra/version.py
 tabular/src/autogluon/tabular/version.py

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,17 @@ setup_pip_venv = """
     python3 -m pip install -U pip
     python3 -m pip install -U setuptools wheel
 
+    python3 -m pip uninstall -y scipy scikit-learn ConfigSpace numpy
+    python3 -m pip install 'numpy==1.19.5'
+    python3 -m pip install 'scipy==1.5.4'
+
+    # ConfigSpace MUST be installed after correct cython and numpy installed
+    # otherwise it will compile against the version in Conda (1.20.x)
+    python3 -m pip install 'ConfigSpace==0.4.14' --no-binary :all:
+
     python3 -m pip install 'graphviz'
     python3 -m pip install 'jupyter-sphinx>=0.2.2'
     python3 -m pip install 'portalocker'
-    python3 -m pip install 'scipy>=1.3.3,<1.5.0'
     python3 -m pip install 'nose'
     python3 -m pip install 'docutils'
     python3 -m pip install 'mu-notedown'

--- a/core/setup.py
+++ b/core/setup.py
@@ -44,8 +44,10 @@ python_requires = '>=3.6, <3.8'
 
 requirements = [
     'numpy==1.19.5',
-    'scipy>=1.3.3,<1.5.0',  # TODO v0.1: Upgrade?
+    'scipy==1.5.4',  # TODO v0.1: Upgrade?
+    'scikit-learn>=0.22.0,<0.24',  # TODO v0.1: Upgrade
     'cython',  # TODO: Do we need cython here?
+    'ConfigSpace==0.4.14',
     'tornado>=5.0.1',
     'requests',
     'matplotlib',
@@ -53,12 +55,10 @@ requirements = [
     'paramiko>=2.4',
     'dask>=2.6.0',
     'distributed>=2.6.0',
-    'ConfigSpace==0.4.14',
     'graphviz<0.9.0,>=0.8.1',
     'scikit-optimize',  # TODO v0.1: Remove?
     'boto3',
     'pandas>=1.0.0,<2.0',
-    'scikit-learn>=0.22.0,<0.24',  # TODO v0.1: Upgrade
     'autograd>=1.3',
     'dill==0.3.3',  # TODO v0.1: Loosen version restriction?
 ]

--- a/extra/setup.py
+++ b/extra/setup.py
@@ -47,7 +47,7 @@ python_requires = '>=3.6, <3.8'
 requirements = [
     'numpy==1.19.5',
     'gluoncv>=0.9.2,<1.0',
-    'scipy>=1.3.3,<1.5.0',
+    'scipy==1.5.4',
     'graphviz<0.9.0,>=0.8.1',
     'bokeh',
     'pandas>=1.0.0,<2.0',

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -44,7 +44,7 @@ python_requires = '>=3.6, <3.8'
 
 requirements = [
     'numpy==1.19.5',
-    'scipy>=1.3.3,<1.5.0',
+    'scipy==1.5.4',
     'catboost>=0.23.0,<0.25',
     'xgboost>=1.2,<1.3',
     'lightgbm>=3.0,<4.0',

--- a/text/setup.py
+++ b/text/setup.py
@@ -46,7 +46,7 @@ python_requires = '>=3.6, <3.8'
 
 requirements = [
     'numpy==1.19.5',
-    'scipy>=1.3.3,<1.5.0',
+    'scipy==1.5.4',
     'tqdm>=4.38.0',
     'pandas>=1.0.0,<2.0',
     'scikit-learn>=0.22.0,<0.24',


### PR DESCRIPTION
*Description of changes:*
- ConfigSpace must be installed after numpy is updated so it is not using 1.20.x coming from conda when installing - this is causing numpy compatibility errors:
```ValueError: numpy.ffff size changed, may indicate binary incompatibility. Expected xxx from C header, got yyy from zzz```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
