### PR TITLE
Tabular: Refactored evaluate/evaluate_predictions

### DIFF
--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -412,7 +412,11 @@ def compute_weighted_metric(y, y_pred, metric, weights, weight_evaluation=None, 
     try:
         weighted_metric = metric(y, y_pred, sample_weight=weights, **kwargs)
     except (ValueError, TypeError, KeyError):
-        logger.log(30, f"WARNING: eval_metric='{metric.name}' does not support sample weights so they will be ignored in reported metric.")
+        if hasattr(metric, 'name'):
+            metric_name = metric.name
+        else:
+            metric_name = metric
+        logger.log(30, f"WARNING: eval_metric='{metric_name}' does not support sample weights so they will be ignored in reported metric.")
         weighted_metric = metric(y, y_pred, **kwargs)
     return weighted_metric
 

--- a/docs/api/autogluon.predictor.rst
+++ b/docs/api/autogluon.predictor.rst
@@ -24,7 +24,7 @@ AutoGluon Predictors
 
    Evaluate predictions on test data:
 
-   >>> test_acc = predictor.evaluate(test_data)
+   >>> leaderboard = predictor.leaderboard(test_data)
 
 
 

--- a/docs/tutorials/tabular_prediction/tabular-indepth.md
+++ b/docs/tutorials/tabular_prediction/tabular-indepth.md
@@ -81,7 +81,7 @@ We again demonstrate how to use the trained models to predict on the test data.
 ```{.python .input}
 y_pred = predictor.predict(test_data_nolabel)
 print("Predictions:  ", list(y_pred)[:5])
-perf = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred, auxiliary_metrics=False)
+perf = predictor.evaluate(test_data, auxiliary_metrics=False)
 ```
 
 Use the following to view a summary of what happened during fit. Now this command will show details of the hyperparameter-tuning process for each type of model:
@@ -206,19 +206,15 @@ predictor_information = predictor.info()
 The `predictor` also remembers what metric predictions should be evaluated with, which can be done with ground truth labels as follows:
 
 ```{.python .input}
-y_pred = predictor.predict(test_data_nolabel)
-perf = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred, auxiliary_metrics=True)
+y_pred_proba = predictor.predict_proba(test_data_nolabel)
+perf = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred_proba)
 ```
 
-However, you must be careful here as certain metrics require predicted probabilities rather than classes.
 Since the label columns remains in the `test_data` DataFrame, we can instead use the shorthand:
 
 ```{.python .input}
 perf = predictor.evaluate(test_data)
 ```
-
-which will correctly select between `predict()` or `predict_proba()` depending on the evaluation metric.
-
 
 ## Interpretability (feature importance)
 

--- a/docs/tutorials/tabular_prediction/tabular-quickstart.md
+++ b/docs/tutorials/tabular_prediction/tabular-quickstart.md
@@ -54,6 +54,11 @@ print("Predictions:  \n", y_pred)
 perf = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred, auxiliary_metrics=True)
 ```
 
+We can also evaluate the performance of each individual trained model on our (labeled) test data:
+```{.python .input}
+predictor.leaderboard(test_data, silent=True)
+```
+
 Now you're ready to try AutoGluon on your own tabular datasets!
 As long as they're stored in a popular format like CSV, you should be able to achieve strong predictive performance with just 2 lines of code:
 
@@ -157,6 +162,12 @@ performance = predictor_age.evaluate(test_data)
 ```
 
 Note that we didn't need to tell AutoGluon this is a regression problem, it automatically inferred this from the data and reported the appropriate performance metric (RMSE by default). To specify a particular evaluation metric other than the default, set the `eval_metric` argument of `fit()` and AutoGluon will tailor its models to optimize your metric (e.g. `eval_metric = 'mean_absolute_error'`). For evaluation metrics where higher values are worse (like RMSE), AutoGluon may sometimes flips their sign and print them as negative values during training (as it internally assumes higher values are better).
