### PR TITLE
[Text Fix] Fix the competition link + Fix docs

### DIFF
--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -190,3 +190,5 @@ print('Total Time = {}s'.format(predictor_sst_hb.results['total_time']))
 print('Accuracy = {:.2f}%'.format(dev_score['acc'] * 100))
 print('F1 = {:.2f}%'.format(dev_score['f1'] * 100))
 ```
+
+You can also try setting `hyperparameters['tune_kwargs']['search_strategy']` to be `'bayesopt'` or `'local_sequential_auto'`.

--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -1,7 +1,7 @@
 # Text Prediction - Customization and Hyperparameter Search
 :label:`sec_textprediction_customization`
 
-This tutorial teaches you how to control the hyperparameter tuning process in `TextPrediction` by specifying:
+This tutorial teaches you how to control the hyperparameter tuning process in `TextPredictor` by specifying:
 
 - A custom search space of candidate hyperparameter values to consider.
 - Which hyperparameter optimization algorithm should be used to actually search through this space.
@@ -33,14 +33,16 @@ train_data.head(10)
 
 ### Pre-configured Hyperparameters in TextPredictor
 
-We provided a series of pre-configured hyperparameters. You may list the keys from `ag_text_presets`.
+We provided a series of pre-configured hyperparameters. You may list the keys from `ag_text_presets` via `list_presets`.
 
 
 ```{.python .input}
-from autogluon.text import ag_text_presets
-ag_text_presets.list_keys()
+from autogluon.text import ag_text_presets, list_presets
+list_presets()
 ```
 
+There are two kinds of presets. The `simple_presets` are pre-defined configurations managed by AutoGluon team. We pre-selected the appropriate model 
+configurations for different scenarios like `medium_quality_faster_train` or `lower_quality_fast_train`. We also list all the additional presets for advanced users. 
 These pre-configured models use different backbones such as ELECTRA, RoBERTa, Multilingual BERT, and different fusion strategies. For example, `electra_small_fuse_late` means to use the ELECTRA-small model as the text backbone and use the late fusion strategy described in ":label:`sec_textprediction_architecture`". By default, we are using `default`, which is the same as `electra_base_fuse_late`. Next, let's try to specify the `presets` in `.fit()` to be `electra_small_fuse_late` and train a model on SSTs.
 
 
@@ -62,7 +64,8 @@ To visualize the pre-registered hyperparameters, you can call `ag_text_presets.c
 
 
 ```{.python .input}
-ag_text_presets.create('electra_small_fuse_late')
+import pprint
+pprint.pprint(ag_text_presets.create('electra_small_fuse_late'))
 ```
 
 Another way to specify customized config is to directly specify the `hyperparameters` argument in `predict.fit()`. Following is an example

--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -48,7 +48,7 @@ These pre-configured models use different backbones such as ELECTRA, RoBERTa, Mu
 from autogluon.text import TextPredictor
 predictor = TextPredictor(path='ag_text_sst_electra_small', eval_metric='acc', label='label')
 predictor.set_verbosity(0)
-predictor.fit(train_data, presets='electra_small_fuse_late', time_limit=60, seed=123)
+predictor.fit(train_data, presets='electra_small_fuse_late', plot_results=True, time_limit=60, seed=123)
 ```
 
 Here, we try to report the performance of both `f1` and `acc`. However, if you really want to obtain the best F1 score, you should better set 
@@ -70,7 +70,7 @@ Another way to specify customized config is to directly specify the `hyperparame
 
 ```{.python .input}
 predictor.fit(train_data, hyperparameters=ag_text_presets.create('electra_small_fuse_late'),
-              time_limit=30, seed=123)
+              time_limit=30, plot_results=True, seed=123)
 ```
 
 ### Change Hyperparameter
@@ -85,7 +85,7 @@ In the example, we change the number of training epochs to 5 and the learning ra
 hyperparameters = ag_text_presets.create('electra_small_fuse_late')
 hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.num_train_epochs'] = 5
 hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.lr'] = ag.core.space.Categorical(5E-5)
-predictor.fit(train_data, hyperparameters=hyperparameters, time_limit=30, seed=123)
+predictor.fit(train_data, hyperparameters=hyperparameters, time_limit=30, plot_results=True, seed=123)
 ```
 
 ### Register Your Own Configuration
@@ -103,7 +103,7 @@ def electra_small_fuse_late_train5():
     hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.wd'] = 1E-2
     return hyperparameters
 
-predictor.fit(train_data, presets='electra_small_fuse_late_train5', time_limit=60, seed=123)
+predictor.fit(train_data, presets='electra_small_fuse_late_train5', plot_results=True, time_limit=60, seed=123)
 ```
 
 ## Perform HPO over a Customized Search Space with Random Search
