### PR TITLE
sample weights functionality

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -346,30 +346,30 @@ class AbstractModel:
         else:
             return y_pred_proba[:, 1]
 
-    def score(self, X, y, metric=None, weights=None, **kwargs):
+    def score(self, X, y, metric=None, sample_weights=None, **kwargs):
         if metric is None:
             metric = self.eval_metric
         if metric.needs_pred:
             y_pred = self.predict(X=X, **kwargs)
         else:
             y_pred = self.predict_proba(X=X, **kwargs)
-        if weights is None:
+        if sample_weights is None:
             return metric(y, y_pred)
         else:
-            return compute_weighted_metric(y, y_pred, metric, weights)
+            return compute_weighted_metric(y, y_pred, metric, sample_weights)
 
 
-    def score_with_y_pred_proba(self, y, y_pred_proba, metric=None, weights=None):
+    def score_with_y_pred_proba(self, y, y_pred_proba, metric=None, sample_weights=None):
         if metric is None:
             metric = self.eval_metric
         if metric.needs_pred:
             y_pred = get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=self.problem_type)
         else:
             y_pred = y_pred_proba
-        if weights is None:
+        if sample_weights is None:
             return metric(y, y_pred)
         else:
-            return compute_weighted_metric(y, y_pred, metric, weights)
+            return compute_weighted_metric(y, y_pred, metric, sample_weights)
 
     def save(self, path: str = None, verbose=True) -> str:
         """
@@ -562,8 +562,8 @@ class AbstractModel:
                     logger.log(15, f"{hyperparam}:   {params_copy[hyperparam]}")
 
         fit_kwargs=scheduler_params['resource'].copy()
-        fit_kwargs['weights'] = kwargs.get('weights', None)
-        fit_kwargs['weights_val'] = kwargs.get('weights_val', None)
+        fit_kwargs['sample_weights'] = kwargs.get('sample_weights', None)
+        fit_kwargs['sample_weights_val'] = kwargs.get('sample_weights_val', None)
         util_args = dict(
             dataset_train_filename=dataset_train_filename,
             dataset_val_filename=dataset_val_filename,

--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -74,8 +74,8 @@ def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_
     time_fit_end = time.time()
     y_pred_proba = model.predict_proba(**predict_proba_args)
     time_pred_end = time.time()
-    sample_weights_val = fit_args.get('sample_weights_val', None)
-    model.val_score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba, sample_weights=sample_weights_val)
+    sample_weight_val = fit_args.get('sample_weight_val', None)
+    model.val_score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba, sample_weight=sample_weight_val)
     model.fit_time = time_fit_end - time_fit_start
     model.predict_time = time_pred_end - time_fit_end
     model.save()

--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 @args()
 def model_trial(args, reporter: LocalStatusReporter):
     """ Training script for hyperparameter evaluation of an arbitrary model that subclasses AbstractModel.
-        
+
         Notes:
             - Model object itself must be passed as kwarg: model
             - All model hyperparameters must be stored in model.params dict that may contain special keys such as:

--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -74,7 +74,8 @@ def fit_and_save_model(model, params, fit_args, predict_proba_args, y_val, time_
     time_fit_end = time.time()
     y_pred_proba = model.predict_proba(**predict_proba_args)
     time_pred_end = time.time()
-    model.val_score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba)
+    sample_weights_val = fit_args.get('sample_weights_val', None)
+    model.val_score = model.score_with_y_pred_proba(y=y_val, y_pred_proba=y_pred_proba, sample_weights=sample_weights_val)
     model.fit_time = time_fit_end - time_fit_start
     model.predict_time = time_pred_end - time_fit_end
     model.save()

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -160,12 +160,7 @@ class BaggedEnsembleModel(AbstractModel):
             self._add_child_times_to_bag(model=model_base)
             return
 
-        weights = kwargs.get('weights', None)
-        if weights is not None:
-            temp_weight_name = '__sample_weights__'
-            while temp_weight_name in X_train.columns:
-                temp_weight_name += '_'
-            X_train[temp_weight_name] = weights
+        sample_weights = kwargs.get('sample_weights', None)
         # TODO: Preprocess data here instead of repeatedly
         kfolds = generate_kfold(X=X_train, y=y_train, n_splits=k_fold, stratified=self.is_stratified(), random_state=self._random_state, n_repeats=n_repeats)
 
@@ -205,12 +200,11 @@ class BaggedEnsembleModel(AbstractModel):
                 fold_model = copy.deepcopy(model_base)
                 fold_model.name = f'{fold_model.name}S{j+1}F{fold_num_in_repeat+1}'  # S5F3 = 3rd fold of the 5th repeat set
                 fold_model.set_contexts(self.path + fold_model.name + os.path.sep)
-                if weights is not None:
-                    X_train_fold, weights_train = extract_column(X_train_fold, temp_weight_name)
-                    X_val_fold, weights_val = extract_column(X_val_fold, temp_weight_name)
-                    kwargs['weights'] = weights_train
-                    kwargs['weights_val'] = weights_val
-                fold_model.fit(X_train=X_train_fold, y_train=y_train_fold, X_val=X_val_fold, y_val=y_val_fold, time_limit=time_limit_fold, **kwargs)
+                kwargs_fold = kwargs.copy()
+                if sample_weights is not None:
+                    kwargs_fold['sample_weights'] = sample_weights[train_index]
+                    kwargs_fold['sample_weights_val'] = sample_weights[val_index]
+                fold_model.fit(X_train=X_train_fold, y_train=y_train_fold, X_val=X_val_fold, y_val=y_val_fold, time_limit=time_limit_fold, **kwargs_fold)
                 time_train_end_fold = time.time()
                 if time_limit is not None:  # Check to avoid unnecessarily predicting and saving a model when an Exception is going to be raised later
                     if i != (fold_end - 1):
@@ -273,16 +267,14 @@ class BaggedEnsembleModel(AbstractModel):
     def _predict_proba(self, X, normalize=False, **kwargs):
         return self.predict_proba(X=X, normalize=normalize, **kwargs)
 
-    def score_with_oof(self, y, weights=None):
+    def score_with_oof(self, y, sample_weights=None):
         self._load_oof()
         valid_indices = self._oof_pred_model_repeats > 0
         y = y[valid_indices]
         y_pred_proba = self.oof_pred_proba[valid_indices]
-        if weights is None:
-            return self.score_with_y_pred_proba(y=y, y_pred_proba=y_pred_proba)
-        else:
-            weights = weights[valid_indices]
-            return self.score_with_y_pred_proba(y=y, y_pred_proba=y_pred_proba, weights=weights)
+        if sample_weights is not None:
+            sample_weights = sample_weights[valid_indices]
+        return self.score_with_y_pred_proba(y=y, y_pred_proba=y_pred_proba, sample_weights=sample_weights)
 
     # TODO: Augment to generate OOF after shuffling each column in X (Batching), this is the fastest way.
     # TODO: v0.1 Reduce logging clutter during OOF importance calculation (Currently logs separately for each child)

--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -53,7 +53,7 @@ class EnsembleSelection:
 
     # TODO: Consider having a removal stage, remove each model and see if score is affected, if improves or not effected, remove it.
     def _fit(self, predictions, labels, time_limit=None, **kwargs):
-        sample_weights = kwargs.get('weights', None)
+        sample_weights = kwargs.get('sample_weights', None)
         ensemble_size = self.ensemble_size
         self.num_input_models_ = len(predictions)
         ensemble = []

--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ...constants import PROBLEM_TYPES
 from ...metrics import log_loss
-from ...utils import get_pred_from_proba
+from ...utils import get_pred_from_proba, compute_weighted_metric
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ class EnsembleSelection:
         else:
             self.random_state = np.random.RandomState(seed=0)
 
-    def fit(self, predictions, labels, time_limit=None, identifiers=None):
+    def fit(self, predictions, labels, time_limit=None, identifiers=None, **kwargs):
         self.ensemble_size = int(self.ensemble_size)
         if self.ensemble_size < 1:
             raise ValueError('Ensemble size cannot be less than one!')
@@ -45,14 +45,15 @@ class EnsembleSelection:
         # if not isinstance(self.metric, Scorer):
         #     raise ValueError('Metric must be of type scorer')
 
-        self._fit(predictions=predictions, labels=labels, time_limit=time_limit)
+        self._fit(predictions=predictions, labels=labels, time_limit=time_limit, **kwargs)
         self._calculate_weights()
         logger.log(15, 'Ensemble weights: ')
         logger.log(15, self.weights_)
         return self
 
     # TODO: Consider having a removal stage, remove each model and see if score is affected, if improves or not effected, remove it.
-    def _fit(self, predictions, labels, time_limit=None):
+    def _fit(self, predictions, labels, time_limit=None, **kwargs):
+        sample_weights = kwargs.get('weights', None)
         ensemble_size = self.ensemble_size
         self.num_input_models_ = len(predictions)
         ensemble = []
@@ -89,7 +90,7 @@ class EnsembleSelection:
             fant_ensemble_prediction = np.zeros(weighted_ensemble_prediction.shape)
             for j, pred in enumerate(predictions):
                 fant_ensemble_prediction[:] = weighted_ensemble_prediction + (1. / float(s + 1)) * pred