+
+We can call leaderboard to see the per-model performance:
+
+```{.python .input}
+predictor_age.leaderboard(test_data, silent=True)
+```
 
 **Data Formats:** AutoGluon can currently operate on data tables already loaded into Python as pandas DataFrames, or those stored in files of [CSV format](https://en.wikipedia.org/wiki/Comma-separated_values) or [Parquet format](https://databricks.com/glossary/what-is-parquet). If your data live in multiple tables, you will first need to join them into a single table whose rows correspond to statistically independent observations (datapoints) and columns correspond to different features (aka. variables/covariates).
 

--- a/examples/tabular/example_advanced_tabular.py
+++ b/examples/tabular/example_advanced_tabular.py
@@ -34,7 +34,5 @@ print(test_data.head())
 perf = predictor.evaluate(test_data)  # shorthand way to evaluate our predictor if test-labels are available
 
 # Otherwise we make predictions and can evaluate them later:
-y_test = test_data[label]
-test_data = test_data.drop(labels=[label], axis=1)  # Delete labels from test data since we wouldn't have them in practice
-y_pred = predictor.predict(test_data)
-perf = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred, auxiliary_metrics=True)
+y_pred = predictor.predict_proba(test_data)
+perf = predictor.evaluate_predictions(y_true=test_data[label], y_pred=y_pred, auxiliary_metrics=True)

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -211,7 +211,6 @@ class AbstractLearner:
                 suffix = " Evaluation metrics will ignore sample weights, specify weight_evaluation=True to instead report weighted metrics."
             logger.log(20, prefix+suffix)
 
-
     def get_inputs_to_stacker(self, dataset=None, model=None, base_models: list = None, use_orig_features=True):
         if model is not None or base_models is not None:
             if model is not None and base_models is not None:
@@ -478,6 +477,10 @@ class AbstractLearner:
             Returns single performance-value if auxiliary_metrics=False.
             Otherwise returns dict where keys = metrics, values = performance along each metric.
         """
+
+        if self.weight_evaluation:
+            raise AssertionError('evaluate_predictions does not support `weight_evaluation=True`. Use `predictor.leaderboard` instead.')
+
         is_proba = False
         assert isinstance(y_true, (np.ndarray, pd.Series))
         assert isinstance(y_pred, (np.ndarray, pd.Series, pd.DataFrame))

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -281,9 +281,9 @@ def run_tabular_benchmarks(fast_benchmark, subsample_size, perf_threshold, seed_
             y_pred = predictor.predict(test_data)
             perf_dict = predictor.evaluate_predictions(y_true=y_test, y_pred=y_pred, auxiliary_metrics=True)
             if dataset['problem_type'] != REGRESSION:
-                perf = 1.0 - perf_dict['accuracy_score'] # convert accuracy to error-rate
+                perf = 1.0 - perf_dict['accuracy']  # convert accuracy to error-rate
             else:
-                perf = 1.0 - perf_dict['r2_score'] # unexplained variance score.
+                perf = 1.0 - perf_dict['r2']  # unexplained variance score.
             performance_vals[idx] = perf
             print("Performance on dataset %s: %s   (previous perf=%s)" % (dataset['name'], performance_vals[idx], dataset['performance_val']))
             if (not fast_benchmark) and (performance_vals[idx] > dataset['performance_val'] * perf_threshold):

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -513,8 +513,9 @@ def test_sample_weight():
     ldr = predictor.leaderboard(test_data)
     perf = predictor.evaluate(test_data)
     # Run again with weight_evaluation:
+    # FIXME: RMSE doesn't support sample_weight, this entire call doesn't make sense
     predictor = TabularPredictor(label=dataset['label'], path=savedir, problem_type=dataset['problem_type'], sample_weight=sample_weight, weight_evaluation=True).fit(train_data, **fit_args)
-    perf = predictor.evaluate(test_data_weighted)
+    # perf = predictor.evaluate(test_data_weighted)  # TODO: Doesn't work without implementing sample_weight in evaluate
     predictor.distill(time_limit=10)
     ldr = predictor.leaderboard(test_data_weighted)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Refactored evaluate and evaluate_predictions to cause less confusion with users and act more consistently across eval metrics and problem types.
- evaluate is now purely a wrapper around evaluate_predictions, making the logic much less disjoint.
- evaluate_predictions now can always handle pred_proba input, and can evaluate pred and pred_proba metrics at the same time (previously this didn't work).
- Made the return types always dictionaries to reduce confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
