### PR TITLE
Tabular: Fixed bug with preprocess_nonadaptive during stacking

### DIFF
--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -134,8 +134,8 @@ class StackerEnsembleModel(BaggedEnsembleModel):
              time_limit=None,
              **kwargs):
         start_time = time.time()
-        # TODO: This could be preprocess=True in general, just have preprocess=False for child models
-        X = self.preprocess(X=X, preprocess=False, fit=True, compute_base_preds=compute_base_preds)
+        # TODO: This could be preprocess_nonadaptive=True in general, just have preprocess_nonadaptive=False for child models
+        X = self.preprocess(X=X, preprocess_nonadaptive=False, fit=True, compute_base_preds=compute_base_preds)
         if time_limit is not None:
             time_limit = time_limit - (time.time() - start_time)
         self._add_stack_to_feature_metadata()


### PR DESCRIPTION
*Issue #, if available:*
#1033 

*Description of changes:*

When `preprocess` was renamed to `preprocess_nonadaptive`, this usage was not updated to the new name, meaning it would default to `preprocess_nonadaptive=True` during stacking, which would cause exceptions in LightGBM during repeated bagging with time_limit set when invalid column names existed.

This PR fixes this bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
