### PR TITLE
[mxnet] Catch mxnet exception

### DIFF
--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -318,7 +318,7 @@ class ImagePredictor(object):
             with MXNetErrorCatcher() as err:
                 self._classifier = task.fit(train_data, tuning_data, 1 - holdout_frac, random_state)
             if err.exc_value is not None:
-                raise RuntimeError(err.exc_value)
+                raise RuntimeError(err.exc_value + err.hint)
         self._classifier._logger.setLevel(log_level)
         self._classifier._logger.propagate = True
         self._fit_summary = task.fit_summary()

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -12,6 +12,7 @@ from autogluon.core.utils import set_logger_verbosity
 from gluoncv.auto.tasks import ImageClassification as _ImageClassification
 from gluoncv.model_zoo import get_model_list
 from ..configs.presets_configs import unpack, _check_gpu_memory_presets
+from ..utils import MXNetErrorCatcher
 
 __all__ = ['ImagePredictor']
 
@@ -314,7 +315,10 @@ class ImagePredictor(object):
         task._logger.propagate = True
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self._classifier = task.fit(train_data, tuning_data, 1 - holdout_frac, random_state)
+            with MXNetErrorCatcher() as err:
+                self._classifier = task.fit(train_data, tuning_data, 1 - holdout_frac, random_state)
+            if err.exc_value is not None:
+                raise RuntimeError(err.exc_value)
         self._classifier._logger.setLevel(log_level)
         self._classifier._logger.propagate = True
         self._fit_summary = task.fit_summary()

--- a/vision/src/autogluon/vision/utils/__init__.py
+++ b/vision/src/autogluon/vision/utils/__init__.py
@@ -1,3 +1,3 @@
 from .learning_rate import *
 from .plot_network import plot_network
-
+from .error_handler import MXNetErrorCatcher

--- a/vision/src/autogluon/vision/utils/error_handler.py
+++ b/vision/src/autogluon/vision/utils/error_handler.py
@@ -1,0 +1,33 @@
+"""Internal deep learning framework error handler"""
+import contextlib
+
+
+class MXNetErrorCatcher(contextlib.AbstractContextManager):
+    def __init__(self):
+        self.exc_value = None
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type:
+            if 'KeyboardInterrupt' in str(exc_value):
+                self.exc_value = 'KeyboardInterrupt'
+                return True
+            lines = [line for line in str(exc_value).splitlines() if 'MXNetError' in line]
+            mxnet_err = ''
+            if lines:
+                mxnet_err = lines[-1].strip()
+            if 'GPU is not enabled' in mxnet_err:
+                print(
+                    """MXNet is not built with GPU support, make sure you have nvidia gpus enabled with
+                    corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version.
+                    You may refer to "https://auto.gluon.ai/stable/install.html" for
+                    detailed installation guide.""")
+            if 'out of memory' in mxnet_err:
+                print(
+                    """CUDA out of memory error detected. Try reduce 'batch_size' in 'hyperparameters',
+                    e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists,
+                    please check if you have other processes occupying too much GPU memory by looking at `nvidia-smi`.
+                    """)
+            self.exc_value = mxnet_err
+        else:
+            self.exc_value = exc_value
+        return True

--- a/vision/src/autogluon/vision/utils/error_handler.py
+++ b/vision/src/autogluon/vision/utils/error_handler.py
@@ -17,14 +17,14 @@ class MXNetErrorCatcher(contextlib.AbstractContextManager):
             if lines:
                 mxnet_err = lines[-1].strip()
             if 'GPU is not enabled' in mxnet_err:
-                self.hint += 'MXNet is not built with GPU support, make sure you have nvidia gpus enabled with' +
-                             'corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version.' +
-                             'You may refer to "https://auto.gluon.ai/stable/install.html" for' +
-                             'detailed installation guide.\n'
+                self.hint += ('MXNet is not built with GPU support, make sure you have nvidia gpus enabled with'
+                              'corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version.'
+                              'You may refer to "https://auto.gluon.ai/stable/install.html" for'
+                              'detailed installation guide.\n')
             if 'out of memory' in mxnet_err:
-                self.hint += 'CUDA out of memory error detected. Try reduce `batch_size` in `hyperparameters`,' +
-                             "e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists," +
-                             'please check if you have other processes occupying too much GPU memory by looking at `nvidia-smi`.\n'
+                self.hint += ('CUDA out of memory error detected. Try reduce `batch_size` in `hyperparameters`,'
+                              "e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists,"
+                              'please check if you have other processes occupying too much GPU memory by looking at `nvidia-smi`.\n')
             self.exc_value = mxnet_err
         else:
             self.exc_value = exc_value

--- a/vision/src/autogluon/vision/utils/error_handler.py
+++ b/vision/src/autogluon/vision/utils/error_handler.py
@@ -5,6 +5,7 @@ import contextlib
 class MXNetErrorCatcher(contextlib.AbstractContextManager):
     def __init__(self):
         self.exc_value = None
+        self.hint = ''
 
     def __exit__(self, exc_type, exc_value, traceback):
         if exc_type:
@@ -16,17 +17,14 @@ class MXNetErrorCatcher(contextlib.AbstractContextManager):
             if lines:
                 mxnet_err = lines[-1].strip()
             if 'GPU is not enabled' in mxnet_err:
