### PR TITLE
Tabular: Refined HPO code / edge case handling

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -519,7 +519,15 @@ class AbstractModel:
 
     def hyperparameter_tune(self, scheduler_options, time_limit=None, **kwargs):
         scheduler_options = copy.deepcopy(scheduler_options)
-        scheduler_options[1]['resource'] = self._preprocess_fit_resources(silent=True, **scheduler_options[1]['resource'])
+        resource = copy.deepcopy(scheduler_options[1]['resource'])
+        if 'num_cpus' in resource:
+            if resource['num_cpus'] == 'auto':
+                resource.pop('num_cpus')
+        if 'num_gpus' in resource:
+            if resource['num_gpus'] == 'auto':
+                resource.pop('num_gpus')
+
+        scheduler_options[1]['resource'] = self._preprocess_fit_resources(silent=True, **resource)
         if 'time_out' not in scheduler_options[1]:
             scheduler_options[1]['time_out'] = time_limit
         return self._hyperparameter_tune(scheduler_options=scheduler_options, **kwargs)

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -609,6 +609,7 @@ class BaggedEnsembleModel(AbstractModel):
             raise ValueError('self.models must be empty to call hyperparameter_tune, value: %s' % self.models)
 
         self.model_base.feature_metadata = self.feature_metadata  # TODO: Move this
+        self.model_base.set_contexts(self.path + 'hpo' + os.path.sep)
 
         # TODO: Preprocess data here instead of repeatedly
         if preprocess_kwargs is None:

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -10,11 +10,12 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 
-from autogluon.core.utils.savers import save_pkl
-from autogluon.core.utils import try_import_lightgbm
 from autogluon.core import Int, Space
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS
 from autogluon.core.features.types import R_OBJECT
+from autogluon.core.models import AbstractModel
+from autogluon.core.utils import try_import_lightgbm
+from autogluon.core.utils.savers import save_pkl
 
 from . import lgb_utils
 from .callbacks import early_stopping_custom
@@ -22,7 +23,6 @@ from .hyperparameters.lgb_trial import lgb_trial
 from .hyperparameters.parameters import get_param_baseline
 from .hyperparameters.searchspaces import get_default_searchspace
 from .lgb_utils import construct_dataset
-from autogluon.core.models import AbstractModel
 from ..utils import fixedvals_from_searchspaces
 
 warnings.filterwarnings("ignore", category=UserWarning, message="Starting from version")  # lightGBM brew libomp warning

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -19,7 +19,7 @@ class AutoTrainer(AbstractTrainer):
         problem_type = kwargs.pop('problem_type', self.problem_type)
         eval_metric = kwargs.pop('eval_metric', self.eval_metric)
         num_classes = kwargs.pop('num_classes', self.num_classes)
-        invalid_model_names = kwargs.pop('invalid_model_names', self.get_model_names())
+        invalid_model_names = kwargs.pop('invalid_model_names', self._get_banned_model_names())
         feature_metadata = kwargs.pop('feature_metadata', self.feature_metadata)
         silent = kwargs.pop('silent', self.verbosity < 3)
 
@@ -53,7 +53,7 @@ class AutoTrainer(AbstractTrainer):
         problem_type = kwargs.pop('problem_type', self.problem_type)
         eval_metric = kwargs.pop('eval_metric', self.eval_metric)
         num_classes = kwargs.pop('num_classes', self.num_classes)
-        invalid_model_names = kwargs.pop('invalid_model_names', self.get_model_names())
+        invalid_model_names = kwargs.pop('invalid_model_names', self._get_banned_model_names())
         feature_metadata = kwargs.pop('feature_metadata', self.feature_metadata)
 
         return get_preset_models_distillation(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Moved HPO artifacts when bagging under the bagged model directory so they never conflict with future models, and the resulting directory layout is less cluttered.
- Added extra edge case handling for banned model names to avoid `.fit_extra` calls overwriting model names if both original `fit` and `fit_extra` used HPO with the same model types. Now this will never happen.
- If resource not specified in HPO kwargs, it will no longer override resources set in the original model to `'auto'`, but instead use the original model's values (could be values other than `'auto'`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
