### PR TITLE
[Bagging][Refactoring] Refactoring bagged training code into separate class to enable distributed strategies

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 from autogluon.core.models.ensemble.fold_fitting_strategy import *
 
-from .fold_fitting_strategy import SequentialLocalFoldFittingStrategy
 from ...constants import MULTICLASS, REGRESSION, SOFTCLASS, QUANTILE, REFIT_FULL_SUFFIX
 from ...utils.exceptions import TimeLimitExceeded
 from ...utils.loaders import load_pkl
@@ -26,7 +25,7 @@ class BaggedEnsembleModel(AbstractModel):
     """
     _oof_filename = 'oof.pkl'
 
-    def __init__(self, model_base: AbstractModel, fold_fitting_strategy: AbstractFoldFittingStrategy = SequentialLocalFoldFittingStrategy, random_state=0, **kwargs):
+    def __init__(self, model_base: AbstractModel, fold_fitting_strategy: AbstractFoldFittingStrategy = None, random_state=0, **kwargs):
         self.model_base = model_base
         self._child_type = type(self.model_base)
         self.models = []

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -168,7 +168,8 @@ class BaggedEnsembleModel(AbstractModel):
         fold_start = n_repeat_start * k_fold + k_fold_start
         fold_end = (n_repeats - 1) * k_fold + k_fold_end
         folds_to_fit = fold_end - fold_start
-        fold_fitting_strategy: AbstractFoldFittingStrategy = SequentialLocalFoldFittingStrategy(self, X, y, sample_weight, time_limit, time_start, models, oof_pred_proba, oof_pred_model_repeats)
+        fold_fitting_strategy: AbstractFoldFittingStrategy = SequentialLocalFoldFittingStrategy(
+            self, X, y, sample_weight, time_limit, time_start, models, oof_pred_proba, oof_pred_model_repeats)
         for j in range(n_repeat_start, n_repeats):  # For each n_repeat
             cur_repeat_count = j - n_repeat_start
             fold_start_n_repeat = fold_start + cur_repeat_count * k_fold

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class AbstractFoldFittingStrategy(object):
+
     @abstractmethod
     def schedule_fold_model_fit(self, model_base, fold_ctx, kwargs):
         """
@@ -66,7 +67,6 @@ class SequentialLocalFoldFittingStrategy(AbstractFoldFittingStrategy):
         time_limit_fold = self._get_fold_time_limit(fold_ctx)
         fold_model = self._fit(model_base, time_start_fold, time_limit_fold, fold_ctx, kwargs)
         fold_model, pred_proba = self._predict_oof(fold_model, fold_ctx)
