### PR TITLE
[Vision] add early stopping strategies

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -18,7 +18,7 @@ DEPENDENT_PACKAGES = {
     'pandas': '>=1.0.0,<2.0',
     'scikit-learn': '>=0.22.0,<0.25',
     'scipy': '==1.5.4',
-    'gluoncv': '>=0.9.4,<0.11.0',
+    'gluoncv': '>=0.10.1,<0.12.0',
     'tqdm': '>=4.38.0',
     'Pillow': '<=8.1',
     'graphviz': '<0.9.0,>=0.8.1',

--- a/vision/src/autogluon/vision/configs/presets_configs.py
+++ b/vision/src/autogluon/vision/configs/presets_configs.py
@@ -27,7 +27,7 @@ preset_image_predictor = dict(
             'lr': Real(1e-5, 1e-2, log=True),
             'batch_size': Categorical(8, 16, 32, 64, 128),
             'epochs': 200,
-            'early_stop_patience': -1
+            'early_stop_patience': 50
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 1024,
@@ -98,7 +98,7 @@ preset_object_detector = dict(
             'lr': Real(1e-5, 1e-3, log=True),
             'batch_size': Categorical(4, 8),
             'epochs': 30,
-            'early_stop_patience': -1
+            'early_stop_patience': 50
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 128,

--- a/vision/src/autogluon/vision/configs/presets_configs.py
+++ b/vision/src/autogluon/vision/configs/presets_configs.py
@@ -26,7 +26,8 @@ preset_image_predictor = dict(
             'model': Categorical('resnet50_v1b', 'resnet101_v1d', 'resnest200'),
             'lr': Real(1e-5, 1e-2, log=True),
             'batch_size': Categorical(8, 16, 32, 64, 128),
-            'epochs': 200
+            'epochs': 200,
+            'early_stop_patience': -1
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 1024,
@@ -42,7 +43,8 @@ preset_image_predictor = dict(
             'model': Categorical('resnet50_v1b', 'resnet34_v1b'),
             'lr': Real(1e-4, 1e-2, log=True),
             'batch_size': Categorical(8, 16, 32, 64, 128),
-            'epochs': 150
+            'epochs': 150,
+            'early_stop_patience': 20
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 512,
@@ -58,7 +60,8 @@ preset_image_predictor = dict(
             'model': 'resnet50_v1b',
             'lr': 0.01,
             'batch_size': 64,
-            'epochs': 50
+            'epochs': 50,
+            'early_stop_patience': 5
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 8,
@@ -75,6 +78,7 @@ preset_image_predictor = dict(
             'lr': Categorical(0.01, 0.005, 0.001),
             'batch_size': Categorical(64, 128),
             'epochs': Categorical(50, 100),
+            'early_stop_patience': 10
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 32,
@@ -93,7 +97,8 @@ preset_object_detector = dict(
             'transfer': 'faster_rcnn_fpn_resnet101_v1d_coco',
             'lr': Real(1e-5, 1e-3, log=True),
             'batch_size': Categorical(4, 8),
-            'epochs': 30
+            'epochs': 30,
+            'early_stop_patience': -1
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 128,
@@ -111,7 +116,8 @@ preset_object_detector = dict(
                                     'center_net_resnet50_v1b_coco'),
             'lr': Real(1e-4, 1e-2, log=True),
             'batch_size': Categorical(8, 16, 32, 64),
-            'epochs': 50
+            'epochs': 50,
+            'early_stop_patience': 20
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 512,
@@ -127,7 +133,8 @@ preset_object_detector = dict(
             'transfer': 'ssd_512_resnet50_v1_coco',
             'lr': 0.01,
             'batch_size': Categorical(8, 16),
-            'epochs': 30
+            'epochs': 30,
+            'early_stop_patience': 5
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 16,
@@ -144,6 +151,7 @@ preset_object_detector = dict(
             'lr': Categorical(0.01, 0.005, 0.001),
             'batch_size': Categorical(32, 64, 128),
             'epochs': Categorical(30, 50),
+            'early_stop_patience': 10
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 32,

--- a/vision/src/autogluon/vision/detector/detector.py
+++ b/vision/src/autogluon/vision/detector/detector.py
@@ -168,16 +168,16 @@ class ObjectDetector(object):
                 Mini batch size
             lr : float
                 Trainer learning rate for optimization process.
-            early_stop_patience : int
+            early_stop_patience : int, default=-1
                 Number of epochs with no improvement after which train is early stopped. Use -1 to disable.
-            early_stop_min_delta : float
+            early_stop_min_delta : float, default=1e-4
                 The small delta value to ignore when evaluating the metric. A large delta helps stablize the early
                 stopping strategy against tiny fluctuation, e.g. 0.5->0.49->0.48->0.499->0.500001 is still considered as
                 a good timing for early stopping.
             early_stop_baseline : float, default=0.0
                 The minimum(baseline) value to trigger early stopping. For example, with `early_stop_baseline=0.5`,
                 early stopping won't be triggered if the metric is less than 0.5 even if plateau is detected.
-            early_stop_max_value : float
+            early_stop_max_value : float, default=1.0
                 The max value for metric, early stop training instantly once the max value is achieved.
             You can get the list of accepted hyperparameters in `config.yaml` saved by this predictor.
         **kwargs :

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -107,7 +107,8 @@ class ImagePredictor(object):
                         'model': Categorical('resnet50_v1b', 'resnet101_v1d', 'resnest200'),
                         'lr': Real(1e-5, 1e-2, log=True),
                         'batch_size': Categorical(8, 16, 32, 64, 128),
-                        'epochs': 200
+                        'epochs': 200,
+                        'early_stop_patience': -1
                         },
                     'hyperparameter_tune_kwargs': {
                         'num_trials': 1024,
@@ -121,7 +122,8 @@ class ImagePredictor(object):
                         'model': Categorical('resnet50_v1b', 'resnet34_v1b'),
                         'lr': Real(1e-4, 1e-2, log=True),
                         'batch_size': Categorical(8, 16, 32, 64, 128),
-                        'epochs': 150
+                        'epochs': 150,
+                        'early_stop_patience': 20
                         },
                     'hyperparameter_tune_kwargs': {
                         'num_trials': 512,
@@ -135,7 +137,8 @@ class ImagePredictor(object):
                         'model': 'resnet50_v1b',
                         'lr': 0.01,
                         'batch_size': 64,
-                        'epochs': 50
+                        'epochs': 50,
+                        'early_stop_patience': 5
                         },
                     'hyperparameter_tune_kwargs': {
                         'num_trials': 8,
@@ -151,6 +154,7 @@ class ImagePredictor(object):
                         'lr': Categorical(0.01, 0.005, 0.001),
                         'batch_size': Categorical(64, 128),
                         'epochs': Categorical(50, 100),
+                        'early_stop_patience': 10
                         },
                     'hyperparameter_tune_kwargs': {
                         'num_trials': 32,
@@ -174,6 +178,17 @@ class ImagePredictor(object):
                 Mini batch size
             lr : float
                 Trainer learning rate for optimization process.
+            early_stop_patience : int, default=-1
+                Number of epochs with no improvement after which train is early stopped. Use -1 to disable.
+            early_stop_min_delta : float, default=1e-4
+                The small delta value to ignore when evaluating the metric. A large delta helps stablize the early
+                stopping strategy against tiny fluctuation, e.g. 0.5->0.49->0.48->0.499->0.500001 is still considered as
+                a good timing for early stopping.
+            early_stop_baseline : float, default=0.0
+                The minimum(baseline) value to trigger early stopping. For example, with `early_stop_baseline=0.5`,
+                early stopping won't be triggered if the metric is less than 0.5 even if plateau is detected.
+            early_stop_max_value : float, default=1.0
+                The max value for metric, early stop training instantly once the max value is achieved.
             You can get the list of accepted hyperparameters in `config.yaml` saved by this predictor.
         **kwargs :
             holdout_frac : float, default = 0.1
@@ -315,6 +330,8 @@ class ImagePredictor(object):
             config.update(scheduler_options)
         if use_rec == True:
             config['use_rec'] = True
+        if 'early_stop_patience' not in config:
+            config['early_stop_patience'] = 10
         # verbosity
         if log_level > logging.INFO:
             logging.getLogger('gluoncv.auto.tasks.image_classification').propagate = False

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import warnings
 
+import numpy as np
 import pandas as pd
 from gluoncv.auto.tasks import ImageClassification as _ImageClassification
 from gluoncv.model_zoo import get_model_list

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -178,17 +178,18 @@ class ImagePredictor(object):
                 Mini batch size
             lr : float
                 Trainer learning rate for optimization process.
-            early_stop_patience : int, default=-1
-                Number of epochs with no improvement after which train is early stopped. Use -1 to disable.
+            early_stop_patience : int, default=10
+                Number of epochs with no improvement after which train is early stopped. Use `None` to disable.
             early_stop_min_delta : float, default=1e-4
                 The small delta value to ignore when evaluating the metric. A large delta helps stablize the early
                 stopping strategy against tiny fluctuation, e.g. 0.5->0.49->0.48->0.499->0.500001 is still considered as
                 a good timing for early stopping.
-            early_stop_baseline : float, default=0.0
+            early_stop_baseline : float, default=None
                 The minimum(baseline) value to trigger early stopping. For example, with `early_stop_baseline=0.5`,
                 early stopping won't be triggered if the metric is less than 0.5 even if plateau is detected.
-            early_stop_max_value : float, default=1.0
-                The max value for metric, early stop training instantly once the max value is achieved.
+                Use `None` to disable.
+            early_stop_max_value : float, default=None
+                The max value for metric, early stop training instantly once the max value is achieved. Use `None` to disable.
             You can get the list of accepted hyperparameters in `config.yaml` saved by this predictor.
         **kwargs :
             holdout_frac : float, default = 0.1
@@ -332,6 +333,13 @@ class ImagePredictor(object):
             config['use_rec'] = True
         if 'early_stop_patience' not in config:
             config['early_stop_patience'] = 10
+        if config['early_stop_patience'] == None:
+            config['early_stop_patience'] = -1
+        # TODO(zhreshold): expose the transform function(or sign function) for converting custom metrics
+        if 'early_stop_baseline' not in config or config['early_stop_baseline'] == None:
+            config['early_stop_baseline'] = -np.Inf
+        if 'early_stop_max_value' not in config or config['early_stop_max_value'] == None:
+            config['early_stop_max_value'] = np.Inf
         # verbosity
         if log_level > logging.INFO:
             logging.getLogger('gluoncv.auto.tasks.image_classification').propagate = False

--- a/vision/tests/unittests/test_image_classification.py
+++ b/vision/tests/unittests/test_image_classification.py
@@ -4,7 +4,7 @@ def test_task():
     dataset, _, test_dataset = Task.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
     model_list = Task.list_models()
     classifier = Task()
-    classifier.fit(dataset, num_trials=2, hyperparameters={'epochs': 1})
+    classifier.fit(dataset, num_trials=2, hyperparameters={'epochs': 1, 'early_stop_patience': 3})
     test_result = classifier.predict(test_dataset)
     single_test = classifier.predict(test_dataset.iloc[0]['image'])
     single_proba = classifier.predict_proba(test_dataset.iloc[0]['image'])

--- a/vision/tests/unittests/test_object_detection.py
+++ b/vision/tests/unittests/test_object_detection.py
@@ -5,7 +5,7 @@ def test_task():
     train_data, _, test_data = dataset.random_split()
 
     detector = Task()
-    detector.fit(train_data, num_trials=1, hyperparameters={'batch_size': 4, 'epochs': 1})
+    detector.fit(train_data, num_trials=1, hyperparameters={'batch_size': 4, 'epochs': 5, 'early_stop_max_value': 0.2})
     test_result = detector.predict(test_data)
     print('test result', test_result)
     detector.save('detector.ag')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add early stopping control for ImagePredictor and ObjectDetector.

New hyperparameters that controls the early stopping bahavior:

```python
"""
early_stop_patience : int, default=-1
    Number of epochs with no improvement after which train is early stopped. Use -1 to disable.
early_stop_min_delta : float, default=1e-4
    The small delta value to ignore when evaluating the metric. A large delta helps stablize the early
    stopping strategy against tiny fluctuation, e.g. 0.5->0.49->0.48->0.499->0.500001 is still considered as
    a good timing for early stopping.
early_stop_baseline : float, default=0.0
    The minimum(baseline) value to trigger early stopping. For example, with `early_stop_baseline=0.5`,
    early stopping won't be triggered if the metric is less than 0.5 even if plateau is detected.
early_stop_max_value : float, default=1.0
    The max value for metric, early stop training instantly once the max value is achieved.
You can get the list of accepted hyperparameters in `config.yaml` saved by this predictor.
"""
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
