### PR TITLE
Fixed exception when providing a dataset to ENAS_Scheduler train_set …

### DIFF
--- a/extra/src/autogluon/extra/contrib/enas/enas_scheduler.py
+++ b/extra/src/autogluon/extra/contrib/enas/enas_scheduler.py
@@ -77,7 +77,7 @@ class ENAS_Scheduler(object):
         ctx = [mx.gpu(i) for i in range(num_gpus)] if num_gpus > 0 else [mx.cpu(0)]
         self.supernet.collect_params().reset_ctx(ctx)
         self.supernet.hybridize()
-        dataset_name = train_set
+        dataset_name = str(train_set)
 
         if isinstance(train_set, str):
             train_set = get_built_in_dataset(dataset_name, train=True, batch_size=batch_size,


### PR DESCRIPTION
…parameter caused by local dataset_name variable being assigned the passed in dataset and then being treated like a string

*Issue #, if available:*
New issue just found.

*Description of changes:*
Now casting the passed in "train_set" argument to function "initialize_miscs" to a string when assigning it to "dataset_name" local variable. This should leave the demo functionality with "imagenet" unchanged, but fixes the problem when passing in an actual data set. The dataset_name variable gets compared to a string on line 105, which raises an exception if the train_set argument to the function is a numpy array or Autogluon Dataset. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
