### PR TITLE
Tabular: Updated predict_proba as_multiclass default to True

### DIFF
--- a/core/src/autogluon/core/data/label_cleaner.py
+++ b/core/src/autogluon/core/data/label_cleaner.py
@@ -182,7 +182,7 @@ class LabelCleanerBinary(LabelCleaner):
             logger.log(20, pos_class_warning)
         self.cat_mappings_dependent_var: dict = {v: k for k, v in self.inv_map.items()}
         self.ordered_class_labels_transformed = [0, 1]
-        self.ordered_class_labels = [self.cat_mappings_dependent_var[label_transformed] for label_transformed in self.ordered_class_labels_transformed]\
+        self.ordered_class_labels = [self.cat_mappings_dependent_var[label_transformed] for label_transformed in self.ordered_class_labels_transformed]
 
     def inverse_transform_proba(self, y, as_pandas=False, as_pred=False):
         if isinstance(y, DataFrame):
@@ -233,7 +233,8 @@ class LabelCleanerMulticlassToBinary(LabelCleanerMulticlass):
         return y
 
     def inverse_transform_proba(self, y, as_pandas=False, as_pred=False):
-        y = self.convert_binary_proba_to_multiclass_proba(y=y, as_pandas=as_pandas)
+        if not isinstance(y, DataFrame):
+            y = self.convert_binary_proba_to_multiclass_proba(y=y, as_pandas=as_pandas)
         return super().inverse_transform_proba(y, as_pandas=as_pandas, as_pred=as_pred)
 
     @staticmethod

--- a/core/src/autogluon/core/data/label_cleaner.py
+++ b/core/src/autogluon/core/data/label_cleaner.py
@@ -7,7 +7,7 @@ from pandas import DataFrame, Series
 
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 
-from autogluon.core.utils import get_pred_from_proba
+from autogluon.core.utils import get_pred_from_proba, get_pred_from_proba_df
 
 logger = logging.getLogger(__name__)
 
@@ -172,7 +172,7 @@ class LabelCleanerBinary(LabelCleaner):
             self.inv_map: dict = {0: 0, 1: 1}
         else:
             self.inv_map: dict = {self.unique_values[0]: 0, self.unique_values[1]: 1}
-            pos_class_warning = f'\tNote: For your binary classification, AutoGluon arbitrarily selected which label-value' \
+            pos_class_warning = f'\tNote: For your binary classification, AutoGluon arbitrarily selected which label-value ' \
                                 f'represents positive ({self.unique_values[1]}) vs negative ({self.unique_values[0]}) class.\n'\
                                 '\tTo explicitly set the positive_class, either rename classes to 1 and 0, or specify positive_class in Predictor init.'
         poslabel = [lbl for lbl in self.inv_map.keys() if self.inv_map[lbl] == 1][0]
@@ -185,19 +185,24 @@ class LabelCleanerBinary(LabelCleaner):
         self.ordered_class_labels = [self.cat_mappings_dependent_var[label_transformed] for label_transformed in self.ordered_class_labels_transformed]\
 
     def inverse_transform_proba(self, y, as_pandas=False, as_pred=False):
-        if not as_pred:
-            return y
-        y_index = None
-        if isinstance(y, Series):
-            y_index = y.index
-            y = y.to_numpy()
-        if as_pred:
+        if isinstance(y, DataFrame):
+            y = copy.deepcopy(y)
+            y.columns = copy.deepcopy(self.ordered_class_labels)
+            if as_pred:
+                y = get_pred_from_proba_df(y, problem_type=self.problem_type_transform)
+            if not as_pandas:
+                y = y.to_numpy()
+        elif as_pred:
+            y_index = None
+            if isinstance(y, Series):
+                y_index = y.index
+                y = y.to_numpy()
             y = get_pred_from_proba(y_pred_proba=y, problem_type=self.problem_type_transform)
             y = self._convert_to_valid_series(y)
             y = y.map(self.cat_mappings_dependent_var)
             y = y.to_numpy()
-        if as_pandas:
-            y = Series(data=y, index=y_index)
+            if as_pandas:
+                y = Series(data=y, index=y_index)
         return y
 
     def _transform(self, y: Series) -> Series:
@@ -206,6 +211,14 @@ class LabelCleanerBinary(LabelCleaner):
 
     def _inverse_transform(self, y: Series) -> Series:
         return y.map(self.cat_mappings_dependent_var)
