### PR TITLE
Tabular: Added extra_metrics argument to leaderboard

### DIFF
--- a/docs/tutorials/tabular_prediction/tabular-indepth.md
+++ b/docs/tutorials/tabular_prediction/tabular-indepth.md
@@ -165,6 +165,12 @@ predictor.leaderboard(extra_info=True, silent=True)
 
 The expanded leaderboard shows properties like how many features are used by each model (`num_features`), which other models are ancestors whose predictions are required inputs for each model (`ancestors`), and how much memory each model and all its ancestors would occupy if simultaneously persisted (`memory_size_w_ancestors`). See the [leaderboard documentation](../../api/autogluon.predictor.html#autogluon.tabular.TabularPredictor.leaderboard) for full details.
 
+To show scores for other metrics, you can specify the `extra_metrics` argument when passing in `test_data`:
+
+```{.python .input}
+predictor.leaderboard(test_data, extra_metrics=['accuracy', 'balanced_accuracy', 'log_loss'], silent=True)
+```
+
 Here's how to specify a particular model to use for prediction instead of AutoGluon's default model-choice:
 
 ```{.python .input}

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -944,7 +944,7 @@ class TabularPredictor:
         return self._learner.evaluate_predictions(y_true=y_true, y_pred=y_pred, silent=silent,
                                                   auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
-    def leaderboard(self, data=None, extra_info=False, only_pareto_frontier=False, silent=False):
+    def leaderboard(self, data=None, extra_info=False, extra_metrics=None, only_pareto_frontier=False, silent=False):
         """
         Output summary of information about models produced during `fit()` as a :class:`pd.DataFrame`.
         Includes information on test and validation scores for all models, model training times, inference times, and stack levels.
@@ -1035,7 +1035,14 @@ class TabularPredictor:
                     If A is a descendant of B, then B is an ancestor of A.
                     If this model is deleted, then all descendant models will no longer be able to infer on new data, and their 'can_infer' values will be False.
                     A model can only have descendant models whose 'stack_level' are higher than itself.
-
+        extra_metrics : list, default = None
+            A list of metrics to calculate scores for and include in the output DataFrame.
+            Only valid when `data` is specified. The scores refer to the scores on `data` (same data as used to calculate the `score_test` column).
+            This list can contain any values which would also be valid for `eval_metric` in predictor init.
+            For example, `extra_metrics=['accuracy', 'roc_auc', 'log_loss']` would be valid in binary classification.
+            This example would return 3 additional columns in the output DataFrame, whose column names match the names of the metrics.
+            Passing `extra_metrics=[predictor.eval_metric]` would return an extra column in the name of the eval metric that has identical values to `score_test`.
+            This also works with custom metrics. If passing an object instead of a string, the column name will be equal to the `.name` attribute of the object.
         only_pareto_frontier : bool, default = False
             If `True`, only return model information of models in the Pareto frontier of the accuracy/latency trade-off (models which achieve the highest score within their end-to-end inference time).
             At minimum this will include the model with the highest score and the model with the lowest inference time.
@@ -1049,7 +1056,8 @@ class TabularPredictor:
         :class:`pd.DataFrame` of model performance summary information.
         """
         data = self.__get_dataset(data) if data is not None else data
-        return self._learner.leaderboard(X=data, extra_info=extra_info, only_pareto_frontier=only_pareto_frontier, silent=silent)
+        return self._learner.leaderboard(X=data, extra_info=extra_info, extra_metrics=extra_metrics,
+                                         only_pareto_frontier=only_pareto_frontier, silent=silent)
 
     def fit_summary(self, verbosity=3):
         """

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -84,11 +84,13 @@ def test_advanced_functionality():
     shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
     predictor = TabularPredictor(label=label, path=savedir).fit(train_data)
     leaderboard = predictor.leaderboard(data=test_data)
-    leaderboard_extra = predictor.leaderboard(data=test_data, extra_info=True)
+    extra_metrics = ['accuracy', 'roc_auc', 'log_loss']
+    leaderboard_extra = predictor.leaderboard(data=test_data, extra_info=True, extra_metrics=extra_metrics)
     assert set(predictor.get_model_names()) == set(leaderboard['model'])
     assert set(predictor.get_model_names()) == set(leaderboard_extra['model'])
     assert set(leaderboard_extra.columns).issuperset(set(leaderboard.columns))
     assert len(leaderboard) == len(leaderboard_extra)
+    assert set(leaderboard_extra.columns).issuperset(set(extra_metrics))  # Assert that extra_metrics are present in output
     num_models = len(predictor.get_model_names())
     feature_importances = predictor.feature_importance(data=test_data)
     original_features = set(train_data.columns)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added extra_metrics argument to leaderboard

Example:

```
leaderboard = predictor.leaderboard(test_data, extra_metrics=['accuracy', 'log_loss', 'roc_auc', 'balanced_accuracy'])
```

Output:

```
                 model  score_test  accuracy  log_loss   roc_auc  balanced_accuracy  score_val  pred_time_test  pred_time_val  fit_time  pred_time_test_marginal  pred_time_val_marginal  fit_time_marginal  stack_level  can_infer  fit_order
0  WeightedEnsemble_L2    0.873784  0.873784 -0.292128  0.925894           0.780252     0.8816        0.100835       0.049910  1.098830                 0.003269                0.005020           0.283787            2       True          3
1             LightGBM    0.873375  0.873375 -0.278360  0.929259           0.789940     0.8800        0.049563       0.028269  0.637271                 0.049563                0.028269           0.637271            1       True          2
2           KNeighbors    0.773160  0.773160      -inf  0.670251           0.621414     0.7752        0.048003       0.016621  0.177772                 0.048003                0.016621           0.177772            1       True          1

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
