### PR TITLE
Removed version specification on pyarrow to allow RAPIDS install

### DIFF
--- a/text/setup.py
+++ b/text/setup.py
@@ -26,7 +26,7 @@ requirements = [
 
     f'autogluon.core=={version}',
     f'autogluon.mxnet=={version}',
-    'pyarrow>=3.0.0',
+    'pyarrow',
     'autogluon-contrib-nlp==0.0.1b20210201',
 ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

RAPIDS depends on a special version of pyarrow not available via pip install, so if autogluon.text was installed after RAPIDS, RAPIDS would break. This change allows the RAPIDS version of pyarrow to remain.

@sxjscience What do you think about removing pyarrow as a dependency? Could it be moved to optional?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