+
+    def transform_proba(self, y: Union[DataFrame, Series, np.ndarray], as_pandas=False):
+        if not as_pandas and isinstance(y, (Series, DataFrame)):
+            y = y.to_numpy()
+        elif isinstance(y, DataFrame):
+            y = copy.deepcopy(y)
+            y.columns = copy.deepcopy(self.ordered_class_labels_transformed)
+        return y
 
 
 class LabelCleanerMulticlassToBinary(LabelCleanerMulticlass):

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -234,6 +234,16 @@ def augment_rare_classes(X, label, threshold):
     logger.log(15, "Replicated some data from rare classes in training set because eval_metric requires all classes")
     return X
 
+
+def get_pred_from_proba_df(y_pred_proba, problem_type=BINARY):
+    """From input DataFrame of pred_proba, return Series of pred"""
+    if problem_type == REGRESSION:
+        y_pred = y_pred_proba
+    else:
+        y_pred = y_pred_proba.idxmax(axis=1)
+    return y_pred
+
+
 def get_pred_from_proba(y_pred_proba, problem_type=BINARY):
     if problem_type == BINARY:
         y_pred = [1 if pred >= 0.5 else 0 for pred in y_pred_proba]

--- a/docs/tutorials/tabular_prediction/tabular-faq.md
+++ b/docs/tutorials/tabular_prediction/tabular-faq.md
@@ -58,7 +58,7 @@ See ["Prediction options" in the In Depth Tutorial](tabular-indepth.html#predict
 
 ### Which classes do predicted probabilities correspond to?
 
-This should become obvious if you specify the `as_pandas` argument like this:
+This should become obvious if you look at the pandas DataFrame column names after specifying the `as_pandas` argument like this:
 
 ```
 predictor.predict_proba(test_data, as_pandas=True)
@@ -78,7 +78,7 @@ You can see which class AutoGluon treats as the positive class in binary classif
 predictor.positive_class
 ```
 
-The positive class can also be retrieved via `predictor.class_labels[-1]`. The output of `predict_proba()` for binary classification is the probability of the positive class.
+The positive class can also be retrieved via `predictor.class_labels[-1]`. The output of `predict_proba(as_multiclass=False)` for binary classification is the probability of the positive class.
 
 ### How can I use AutoGluon for interpretability?
 

--- a/docs/tutorials/tabular_prediction/tabular-kaggle.md
+++ b/docs/tutorials/tabular_prediction/tabular-kaggle.md
@@ -88,10 +88,10 @@ For multiclass classification tasks, you can see which classes AutoGluon's predi
 predictor.class_labels  # classes in this list correspond to columns of predict_proba() output
 ```
 
-Alternatively, the following command should clarify which predicted-probability corresponds to which class:
+Now, lets get prediction probabilities for the entire test data, while only getting the positive class predictions by specifying:
 
 ```
-y_predproba = predictor.predict_proba(test_data)
+y_predproba = predictor.predict_proba(test_data, as_multiclass=False)
 ```
 
 Now that we have made a prediction for each row in the test dataset, we can submit these predictions to Kaggle. Most Kaggle competitions provide a sample submission file, in which you can simply overwrite the sample predictions with your own as we do below:

--- a/docs/tutorials/tabular_prediction/tabular-quickstart.md
+++ b/docs/tutorials/tabular_prediction/tabular-quickstart.md
@@ -82,8 +82,6 @@ For tabular problems, `fit()` returns a `Predictor` object. For classification, 
 
 ```{.python .input}
 pred_probs = predictor.predict_proba(test_data_nolab)
-positive_class = predictor.positive_class  # which label is considered 'positive' class
-print(f"Predicted probabilities of class '{positive_class}': ")
 pred_probs.head(5)
 ```
 

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -64,6 +64,8 @@ class AbstractLearner:
         self.trainer_path = None
         self.reset_paths = False
 
+        self._pre_X_rows = None
+        self._post_X_rows = None
         self._positive_class = positive_class
         self.sample_weight = sample_weight
         self.weight_evaluation = weight_evaluation

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -60,7 +60,9 @@ class DefaultLearner(AbstractLearner):
             logger.log(20, f'Tuning Data Columns: {len([column for column in X_val.columns if column != self.label])}')
         time_preprocessing_start = time.time()
         logger.log(20, 'Preprocessing data ...')
+        self._pre_X_rows = len(X)
         X, y, X_val, y_val, X_unlabeled, holdout_frac, num_bag_folds = self.general_data_processing(X, X_val, X_unlabeled, holdout_frac, num_bag_folds)
+        self._post_X_rows = len(X)
         time_preprocessing_end = time.time()
         self._time_fit_preprocessing = time_preprocessing_end - time_preprocessing_start
         logger.log(20, f'Data preprocessing and feature engineering runtime = {round(self._time_fit_preprocessing, 2)}s ...')

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -14,7 +14,8 @@ from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.dataset import TabularDataset
 from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, AUTO_WEIGHT, BALANCE_WEIGHT
-from autogluon.core.utils import plot_performance_vs_trials, plot_summary_of_models, plot_tabular_models, set_logger_verbosity, get_pred_from_proba
+from autogluon.core.utils import plot_performance_vs_trials, plot_summary_of_models, plot_tabular_models
+from autogluon.core.utils import get_pred_from_proba_df, set_logger_verbosity
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_pkl
 from autogluon.core.utils.utils import setup_outputdir, default_holdout_frac
@@ -851,7 +852,7 @@ class TabularPredictor:
         data = self.__get_dataset(data)
         return self._learner.predict(X=data, model=model, as_pandas=as_pandas)
 
-    def predict_proba(self, data, model=None, as_pandas=True, as_multiclass=False):
+    def predict_proba(self, data, model=None, as_pandas=True, as_multiclass=True):
         """
         Use trained models to produce predicted class probabilities rather than class-labels (if task is classification).
         If `predictor.problem_type` is regression, this functions identically to `predict`, returning the same output.
@@ -869,17 +870,18 @@ class TabularPredictor:
             Whether to return the output as a pandas object (True) or numpy array (False).
             Pandas object is a DataFrame if this is a multiclass problem or `as_multiclass=True`, otherwise it is a Series.
             If the output is a DataFrame, the column order will be equivalent to `predictor.class_labels`.
-        as_multiclass : bool, default = False
+        as_multiclass : bool, default = True
             Whether to return binary classification probabilities as if they were for multiclass classification.
                 Output will contain two columns, and if `as_pandas=True`, the column names will correspond to the binary class labels.
                 The columns will be the same order as `predictor.class_labels`.
+            If False, output will contain only 1 column for the positive class (get positive_class name via `predictor.positive_class`).
             Only impacts output for binary classification problems.
 
         Returns
         -------
         Array of predicted class-probabilities, corresponding to each row in the given data.
-        May be a :class:`np.ndarray` or :class:`pd.Series` / :class:`pd.DataFrame` depending on `as_pandas` and `as_multiclass` arguments and the type of prediction problem.
-        For binary classification problems, the output contains for each datapoint only the predicted probability of the positive class, unless you specify `as_multiclass=True`.
+        May be a :class:`np.ndarray` or :class:`pd.DataFrame` / :class:`pd.Series` depending on `as_pandas` and `as_multiclass` arguments and the type of prediction problem.
+        For binary classification problems, the output contains for each datapoint the predicted probabilities of the negative and positive classes, unless you specify `as_multiclass=False`.
         """
         data = self.__get_dataset(data)
         return self._learner.predict_proba(X=data, model=model, as_pandas=as_pandas, as_multiclass=as_multiclass)
@@ -934,8 +936,8 @@ class TabularPredictor:
         Scalar performance value if `auxiliary_metrics = False`.
         If `auxiliary_metrics = True`, returns dict where keys = metrics, values = performance along each metric.
         """
-        return self._learner.evaluate(y_true=y_true, y_pred=y_pred, silent=silent,
-                                      auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
+        return self._learner.evaluate_predictions(y_true=y_true, y_pred=y_pred, silent=silent,
+                                                  auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
     def leaderboard(self, data=None, extra_info=False, only_pareto_frontier=False, silent=False):
         """
@@ -1224,7 +1226,7 @@ class TabularPredictor:
         --------
         >>> from autogluon.tabular import TabularPredictor
         >>> predictor = TabularPredictor(label='class').fit('train.csv', label='class', auto_stack=True)  # predictor is in bagged mode.
-        >>> model = 'WeightedEnsemble_L1'
+        >>> model = 'WeightedEnsemble_L2'
         >>> train_data_transformed = predictor.transform_features(model=model)  # Internal training DataFrame used as input to `model.fit()` for each model trained in predictor.fit()`
         >>> test_data_transformed = predictor.transform_features('test.csv', model=model)  # Internal test DataFrame used as input to `model.predict_proba()` during `predictor.predict_proba(test_data, model=model)`
 
@@ -1244,7 +1246,7 @@ class TabularPredictor:
         labels : :class:`np.ndarray` or :class:`pd.Series`
             Labels to transform.
             If `proba=False`, an example input would be the output of `predictor.predict(test_data)`.
-            If `proba=True`, an example input would be the output of `predictor.predict_proba(test_data)`.
+            If `proba=True`, an example input would be the output of `predictor.predict_proba(test_data, as_multiclass=False)`.
         inverse : boolean, default = False
             When `True`, the input labels are treated as being in the internal representation and the original representation is outputted.
         proba : boolean, default = False
@@ -1600,21 +1602,15 @@ class TabularPredictor:
         -------
         :class:`pd.Series` object of the out-of-fold training predictions of the model.
         """
-        y_pred_proba_oof_transformed = self.get_oof_pred_proba(model=model, transformed=True)
-        y_index = y_pred_proba_oof_transformed.index
-        y_pred_oof_transformed = get_pred_from_proba(y_pred_proba=y_pred_proba_oof_transformed.to_numpy(), problem_type=self._trainer.problem_type)
-        y_pred_oof_transformed = pd.Series(data=y_pred_oof_transformed, index=y_index, name=self.label)
-        if transformed:
-            return y_pred_oof_transformed
-        else:
-            return self.transform_labels(labels=y_pred_oof_transformed, inverse=True, proba=False)
+        y_pred_proba_oof = self.get_oof_pred_proba(model=model, transformed=transformed, as_multiclass=True)
+        return get_pred_from_proba_df(y_pred_proba_oof, problem_type=self.problem_type)
 
     # TODO: Improve error messages when trying to get oof from refit_full and distilled models.
     # TODO: v0.1 add tutorial related to this method, as it is very powerful.
     # TODO: v0.1 This can cause very strange issues related to index mismatches with original training data on extreme edge cases (multiclass where autogluon duplicated rows in data due to rare classes and eval_metric was logloss)
     #  This is a very rare case but needs to be fixed by v0.1 release
     #  It might be good enough to do an inner join on training data, but it needs to be tested
-    def get_oof_pred_proba(self, model: str = None, transformed=False, as_multiclass=False) -> Union[pd.DataFrame, pd.Series]:
+    def get_oof_pred_proba(self, model: str = None, transformed=False, as_multiclass=True) -> Union[pd.DataFrame, pd.Series]:
         """
         Note: This is advanced functionality not intended for normal usage.
 
@@ -1640,10 +1636,11 @@ class TabularPredictor:
             Whether the output values should be of the original label representation (False) or the internal label representation (True).
             The internal representation for binary and multiclass classification are integers numbering the k possible classes from 0 to k-1, while the original representation is identical to the label classes provided during fit.
             Generally, most users will want the original representation and keep `transformed=False`.
-        as_multiclass : bool, default = False
+        as_multiclass : bool, default = True
             Whether to return binary classification probabilities as if they were for multiclass classification.
                 Output will contain two columns, and if `transformed=False`, the column names will correspond to the binary class labels.
                 The columns will be the same order as `predictor.class_labels`.
+            If False, output will contain only 1 column for the positive class (get positive_class name via `predictor.positive_class`).
             Only impacts output for binary classification problems.
 
         Returns
@@ -1663,7 +1660,7 @@ class TabularPredictor:
             if as_multiclass and self.problem_type == BINARY:
                 y_pred_proba_oof_transformed = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_pred_proba_oof_transformed, as_pandas=True)
                 if not transformed:
