### PR TITLE
Tabular: Added efficient OOF functionality to RF/XT models

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -483,7 +483,12 @@ class AbstractModel:
         For multiclass and softclass classification, keeps y_pred_proba as a 2 dimensional array of prediction probabilities for each class.
         For regression, converts y_pred_proba to a 1 dimensional array of predictions.
         """
-        if self.problem_type == BINARY:
+        if self.problem_type == REGRESSION:
+            if len(y_pred_proba.shape) == 1:
+                return y_pred_proba
+            else:
+                return y_pred_proba[:, 1]
+        elif self.problem_type == BINARY:
             if len(y_pred_proba.shape) == 1:
                 return y_pred_proba
             elif y_pred_proba.shape[1] > 1:
@@ -492,7 +497,7 @@ class AbstractModel:
                 return y_pred_proba
         elif y_pred_proba.shape[1] > 2:  # Multiclass, Softclass
             return y_pred_proba
-        else:  # Regression
+        else:  # Unknown problem type
             return y_pred_proba[:, 1]
 
     def score(self, X, y, metric=None, sample_weight=None, **kwargs):

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -498,7 +498,7 @@ class AbstractModel:
         elif y_pred_proba.shape[1] > 2:  # Multiclass, Softclass
             return y_pred_proba
         else:  # Unknown problem type
-            return y_pred_proba[:, 1]
+            raise AssertionError(f'Unknown y_pred_proba format for `problem_type="{self.problem_type}"`.')
 
     def score(self, X, y, metric=None, sample_weight=None, **kwargs):
         if metric is None:

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -319,7 +319,7 @@ class BaggedEnsembleModel(AbstractModel):
             logger.log(15, '\t`use_child_oof` was specified for this model. It will function similarly to a bagged model, but will only fit one child model.')
             time_start_predict = time.time()
             if model_base._get_tags().get('valid_oof', False):
-                self._oof_pred_proba = model_base.get_oof_pred_proba(X=X)
+                self._oof_pred_proba = model_base.get_oof_pred_proba(X=X, y=y)
             else:
                 logger.warning('\tWARNING: `use_child_oof` was specified but child model does not have a dedicated `get_oof_pred_proba` method. This model may have heavily overfit validation scores.')
                 self._oof_pred_proba = model_base.predict_proba(X=X)

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -245,8 +245,9 @@ class RFModel(AbstractModel):
 
         # TODO: Regression does not return NaN for missing rows, instead it sets them to 0. This makes life hard.
         #  The below code corrects the missing rows to NaN instead of 0.
-        # Don't bother if >40 trees, near impossible to have missing
-        if self.problem_type == REGRESSION and self.model.n_estimators <= 40:
+        # Don't bother if >60 trees, near impossible to have missing
+        # If using 68% of data for training, chance of missing for each row is 1 in 11 billion.
+        if self.problem_type == REGRESSION and self.model.n_estimators <= 60:
             from sklearn.ensemble._forest import _get_n_samples_bootstrap, _generate_unsampled_indices
             n_samples = len(y)
 
@@ -292,7 +293,7 @@ class RFModel(AbstractModel):
     @classmethod
     def _get_default_ag_args_ensemble(cls) -> dict:
         default_ag_args_ensemble = super()._get_default_ag_args_ensemble()
-        extra_ag_args_ensemble = {'use_child_oof': True}
+        extra_ag_args_ensemble = {'use_child_oof': False}
         default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
 

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -10,6 +10,7 @@ import psutil
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS, QUANTILE
 from autogluon.core.utils.exceptions import NotEnoughMemoryError, TimeLimitExceeded
 from autogluon.core.features.types import R_OBJECT
+from autogluon.core.utils.utils import normalize_pred_probas
 
 from autogluon.core.models.abstract.model_trial import skip_hpo
 from autogluon.core.models import AbstractModel
@@ -35,6 +36,7 @@ class RFModel(AbstractModel):
             # Disabled by default because it appears to degrade performance
             try:
                 # TODO: Use sklearnex instead once a suitable toggle option is provided that won't impact future models
+                # FIXME: DAAL OOB score is broken, returns biased predictions. Without this optimization, can't compute Efficient OOF.
                 from daal4py.sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
                 logger.log(15, '\tUsing daal4py RF backend...')
                 self._daal = True
@@ -66,6 +68,8 @@ class RFModel(AbstractModel):
             'n_estimators': 300,
             'n_jobs': -1,
             'random_state': 0,
+            'bootstrap': True,  # Required for OOB estimates, setting to False will raise exception if bagging.
+            # 'oob_score': True,  # Disabled by default as it is better to do it post-fit via custom logic.
         }
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
@@ -191,6 +195,81 @@ class RFModel(AbstractModel):
         y_pred_proba = self.model.predict_proba(X)
         return self._convert_proba_to_unified_form(y_pred_proba)
 
+    def get_oof_pred_proba(self, X, normalize=None, **kwargs):
+        """X should be the same X passed to `.fit`"""
+        y_oof_pred_proba = self._get_oof_pred_proba(X=X, **kwargs)
+        if normalize is None:
+            normalize = self.normalize_pred_probas
+        if normalize:
+            y_oof_pred_proba = normalize_pred_probas(y_oof_pred_proba, self.problem_type)
+        y_oof_pred_proba = y_oof_pred_proba.astype(np.float32)
+        return y_oof_pred_proba
+
+    # FIXME: Unknown if this works with quantile regression
+    def _get_oof_pred_proba(self, X, y, **kwargs):
+        if self._daal:
+            raise AssertionError('DAAL forest backend does not support out-of-bag predictions.')
+        if not self.model.bootstrap:
+            raise ValueError('Forest models must set `bootstrap=True` to compute out-of-fold predictions via out-of-bag predictions.')
+
+        # TODO: This can also be done via setting `oob_score=True` in model params,
+        #  but getting the correct `pred_time_val` that way is not easy, since we can't time the internal call.
+        if (getattr(self.model, "oob_decision_function_", None) is None and getattr(self.model, "oob_prediction_", None) is None) \
+                and callable(getattr(self.model, "_set_oob_score", None)):
+            X = self.preprocess(X)
+
+            if getattr(self.model, "n_classes_", None) is not None:
+                if self.model.n_outputs_ == 1:
+                    self.model.n_classes_ = [self.model.n_classes_]
+            from sklearn.tree._tree import DTYPE, DOUBLE
+            X, y = self.model._validate_data(X, y, multi_output=True, accept_sparse="csc", dtype=DTYPE)
+            if y.ndim == 1:
+                # reshape is necessary to preserve the data contiguity against vs
+                # [:, np.newaxis] that does not.
+                y = np.reshape(y, (-1, 1))
+            if getattr(y, "dtype", None) != DOUBLE or not y.flags.contiguous:
+                y = np.ascontiguousarray(y, dtype=DOUBLE)
+            self.model._set_oob_score(X, y)
+            if getattr(self.model, "n_classes_", None) is not None:
+                if self.model.n_outputs_ == 1:
+                    self.model.n_classes_ = self.model.n_classes_[0]
+
+        if getattr(self.model, "oob_decision_function_", None) is not None:
+            y_oof_pred_proba = self.model.oob_decision_function_
+            self.model.oob_decision_function_ = None  # save memory
+        elif getattr(self.model, "oob_prediction_", None) is not None:
+            y_oof_pred_proba = self.model.oob_prediction_
+            self.model.oob_prediction_ = None  # save memory
+        else:
+            raise AssertionError(f'Model class {type(self.model)} does not support out-of-fold prediction generation.')
+
+        # TODO: Regression does not return NaN for missing rows, instead it sets them to 0. This makes life hard.
+        #  The below code corrects the missing rows to NaN instead of 0.
+        # Don't bother if >40 trees, near impossible to have missing
+        if self.problem_type == REGRESSION and self.model.n_estimators <= 40:
+            from sklearn.ensemble._forest import _get_n_samples_bootstrap, _generate_unsampled_indices
+            n_samples = len(y)
+
+            n_predictions = np.zeros(n_samples)
+            n_samples_bootstrap = _get_n_samples_bootstrap(n_samples, self.model.max_samples)
+            for estimator in self.model.estimators_:
+                unsampled_indices = _generate_unsampled_indices(estimator.random_state, n_samples, n_samples_bootstrap)
+                n_predictions[unsampled_indices] += 1
+            missing_row_mask = n_predictions == 0
+            y_oof_pred_proba[missing_row_mask] = np.nan
+
+        # fill missing prediction rows with average of non-missing rows
+        if np.isnan(np.sum(y_oof_pred_proba)):
+            if len(y_oof_pred_proba.shape) == 1:
+                col_mean = np.nanmean(y_oof_pred_proba)
+                y_oof_pred_proba[np.isnan(y_oof_pred_proba)] = col_mean
+            else:
+                col_mean = np.nanmean(y_oof_pred_proba, axis=0)
+                inds = np.where(np.isnan(y_oof_pred_proba))
+                y_oof_pred_proba[inds] = np.take(col_mean, inds[1])
+
+        return self._convert_proba_to_unified_form(y_oof_pred_proba)
+
     # TODO: Add HPO
     def _hyperparameter_tune(self, **kwargs):
         return skip_hpo(self, **kwargs)
@@ -209,3 +288,13 @@ class RFModel(AbstractModel):
         )
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
+
+    @classmethod
+    def _get_default_ag_args_ensemble(cls) -> dict:
+        default_ag_args_ensemble = super()._get_default_ag_args_ensemble()
+        extra_ag_args_ensemble = {'use_child_oof': True}
+        default_ag_args_ensemble.update(extra_ag_args_ensemble)
+        return default_ag_args_ensemble
+
+    def _more_tags(self):
+        return {'valid_oof': True}

--- a/tabular/src/autogluon/tabular/models/rf/rf_rapids_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_rapids_model.py
@@ -48,3 +48,14 @@ class RFRapidsModel(RFModel):
         self.model = self._get_model_type()(**self._get_model_params())
         self.model = self.model.fit(X, y)
         self.params_trained['n_estimators'] = self.model.n_estimators
+
+    # FIXME: Efficient OOF doesn't work in RAPIDS
+    @classmethod
+    def _get_default_ag_args_ensemble(cls) -> dict:
+        default_ag_args_ensemble = super()._get_default_ag_args_ensemble()
+        extra_ag_args_ensemble = {'use_child_oof': False}
+        default_ag_args_ensemble.update(extra_ag_args_ensemble)
+        return default_ag_args_ensemble
+
+    def _more_tags(self):
+        return {'valid_oof': False}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added efficient OOF functionality to RF/XT models
- This should give a 10x train/infer speed-up and 10x disk space reduction in bagged modes, with roughly equivalent model quality.
- DAAL and RAPIDS don't support the necessary methods to do this, so only raw sklearn is accelerated at present.
- Fixed efficient OOF KNN crashing on regression problems.

TODO:

- [x] Benchmark

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