-
         self._update_bagged_ensembe(fold_model, pred_proba, fold_ctx)
 
     def _get_fold_time_limit(self, fold_ctx):

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -1,0 +1,132 @@
+import copy
+import logging
+import os
+import time
+from abc import abstractmethod
+
+from ...utils.exceptions import TimeLimitExceeded
+
+logger = logging.getLogger(__name__)
+
+
+class AbstractFoldFittingStrategy(object):
+    @abstractmethod
+    def schedule_fold_model_fit(self, model_base, fold_ctx, kwargs):
+        """
+        Schedule fold model training. By design this part is supposed to be 'lazy' evaluator no actual training is performed here.
+        Distributed fitters will handle jobs scheduling here.
+        """
+        pass
+
+    @abstractmethod
+    def after_all_folds_scheduled(self):
+        """
+        Method is called when all the folds are scheduled.
+        Local fitters will perform training here.
+        Distributed fitters will handle job handles and results retrieval here.
+        """
+        pass
+
+
+class SequentialLocalFoldFittingStrategy(AbstractFoldFittingStrategy):
+    """
+    This strategy fits the folds locally in a sequence.
+    """
+
+    def __init__(self, bagged_ensemble_model, X, y, sample_weight, time_limit, time_start, models, oof_pred_proba, oof_pred_model_repeats):
+        """
+        Parameters
+        ----------
+        path : str
+            Directory location to store all outputs.
+        params: dict
+            Fitting parameters
+
+        """
+        self.X = X
+        self.y = y
+        self.sample_weight = sample_weight
+        self.time_limit = time_limit
+        self.time_start = time_start
+        self.models = models
+        self.oof_pred_proba = oof_pred_proba
+        self.oof_pred_model_repeats = oof_pred_model_repeats
+        self.bagged_ensemble_model = bagged_ensemble_model
+        self.jobs = []
+
+    def schedule_fold_model_fit(self, model_base, fold_ctx, kwargs):
+        self.jobs.append([model_base, fold_ctx, kwargs])
+
+    def after_all_folds_scheduled(self):
+        for job in self.jobs:
+            self._fit_fold_model(*job)
+
+    def _fit_fold_model(self, model_base, fold_ctx, kwargs):
+        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = self._get_fold_properties(fold_ctx)
+        time_elapsed = time.time() - self.time_start
+        if self.time_limit is not None:
+            time_left = self.time_limit - time_elapsed
+            required_time_per_fold = time_left / folds_left
+            time_limit_fold = required_time_per_fold * 0.8
+            if folds_finished > 0:
+                expected_time_required = time_elapsed * folds_to_fit / folds_finished
+                expected_remaining_time_required = expected_time_required * folds_left / folds_to_fit
+                if expected_remaining_time_required > time_left:
+                    raise TimeLimitExceeded
+            if time_left <= 0:
+                raise TimeLimitExceeded
+        else:
+            time_limit_fold = None
+        time_start_fold = time.time()
+        train_index, val_index = fold
+        X_fold, X_val_fold = self.X.iloc[train_index, :], self.X.iloc[val_index, :]
+        y_fold, y_val_fold = self.y.iloc[train_index], self.y.iloc[val_index]
+        fold_model = copy.deepcopy(model_base)
+        fold_model.name = f'{fold_model.name}{model_name_suffix}'
+        fold_model.set_contexts(self.bagged_ensemble_model.path + fold_model.name + os.path.sep)
+        kwargs_fold = kwargs.copy()
+        if self.sample_weight is not None:
+            kwargs_fold['sample_weight'] = self.sample_weight[train_index]
+            kwargs_fold['sample_weight_val'] = self.sample_weight[val_index]
+
+        fold_model, pred_proba = self._model_fit(X_fold, X_val_fold, fold_model, kwargs_fold, time_limit_fold, y_fold, y_val_fold, time_start_fold, fold_ctx)
+
+        train_index, val_index = fold_ctx['fold']
+        model_to_append = fold_model
+        if self.bagged_ensemble_model.low_memory:
+            self.bagged_ensemble_model.save_child(fold_model, verbose=False)
+            model_to_append = fold_model.name
+        self.models.append(model_to_append)
+        self.oof_pred_proba[val_index] += pred_proba
+        self.oof_pred_model_repeats[val_index] += 1
+        self.bagged_ensemble_model._add_child_times_to_bag(model=fold_model)
+
+    def _model_fit(self, X_fold, X_val_fold, fold_model, kwargs_fold, time_limit_fold, y_fold, y_val_fold, time_start_fold, fold_ctx):
+        fold_model.fit(X=X_fold, y=y_fold, X_val=X_val_fold, y_val=y_val_fold, time_limit=time_limit_fold, **kwargs_fold)
+        time_train_end_fold = time.time()
+        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = self._get_fold_properties(fold_ctx)
+
+        if self.time_limit is not None:  # Check to avoid unnecessarily predicting and saving a model when an Exception is going to be raised later
+            if is_last_fold:
+                time_elapsed = time.time() - self.time_start
+                time_left = self.time_limit - time_elapsed
+                expected_time_required = time_elapsed * folds_to_fit / (folds_finished + 1)
+                expected_remaining_time_required = expected_time_required * (folds_left - 1) / folds_to_fit
+                if expected_remaining_time_required > time_left:
+                    raise TimeLimitExceeded
+        pred_proba = fold_model.predict_proba(X_val_fold)
+        time_predict_end_fold = time.time()
+        fold_model.fit_time = time_train_end_fold - time_start_fold
+        fold_model.predict_time = time_predict_end_fold - time_train_end_fold
+        fold_model.val_score = fold_model.score_with_y_pred_proba(y=y_val_fold, y_pred_proba=pred_proba)
+        fold_model.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
+        if not self.bagged_ensemble_model.params.get('save_bag_folds', True):
+            fold_model.model = None
+        return fold_model, pred_proba
+
+    @staticmethod
+    def _get_fold_properties(fold_ctx):
+        fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix = [
+            fold_ctx[f] for f in ['fold', 'folds_finished', 'folds_left', 'folds_to_fit', 'is_last_fold', 'model_name_suffix']
+        ]
+        return fold, folds_finished, folds_left, folds_to_fit, is_last_fold, model_name_suffix

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -20,7 +20,6 @@ from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_pkl
 from autogluon.core.utils.utils import setup_outputdir, default_holdout_frac, get_approximate_df_mem_usage
 from autogluon.core.utils.decorators import apply_presets
