### PR TITLE
[CV][Bugfix] Addressing multiprocessing.context.TimeoutError in fork mode

### DIFF
--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -19,6 +19,8 @@ from ..utils import MXNetErrorCatcher
 
 __all__ = ['ImagePredictor']
 
+from autogluon.core.utils.multiprocessing_utils import is_fork_enabled
+
 logger = logging.getLogger()  # return root logger
 
 
@@ -328,6 +330,9 @@ class ImagePredictor(object):
             config['max_reward'] = max_reward
         if nthreads_per_trial is not None:
             config['nthreads_per_trial'] = nthreads_per_trial
+        elif is_fork_enabled():
+            # This is needed to address multiprocessing.context.TimeoutError in fork mode
+            config['nthreads_per_trial'] = 0
         if ngpus_per_trial is not None:
             config['ngpus_per_trial'] = ngpus_per_trial
         if isinstance(hyperparameters, dict):


### PR DESCRIPTION
*Description of changes:*
CV models dataloaders throw a `TimeoutError` in fork multiprocessing mode - setting `nthreads_per_trial=0` when it's not provided and the multiprocessing mode is `fork`

see also: https://github.com/apache/incubator-mxnet/issues/11872

```python
import autogluon.core as ag
from autogluon.vision import ImagePredictor
import multiprocessing

print(f'Start modes available: {multiprocessing.get_all_start_methods()}')
multiprocessing.set_start_method('fork', force=True)
print(f'Active start mode: {multiprocessing.get_start_method(allow_none=True)}')

train_dataset, _, test_dataset = ImagePredictor.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
predictor = ImagePredictor()
predictor.fit(train_dataset, hyperparameters={'epochs': 2})some build time
```

Error:
```
Worker timed out after 120 seconds. This might be caused by 

            - Slow transform. Please increase timeout to allow slower data loading in each worker.
            - Insufficient shared_memory if `timeout` is large enough.
            Please consider reduce `num_workers` or increase shared_memory in system.
            

---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-4-f64cfaa365f4> in <module>
      2 predictor = ImagePredictor()
      3 # since the original dataset does not provide validation split, the `fit` function splits it randomly with 90/10 ratio
----> 4 predictor.fit(train_dataset, hyperparameters={'epochs': 2})  # you can trust the default config, we reduce the # epoch to save some build time

~/Projects/autogluon/vision/src/autogluon/vision/configs/presets_configs.py in _call(*args, **kwargs)
     13         def _call(*args, **kwargs):
     14             gargs, gkwargs = set_presets(preset_name, *args, **kwargs)
---> 15             return f(*gargs, **gkwargs)
     16         return _call
     17     return _unpack_inner

~/Projects/autogluon/vision/src/autogluon/vision/predictor/predictor.py in fit(self, train_data, tuning_data, time_limit, presets, hyperparameters, **kwargs)
    380                 self._classifier = task.fit(train_data, tuning_data, 1 - holdout_frac, random_state)
    381             if err.exc_value is not None:
--> 382                 raise RuntimeError(err.exc_value + err.hint)
    383         self._classifier._logger.setLevel(log_level)
    384         self._classifier._logger.propagate = True

RuntimeError: Unexpected error happened during fit: { 'args': "{'img_cls': {'model': 'resnet18_v1b', 'use_pretrained': True, "
          "'use_gn': False, 'batch_norm': False, 'use_se': False, "
          "'last_gamma': False}, 'train': {'pretrained_base': True, "
          "'batch_size': 8, 'epochs': 2, 'lr': 0.01, 'lr_decay': 0.1, "
          "'lr_decay_period': 0, 'lr_decay_epoch': '40, 60', 'lr_mode': "
          "'step', 'warmup_lr': 0.0, 'warmup_epochs': 0, "
          "'num_training_samples': -1, 'num_workers': 12, 'wd': 0.0001, "
          "'momentum': 0.9, 'teacher': None, 'hard_weight': 0.5, 'dtype': "
          "'float32', 'input_size': 224, 'crop_ratio': 0.875, 'use_rec': "
          "False, 'rec_train': 'auto', 'rec_train_idx': 'auto', 'rec_val': "
          "'auto', 'rec_val_idx': 'auto', 'data_dir': 'auto', 'mixup': False, "
          "'no_wd': False, 'label_smoothing': False, 'temperature': 20, "
          "'resume_epoch': 0, 'mixup_alpha': 0.2, 'mixup_off_epoch': 0, "
          "'log_interval': 50, 'mode': '', 'start_epoch': 0, "
          "'transfer_lr_mult': 0.01, 'output_lr_mult': 0.1, "
          "'early_stop_patience': 10, 'early_stop_min_delta': 0.001, "
          "'early_stop_baseline': -inf, 'early_stop_max_value': inf}, 'valid': "
          "{'batch_size': 8, 'num_workers': 12}, 'gpus': []}",
  'time': 120.43467783927917,
  'traceback': 'Traceback (most recent call last):\n'
               '  File '
               '"/Users/user/Projects/venv/lib/python3.7/site-packages/gluoncv/auto/tasks/image_classification.py", '
               'line 138, in _train_image_classification\n'
               '    result = estimator.fit(train_data=train_data, '
               'val_data=val_data, time_limit=wall_clock_tick-tic)\n'
               '  File '
               '"/Users/user/Projects/venv/lib/python3.7/site-packages/gluoncv/auto/estimators/base_estimator.py", '
               'line 175, in fit\n'
               '    ret = self._fit(train_data, val_data, '
               'time_limit=time_limit) if not resume else \\\n'
               '  File '
               '"/Users/user/Projects/venv/lib/python3.7/site-packages/gluoncv/auto/estimators/image_classification/image_classification.py", '
               'line 81, in _fit\n'
               '    return self._resume_fit(train_data, val_data, '
               'time_limit=time_limit)\n'
               '  File '
               '"/Users/user/Projects/venv/lib/python3.7/site-packages/gluoncv/auto/estimators/image_classification/image_classification.py", '
               'line 110, in _resume_fit\n'
               '    return self._train_loop(train_loader, val_loader, '
               'time_limit=time_limit)\n'
               '  File '
               '"/Users/user/Projects/venv/lib/python3.7/site-packages/gluoncv/auto/estimators/image_classification/image_classification.py", '
               'line 163, in _train_loop\n'
               '    for i, batch in enumerate(train_data):\n'
               '  File '
               '"/Users/user/Projects/venv/lib/python3.7/site-packages/mxnet/gluon/data/dataloader.py", '
               'line 484, in __next__\n'
               '    batch = pickle.loads(ret.get(self._timeout))\n'
               '  File '
               '"/Users/user/anaconda3/envs/py37/lib/python3.7/multiprocessing/pool.py", '
               'line 653, in get\n'
               '    raise TimeoutError\n'
               'multiprocessing.context.TimeoutError\n',
  'train_acc': -1,
  'valid_acc': -1}

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