@@ -145,6 +145,7 @@ predictor_sst_rs.fit(train_data,
                       hyperparameters=electra_small_basic_demo_hpo(),
                       time_limit=60 * 2,
                       num_trials=4,
+                      plot_results=True,
                       seed=123)
 ```
 
@@ -174,6 +175,7 @@ predictor_sst_bo.fit(train_data,
                      hyperparameters=hyperparameters,
                      time_limit=60 * 2,
                      num_trials=4,
+                     plot_results=True,
                      seed=123)
 ```
 
@@ -202,6 +204,7 @@ predictor_sst_hb.fit(train_data,
                      hyperparameters=hyperparameters,
                      time_limit=60 * 2,
                      num_trials=8,
+                     plot_results=True,
                      seed=123)
 ```
 

--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -48,7 +48,7 @@ These pre-configured models use different backbones such as ELECTRA, RoBERTa, Mu
 from autogluon.text import TextPredictor
 predictor = TextPredictor(path='ag_text_sst_electra_small', eval_metric='acc', label='label')
 predictor.set_verbosity(0)
-predictor.fit(train_data, presets='electra_small_fuse_late', plot_results=True, time_limit=60, seed=123)
+predictor.fit(train_data, presets='electra_small_fuse_late', time_limit=60, seed=123)
 ```
 
 Here, we try to report the performance of both `f1` and `acc`. However, if you really want to obtain the best F1 score, you should better set 
@@ -70,7 +70,7 @@ Another way to specify customized config is to directly specify the `hyperparame
 
 ```{.python .input}
 predictor.fit(train_data, hyperparameters=ag_text_presets.create('electra_small_fuse_late'),
-              time_limit=30, plot_results=True, seed=123)
+              time_limit=30, seed=123)
 ```
 
 ### Change Hyperparameter
@@ -85,7 +85,7 @@ In the example, we change the number of training epochs to 5 and the learning ra
 hyperparameters = ag_text_presets.create('electra_small_fuse_late')
 hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.num_train_epochs'] = 5
 hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.lr'] = ag.core.space.Categorical(5E-5)
-predictor.fit(train_data, hyperparameters=hyperparameters, time_limit=30, plot_results=True, seed=123)
+predictor.fit(train_data, hyperparameters=hyperparameters, time_limit=30, seed=123)
 ```
 
 ### Register Your Own Configuration
@@ -103,7 +103,7 @@ def electra_small_fuse_late_train5():
     hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.wd'] = 1E-2
     return hyperparameters
 
-predictor.fit(train_data, presets='electra_small_fuse_late_train5', plot_results=True, time_limit=60, seed=123)
+predictor.fit(train_data, presets='electra_small_fuse_late_train5', time_limit=60, seed=123)
 ```
 
 ## Perform HPO over a Customized Search Space with Random Search
@@ -145,7 +145,6 @@ predictor_sst_rs.fit(train_data,
                       hyperparameters=electra_small_basic_demo_hpo(),
                       time_limit=60 * 2,
                       num_trials=4,
-                      plot_results=True,
                       seed=123)
 ```
 
@@ -175,7 +174,6 @@ predictor_sst_bo.fit(train_data,
                      hyperparameters=hyperparameters,
                      time_limit=60 * 2,
                      num_trials=4,
-                     plot_results=True,
                      seed=123)
 ```
 
@@ -204,7 +202,6 @@ predictor_sst_hb.fit(train_data,
                      hyperparameters=hyperparameters,
                      time_limit=60 * 2,
                      num_trials=8,
-                     plot_results=True,
                      seed=123)
 ```
 

