### PR TITLE
Part 1 of Tabular pkl compression PR: https://github.com/awslabs/autogluon/pull/654 

### DIFF
--- a/core/src/autogluon/core/utils/compression_utils.py
+++ b/core/src/autogluon/core/utils/compression_utils.py
@@ -1,0 +1,33 @@
+import gzip
+import bz2
+import lzma
+
+
+compression_fn_map = {
+    None: {
+        'open': open,
+        'extension': '',
+    },
+    'gzip': {
+        'open': gzip.open,
+        'extension': 'gz',
+    },
+    'bz2': {
+        'open': bz2.open,
+        'extension': 'bz2',
+    },
+    'lzma': {
+        'open': lzma.open,
+        'extension': 'lzma',
+    },
+}
+
+def get_validated_path(filename, compression_fn=None):
+    if compression_fn is not None:
+        validated_path = f"{filename}.{compression_fn_map[compression_fn]['extension']}"
+    else:
+        validated_path = filename
+    return validated_path
+
+def get_compression_map():
+    return compression_fn_map

--- a/core/src/autogluon/core/utils/loaders/load_pkl.py
+++ b/core/src/autogluon/core/utils/loaders/load_pkl.py
@@ -1,11 +1,16 @@
 import io, logging, pickle, boto3
 
-from . import load_pointer
-from .. import s3_utils
+from ..loaders import load_pointer
+from ...utils import s3_utils
+from ...utils import compression_utils
 
 logger = logging.getLogger(__name__)
 
-def load(path, format=None, verbose=True):
+
+def load(path, format=None, verbose=True, **kwargs):
+    compression_fn = kwargs.get('compression_fn', None)
+    compression_fn_kwargs = kwargs.get('compression_fn_kwargs', None)
+
     if path.endswith('.pointer'):
         format = 'pointer'
     elif s3_utils.is_s3_url(path):
@@ -22,8 +27,19 @@ def load(path, format=None, verbose=True):
         return pickle.loads(s3.Bucket(s3_bucket).Object(s3_prefix).get()['Body'].read())
 
     if verbose: logger.log(15, 'Loading: %s' % path)
-    with open(path, 'rb') as fin:
-        object = pickle.load(fin)
+
+    compression_fn_map = compression_utils.get_compression_map()
+    validated_path = compression_utils.get_validated_path(path, compression_fn=compression_fn)
+
+    if compression_fn_kwargs is None:
+        compression_fn_kwargs = {}
+
+    if compression_fn in compression_fn_map:
+        with compression_fn_map[compression_fn]['open'](validated_path, 'rb', **compression_fn_kwargs) as fin:
+            object = pickle.load(fin)
+    else:
+        raise ValueError(f'compression_fn={compression_fn} or compression_fn_kwargs={compression_fn_kwargs} are not valid. Valid function values: {compression_fn_map.keys()}')
+
     return object
 
 

--- a/core/src/autogluon/core/utils/savers/save_pkl.py
+++ b/core/src/autogluon/core/utils/savers/save_pkl.py
@@ -2,17 +2,27 @@
 import os, pickle, tempfile, logging, boto3
 
 from ...utils import s3_utils
+from ...utils import compression_utils
 
 logger = logging.getLogger(__name__)
 
+compression_fn_map = compression_utils.get_compression_map()
 
 # TODO: object -> obj?
-def save(path, object, format=None, verbose=True):
+def save(path, object, format=None, verbose=True, **kwargs):
+    compression_fn = kwargs.get('compression_fn', None)
+    compression_fn_kwargs = kwargs.get('compression_fn_kwargs', None)
+
+    if compression_fn in compression_fn_map:
+        validated_path = compression_utils.get_validated_path(path, compression_fn)
+    else:
+        raise ValueError(f'compression_fn={compression_fn} is not a valid compression_fn. Valid values: {compression_fn_map.keys()}')
+
     pickle_fn = lambda o, buffer: pickle.dump(o, buffer, protocol=4)
-    save_with_fn(path, object, pickle_fn, format=format, verbose=verbose)
+    save_with_fn(validated_path, object, pickle_fn, format=format, verbose=verbose, compression_fn=compression_fn,
+                 compression_fn_kwargs=compression_fn_kwargs)
 
-
-def save_with_fn(path, object, pickle_fn, format=None, verbose=True):
+def save_with_fn(path, object, pickle_fn, format=None, verbose=True, compression_fn=None, compression_fn_kwargs=None):
     if verbose:
         logger.log(15, 'Saving '+str(path))
     if s3_utils.is_s3_url(path):
