### PR TITLE
Tabular: Fix predictor.info() exception

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1,3 +1,7 @@
+import copy
+import logging
+import os
+import time
 from collections import Counter
 from statistics import mean
 
@@ -583,6 +587,14 @@ class BaggedEnsembleModel(AbstractModel):
             max_memory_size = info['memory_size']
             min_memory_size = info['memory_size'] - sum_memory_size_child + max_memory_size_child
 
+        # Necessary if save_space is used as save_space deletes model_base.
+        if len(self.models) > 0:
+            child_model = self.load_child(self.models[0])
+        else:
+            child_model = self._get_model_base()
+        child_hyperparameters = child_model.params
+        child_ag_args_fit = child_model.params_aux
+
         bagged_info = dict(
             child_model_type=self._child_type.__name__,
             num_child_models=len(self.models),
@@ -597,9 +609,9 @@ class BaggedEnsembleModel(AbstractModel):
             bagged_mode=self._bagged_mode,
             max_memory_size=max_memory_size,  # Memory used when all children are loaded into memory at once.
             min_memory_size=min_memory_size,  # Memory used when only the largest child is loaded into memory.
-            child_hyperparameters=self._get_model_base().params,
+            child_hyperparameters=child_hyperparameters,
             child_hyperparameters_fit=self._get_compressed_params_trained(),
-            child_ag_args_fit=self._get_model_base().params_aux,
+            child_ag_args_fit=child_ag_args_fit,
         )
         info['bagged_info'] = bagged_info
         info['children_info'] = children_info

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -7,15 +7,14 @@ from statistics import mean
 
 import numpy as np
 import pandas as pd
-from autogluon.core.models.ensemble.fold_fitting_strategy import *
 
+from .fold_fitting_strategy import AbstractFoldFittingStrategy, SequentialLocalFoldFittingStrategy
+from ..abstract.abstract_model import AbstractModel
 from ...constants import MULTICLASS, REGRESSION, SOFTCLASS, QUANTILE, REFIT_FULL_SUFFIX
 from ...utils.exceptions import TimeLimitExceeded
 from ...utils.loaders import load_pkl
 from ...utils.savers import save_pkl
 from ...utils.utils import generate_kfold, _compute_fi_with_stddev
-
-from ..abstract.abstract_model import AbstractModel
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed an exception that is raised when using bagging. After calling `predictor.save_space()`, calls to `predictor.persist_models` and `predictor.info()` will raise exceptions.
- This PR fixes that issue so they still work correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