--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -162,37 +162,11 @@ print('Accuracy = {:.2f}%'.format(dev_score['acc'] * 100))
 print('F1 = {:.2f}%'.format(dev_score['f1'] * 100))
 ```
 
-## Use Bayesian Optimization
-
-Instead of random search, we can perform HPO via [Bayesian Optimization](https://distill.pub/2020/bayesian-optimization/).
-Here we specify **bayesopt** as the searcher.
-
-
-```{.python .input}
-hyperparameters = electra_small_basic_demo_hpo()
-hyperparameters['tune_kwargs']['search_strategy'] = 'bayesopt'
-predictor_sst_bo = TextPredictor(path='ag_text_sst_bo', label='label', eval_metric='acc')
-predictor_sst_bo.set_verbosity(0)
-predictor_sst_bo.fit(train_data,
-                     hyperparameters=hyperparameters,
-                     time_limit=60 * 2,
-                     num_trials=4,
-                     seed=123)
-```
-
-
-```{.python .input}
-dev_score = predictor_sst_bo.evaluate(dev_data, metrics=['acc', 'f1'])
-print('Best Config = {}'.format(predictor_sst_bo.results['best_config']))
-print('Total Time = {}s'.format(predictor_sst_bo.results['total_time']))
-print('Accuracy = {:.2f}%'.format(dev_score['acc'] * 100))
-print('F1 = {:.2f}%'.format(dev_score['f1'] * 100))
-```
-
 ## Use Bayesian Optimization + Hyperband
 
-Alternatively, we can instead use the [Hyperband algorithm](https://arxiv.org/pdf/1603.06560.pdf) for HPO.
-Hyperband will try multiple hyperparameter configurations simultaneously and will early stop training under poor configurations to free compute resources for exploring new hyperparameter configurations. It may be able to identify good hyperparameter values more quickly than other search strategies in your applications. In the following, we will use a combination of [Hyperband and Bayesian Optimization](https://arxiv.org/abs/2003.10865).
+Alternatively, we can use more advanced searchers like the combination of [Bayesian Optimization](https://distill.pub/2020/bayesian-optimization/) and [Hyperband algorithm](https://arxiv.org/pdf/1603.06560.pdf) for HPO.
+Hyperband will try multiple hyperparameter configurations simultaneously and will early stop training under poor configurations to free compute resources for exploring new hyperparameter configurations. 
+It may be able to identify good hyperparameter values more quickly than other search strategies in your applications. You may refer to [Hyperband and Bayesian Optimization](https://arxiv.org/abs/2003.10865) for more details.
 
 
 ```{.python .input}

--- a/docs/tutorials/text_prediction/multimodal_text.md
+++ b/docs/tutorials/text_prediction/multimodal_text.md
@@ -13,12 +13,16 @@ import os
 import warnings
 warnings.filterwarnings('ignore')
 np.random.seed(123)
+```
+
+```{.python .input}
 !python3 -m pip install openpyxl
 ```
 
 ## Book Price Prediction 
 
-To demonstrate the usage, we are going to use the book price prediction dataset used in the [MachineHack Salary Prediction Hackathon](https://www.machinehack.com/hackathons/predict_the_price_of_books/overview), which attempts to predict the price of the book given the other features like the author of the book, the 
+To demonstrate the usage, we are going to use the book price prediction dataset used in the [MachineHack Salary Prediction Hackathon](https://www.machinehack.com/hackathons/predict_the_price_of_books/overview), 
+which attempts to predict the price of the book given the other features like the author of the book, the abstract, the rating of the book and other features.
 
 
 ```{.python .input}
@@ -67,9 +71,8 @@ Also, to save time, we will subsample 1500 rows from the data and only train for
 
 ```{.python .input}
 from autogluon.text import TextPredictor
-!rm -rf ag_text_book_price_prediction
 predictor = TextPredictor(label='Price', path='ag_text_book_price_prediction')
-sampled_train_df = train_df.sample(1500, random_state=123)
+sampled_train_df = train_df.iloc[100:].sample(1500, random_state=123)
 predictor.fit(sampled_train_df, time_limit=3 * 60, seed=123)
 ```
 