-                scores[j] = self._calculate_regret(y_true=labels, y_pred_proba=fant_ensemble_prediction, metric=self.metric)
+                scores[j] = self._calculate_regret(y_true=labels, y_pred_proba=fant_ensemble_prediction, metric=self.metric, sample_weights=sample_weights)
 
             all_best = np.argwhere(scores == np.nanmin(scores)).flatten()
 
@@ -142,13 +143,16 @@ class EnsembleSelection:
 
         logger.debug("Ensemble indices: "+str(self.indices_))
 
-    def _calculate_regret(self, y_true, y_pred_proba, metric):
+    def _calculate_regret(self, y_true, y_pred_proba, metric, sample_weights=None):
         if metric.needs_pred:
             preds = get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=self.problem_type)
         else:
             preds = y_pred_proba
-
-        return metric._optimum - metric(y_true, preds)
+        if sample_weights is None:
+            score = metric(y_true, preds)
+        else:
+            score = compute_weighted_metric(y_true, preds, metric, sample_weights)
+        return metric._optimum - score
 
     def _calculate_weights(self):
         ensemble_members = Counter(self.indices_).most_common()

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -31,14 +31,14 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         return X
 
     # TODO: Check memory after loading best model predictions, only load top X model predictions that fit in memory
-    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, **kwargs):
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, sample_weight=None, **kwargs):
         if self.base_model_names is None:
             self.base_model_names = self._infer_base_model_names()
             self.features = self._set_stack_columns(base_model_names=self.base_model_names)
         X_train = self.preprocess(X_train)
 
         self.model = self.model_base(ensemble_size=self.params['ensemble_size'], problem_type=self.problem_type, metric=self.stopping_metric)
-        self.model = self.model.fit(X_train, y_train, time_limit=time_limit, **kwargs)
+        self.model = self.model.fit(X_train, y_train, time_limit=time_limit, sample_weight=sample_weight)
         self.base_model_names, self.model.weights_ = self.remove_zero_weight_models(self.base_model_names, self.model.weights_)
         self.features = self._set_stack_columns(base_model_names=self.base_model_names)
         self.params_trained['ensemble_size'] = self.model.ensemble_size

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -38,7 +38,7 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         X_train = self.preprocess(X_train)
 
         self.model = self.model_base(ensemble_size=self.params['ensemble_size'], problem_type=self.problem_type, metric=self.stopping_metric)
-        self.model = self.model.fit(X_train, y_train, time_limit=time_limit)
+        self.model = self.model.fit(X_train, y_train, time_limit=time_limit, **kwargs)
         self.base_model_names, self.model.weights_ = self.remove_zero_weight_models(self.base_model_names, self.model.weights_)
         self.features = self._set_stack_columns(base_model_names=self.base_model_names)
         self.params_trained['ensemble_size'] = self.model.ensemble_size

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -381,7 +381,16 @@ def extract_column(X, col_name):
     return X, w
 
 
-def compute_weighted_metric(y, y_pred, metric, weights):
+def compute_weighted_metric(y, y_pred, metric, weights, weight_evaluation=None):
+    """ Report weighted metric if: weights is not None, weight_evaluation=True, and the given metric supports sample weights.
+        If weight_evaluation=None, it will be set to False if weights=None, True otherwise.
+    """
+    if weight_evaluation is None:
+        weight_evaluation = not (weights is None)
+    if weight_evaluation and weights is None:
+        raise ValueError("Sample weights cannot be None when weight_evaluation=True.")
+    if not weight_evaluation:
+        return metric(y, y_pred)
     try:
         weighted_metric = metric(y, y_pred, sample_weight=weights)
     except (ValueError, TypeError, KeyError):

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -681,6 +681,5 @@ def get_gpu_free_memory():
         memory_free_info = _output_to_list(subprocess.check_output(COMMAND.split()))[1:]
         memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
     except:
-        # could fail due to
         memory_free_values = []
     return memory_free_values

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -372,6 +372,23 @@ def infer_eval_metric(problem_type: str) -> Scorer:
         return root_mean_squared_error
 
 