@@ -21,9 +31,12 @@ def save_with_fn(path, object, pickle_fn, format=None, verbose=True):
         save_s3(path, object, pickle_fn, verbose=verbose)
     else:
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, 'wb') as fout:
-            pickle_fn(object, fout)
 
+        if compression_fn_kwargs is None:
+            compression_fn_kwargs = {}
+
+        with compression_fn_map[compression_fn]['open'](path, 'wb', **compression_fn_kwargs) as fout:
+            pickle_fn(object, fout)
 
 def save_s3(path: str, obj, pickle_fn, verbose=True):
     if verbose:

--- a/core/tests/unittests/test_compression_utils.py
+++ b/core/tests/unittests/test_compression_utils.py
@@ -1,0 +1,76 @@
+import gzip
+import bz2
+import lzma
+
+from autogluon.core.utils import compression_utils
+
+
+def test_get_validated_path_no_compression_fn():
+    no_extension_filepath = 'dummy_file'
+    assert(compression_utils.get_validated_path(no_extension_filepath) == no_extension_filepath)
+
+    single_extension_filepath = 'dummy_file.pkl'
+    assert(compression_utils.get_validated_path(single_extension_filepath) == single_extension_filepath)
+
+    multiple_extension_filepath = 'dummy_file.fake-foo.zip.pkl'
+    assert(compression_utils.get_validated_path(multiple_extension_filepath) == multiple_extension_filepath)
+
+def test_get_validated_path_with_compression_fn():
+    compression_fns = ['gzip', 'lzma', 'bz2']
+
+    no_extension_filepath = 'dummy_file'
+
+    expected_no_ext_gzip_filepath = "dummy_file.gz"
+    expected_no_ext_lzma_filepath = "dummy_file.lzma"
+    expected_no_ext_bz2_filepath = "dummy_file.bz2"
+    assert(compression_utils.get_validated_path(no_extension_filepath, compression_fns[0])
+           == expected_no_ext_gzip_filepath)
+    assert(compression_utils.get_validated_path(no_extension_filepath, compression_fns[1])
+           == expected_no_ext_lzma_filepath)
+    assert(compression_utils.get_validated_path(no_extension_filepath, compression_fns[2])
+           == expected_no_ext_bz2_filepath)
+
+    single_extension_filepath = 'dummy_file.pkl'
+
+    expected_pkl_gzip_filepath = "dummy_file.pkl.gz"
+    expected_pkl_lzma_filepath = "dummy_file.pkl.lzma"
+    expected_pkl_bz2_filepath = "dummy_file.pkl.bz2"
+    assert(compression_utils.get_validated_path(single_extension_filepath, compression_fns[0])
+           == expected_pkl_gzip_filepath)
+    assert(compression_utils.get_validated_path(single_extension_filepath, compression_fns[1])
+           == expected_pkl_lzma_filepath)
+    assert(compression_utils.get_validated_path(single_extension_filepath, compression_fns[2])
+           == expected_pkl_bz2_filepath)
+
+    multiple_extension_filepath = 'dummy_file.fake-foo.zip.pkl'
+
+    expected_multi_gzip_filepath = "dummy_file.fake-foo.zip.pkl.gz"
+    expected_multi_lzma_filepath = "dummy_file.fake-foo.zip.pkl.lzma"
+    expected_multi_bz2_filepath = "dummy_file.fake-foo.zip.pkl.bz2"
+    assert (compression_utils.get_validated_path(multiple_extension_filepath, compression_fns[0])
+            == expected_multi_gzip_filepath)
+    assert (compression_utils.get_validated_path(multiple_extension_filepath, compression_fns[1])
+            == expected_multi_lzma_filepath)
+    assert (compression_utils.get_validated_path(multiple_extension_filepath, compression_fns[2])
+            == expected_multi_bz2_filepath)
+
+def test_get_compression_map():
+    expected_compression_fn_map = {
+        None: {
+            'open': open,
+            'extension': '',
+        },
+        'gzip': {
+            'open': gzip.open,
+            'extension': 'gz',
+        },
+        'bz2': {
+            'open': bz2.open,
+            'extension': 'bz2',
+        },
+        'lzma': {
+            'open': lzma.open,
+            'extension': 'lzma',
+        },
+    }
+    assert compression_utils.get_compression_map() == expected_compression_fn_map


### PR DESCRIPTION
*[Issue # 581](https://github.com/awslabs/autogluon/issues/581)*

*Description of changes:*
In an effort to break up the larger, outdated [Tabular pkl compression PR](https://github.com/awslabs/autogluon/pull/654) into smaller chunks, this PR takes the first step by adding `compression_fn` and `compression_fn_kwargs` to `load_pkl.py` and `save_pkl.py` as well as unit tests and utility functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