-                    y_pred_proba_oof_transformed.columns = copy.deepcopy(self._learner.label_cleaner.ordered_class_labels)
+                    y_pred_proba_oof_transformed.columns = copy.deepcopy(self._learner.class_labels)
         if transformed:
             return y_pred_proba_oof_transformed
         else:
@@ -1673,19 +1670,14 @@ class TabularPredictor:
     def positive_class(self):
         """
         Returns the positive class name in binary classification. Useful for computing metrics such as F1 which require a positive and negative class.
-        In binary classification, :class:`TabularPredictor.predict_proba()` returns the estimated probability that each row belongs to the positive class.
+        In binary classification, :class:`TabularPredictor.predict_proba(as_multiclass=False)` returns the estimated probability that each row belongs to the positive class.
         Will print a warning and return None if called when `predictor.problem_type != 'binary'`.
 
         Returns
         -------
         The positive class name in binary classification or None if the problem is not binary classification.
         """
-        if not self._learner.is_fit:
-            raise AssertionError('Predictor must be fit to return positive_class.')
-        if self.problem_type != BINARY:
-            logger.warning(f"Warning: Attempted to retrieve positive class label in a non-binary problem. Positive class labels only exist in binary classification. Returning None instead. self.problem_type is '{self.problem_type}' but positive_class only exists for '{BINARY}'.")
-            return None
-        return self._learner.label_cleaner.cat_mappings_dependent_var[1]
+        return self._learner.positive_class
 
     def load_data_internal(self, data='train', return_X=True, return_y=True):
         """
@@ -2031,22 +2023,22 @@ class TabularPredictor:
             self._learner.persist_trainer(low_memory=True)
             self._trainer: AbstractTrainer = self._learner.load_trainer()  # Trainer object
 
-    # TODO: Update and correct the logging message on loading directions
     def save(self):
         """
         Save this Predictor to file in directory specified by this Predictor's `path`.
         Note that :meth:`TabularPredictor.fit` already saves the predictor object automatically
         (we do not recommend modifying the Predictor object yourself as it tracks many trained models).
         """
+        path = self.path
         tmp_learner = self._learner
         tmp_trainer = self._trainer
         self._learner.save()
         self._learner = None
         self._trainer = None
-        save_pkl.save(path=tmp_learner.path + self.predictor_file_name, object=self)
+        save_pkl.save(path=path + self.predictor_file_name, object=self)
         self._learner = tmp_learner
         self._trainer = tmp_trainer
-        logger.log(20, "TabularPredictor saved. To load, use: TabularPredictor.load(\"%s\")" % self.path)
+        logger.log(20, f'TabularPredictor saved. To load, use: predictor = TabularPredictor.load("{self.path}")')
 
     @classmethod
     def load(cls, path, verbosity=2):
@@ -2088,12 +2080,6 @@ class TabularPredictor:
             logger.warning('############################## WARNING ##############################')
             logger.warning('')
 
-        return predictor
-
-    @classmethod
-    def from_learner(cls, learner: AbstractLearner):
-        predictor = cls(label=learner.label, path=learner.path)
-        predictor._set_post_fit_vars(learner=learner)
         return predictor
 
     @staticmethod
@@ -2319,3 +2305,9 @@ class _TabularPredictorExperimental(TabularPredictor):
         else:
             logger.log(20, 'No further advice found.')
         logger.log(20, '================================================================')
+
+    @classmethod
+    def from_learner(cls, learner: AbstractLearner):
+        predictor = cls(label=learner.label, path=learner.path)
+        predictor._set_post_fit_vars(learner=learner)
+        return predictor

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -290,9 +290,9 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
             if predictor._trainer.bagged_mode:
                 # TODO: Test index alignment with original training data (first handle duplicated rows / dropped rows edge cases)
                 y_pred_oof = predictor.get_oof_pred()
-                y_pred_proba_oof = predictor.get_oof_pred_proba()
+                y_pred_proba_oof = predictor.get_oof_pred_proba(as_multiclass=False)
                 y_pred_oof_transformed = predictor.get_oof_pred(transformed=True)
-                y_pred_proba_oof_transformed = predictor.get_oof_pred_proba(transformed=True)
+                y_pred_proba_oof_transformed = predictor.get_oof_pred_proba(as_multiclass=False, transformed=True)
 
                 # Assert expected type output
                 assert isinstance(y_pred_oof, pd.Series)
@@ -302,7 +302,7 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
                     assert isinstance(y_pred_proba_oof_transformed, pd.DataFrame)
                 else:
                     if predictor.problem_type == BINARY:
-                        assert isinstance(predictor.get_oof_pred_proba(as_multiclass=True), pd.DataFrame)
+                        assert isinstance(predictor.get_oof_pred_proba(), pd.DataFrame)
                     assert isinstance(y_pred_proba_oof, pd.Series)
                     assert isinstance(y_pred_proba_oof_transformed, pd.Series)
 


### PR DESCRIPTION
*Issue #, if available:*
#976 

*Description of changes:*

- Updated predict_proba as_multiclass default to True
- Refactored evaluate_predictions to be much nicer to use (auto convert pred_proba -> pred instead of crashing, helpful error message, etc.)
- Applied as_multiclass=True standard across other methods in Tabular such as get_oof_pred_proba
- Fixed get_oof_pred_proba in a variety of nasty rare edge cases: duplicated rows, dropped rows, internal binary/external multiclass
- Disabled usage of tuning_data while bagging (raises an exception), otherwise get_oof_pred_proba becomes very confusing and misleading.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