+def extract_column(X, col_name):
+    """Extract specified column from dataframe. """
+    if col_name is None or col_name not in list(X.columns):
+        return X, None
+    w = X[col_name].copy()
+    X = X.drop(col_name, axis=1)
+    return X, w
+
+
+def compute_weighted_metric(y, y_pred, metric, weights):
+    try:
+        weighted_metric = metric(y, y_pred, sample_weight=weights)
+    except (ValueError, TypeError, KeyError):
+        logger.log(30, f"WARNING: eval_metric='{metric.name}' does not support sample weights so they will be ignored in reported metric.")
+        weighted_metric = metric(y, y_pred)
+    return weighted_metric
+
 # Note: Do not send training data as input or the importances will be overfit.
 # TODO: Improve time estimate (Currently pessimistic)
 def compute_permutation_feature_importance(X: pd.DataFrame, y: pd.Series, predict_func: Callable[..., np.ndarray], eval_metric: Scorer, features: list = None, subsample_size=None, num_shuffle_sets: int = None,
@@ -664,6 +681,6 @@ def get_gpu_free_memory():
         memory_free_info = _output_to_list(subprocess.check_output(COMMAND.split()))[1:]
         memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
     except:
-        # could fail due to 
+        # could fail due to
         memory_free_values = []
     return memory_free_values

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -160,6 +160,15 @@ class AbstractLearner:
             if self.weight_evaluation and X_val is not None and self.sample_weight not in X_val.columns:
                 raise KeyError(f"sample_weight column '{self.sample_weight}' cannot be missing from validation data if weight_evaluation=True")
 
+            if self.sample_weight is not None:
+                prefix = f"Values in column '{self.sample_weight}' used as sample weights instead of predictive features."
+                if self.weight_evaluation:
+                    suffix = " Evaluation will report weighted metrics, so ensure same column exists in test data."
+                else:
+                    suffix = " Evaluation metrics will ignore sample weights, specify weight_evaluation=True to instead report weighted metrics."
+                logger.log(20, prefix+suffix)
+
+
     def get_inputs_to_stacker(self, dataset=None, model=None, base_models: list = None, use_orig_features=True):
         if model is not None or base_models is not None:
             if model is not None and base_models is not None:

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -8,7 +8,7 @@ import pandas as pd
 from pandas import DataFrame
 
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
-from autogluon.core.utils.utils import augment_rare_classes
+from autogluon.core.utils.utils import augment_rare_classes, extract_column
 
 from .abstract_learner import AbstractLearner
 from ..trainer.auto_trainer import AutoTrainer
@@ -78,6 +78,8 @@ class DefaultLearner(AbstractLearner):
             low_memory=True,
             k_fold=num_bag_folds,  # TODO: Consider moving to fit call
             n_repeats=num_bag_sets,  # TODO: Consider moving to fit call
+            weight_column=self.weight_column,
+            weight_evaluation=self.weight_evaluation,
             save_data=self.cache_data,
             random_state=self.random_state,
             verbosity=verbosity
@@ -129,7 +131,7 @@ class DefaultLearner(AbstractLearner):
         X, y = self.extract_label(X)
         self.label_cleaner = LabelCleaner.construct(problem_type=self.problem_type, y=y, y_uncleaned=y_uncleaned, positive_class=self._positive_class)
         y = self.label_cleaner.transform(y)
-
+        X, w = extract_column(X, self.weight_column)
         if self.label_cleaner.num_classes is not None and self.problem_type != BINARY:
             logger.log(20, f'Train Data Class Count: {self.label_cleaner.num_classes}')
 
@@ -139,11 +141,14 @@ class DefaultLearner(AbstractLearner):
                 logger.warning('All X_val data contained low frequency classes, ignoring X_val and generating from subset of X')
                 X_val = None
                 y_val = None
+                w_val = None
             else:
                 X_val, y_val = self.extract_label(X_val)
                 y_val = self.label_cleaner.transform(y_val)
+                X_val, w_val = extract_column(X_val, self.weight_column)
         else:
             y_val = None
+            w_val = None
 
         # TODO: Move this up to top of data before removing data, this way our feature generator is better
         logger.log(20, f'Using Feature Generators to preprocess the data ...')
@@ -187,6 +192,17 @@ class DefaultLearner(AbstractLearner):
             if X_unlabeled is not None:
                 X_unlabeled = X_super.tail(len(X_unlabeled)).set_index(X_unlabeled.index)
             del X_super
+        if w is not None:
+            X[self.weight_column] = w
+            if X_val is not None:
+                if w_val is not None:
+                    X_val[self.weight_column] = w_val
+                elif not self.weight_evaluation:
+                    nan_vals = np.empty((len(X_val),))
+                    nan_vals[:] = np.nan
+                    X_val[self.weight_column] = nan_vals
+                else:
+                    raise ValueError(f"Weight column '{self.weight_column}' cannot be missing from X_val with weight_evaluation specified.")
 
         return X, y, X_val, y_val, X_unlabeled, holdout_frac, num_bag_folds
 

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -192,7 +192,7 @@ class DefaultLearner(AbstractLearner):
             if X_unlabeled is not None:
                 X_unlabeled = X_super.tail(len(X_unlabeled)).set_index(X_unlabeled.index)
             del X_super
-        if w is not None:
+        if w is not None:  # TODO: consider not bundling sample-weights inside X, X_val
             X[self.sample_weight] = w
             if X_val is not None:
                 if w_val is not None:

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -78,7 +78,7 @@ class DefaultLearner(AbstractLearner):
             low_memory=True,
             k_fold=num_bag_folds,  # TODO: Consider moving to fit call
             n_repeats=num_bag_sets,  # TODO: Consider moving to fit call
-            weight_column=self.weight_column,
+            sample_weight=self.sample_weight,
             weight_evaluation=self.weight_evaluation,
             save_data=self.cache_data,
             random_state=self.random_state,
@@ -131,7 +131,7 @@ class DefaultLearner(AbstractLearner):
         X, y = self.extract_label(X)
         self.label_cleaner = LabelCleaner.construct(problem_type=self.problem_type, y=y, y_uncleaned=y_uncleaned, positive_class=self._positive_class)
         y = self.label_cleaner.transform(y)
-        X, w = extract_column(X, self.weight_column)
+        X, w = extract_column(X, self.sample_weight)
         if self.label_cleaner.num_classes is not None and self.problem_type != BINARY:
             logger.log(20, f'Train Data Class Count: {self.label_cleaner.num_classes}')
 
@@ -145,7 +145,7 @@ class DefaultLearner(AbstractLearner):
             else:
                 X_val, y_val = self.extract_label(X_val)
                 y_val = self.label_cleaner.transform(y_val)
-                X_val, w_val = extract_column(X_val, self.weight_column)
+                X_val, w_val = extract_column(X_val, self.sample_weight)
         else:
             y_val = None
             w_val = None
@@ -193,16 +193,16 @@ class DefaultLearner(AbstractLearner):
                 X_unlabeled = X_super.tail(len(X_unlabeled)).set_index(X_unlabeled.index)
             del X_super
         if w is not None:
-            X[self.weight_column] = w
+            X[self.sample_weight] = w
             if X_val is not None:
                 if w_val is not None:
-                    X_val[self.weight_column] = w_val
+                    X_val[self.sample_weight] = w_val
                 elif not self.weight_evaluation:
                     nan_vals = np.empty((len(X_val),))
                     nan_vals[:] = np.nan
-                    X_val[self.weight_column] = nan_vals
+                    X_val[self.sample_weight] = nan_vals
                 else:
-                    raise ValueError(f"Weight column '{self.weight_column}' cannot be missing from X_val with weight_evaluation specified.")
+                    raise ValueError(f"sample_weight column '{self.sample_weight}' cannot be missing from X_val if weight_evaluation=True")
 
         return X, y, X_val, y_val, X_unlabeled, holdout_frac, num_bag_folds
 

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -71,8 +71,8 @@ class CatBoostModel(AbstractModel):
             params['loss_function'] = SoftclassObjective.SoftLogLossObjective()
             params['eval_metric'] = SoftclassCustomMetric.SoftLogLossMetric()
 
-        weights = kwargs.get('weights', None)
-        weights_val = kwargs.get('weights_val', None)
+        sample_weights = kwargs.get('sample_weights', None)
+        sample_weights_val = kwargs.get('sample_weights_val', None)
         model_type = CatBoostClassifier if self.problem_type in PROBLEM_TYPES_CLASSIFICATION else CatBoostRegressor
         if isinstance(params['eval_metric'], str):
             metric_name = params['eval_metric']
@@ -105,11 +105,11 @@ class CatBoostModel(AbstractModel):
         start_time = time.time()
         X_train = self.preprocess(X_train)
         cat_features = list(X_train.select_dtypes(include='category').columns)
-        X_train = Pool(data=X_train, label=y_train, cat_features=cat_features, weight=weights)
+        X_train = Pool(data=X_train, label=y_train, cat_features=cat_features, weight=sample_weights)
 
         if X_val is not None:
             X_val = self.preprocess(X_val)
-            X_val = Pool(data=X_val, label=y_val, cat_features=cat_features, weight=weights_val)
+            X_val = Pool(data=X_val, label=y_val, cat_features=cat_features, weight=sample_weights_val)
             eval_set = X_val
             if num_rows_train <= 10000:
                 modifier = 1

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -60,7 +60,7 @@ class CatBoostModel(AbstractModel):
 
     # TODO: Use Pool in preprocess, optimize bagging to do Pool.split() to avoid re-computing pool for each fold! Requires stateful + y
     #  Pool is much more memory efficient, avoids copying data twice in memory
-    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_gpus=0, **kwargs):
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_gpus=0, sample_weight=None, sample_weight_val=None, **kwargs):
         try_import_catboost()
         from catboost import CatBoostClassifier, CatBoostRegressor, Pool
         params = self.params.copy()
@@ -71,8 +71,6 @@ class CatBoostModel(AbstractModel):
             params['loss_function'] = SoftclassObjective.SoftLogLossObjective()
             params['eval_metric'] = SoftclassCustomMetric.SoftLogLossMetric()
 
-        sample_weights = kwargs.get('sample_weights', None)
-        sample_weights_val = kwargs.get('sample_weights_val', None)
         model_type = CatBoostClassifier if self.problem_type in PROBLEM_TYPES_CLASSIFICATION else CatBoostRegressor
         if isinstance(params['eval_metric'], str):
             metric_name = params['eval_metric']
@@ -105,11 +103,11 @@ class CatBoostModel(AbstractModel):
         start_time = time.time()
         X_train = self.preprocess(X_train)
         cat_features = list(X_train.select_dtypes(include='category').columns)
-        X_train = Pool(data=X_train, label=y_train, cat_features=cat_features, weight=sample_weights)
+        X_train = Pool(data=X_train, label=y_train, cat_features=cat_features, weight=sample_weight)
 
         if X_val is not None:
             X_val = self.preprocess(X_val)
-            X_val = Pool(data=X_val, label=y_val, cat_features=cat_features, weight=sample_weights_val)
+            X_val = Pool(data=X_val, label=y_val, cat_features=cat_features, weight=sample_weight_val)
             eval_set = X_val
             if num_rows_train <= 10000:
                 modifier = 1

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -71,6 +71,8 @@ class CatBoostModel(AbstractModel):
             params['loss_function'] = SoftclassObjective.SoftLogLossObjective()
             params['eval_metric'] = SoftclassCustomMetric.SoftLogLossMetric()
 
+        weights = kwargs.get('weights', None)
+        weights_val = kwargs.get('weights_val', None)
         model_type = CatBoostClassifier if self.problem_type in PROBLEM_TYPES_CLASSIFICATION else CatBoostRegressor
         if isinstance(params['eval_metric'], str):
             metric_name = params['eval_metric']
@@ -103,11 +105,11 @@ class CatBoostModel(AbstractModel):
         start_time = time.time()
         X_train = self.preprocess(X_train)
         cat_features = list(X_train.select_dtypes(include='category').columns)
-        X_train = Pool(data=X_train, label=y_train, cat_features=cat_features)
+        X_train = Pool(data=X_train, label=y_train, cat_features=cat_features, weight=weights)
 
         if X_val is not None:
             X_val = self.preprocess(X_val)
-            X_val = Pool(data=X_val, label=y_val, cat_features=cat_features)
+            X_val = Pool(data=X_val, label=y_val, cat_features=cat_features, weight=weights_val)
             eval_set = X_val
             if num_rows_train <= 10000:
                 modifier = 1

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -157,9 +157,9 @@ class NNFastAiTabularModel(AbstractModel):
         from .callbacks import EarlyStoppingCallbackWithTimeLimit, SaveModelCallback
 
         start_time = time.time()
-        weights = kwargs.get('weights', None)
-        if weights is not None:
-            logger.log(15, "Sample weights not yet supported for NNFastAiTabularModel, this model will ignore them in training.")
+        sample_weights = kwargs.get('sample_weights', None)
+        if sample_weights is not None:  # TODO: support
+            logger.log(15, "sample_weights not yet supported for NNFastAiTabularModel, this model will ignore them in training.")
 
         params = self.params.copy()
 

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -147,7 +147,7 @@ class NNFastAiTabularModel(AbstractModel):
             df[c] = df[c].fillna(self.columns_fills[c])
         return df
 
-    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_cpus=None, num_gpus=0, **kwargs):
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_cpus=None, num_gpus=0, sample_weight=None, **kwargs):
         try_import_fastai_v1()
         import torch
         from fastai.layers import LabelSmoothingCrossEntropy
@@ -157,9 +157,8 @@ class NNFastAiTabularModel(AbstractModel):
         from .callbacks import EarlyStoppingCallbackWithTimeLimit, SaveModelCallback
 
         start_time = time.time()