-from autogluon.core.models.ensemble.fold_fitting_strategy import SequentialLocalFoldFittingStrategy
 
 from ..configs.hyperparameter_configs import get_hyperparameter_config
 from ..configs.feature_generator_presets import get_default_feature_generator
@@ -645,7 +644,6 @@ class TabularPredictor:
         ag_args_fit = kwargs['ag_args_fit']
         ag_args_ensemble = kwargs['ag_args_ensemble']
         excluded_model_types = kwargs['excluded_model_types']
-        fold_fitting_strategy = kwargs['fold_fitting_strategy']
 
         if ag_args is None:
             ag_args = {}
@@ -704,7 +702,6 @@ class TabularPredictor:
             'ag_args_ensemble': ag_args_ensemble,
             'ag_args_fit': ag_args_fit,
             'excluded_model_types': excluded_model_types,
-            'fold_fitting_strategy': fold_fitting_strategy,
         }
         self._learner.fit(X=train_data, X_val=tuning_data, X_unlabeled=unlabeled_data,
                           holdout_frac=holdout_frac, num_bag_folds=num_bag_folds, num_bag_sets=num_bag_sets, num_stack_levels=num_stack_levels,
@@ -2248,9 +2245,6 @@ class TabularPredictor:
 
             # quantile levels
             quantile_levels=None,
-
-            # Fitting strategy for bagged ensemble models
-            fold_fitting_strategy=SequentialLocalFoldFittingStrategy,
         )
 
         allowed_kwarg_names = list(fit_extra_kwargs_default.keys())

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -18,6 +18,7 @@ from autogluon.core.utils.savers import save_json, save_pkl
 
 from .utils import process_hyperparameters
 from ..augmentation.distill_utils import format_distillation_labels, augment_data
