### PR TITLE
Fix NaN score issue in NN model

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -345,7 +345,7 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
                 if (val_metric >= best_val_metric) or (e == 0):
                     if np.isnan(val_metric):
                         if e == 0:
-                            raise RuntimeError("NaNs encountered during TabularNeuralNetModel training. Features/labels may be improperly formatted or NN weights may have diverged.")
+                            raise RuntimeError("NaNs encountered in TabularNeuralNetModel training. Features/labels may be improperly formatted or NN weights may have diverged.")
                         else:
                             break
                     else:

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -342,19 +342,19 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
             train_loss = cumulative_loss/float(train_dataset.num_examples)  # training loss this epoch
             if val_dataset is not None:
                 val_metric = self.score(X=val_dataset, y=y_val, metric=self.stopping_metric)
-                if (val_metric >= best_val_metric) or (e == 0):
-                    if np.isnan(val_metric):
-                        if e == 0:
-                            raise RuntimeError("NaNs encountered in TabularNeuralNetModel training. Features/labels may be improperly formatted or NN weights may have diverged.")
-                        else:
-                            break
+                if np.isnan(val_metric):
+                    if e == 0:
+                        raise RuntimeError("NaNs encountered in TabularNeuralNetModel training. Features/labels may be improperly formatted or NN weights may have diverged.")
                     else:
-                        if val_metric > best_val_metric:
-                            val_improve_epoch = e
-                        best_val_metric = val_metric
-                        best_val_epoch = e
-                        # Until functionality is added to restart training from a particular epoch, there is no point in saving params without test_dataset
-                        self.model.save_parameters(net_filename)
+                        logger.warning("Warning: NaNs encountered in TabularNeuralNetModel training. Reverting model to last checkpoint without NaNs.")
+                        break
+                if (val_metric >= best_val_metric) or (e == 0):
+                    if val_metric > best_val_metric:
+                        val_improve_epoch = e
+                    best_val_metric = val_metric
+                    best_val_epoch = e
+                    # Until functionality is added to restart training from a particular epoch, there is no point in saving params without test_dataset
+                    self.model.save_parameters(net_filename)
             else:
                 best_val_epoch = e
             if val_dataset is not None:

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -343,7 +343,12 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
             if val_dataset is not None:
                 val_metric = self.score(X=val_dataset, y=y_val, metric=self.stopping_metric)
                 if (val_metric >= best_val_metric) or (e == 0):
-                    if not np.isnan(val_metric):
+                    if np.isnan(val_metric):
+                        if e == 0:
+                            raise RuntimeError("NaNs encountered during TabularNeuralNetModel training. Features/labels may be improperly formatted or NN weights may have diverged.")
+                        else:
+                            break
+                    else:
                         if val_metric > best_val_metric:
                             val_improve_epoch = e
                         best_val_metric = val_metric


### PR DESCRIPTION
If NN detects NaN validation score during training, will break and revert to last checkpoint with non-NaN validation score (or raise RuntimeError if no checkpoint exists yet). 

*Issue #, if available:* https://github.com/awslabs/autogluon/issues/932