-        sample_weights = kwargs.get('sample_weights', None)
-        if sample_weights is not None:  # TODO: support
-            logger.log(15, "sample_weights not yet supported for NNFastAiTabularModel, this model will ignore them in training.")
+        if sample_weight is not None:  # TODO: support
+            logger.log(15, "sample_weight not yet supported for NNFastAiTabularModel, this model will ignore them in training.")
 
         params = self.params.copy()
 

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -157,6 +157,9 @@ class NNFastAiTabularModel(AbstractModel):
         from .callbacks import EarlyStoppingCallbackWithTimeLimit, SaveModelCallback
 
         start_time = time.time()
+        weights = kwargs.get('weights', None)
+        if weights is not None:
+            logger.log(15, "Sample weights not yet supported for NNFastAiTabularModel, this model will ignore them in training.")
 
         params = self.params.copy()
 

--- a/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
+++ b/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
@@ -80,6 +80,10 @@ class FastTextModel(AbstractModel):
             else:
                 params['verbose'] = 2
 
+        sample_weights = kwargs.get('sample_weights', None)
+        if sample_weights is not None:
+            logger.log(15, "sample_weights not yet supported for FastTextModel, this model will ignore them in training.")
+
         X_train = self.preprocess(X_train)
         logger.debug("NLP features %s", self.features)
 
@@ -99,7 +103,7 @@ class FastTextModel(AbstractModel):
             if quantize_model:
                 self.model.quantize(input=f.name, retrain=True)
             gc.collect()
-            mem_curr = psutil.Process().memory_info().rss 
+            mem_curr = psutil.Process().memory_info().rss
             self._model_size_estimate = max(mem_curr - mem_start, 100000000 if quantize_model else 800000000)
             logger.debug("finish training FastText model")
 
@@ -180,8 +184,8 @@ class FastTextModel(AbstractModel):
         # load binary fasttext model
         if obj._model_bin_available:
             fasttext_model_file_name = obj.path + cls.model_bin_file_name
-            # TODO: hack to subpress a deprecation warning from fasttext 
-            # remove it once offcial fasttext is updated beyond 0.9.2 
+            # TODO: hack to subpress a deprecation warning from fasttext
+            # remove it once offcial fasttext is updated beyond 0.9.2
             # https://github.com/facebookresearch/fastText/issues/1067
             with open(os.devnull, 'w') as f, contextlib.redirect_stderr(f):
                 obj.model = fasttext.load_model(fasttext_model_file_name)

--- a/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
+++ b/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
@@ -59,7 +59,7 @@ class FastTextModel(AbstractModel):
         default_ag_args.update(extra_ag_args)
         return default_ag_args
 
-    def _fit(self, X_train, y_train, **kwargs):
+    def _fit(self, X_train, y_train, sample_weight=None, **kwargs):
         if self.problem_type not in (BINARY, MULTICLASS):
             raise ValueError(
                 "FastText model only supports binary or multiclass classification"
@@ -80,9 +80,8 @@ class FastTextModel(AbstractModel):
             else:
                 params['verbose'] = 2
 
-        sample_weights = kwargs.get('sample_weights', None)
-        if sample_weights is not None:
-            logger.log(15, "sample_weights not yet supported for FastTextModel, this model will ignore them in training.")
+        if sample_weight is not None:
+            logger.log(15, "sample_weight not yet supported for FastTextModel, this model will ignore them in training.")
 
         X_train = self.preprocess(X_train)
         logger.debug("NLP features %s", self.features)

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -59,13 +59,12 @@ class KNNModel(AbstractModel):
         spaces = {}
         return spaces
 
-    def _fit(self, X_train, y_train, time_limit=None, **kwargs):
+    def _fit(self, X_train, y_train, time_limit=None, sample_weight=None, **kwargs):
         time_start = time.time()
         X_train = self.preprocess(X_train)
         self._validate_fit_memory_usage(X_train=X_train)  # TODO: Can incorporate this into samples, can fit on portion of data to satisfy memory instead of raising exception immediately
-        sample_weights = kwargs.get('sample_weights', None)
-        if sample_weights is not None:  # TODO: support
-            logger.log(15, "sample_weights not yet supported for KNNModel, this model will ignore them in training.")
+        if sample_weight is not None:  # TODO: support
+            logger.log(15, "sample_weight not yet supported for KNNModel, this model will ignore them in training.")
 
         num_rows_max = len(X_train)
         # FIXME: v0.1 Must store final num rows for refit_full or else will use everything! Worst case refit_full could train far longer than the original model.

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -63,6 +63,9 @@ class KNNModel(AbstractModel):
         time_start = time.time()
         X_train = self.preprocess(X_train)
         self._validate_fit_memory_usage(X_train=X_train)  # TODO: Can incorporate this into samples, can fit on portion of data to satisfy memory instead of raising exception immediately
+        weights = kwargs.get('weights', None)
+        if weights is not None:
+            logger.log(15, "Sample weights not yet supported for KNNModel, this model will ignore them in training.")
 
         num_rows_max = len(X_train)
         # FIXME: v0.1 Must store final num rows for refit_full or else will use everything! Worst case refit_full could train far longer than the original model.

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -63,9 +63,9 @@ class KNNModel(AbstractModel):
         time_start = time.time()
         X_train = self.preprocess(X_train)
         self._validate_fit_memory_usage(X_train=X_train)  # TODO: Can incorporate this into samples, can fit on portion of data to satisfy memory instead of raising exception immediately
-        weights = kwargs.get('weights', None)
-        if weights is not None:
-            logger.log(15, "Sample weights not yet supported for KNNModel, this model will ignore them in training.")
+        sample_weights = kwargs.get('sample_weights', None)
+        if sample_weights is not None:  # TODO: support
+            logger.log(15, "sample_weights not yet supported for KNNModel, this model will ignore them in training.")
 
         num_rows_max = len(X_train)
         # FIXME: v0.1 Must store final num rows for refit_full or else will use everything! Worst case refit_full could train far longer than the original model.

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -65,8 +65,8 @@ class LGBModel(AbstractModel):
 
         # TODO: kwargs can have num_cpu, num_gpu. Currently these are ignored.
         verbosity = kwargs.get('verbosity', 2)
-        weights = kwargs.get('weights', None)
-        weights_val = kwargs.get('weights_val', None)
+        sample_weights = kwargs.get('sample_weights', None)
+        sample_weights_val = kwargs.get('sample_weights_val', None)
         params = fixedvals_from_searchspaces(params)
 
         if verbosity <= 1:
@@ -80,7 +80,7 @@ class LGBModel(AbstractModel):
 
         stopping_metric, stopping_metric_name = self._get_stopping_metric_internal()
         dataset_train, dataset_val = self.generate_datasets(X_train=X_train, y_train=y_train, params=params, X_val=X_val, y_val=y_val,
-                                                            weights=weights, weights_val=weights_val, dataset_train=dataset_train, dataset_val=dataset_val)
+                                                            sample_weights=sample_weights, sample_weights_val=sample_weights_val, dataset_train=dataset_train, dataset_val=dataset_val)
         gc.collect()
 
         num_boost_round = params.pop('num_boost_round', 1000)
@@ -240,7 +240,7 @@ class LGBModel(AbstractModel):
         else:
             return X
 
-    def generate_datasets(self, X_train: DataFrame, y_train: Series, params, X_val=None, y_val=None, weights=None, weights_val=None, dataset_train=None, dataset_val=None, save=False):
+    def generate_datasets(self, X_train: DataFrame, y_train: Series, params, X_val=None, y_val=None, sample_weights=None, sample_weights_val=None, dataset_train=None, dataset_val=None, save=False):
         lgb_dataset_params_keys = ['objective', 'two_round', 'num_threads', 'num_classes', 'verbose']  # Keys that are specific to lightGBM Dataset object construction.
         data_params = {key: params[key] for key in lgb_dataset_params_keys if key in params}.copy()
 
@@ -262,11 +262,11 @@ class LGBModel(AbstractModel):
 
         if not dataset_train:
             # X_train, W_train = self.convert_to_weight(X=X_train)
-            dataset_train = construct_dataset(x=X_train, y=y_train, location=f'{self.path}datasets{os.path.sep}train', params=data_params, save=save, weight=weights)
+            dataset_train = construct_dataset(x=X_train, y=y_train, location=f'{self.path}datasets{os.path.sep}train', params=data_params, save=save, weight=sample_weights)
             # dataset_train = construct_dataset_lowest_memory(X=X_train, y=y_train, location=self.path + 'datasets/train', params=data_params)
         if (not dataset_val) and (X_val is not None) and (y_val is not None):
             # X_val, W_val = self.convert_to_weight(X=X_val)
-            dataset_val = construct_dataset(x=X_val, y=y_val, location=f'{self.path}datasets{os.path.sep}val', reference=dataset_train, params=data_params, save=save, weight=weights_val)
+            dataset_val = construct_dataset(x=X_val, y=y_val, location=f'{self.path}datasets{os.path.sep}val', reference=dataset_train, params=data_params, save=save, weight=sample_weights_val)
             # dataset_val = construct_dataset_lowest_memory(X=X_val, y=y_val, location=self.path + 'datasets/val', reference=dataset_train, params=data_params)
         if self.problem_type == SOFTCLASS:
             if y_train_og is not None:

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -65,6 +65,8 @@ class LGBModel(AbstractModel):
 
         # TODO: kwargs can have num_cpu, num_gpu. Currently these are ignored.
         verbosity = kwargs.get('verbosity', 2)