@@ -79,7 +82,7 @@ Likewise, we can get the predictions and extract embeddings with the same API.
 
 
 ```{.python .input}
-test_df = train_df.sample(5, random_state=245)
+test_df = train_df.iloc[:100].sample(5, random_state=245)
 predictions = predictor.predict(test_df, as_pandas=True)
 print('Predictions:')
 print('------------')

--- a/examples/text_prediction/README.md
+++ b/examples/text_prediction/README.md
@@ -54,7 +54,7 @@ Once the script is finished, you will see a `submission.xlsx` file generate in t
 ## Predict Salary of Data Scientists
 Here, we provide the example that shows how to use AutoGluon to achieve top performance in MachineHack Data Scientist Salary Prediction Hackathon. 
 To join the hackathon, you can first go to [MachineHack Website](https://www.machinehack.com/hackathon) and switch to "Active" and 
-go to ""
+go to "Predict The Data Scientists Salary In India Hackathon".
 This will bring you to the link: [link](https://www.machinehack.com/hackathons/predict_the_data_scientists_salary_in_india_hackathon/overview)
 
 !IMPORTANT, you can not directly access the link and will have to follow the previous steps.

--- a/examples/text_prediction/README.md
+++ b/examples/text_prediction/README.md
@@ -2,8 +2,12 @@
 
 ## Product Sentiment Classification
 
-Here, we provide the example that shows how to use AutoGluon to achieve top performance in 
-[Product Sentiment Classification Hackathon](https://www.machinehack.com/hackathons/product_sentiment_classification_weekend_hackathon_19/leaderboard) 
+Here, we provide the example that shows how to use AutoGluon to achieve top performance in MachineHack Product Sentiment Classification Competition. 
+To join the hackathon, you can first go to [MachineHack Website](https://www.machinehack.com/hackathon) and switch to "Late Submission" and 
+then go to "Product Sentiment Classification".
+This will bring you to the link: [link](https://www.machinehack.com/hackathons/product_sentiment_classification_weekend_hackathon_19/leaderboard)
+
+!IMPORTANT, you can not directly access the link and will have to follow the previous steps.
 
 ```
 mkdir -p machine_hack_product_sentiment
@@ -21,7 +25,13 @@ python3 run_competition.py --train_file machine_hack_product_sentiment/all_train
 It will generate a `submission.csv` file and you can try to submit that to the competition leaderboard. 
 
 ## Predict Price of Book
-Here, we provide the example that shows how to use AutoGluon to achieve top performance in [Book Price Prediction](https://www.machinehack.com/hackathons/predict_the_price_of_books/overview).
+Here, we provide the example that shows how to use AutoGluon to achieve top performance in MachineHack Book Price Prediction Hackathon.
+To join the hackathon, you can first go to [MachineHack Website](https://www.machinehack.com/hackathon) and switch to "Active" and 
+go to "Predict The Price Of Books".
+This will bring you to the [link](https://www.machinehack.com/hackathons/predict_the_price_of_books/overview)
+
+!IMPORTANT, you can not directly access the link and will have to follow the previous steps.
+
 Also, you will need to install `openpyxl` to read from xlsx file.
 
 ```
@@ -42,7 +52,13 @@ Once the script is finished, you will see a `submission.xlsx` file generate in t
 !IMPORTANT. Try to run the experiment on a p3.2x instance :).
 
 ## Predict Salary of Data Scientists
-Here, we provide the example that shows how to use AutoGluon to achieve top performance in [Data Scientist Salary Prediction](https://www.machinehack.com/hackathons/predict_the_data_scientists_salary_in_india_hackathon/overview).
+Here, we provide the example that shows how to use AutoGluon to achieve top performance in MachineHack Data Scientist Salary Prediction Hackathon. 
+To join the hackathon, you can first go to [MachineHack Website](https://www.machinehack.com/hackathon) and switch to "Active" and 
+go to ""
+This will bring you to the link: [link](https://www.machinehack.com/hackathons/predict_the_data_scientists_salary_in_india_hackathon/overview)
+
+!IMPORTANT, you can not directly access the link and will have to follow the previous steps.
+
 Also, you will need to install `openpyxl` to read from xlsx file.
 
 ```

--- a/text/src/autogluon/text/__init__.py
+++ b/text/src/autogluon/text/__init__.py
@@ -1,5 +1,5 @@
 from . import text_prediction
 from .text_prediction import TextPredictor
-from .text_prediction.presets import ag_text_presets
+from .text_prediction.presets import ag_text_presets, list_presets
 
-__all__ = ['text_prediction', 'TextPredictor', 'ag_text_presets']
+__all__ = ['text_prediction', 'TextPredictor', 'ag_text_presets', 'list_presets']

--- a/text/src/autogluon/text/text_prediction/presets.py
+++ b/text/src/autogluon/text/text_prediction/presets.py
@@ -14,7 +14,11 @@ ag_text_presets = Registry('ag_text_presets')
 
 def list_presets():
     """List the presets available in AutoGluon-Text"""
-    return ag_text_presets.list_keys()
+    simple_presets = ['default', 'lower_quality_fast_train',
+                      'medium_quality_faster_train', 'best_quality']
+    return {'simple_presets': simple_presets,
+            'advanced_presets': [key for key in ag_text_presets.list_keys()
+                        if key not in simple_presets]}
 
 
 def base() -> dict:


### PR DESCRIPTION
Somehow the MachineHack competitions cannot be directly accessed via the link and we must provide the instruction about how to go to the page.