### PR TITLE
Remove bokeh dependency

### DIFF
--- a/extra/setup.py
+++ b/extra/setup.py
@@ -25,7 +25,6 @@ requirements = [
     'gluoncv',
     'graphviz',
 
-    'bokeh',  # TODO: Remove bokeh, it should be purely optional and specific to core, not extra
     f'autogluon.core=={version}',
 ]
 


### PR DESCRIPTION
*Issue #, if available:*
#1051

*Description of changes:*

Removes bokeh dependency in autogluon.extra, which was only used optionally for plots. Since it caused numerous issues related to tornado dependencies in Kaggle (crash on importing AutoGluon), better to have it be purely optional, as a warning is shown to users who try to make plots telling them to install it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