+        weights = kwargs.get('weights', None)
+        weights_val = kwargs.get('weights_val', None)
         params = fixedvals_from_searchspaces(params)
 
         if verbosity <= 1:
@@ -77,7 +79,8 @@ class LGBModel(AbstractModel):
             verbose_eval = 1
 
         stopping_metric, stopping_metric_name = self._get_stopping_metric_internal()
-        dataset_train, dataset_val = self.generate_datasets(X_train=X_train, y_train=y_train, params=params, X_val=X_val, y_val=y_val, dataset_train=dataset_train, dataset_val=dataset_val)
+        dataset_train, dataset_val = self.generate_datasets(X_train=X_train, y_train=y_train, params=params, X_val=X_val, y_val=y_val,
+                                                            weights=weights, weights_val=weights_val, dataset_train=dataset_train, dataset_val=dataset_val)
         gc.collect()
 
         num_boost_round = params.pop('num_boost_round', 1000)
@@ -237,12 +240,10 @@ class LGBModel(AbstractModel):
         else:
             return X
 
-    def generate_datasets(self, X_train: DataFrame, y_train: Series, params, X_val=None, y_val=None, dataset_train=None, dataset_val=None, save=False):
+    def generate_datasets(self, X_train: DataFrame, y_train: Series, params, X_val=None, y_val=None, weights=None, weights_val=None, dataset_train=None, dataset_val=None, save=False):
         lgb_dataset_params_keys = ['objective', 'two_round', 'num_threads', 'num_classes', 'verbose']  # Keys that are specific to lightGBM Dataset object construction.
         data_params = {key: params[key] for key in lgb_dataset_params_keys if key in params}.copy()
 
-        W_train = None  # TODO: Add weight support
-        W_test = None  # TODO: Add weight support
         if X_train is not None:
             X_train = self.preprocess(X_train, is_train=True)
         if X_val is not None:
@@ -261,11 +262,11 @@ class LGBModel(AbstractModel):
 
         if not dataset_train:
             # X_train, W_train = self.convert_to_weight(X=X_train)
-            dataset_train = construct_dataset(x=X_train, y=y_train, location=f'{self.path}datasets{os.path.sep}train', params=data_params, save=save, weight=W_train)
+            dataset_train = construct_dataset(x=X_train, y=y_train, location=f'{self.path}datasets{os.path.sep}train', params=data_params, save=save, weight=weights)
             # dataset_train = construct_dataset_lowest_memory(X=X_train, y=y_train, location=self.path + 'datasets/train', params=data_params)
         if (not dataset_val) and (X_val is not None) and (y_val is not None):
             # X_val, W_val = self.convert_to_weight(X=X_val)
-            dataset_val = construct_dataset(x=X_val, y=y_val, location=f'{self.path}datasets{os.path.sep}val', reference=dataset_train, params=data_params, save=save, weight=W_test)
+            dataset_val = construct_dataset(x=X_val, y=y_val, location=f'{self.path}datasets{os.path.sep}val', reference=dataset_train, params=data_params, save=save, weight=weights_val)
             # dataset_val = construct_dataset_lowest_memory(X=X_val, y=y_val, location=self.path + 'datasets/val', reference=dataset_train, params=data_params)
         if self.problem_type == SOFTCLASS:
             if y_train_og is not None:

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -130,7 +130,7 @@ class LinearModel(AbstractModel):
             y_train = y_train.astype(int).values
 
         X_train = self.preprocess(X_train, is_train=True, vect_max_features=hyperparams['vectorizer_dict_size'])
-
+        weights = kwargs.get('weights', None)
         params = {k: v for k, v in self.params.items() if k in self.model_params}
 
         # Ridge/Lasso are using alpha instead of C, which is C^-1
@@ -146,7 +146,7 @@ class LinearModel(AbstractModel):
         logger.log(15, f'Training Model with the following hyperparameter settings:')
         logger.log(15, model)
 
-        self.model = model.fit(X_train, y_train)
+        self.model = model.fit(X_train, y_train, sample_weight=weights)
 
     # TODO: Add HPO
     def _hyperparameter_tune(self, **kwargs):

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -130,7 +130,7 @@ class LinearModel(AbstractModel):
             y_train = y_train.astype(int).values
 
         X_train = self.preprocess(X_train, is_train=True, vect_max_features=hyperparams['vectorizer_dict_size'])
-        weights = kwargs.get('weights', None)
+        sample_weights = kwargs.get('sample_weights', None)
         params = {k: v for k, v in self.params.items() if k in self.model_params}
 
         # Ridge/Lasso are using alpha instead of C, which is C^-1
@@ -146,7 +146,7 @@ class LinearModel(AbstractModel):
         logger.log(15, f'Training Model with the following hyperparameter settings:')
         logger.log(15, model)
 
-        self.model = model.fit(X_train, y_train, sample_weight=weights)
+        self.model = model.fit(X_train, y_train, sample_weight=sample_weights)
 
     # TODO: Add HPO
     def _hyperparameter_tune(self, **kwargs):

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -123,14 +123,13 @@ class LinearModel(AbstractModel):
 
     # TODO: It could be possible to adaptively set max_iter [1] to approximately respect time_limit based on sample-size, feature-dimensionality, and the solver used.
     #  [1] https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#examples-using-sklearn-linear-model-logisticregression
-    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, **kwargs):
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, sample_weight=None, **kwargs):
         hyperparams = self.params.copy()
 
         if self.problem_type == BINARY:
             y_train = y_train.astype(int).values
 
         X_train = self.preprocess(X_train, is_train=True, vect_max_features=hyperparams['vectorizer_dict_size'])
-        sample_weights = kwargs.get('sample_weights', None)
         params = {k: v for k, v in self.params.items() if k in self.model_params}
 
         # Ridge/Lasso are using alpha instead of C, which is C^-1
@@ -146,7 +145,7 @@ class LinearModel(AbstractModel):
         logger.log(15, f'Training Model with the following hyperparameter settings:')
         logger.log(15, model)
 
-        self.model = model.fit(X_train, y_train, sample_weight=sample_weights)
+        self.model = model.fit(X_train, y_train, sample_weight=sample_weight)
 
     # TODO: Add HPO
     def _hyperparameter_tune(self, **kwargs):

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -75,7 +75,7 @@ class RFModel(AbstractModel):
         n_estimators_test = min(4, max(1, math.floor(n_estimators_minimum/5)))
 
         X_train = self.preprocess(X_train)
-        weights = kwargs.get('weights', None)
+        sample_weights = kwargs.get('sample_weights', None)
         n_estimator_increments = [n_estimators_final]
 
         # Very rough guess to size of a single tree before training
@@ -111,7 +111,7 @@ class RFModel(AbstractModel):
         for i, n_estimators in enumerate(n_estimator_increments):
             if i != 0:
                 self.model.n_estimators = n_estimators
-            self.model = self.model.fit(X_train, y_train, sample_weight=weights)
+            self.model = self.model.fit(X_train, y_train, sample_weight=sample_weights)
             if (i == 0) and (len(n_estimator_increments) > 1):
                 time_elapsed = time.time() - time_train_start
                 model_size_bytes = 0

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -65,7 +65,7 @@ class RFModel(AbstractModel):
         }
         return spaces
 
-    def _fit(self, X_train, y_train, time_limit=None, **kwargs):
+    def _fit(self, X_train, y_train, time_limit=None, sample_weight=None, **kwargs):
         time_start = time.time()
         max_memory_usage_ratio = self.params_aux['max_memory_usage_ratio']
         hyperparams = self.params.copy()
@@ -75,7 +75,6 @@ class RFModel(AbstractModel):
         n_estimators_test = min(4, max(1, math.floor(n_estimators_minimum/5)))
 
         X_train = self.preprocess(X_train)
-        sample_weights = kwargs.get('sample_weights', None)
         n_estimator_increments = [n_estimators_final]
 
         # Very rough guess to size of a single tree before training
@@ -111,7 +110,7 @@ class RFModel(AbstractModel):
         for i, n_estimators in enumerate(n_estimator_increments):
             if i != 0:
                 self.model.n_estimators = n_estimators
-            self.model = self.model.fit(X_train, y_train, sample_weight=sample_weights)
+            self.model = self.model.fit(X_train, y_train, sample_weight=sample_weight)
             if (i == 0) and (len(n_estimator_increments) > 1):
                 time_elapsed = time.time() - time_train_start
                 model_size_bytes = 0

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -75,6 +75,7 @@ class RFModel(AbstractModel):
         n_estimators_test = min(4, max(1, math.floor(n_estimators_minimum/5)))
 
         X_train = self.preprocess(X_train)
+        weights = kwargs.get('weights', None)
         n_estimator_increments = [n_estimators_final]
 
         # Very rough guess to size of a single tree before training