-                print(
-                    """MXNet is not built with GPU support, make sure you have nvidia gpus enabled with
-                    corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version.
-                    You may refer to "https://auto.gluon.ai/stable/install.html" for
-                    detailed installation guide.""")
+                self.hint += 'MXNet is not built with GPU support, make sure you have nvidia gpus enabled with'
+                    + 'corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version.'
+                    + 'You may refer to "https://auto.gluon.ai/stable/install.html" for'
+                    + 'detailed installation guide.\n'
             if 'out of memory' in mxnet_err:
-                print(
-                    """CUDA out of memory error detected. Try reduce 'batch_size' in 'hyperparameters',
-                    e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists,
-                    please check if you have other processes occupying too much GPU memory by looking at `nvidia-smi`.
-                    """)
+                self.hint += 'CUDA out of memory error detected. Try reduce `batch_size` in `hyperparameters`,'
+                    + "e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists,"
+                    + 'please check if you have other processes occupying too much GPU memory by looking at `nvidia-smi`.\n'
             self.exc_value = mxnet_err
         else:
             self.exc_value = exc_value

--- a/vision/src/autogluon/vision/utils/error_handler.py
+++ b/vision/src/autogluon/vision/utils/error_handler.py
@@ -17,14 +17,14 @@ class MXNetErrorCatcher(contextlib.AbstractContextManager):
             if lines:
                 mxnet_err = lines[-1].strip()
             if 'GPU is not enabled' in mxnet_err:
-                self.hint += 'MXNet is not built with GPU support, make sure you have nvidia gpus enabled with'
-                    + 'corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version.'
-                    + 'You may refer to "https://auto.gluon.ai/stable/install.html" for'
-                    + 'detailed installation guide.\n'
+                self.hint += 'MXNet is not built with GPU support, make sure you have nvidia gpus enabled with' +
+                             'corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version.' +
+                             'You may refer to "https://auto.gluon.ai/stable/install.html" for' +
+                             'detailed installation guide.\n'
             if 'out of memory' in mxnet_err:
-                self.hint += 'CUDA out of memory error detected. Try reduce `batch_size` in `hyperparameters`,'
-                    + "e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists,"
-                    + 'please check if you have other processes occupying too much GPU memory by looking at `nvidia-smi`.\n'
+                self.hint += 'CUDA out of memory error detected. Try reduce `batch_size` in `hyperparameters`,' +
+                             "e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists," +
+                             'please check if you have other processes occupying too much GPU memory by looking at `nvidia-smi`.\n'
             self.exc_value = mxnet_err
         else:
             self.exc_value = exc_value

--- a/vision/src/autogluon/vision/utils/error_handler.py
+++ b/vision/src/autogluon/vision/utils/error_handler.py
@@ -15,15 +15,15 @@ class MXNetErrorCatcher(contextlib.AbstractContextManager):
             lines = [line for line in str(exc_value).splitlines() if 'MXNetError' in line]
             mxnet_err = ''
             if lines:
-                mxnet_err = lines[-1].strip()
+                mxnet_err = lines[-1].strip() + '\n'
             if 'GPU is not enabled' in mxnet_err:
-                self.hint += ('MXNet is not built with GPU support, make sure you have nvidia gpus enabled with'
-                              'corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version.'
-                              'You may refer to "https://auto.gluon.ai/stable/install.html" for'
+                self.hint += ('MXNet is not built with GPU support, make sure you have nvidia gpus enabled with '
+                              'corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version. '
+                              'You may refer to "https://auto.gluon.ai/stable/install.html" for '
                               'detailed installation guide.\n')
             if 'out of memory' in mxnet_err:
-                self.hint += ('CUDA out of memory error detected. Try reduce `batch_size` in `hyperparameters`,'
-                              "e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists,"
+                self.hint += ('CUDA out of memory error detected. Try reduce `batch_size` in `hyperparameters`, '
+                              "e.g., fit(train_data, val_data, hyperparameters={'batch_size': 2}). If the error persists, "
                               'please check if you have other processes occupying too much GPU memory by looking at `nvidia-smi`.\n')
             self.exc_value = mxnet_err
         else:

--- a/vision/src/autogluon/vision/utils/error_handler.py
+++ b/vision/src/autogluon/vision/utils/error_handler.py
@@ -13,7 +13,7 @@ class MXNetErrorCatcher(contextlib.AbstractContextManager):
                 self.exc_value = 'KeyboardInterrupt'
                 return True
             lines = [line for line in str(exc_value).splitlines() if 'MXNetError' in line]
-            mxnet_err = ''
+            mxnet_err = str(exc_value)
             if lines:
                 mxnet_err = lines[-1].strip() + '\n'
             if 'GPU is not enabled' in mxnet_err:


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/autogluon/issues/945

*Description of changes:*

Catch MXNet errors, provide highlights and solutions to common errors.

Reproduce the error in #945, the new error message becomes:

```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    predictor.fit(train_dataset, hyperparameters={'epochs': 1}, hyperparameter_tune_kwargs={'num_trials': 2})
  File "/home/ubuntu/test_mxnet_error_catcher/autogluon/vision/src/autogluon/vision/configs/presets_configs.py", line 15, in _call
    return f(*gargs, **gkwargs)
  File "/home/ubuntu/test_mxnet_error_catcher/autogluon/vision/src/autogluon/vision/predictor/predictor.py", line 321, in fit
    raise RuntimeError(err.exc_value + err.hint)
RuntimeError: 'MXNetError: GPU is not enabled\n',
MXNet is not built with GPU support, make sure you have nvidia gpus enabled with corresponding mxnet-cuxxx version installed, where `xxx` is the cuda version. You may refer to "https://auto.gluon.ai/stable/install.html" for detailed installation guide.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