+from autogluon.core.models.ensemble.fold_fitting_strategy import SequentialLocalFoldFittingStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -307,7 +308,8 @@ class AbstractTrainer:
 
     def stack_new_level_core(self, X, y, models: Union[List[AbstractModel], dict], X_val=None, y_val=None, X_unlabeled=None,
                              level=1, base_model_names: List[str] = None, stack_name='core',
-                             ag_args=None, ag_args_fit=None, ag_args_ensemble=None, excluded_model_types=None, ensemble_type=StackerEnsembleModel, name_suffix: str = None, get_models_func=None, **kwargs) -> List[str]:
+                             ag_args=None, ag_args_fit=None, ag_args_ensemble=None, excluded_model_types=None, ensemble_type=StackerEnsembleModel,
+                             name_suffix: str = None, get_models_func=None, fold_fitting_strategy=SequentialLocalFoldFittingStrategy, **kwargs) -> List[str]:
         """
         Trains all models using the data provided.
         If level > 1, then the models will use base model predictions as additional features.
@@ -347,6 +349,7 @@ class AbstractTrainer:
                     'base_model_paths_dict': base_model_paths,
                     'base_model_types_dict': base_model_types,
                     'random_state': level + self.random_state,
+                    'fold_fitting_strategy': fold_fitting_strategy,
                 }
                 get_models_kwargs.update(dict(
                     ag_args_ensemble=ag_args_ensemble,

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -308,7 +308,7 @@ class AbstractTrainer:
     def stack_new_level_core(self, X, y, models: Union[List[AbstractModel], dict], X_val=None, y_val=None, X_unlabeled=None,
                              level=1, base_model_names: List[str] = None, stack_name='core',
                              ag_args=None, ag_args_fit=None, ag_args_ensemble=None, excluded_model_types=None, ensemble_type=StackerEnsembleModel,
-                             name_suffix: str = None, get_models_func=None, fold_fitting_strategy=None, **kwargs) -> List[str]:
+                             name_suffix: str = None, get_models_func=None, **kwargs) -> List[str]:
         """
         Trains all models using the data provided.
         If level > 1, then the models will use base model predictions as additional features.
@@ -348,7 +348,6 @@ class AbstractTrainer:
                     'base_model_paths_dict': base_model_paths,
                     'base_model_types_dict': base_model_types,
                     'random_state': level + self.random_state,
-                    'fold_fitting_strategy': fold_fitting_strategy,
                 }
                 get_models_kwargs.update(dict(
                     ag_args_ensemble=ag_args_ensemble,

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -18,7 +18,6 @@ from autogluon.core.utils.savers import save_json, save_pkl
 
 from .utils import process_hyperparameters
 from ..augmentation.distill_utils import format_distillation_labels, augment_data
-from autogluon.core.models.ensemble.fold_fitting_strategy import SequentialLocalFoldFittingStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -309,7 +308,7 @@ class AbstractTrainer:
     def stack_new_level_core(self, X, y, models: Union[List[AbstractModel], dict], X_val=None, y_val=None, X_unlabeled=None,
                              level=1, base_model_names: List[str] = None, stack_name='core',
                              ag_args=None, ag_args_fit=None, ag_args_ensemble=None, excluded_model_types=None, ensemble_type=StackerEnsembleModel,
-                             name_suffix: str = None, get_models_func=None, fold_fitting_strategy=SequentialLocalFoldFittingStrategy, **kwargs) -> List[str]:
+                             name_suffix: str = None, get_models_func=None, fold_fitting_strategy=None, **kwargs) -> List[str]:
         """
         Trains all models using the data provided.
         If level > 1, then the models will use base model predictions as additional features.

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -19,6 +19,8 @@ from ..utils import MXNetErrorCatcher
 
 __all__ = ['ImagePredictor']
 
+from autogluon.core.utils.multiprocessing_utils import is_fork_enabled
+
 logger = logging.getLogger()  # return root logger
 
 
@@ -328,6 +330,9 @@ class ImagePredictor(object):
             config['max_reward'] = max_reward
         if nthreads_per_trial is not None:
             config['nthreads_per_trial'] = nthreads_per_trial
+        elif is_fork_enabled():
+            # This is needed to address multiprocessing.context.TimeoutError in fork mode
+            config['nthreads_per_trial'] = 0
         if ngpus_per_trial is not None:
             config['ngpus_per_trial'] = ngpus_per_trial
         if isinstance(hyperparameters, dict):


### PR DESCRIPTION
*Description of changes:*
This PR does 2 things: 
1. moves folds training code into separate strategy class to isolate fold training code from bagging part
1. changes processing model to map-reduce (schedule all jobs first, then wait to get the results) - this is needed for distributed training where scheduling is happening asynchronously.

Custom strategies can be plugged via:

```python
    predictor = TabularPredictor(label=label, path='/Users/ashyrkou/Projects/autogluon/temp/').fit(
        ...
        fold_fitting_strategy=SequentialLocalFoldFittingStrategy,
        ...
    )
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