@@ -110,7 +111,7 @@ class RFModel(AbstractModel):
         for i, n_estimators in enumerate(n_estimator_increments):
             if i != 0:
                 self.model.n_estimators = n_estimators
-            self.model = self.model.fit(X_train, y_train)
+            self.model = self.model.fit(X_train, y_train, sample_weight=weights)
             if (i == 0) and (len(n_estimator_increments) > 1):
                 time_elapsed = time.time() - time_train_start
                 model_size_bytes = 0

--- a/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
@@ -355,6 +355,9 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
             if num_gpus > 1:
                 logger.warning("TabTransformer not yet configured to use more than 1 GPU. 'num_gpus' set to >1, but we will be using only 1 GPU.")
 
+        sample_weights = kwargs.get('sample_weights', None)
+        if sample_weights is not None:
+            logger.log(15, "sample_weights not yet supported for TabTransformerModel, this model will ignore them in training.")
 
         if self.problem_type ==REGRESSION:
             self.params['n_classes'] = 1
@@ -521,14 +524,14 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
 
         """
         List of features to add (Updated by Anthony Galczak 11-19-20):
-        
-        1) Allow for saving of pretrained model for future use. This will be done in a future PR as the 
+
+        1) Allow for saving of pretrained model for future use. This will be done in a future PR as the
         "pretrain API change".
-        
+
         2) Investigate options for when the unlabeled schema does not match the training schema. Currently,
         we do not allow such mismatches and the schemas must match exactly. We can investigate ways to use
         less or more columns from the unlabeled data. This will likely require a design meeting.
-        
+
         3) Bug where HPO doesn't work when cuda is enabled.
         "RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method"
         Update: This will likely be fixed in a future change to HPO in AutoGluon.

--- a/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
+++ b/tabular/src/autogluon/tabular/models/tab_transformer/tab_transformer_model.py
@@ -338,7 +338,7 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
                 pass
             logger.log(15, "Best model found in epoch %d" % best_val_epoch)
 
-    def _fit(self, X_train, y_train, X_val=None, y_val=None, X_unlabeled=None, time_limit=None, reporter=None, **kwargs):
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, X_unlabeled=None, time_limit=None, reporter=None, sample_weight=None, **kwargs):
         import torch
 
         num_gpus = kwargs.get('num_gpus', None)
@@ -355,9 +355,8 @@ class TabTransformerModel(AbstractNeuralNetworkModel):
             if num_gpus > 1:
                 logger.warning("TabTransformer not yet configured to use more than 1 GPU. 'num_gpus' set to >1, but we will be using only 1 GPU.")
 
-        sample_weights = kwargs.get('sample_weights', None)
-        if sample_weights is not None:
-            logger.log(15, "sample_weights not yet supported for TabTransformerModel, this model will ignore them in training.")
+        if sample_weight is not None:
+            logger.log(15, "sample_weight not yet supported for TabTransformerModel, this model will ignore them in training.")
 
         if self.problem_type ==REGRESSION:
             self.params['n_classes'] = 1

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -156,7 +156,7 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
                                                     params['layers'][0]*prop_vector_features*np.log10(vector_dim+10) )))
         return
 
-    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_cpus=1, num_gpus=0, reporter=None, **kwargs):
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_cpus=1, num_gpus=0, reporter=None, sample_weight=None, **kwargs):
         """ X_train (pd.DataFrame): training data features (not necessarily preprocessed yet)
             X_val (pd.DataFrame): test data features (should have same column names as Xtrain)
             y_train (pd.Series):
@@ -167,9 +167,8 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         try_import_mxnet()
         import mxnet as mx
         self.verbosity = kwargs.get('verbosity', 2)
-        sample_weights = kwargs.get('sample_weights', None)
-        if sample_weights is not None:  # TODO: support
-            logger.log(15, "sample_weights not yet supported for TabularNeuralNetModel, this model will ignore them in training.")
+        if sample_weight is not None:  # TODO: support
+            logger.log(15, "sample_weight not yet supported for TabularNeuralNetModel, this model will ignore them in training.")
 
         params = self.params.copy()
         params = fixedvals_from_searchspaces(params)

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -166,8 +166,12 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         start_time = time.time()
         try_import_mxnet()
         import mxnet as mx
-        params = self.params.copy()
         self.verbosity = kwargs.get('verbosity', 2)
+        weights = kwargs.get('weights', None)
+        if weights is not None:
+            logger.log(15, "Sample weights not yet supported for TabularNeuralNetModel, this model will ignore them in training.")
+
+        params = self.params.copy()
         params = fixedvals_from_searchspaces(params)
         if self.feature_metadata is None:
             raise ValueError("Trainer class must set feature_metadata for this model")

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -167,9 +167,9 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         try_import_mxnet()
         import mxnet as mx
         self.verbosity = kwargs.get('verbosity', 2)
