### PR TITLE
Tabular: RF/XT Efficient OOB

### DIFF
--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -69,7 +69,10 @@ class RFModel(AbstractModel):
             'n_jobs': -1,
             'random_state': 0,
             'bootstrap': True,  # Required for OOB estimates, setting to False will raise exception if bagging.
-            'min_samples_leaf': 5,  # Significantly reduces info leakage to stacker models. Never use the default/1 when using as base model.
+            # TODO: min_samples_leaf=5 is too large on most problems, however on some datasets it helps a lot (airlines likes >40 min_samples_leaf, adult likes 2 much better than 1)
+            #  This value would need to be tuned per dataset, likely very worthwhile.
+            #  Higher values = less OOF info leak, default = 1, which maximizes info leak.
+            # 'min_samples_leaf': 5,  # Significantly reduces info leakage to stacker models. Never use the default/1 when using as base model.
             # 'oob_score': True,  # Disabled by default as it is better to do it post-fit via custom logic.
         }
         for param, val in default_params.items():

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -65,10 +65,11 @@ class RFModel(AbstractModel):
 
     def _set_default_params(self):
         default_params = {
-            'n_estimators': 300,
+            'n_estimators': 600,
             'n_jobs': -1,
             'random_state': 0,
             'bootstrap': True,  # Required for OOB estimates, setting to False will raise exception if bagging.
+            'min_samples_leaf': 5,  # Significantly reduces info leakage to stacker models. Never use the default/1 when using as base model.
             # 'oob_score': True,  # Disabled by default as it is better to do it post-fit via custom logic.
         }
         for param, val in default_params.items():
@@ -293,7 +294,7 @@ class RFModel(AbstractModel):
     @classmethod
     def _get_default_ag_args_ensemble(cls) -> dict:
         default_ag_args_ensemble = super()._get_default_ag_args_ensemble()
-        extra_ag_args_ensemble = {'use_child_oof': False}
+        extra_ag_args_ensemble = {'use_child_oof': True}
         default_ag_args_ensemble.update(extra_ag_args_ensemble)
         return default_ag_args_ensemble
 

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -65,7 +65,9 @@ class RFModel(AbstractModel):
 
     def _set_default_params(self):
         default_params = {
-            'n_estimators': 600,
+            # TODO: 600 is much better, but increases info leakage in stacking -> therefore 300 is ~equal in stack ensemble final quality.
+            #  Consider adding targeted noise to OOF to avoid info leakage, or increase `min_samples_leaf`.
+            'n_estimators': 300,
             'n_jobs': -1,
             'random_state': 0,
             'bootstrap': True,  # Required for OOB estimates, setting to False will raise exception if bagging.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Enable efficient OOB by default.
- ~2.3x faster inference speed, large disk usage reduction, slightly worse quality on datasets <10,000 rows, better quality on datasets >10,000 rows.
- Increases OOF info leakage, will want to investigate work-arounds in follow-up PRs. Added current findings to code comments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