-        weights = kwargs.get('weights', None)
-        if weights is not None:
-            logger.log(15, "Sample weights not yet supported for TabularNeuralNetModel, this model will ignore them in training.")
+        sample_weights = kwargs.get('sample_weights', None)
+        if sample_weights is not None:  # TODO: support
+            logger.log(15, "sample_weights not yet supported for TabularNeuralNetModel, this model will ignore them in training.")
 
         params = self.params.copy()
         params = fixedvals_from_searchspaces(params)

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -173,7 +173,8 @@ class TextPredictionV1Model(AbstractModel):
     def _fit(self, X_train: pd.DataFrame, y_train: pd.Series,
              X_val: Optional[pd.DataFrame] = None,
              y_val: Optional[pd.Series] = None,
-             time_limit: Optional[int] = None, **kwargs):
+             time_limit: Optional[int] = None,
+             sample_weight=None, **kwargs):
         """The internal fit function
 
         Parameters
@@ -205,9 +206,8 @@ class TextPredictionV1Model(AbstractModel):
         verbosity = kwargs.get('verbosity', 2)
         num_cpus = kwargs.get('num_cpus', None)
         num_gpus = kwargs.get('num_gpus', None)
-        sample_weights = kwargs.get('sample_weights', None)
-        if sample_weights is not None:  # TODO: support
-            logger.log(15, "sample_weights not yet supported for TextPredictionV1Model, this model will ignore them in training.")
+        if sample_weight is not None:  # TODO: support
+            logger.log(15, "sample_weight not yet supported for TextPredictionV1Model, this model will ignore them in training.")
 
         # Infer resource
         resource = get_recommended_resource(nthreads_per_trial=num_cpus,

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -205,6 +205,9 @@ class TextPredictionV1Model(AbstractModel):
         verbosity = kwargs.get('verbosity', 2)
         num_cpus = kwargs.get('num_cpus', None)
         num_gpus = kwargs.get('num_gpus', None)
+        sample_weights = kwargs.get('sample_weights', None)
+        if sample_weights is not None:  # TODO: support
+            logger.log(15, "sample_weights not yet supported for TextPredictionV1Model, this model will ignore them in training.")
 
         # Infer resource
         resource = get_recommended_resource(nthreads_per_trial=num_cpus,

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -77,8 +77,8 @@ class XGBoostModel(AbstractModel):
             verbose = True
             verbose_eval = 1
 
-        weights = kwargs.get('weights', None)
-        weights_val = kwargs.get('weights_val', None)
+        sample_weights = kwargs.get('sample_weights', None)
+        sample_weights_val = kwargs.get('sample_weights_val', None)  # TODO: utilize sample_weights_val in early-stopping if provided
         X_train = self.preprocess(X_train, is_train=True, max_category_levels=max_category_levels)
         num_rows_train = X_train.shape[0]
 
@@ -118,7 +118,7 @@ class XGBoostModel(AbstractModel):
             eval_metric=eval_metric,
             verbose=False,
             callbacks=callbacks,
-            sample_weight=weights
+            sample_weight=sample_weights
         )
 
         bst = self.model.get_booster()

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -60,7 +60,8 @@ class XGBoostModel(AbstractModel):
 
         return X
 
-    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_gpus=0, **kwargs):
+    def _fit(self, X_train, y_train, X_val=None, y_val=None, time_limit=None, num_gpus=0, sample_weight=None, sample_weight_val=None, **kwargs):
+        # TODO: utilize sample_weight_val in early-stopping if provided
         start_time = time.time()
 
         params = self.params.copy()
@@ -77,8 +78,6 @@ class XGBoostModel(AbstractModel):
             verbose = True
             verbose_eval = 1
 
-        sample_weights = kwargs.get('sample_weights', None)
-        sample_weights_val = kwargs.get('sample_weights_val', None)  # TODO: utilize sample_weights_val in early-stopping if provided
         X_train = self.preprocess(X_train, is_train=True, max_category_levels=max_category_levels)
         num_rows_train = X_train.shape[0]
 
@@ -118,7 +117,7 @@ class XGBoostModel(AbstractModel):
             eval_metric=eval_metric,
             verbose=False,
             callbacks=callbacks,
-            sample_weight=sample_weights
+            sample_weight=sample_weight
         )
 
         bst = self.model.get_booster()

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -76,7 +76,9 @@ class XGBoostModel(AbstractModel):
         else:
             verbose = True
             verbose_eval = 1
-        
+
+        weights = kwargs.get('weights', None)
+        weights_val = kwargs.get('weights_val', None)
         X_train = self.preprocess(X_train, is_train=True, max_category_levels=max_category_levels)
         num_rows_train = X_train.shape[0]
 
@@ -115,7 +117,8 @@ class XGBoostModel(AbstractModel):
             eval_set=eval_set,
             eval_metric=eval_metric,
             verbose=False,
-            callbacks=callbacks
+            callbacks=callbacks,
+            sample_weight=weights
         )
 
         bst = self.model.get_booster()

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -173,7 +173,7 @@ class TabularPredictor(TabularPredictorV1):
         self.verbosity = verbosity
         set_logger_verbosity(self.verbosity, logger=logger)
         self.sample_weight = sample_weight  # TODO: add support for sample_weight= 'auto', 'balanced'
-        self.weight_evaluation = weight_evaluation
+        self.weight_evaluation = weight_evaluation  # TODO: sample_weight and weight_evaluation can both be properties that link to self._learner.sample_weight, self._learner.weight_evaluation
         self._validate_init_kwargs(kwargs)
         path = setup_outputdir(path)
 
@@ -631,14 +631,6 @@ class TabularPredictor(TabularPredictorV1):
 
         if holdout_frac is None:
             holdout_frac = default_holdout_frac(len(train_data), ag_args.get('hyperparameter_tune_kwargs', None) is not None)
-
-        if self.sample_weight is not None:
-            prefix = f"Values in column '{self.sample_weight}' used as sample weights instead of predictive features."
-            if self.weight_evaluation:
-                suffix = " Evaluation will report weighted metrics, so ensure same column exists in test data."
-            else:
-                suffix = " Evaluation metrics will ignore sample weights, specify weight_evaluation=True to instead report weighted metrics."
-            logger.log(20, prefix+suffix)
 
         if kwargs['_save_bag_folds'] is not None:
             if ag_args_ensemble is None:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -524,9 +524,10 @@ class TabularPredictor(TabularPredictorV1):
             weight_column : str, default = None
                 If specified, indicates which column of the data should be treated as sample weights. This column will NOT be considered as a predictive feature.
                 Sample weights should be non-negative (and cannot be nan), with larger values indicating which rows are more important than others.
-            weight_evaluation : bool, defautl = False
+            weight_evaluation : bool, default = False
                 Only considered when `weight_column` has been specified. Determines whether sample weights should be taken into account when computing evaluation metrics on validation/test data.
                 If True, then weighted metrics will be reported based on the sample weights provided in the specified `weight_column` (in which case `weight_column` must also be present in test data).
+                In this case, the 'best' model used by default for prediction will also be decided based on a weighted version of evaluation metric.
             verbosity : int
                 If specified, overrides the existing `predictor.verbosity` value.
 

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -78,6 +78,7 @@ class TabularPredictor(TabularPredictorV1):
     sample_weight : str, default = None
         If specified, this column-name indicates which column of the data should be treated as sample weights. This column will NOT be considered as a predictive feature.
         Sample weights should be non-negative (and cannot be nan), with larger values indicating which rows are more important than others.
+        If you want your usage of sample weights to match results obtained outside of this Predictor, then ensure sample weights for your training (or tuning) data sum to the number of rows in the training (or tuning) data.
     weight_evaluation : bool, default = False
         Only considered when `sample_weight` column has been specified. Determines whether sample weights should be taken into account when computing evaluation metrics on validation/test data.
         If True, then weighted metrics will be reported based on the sample weights provided in the specified `sample_weight` (in which case `sample_weight` column must also be present in test data).
@@ -171,7 +172,7 @@ class TabularPredictor(TabularPredictorV1):
     ):
         self.verbosity = verbosity
         set_logger_verbosity(self.verbosity, logger=logger)
-        self.sample_weight = sample_weight  # TODO: add support for sample_weight='auto'
+        self.sample_weight = sample_weight  # TODO: add support for sample_weight= 'auto', 'balanced'
         self.weight_evaluation = weight_evaluation
         self._validate_init_kwargs(kwargs)
         path = setup_outputdir(path)
@@ -647,8 +648,7 @@ class TabularPredictor(TabularPredictorV1):
         core_kwargs = {'ag_args': ag_args, 'ag_args_ensemble': ag_args_ensemble, 'ag_args_fit': ag_args_fit, 'excluded_model_types': excluded_model_types}
         self._learner.fit(X=train_data, X_val=tuning_data, X_unlabeled=unlabeled_data,
                           holdout_frac=holdout_frac, num_bag_folds=num_bag_folds, num_bag_sets=num_bag_sets, num_stack_levels=num_stack_levels,
-                          hyperparameters=hyperparameters, core_kwargs=core_kwargs,
-                          time_limit=time_limit, verbosity=verbosity, sample_weight=self.sample_weight, weight_evaluation=self.weight_evaluation)
+                          hyperparameters=hyperparameters, core_kwargs=core_kwargs, time_limit=time_limit, verbosity=verbosity)
         self._set_post_fit_vars()
 
         self._post_fit(

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -862,6 +862,7 @@ class AbstractTrainer:
             level=level,
         )
         weighted_ensemble_model = weighted_ensemble_model[0]
+        w = None
         if self.weight_evaluation:
             X, w = extract_column(X, self.weight_column)
         models = self._train_multi(X_train=X, y_train=y, X_val=None, y_val=None, models=[weighted_ensemble_model], k_fold=k_fold, n_repeats=n_repeats, hyperparameter_tune_kwargs=None, feature_prune=False, stack_name=stack_name, level=level, time_limit=time_limit, ens_sample_weights=w)

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -29,8 +29,7 @@ class AutoTrainer(AbstractTrainer):
 
     def fit(self, X_train, y_train, hyperparameters, X_val=None, y_val=None, X_unlabeled=None, feature_prune=False, holdout_frac=0.1, num_stack_levels=0, core_kwargs: dict = None, time_limit=None, **kwargs):
         for key in kwargs:
-            if key not in ['weight_column', 'weight_evaluation']:
-                logger.warning(f'Warning: Unknown argument passed to `AutoTrainer.fit()`. Argument: {key}')
+            logger.warning(f'Warning: Unknown argument passed to `AutoTrainer.fit()`. Argument: {key}')
 
         if self.bagged_mode:
             if (y_val is not None) and (X_val is not None):

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -29,7 +29,8 @@ class AutoTrainer(AbstractTrainer):
 
     def fit(self, X_train, y_train, hyperparameters, X_val=None, y_val=None, X_unlabeled=None, feature_prune=False, holdout_frac=0.1, num_stack_levels=0, core_kwargs: dict = None, time_limit=None, **kwargs):
         for key in kwargs:
-            logger.warning(f'Warning: Unknown argument passed to `AutoTrainer.fit()`. Argument: {key}')
+            if key not in ['weight_column', 'weight_evaluation']:
+                logger.warning(f'Warning: Unknown argument passed to `AutoTrainer.fit()`. Argument: {key}')
 
         if self.bagged_mode:
             if (y_val is not None) and (X_val is not None):

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -508,14 +508,13 @@ def test_sample_weights():
     test_data_weighted[sample_weight] = test_weights
     fit_args = {'time_limit': 20}
     predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type'], sample_weight=sample_weight).fit(train_data, **fit_args)
-    predictor.distill(time_limit=5)
     ldr = predictor.leaderboard(test_data)
     perf = predictor.evaluate(test_data)
     # Run again with weight_evaluation:
     predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type'], sample_weight=sample_weight, weight_evaluation=True).fit(train_data, **fit_args)
-    ldr = predictor.leaderboard(test_data_weighted)
     perf = predictor.evaluate(test_data_weighted)
-    predictor.distill(time_limit=5)
+    predictor.distill(time_limit=10)
+    ldr = predictor.leaderboard(test_data_weighted)
 
 
 

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -486,6 +486,38 @@ def test_tabular_bag():
                            seed_val=seed_val, fit_args=fit_args)
 
 
+def test_sample_weights():
+    dataset = {'url': 'https://autogluon.s3.amazonaws.com/datasets/toyRegression.zip',
+               'name': 'toyRegression',
+               'problem_type': REGRESSION,
+               'label': 'y',
+               'performance_val': 0.183}
+    directory_prefix = './datasets/'
+    train_file = 'train_data.csv'
+    test_file = 'test_data.csv'
+    train_data, test_data = load_data(directory_prefix=directory_prefix, train_file=train_file, test_file=test_file, name=dataset['name'], url=dataset['url'])
+    print(f"Evaluating Benchmark Dataset {dataset['name']}")
+    directory = directory_prefix + dataset['name'] + "/"
+    savedir = directory + 'AutogluonOutput/'
+    shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
+    weight_column = 'sample_weights'
+    weights = np.abs(np.random.rand(len(train_data),))
+    test_weights = np.abs(np.random.rand(len(test_data),))
+    train_data[weight_column] = weights
+    test_data_weighted = test_data.copy()
+    test_data_weighted[weight_column] = test_weights
+    fit_args = {'weight_column': weight_column, 'time_limit': 20}
+    predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type']).fit(train_data, **fit_args)
+    ldr = predictor.leaderboard(test_data)
+    perf = predictor.evaluate(test_data)
+    # Run again with weight_evaluation:
+    fit_args['weight_evaluation'] = True
+    predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type']).fit(train_data, **fit_args)
+    ldr = predictor.leaderboard(test_data_weighted)
+    perf = predictor.evaluate(test_data_weighted)
+
+
+
 @pytest.mark.skip(reason="Ignored for now, since stacking is disabled without bagging.")
 def test_tabular_stack1():
     ############ Benchmark options you can set: ########################

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -500,21 +500,22 @@ def test_sample_weights():
     directory = directory_prefix + dataset['name'] + "/"
     savedir = directory + 'AutogluonOutput/'
     shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
-    weight_column = 'sample_weights'
+    sample_weight = 'sample_weights'
     weights = np.abs(np.random.rand(len(train_data),))
     test_weights = np.abs(np.random.rand(len(test_data),))
-    train_data[weight_column] = weights
+    train_data[sample_weight] = weights
     test_data_weighted = test_data.copy()
-    test_data_weighted[weight_column] = test_weights
-    fit_args = {'weight_column': weight_column, 'time_limit': 20}
-    predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type']).fit(train_data, **fit_args)
+    test_data_weighted[sample_weight] = test_weights
+    fit_args = {'time_limit': 20}
+    predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type'], sample_weight=sample_weight).fit(train_data, **fit_args)
+    predictor.distill(time_limit=5)
     ldr = predictor.leaderboard(test_data)
     perf = predictor.evaluate(test_data)
     # Run again with weight_evaluation:
-    fit_args['weight_evaluation'] = True
-    predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type']).fit(train_data, **fit_args)
+    predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type'], sample_weight=sample_weight, weight_evaluation=True).fit(train_data, **fit_args)
     ldr = predictor.leaderboard(test_data_weighted)
     perf = predictor.evaluate(test_data_weighted)
+    predictor.distill(time_limit=5)
 
 
 

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -486,7 +486,7 @@ def test_tabular_bag():
                            seed_val=seed_val, fit_args=fit_args)
 
 
-def test_sample_weights():
+def test_sample_weight():
     dataset = {'url': 'https://autogluon.s3.amazonaws.com/datasets/toyRegression.zip',
                'name': 'toyRegression',
                'problem_type': REGRESSION,


### PR DESCRIPTION
Related Issues: #33 

Sample-weights functionality added. Example script:

```
from autogluon.tabular import TabularDataset, TabularPredictor
import numpy as np
import pandas as pd

train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
subsample_size = 100  # subsample subset of data for faster demo, try setting this to much larger values
train_data = train_data.sample(n=subsample_size, random_state=0)
train_data_noweight = train_data.copy()  # training data without weights

label = 'class'
pos_class = ' >50K'
sample_weight = 'weight'

weights = np.zeros((len(train_data),))
weights[train_data[label]==pos_class] = 1  # models that can handle sample weights will only learn to predict positive class this way.
train_data[sample_weight] = weights
print(train_data.head())



## Train predictor with sample-weighting but without reporting weighted metrics:

predictor = TabularPredictor(label=label, sample_weight=sample_weight).fit(train_data)
performance = predictor.evaluate(train_data_noweight)  # weights not needed in test data because weight_evaluation not specified.
predictor.leaderboard(train_data_noweight)

## Output (models which ignore sample-weights do the best since we used extreme sample weights here but are considering original metric):

                  model  score_test  score_val  pred_time_test  pred_time_val  fit_time  pred_time_test_marginal  pred_time_val_marginal  fit_time_marginal  stack_level  can_infer  fit_order
0        KNeighborsDist        0.93       0.65        0.106977       0.107285  0.001523                 0.106977                0.107285           0.001523            0       True          6
1       NeuralNetFastAI        0.84       0.90        0.170466       0.118562  8.476372                 0.170466                0.118562           8.476372            0       True         12
2   WeightedEnsemble_L1        0.84       0.90        0.174107       0.121302  9.203398                 0.003641                0.002740           0.727026            1       True         14
3        NeuralNetMXNet        0.81       0.85        0.116029       0.023758  3.213731                 0.116029                0.023758           3.213731            0       True         11
4        KNeighborsUnif        0.75       0.70        0.108753       0.106495  0.002271                 0.108753                0.106495           0.002271            0       True          5
5               XGBoost        0.26       0.25        0.023181       0.013916  0.366666                 0.023181                0.013916           0.366666            0       True         10
6            LightGBMXT        0.26       0.25        0.024338       0.030474  0.286936                 0.024338                0.030474           0.286936            0       True          8
7         LightGBMLarge        0.26       0.25        0.028656       0.018944  0.321018                 0.028656                0.018944           0.321018            0       True         13
8              LightGBM        0.26       0.25        0.029913       0.017574  0.245766                 0.029913                0.017574           0.245766            0       True          7
9              CatBoost        0.26       0.25        0.049470       0.019500  1.075555                 0.049470                0.019500           1.075555            0       True          9
10     RandomForestEntr        0.26       0.25        0.129918       0.117492  0.571822                 0.129918                0.117492           0.571822            0       True          2
11     RandomForestGini        0.26       0.25        0.131269       0.113353  0.591314                 0.131269                0.113353           0.591314            0       True          1
12       ExtraTreesGini        0.26       0.25        0.132937       0.116305  0.472288                 0.132937                0.116305           0.472288            0       True          3
13       ExtraTreesEntr        0.26       0.25        0.134349       0.115802  0.465550                 0.134349                0.115802           0.465550            0       True          4
                  model  score_test  score_val  pred_time_test  ...  fit_time_marginal  stack_level  can_infer  fit_order
0        KNeighborsDist        0.93       0.65        0.106977  ...           0.001523            0       True          6
1       NeuralNetFastAI        0.84       0.90        0.170466  ...           8.476372            0       True         12
2   WeightedEnsemble_L1        0.84       0.90        0.174107  ...           0.727026            1       True         14
3        NeuralNetMXNet        0.81       0.85        0.116029  ...           3.213731            0       True         11
4        KNeighborsUnif        0.75       0.70        0.108753  ...           0.002271            0       True          5
5               XGBoost        0.26       0.25        0.023181  ...           0.366666            0       True         10
6            LightGBMXT        0.26       0.25        0.024338  ...           0.286936            0       True          8
7         LightGBMLarge        0.26       0.25        0.028656  ...           0.321018            0       True         13
8              LightGBM        0.26       0.25        0.029913  ...           0.245766            0       True          7
9              CatBoost        0.26       0.25        0.049470  ...           1.075555            0       True          9
10     RandomForestEntr        0.26       0.25        0.129918  ...           0.571822            0       True          2
11     RandomForestGini        0.26       0.25        0.131269  ...           0.591314            0       True          1
12       ExtraTreesGini        0.26       0.25        0.132937  ...           0.472288            0       True          3
13       ExtraTreesEntr        0.26       0.25        0.134349  ...           0.465550            0       True          4

## Train predictor with sample-weighting and report weighted metrics:

predictor = TabularPredictor(label=label, sample_weight=sample_weight, weight_evaluation=True).fit(train_data)
performance = predictor.evaluate(train_data)  # weights are needed now in the test data
predictor.leaderboard(train_data)

## Output (models which ignore sample-weights do worse now since the metric we care about is now similarly weighted):

                  model  score_test  score_val  pred_time_test  ...  fit_time_marginal  stack_level  can_infer  fit_order
0               XGBoost    1.000000        1.0        0.016571  ...           0.217509            0       True         10
1         LightGBMLarge    1.000000        1.0        0.018913  ...           0.639915            0       True         13
2              CatBoost    1.000000        1.0        0.019209  ...           1.001294            0       True          9
3            LightGBMXT    1.000000        1.0        0.019859  ...           0.250556            0       True          8
4              LightGBM    1.000000        1.0        0.022115  ...           0.320440            0       True          7
5   WeightedEnsemble_L1    1.000000        1.0        0.023454  ...           1.200252            1       True         14
6        ExtraTreesGini    1.000000        1.0        0.123344  ...           0.547743            0       True          3
7        ExtraTreesEntr    1.000000        1.0        0.129012  ...           0.532536            0       True          4
8      RandomForestEntr    1.000000        1.0        0.131815  ...           0.720166            0       True          2
9      RandomForestGini    1.000000        1.0        0.132052  ...           0.606035            0       True          1
10       KNeighborsDist    0.846154        0.2        0.109156  ...           0.001933            0       True          6
11      NeuralNetFastAI    0.846154        0.6        0.186419  ...           7.150270            0       True         12
12       KNeighborsUnif    0.192308        0.0        0.109623  ...           0.002280            0       True          5
13       NeuralNetMXNet    0.192308        0.4        0.120182  ...           2.294746            0       True         11
```