### PR TITLE
Improved access method for `__version__`

### DIFF
--- a/core/src/autogluon/core/__init__.py
+++ b/core/src/autogluon/core/__init__.py
@@ -18,3 +18,8 @@ __logging.getLogger("distributed.logging.distributed").setLevel(__logging.ERROR)
 __logging.getLogger("distributed.worker").setLevel(__logging.ERROR)
 
 __logging.basicConfig(format='%(message)s')  # just print message in logs
+
+try:
+    from .version import __version__
+except ImportError:
+    pass

--- a/core/src/autogluon/core/__init__.py
+++ b/core/src/autogluon/core/__init__.py
@@ -19,7 +19,4 @@ __logging.getLogger("distributed.worker").setLevel(__logging.ERROR)
 
 __logging.basicConfig(format='%(message)s')  # just print message in logs
 
-try:
-    from .version import __version__
-except ImportError:
-    pass
+from .version import __version__

--- a/core/tests/unittests/test_import_version.py
+++ b/core/tests/unittests/test_import_version.py
@@ -1,0 +1,6 @@
+import autogluon.core
+
+
+def test_import_version():
+    assert isinstance(autogluon.core.__version__, str)
+    assert len(autogluon.core.__version__) != 0

--- a/extra/src/autogluon/extra/__init__.py
+++ b/extra/src/autogluon/extra/__init__.py
@@ -1,6 +1,3 @@
 from autogluon.extra.model_zoo import *
 
-try:
-    from .version import __version__
-except ImportError:
-    pass
+from .version import __version__

--- a/extra/src/autogluon/extra/__init__.py
+++ b/extra/src/autogluon/extra/__init__.py
@@ -1,1 +1,6 @@
 from autogluon.extra.model_zoo import *
+
+try:
+    from .version import __version__
+except ImportError:
+    pass

--- a/features/src/autogluon/features/__init__.py
+++ b/features/src/autogluon/features/__init__.py
@@ -1,6 +1,3 @@
 from .generators import *
 
-try:
-    from .version import __version__
-except ImportError:
-    pass
+from .version import __version__

--- a/features/src/autogluon/features/__init__.py
+++ b/features/src/autogluon/features/__init__.py
@@ -1,1 +1,6 @@
 from .generators import *
+
+try:
+    from .version import __version__
+except ImportError:
+    pass

--- a/mxnet/src/autogluon/mxnet/__init__.py
+++ b/mxnet/src/autogluon/mxnet/__init__.py
@@ -1,1 +1,6 @@
 from .task import *
+
+try:
+    from .version import __version__
+except ImportError:
+    pass

--- a/mxnet/src/autogluon/mxnet/__init__.py
+++ b/mxnet/src/autogluon/mxnet/__init__.py
@@ -1,6 +1,3 @@
 from .task import *
 
-try:
-    from .version import __version__
-except ImportError:
-    pass
+from .version import __version__

--- a/tabular/src/autogluon/tabular/__init__.py
+++ b/tabular/src/autogluon/tabular/__init__.py
@@ -3,6 +3,11 @@ import logging
 from autogluon.core.dataset import TabularDataset
 from autogluon.core.features.feature_metadata import FeatureMetadata
 
+try:
+    from .version import __version__
+except ImportError:
+    pass
+
 from .predictor import TabularPredictor
 
 logging.basicConfig(format='%(message)s')  # just print message in logs

--- a/text/src/autogluon/text/__init__.py
+++ b/text/src/autogluon/text/__init__.py
@@ -2,4 +2,7 @@ from . import text_prediction
 from .text_prediction import TextPredictor
 from .text_prediction.presets import ag_text_presets, list_presets
 
-__all__ = ['text_prediction', 'TextPredictor', 'ag_text_presets', 'list_presets']
+try:
+    from .version import __version__
+except ImportError:
+    pass

--- a/text/src/autogluon/text/__init__.py
+++ b/text/src/autogluon/text/__init__.py
@@ -2,7 +2,4 @@ from . import text_prediction
 from .text_prediction import TextPredictor
 from .text_prediction.presets import ag_text_presets, list_presets
 
-try:
-    from .version import __version__
-except ImportError:
-    pass
+from .version import __version__

--- a/vision/src/autogluon/vision/__init__.py
+++ b/vision/src/autogluon/vision/__init__.py
@@ -4,7 +4,4 @@ from .detector import ObjectDetector
 ImageDataset = ImagePredictor.Dataset
 ImageDetectionDataset = ObjectDetector.Dataset
 
-try:
-    from .version import __version__
-except ImportError:
-    pass
+from .version import __version__

--- a/vision/src/autogluon/vision/__init__.py
+++ b/vision/src/autogluon/vision/__init__.py
@@ -3,3 +3,8 @@ from .detector import ObjectDetector
 
 ImageDataset = ImagePredictor.Dataset
 ImageDetectionDataset = ObjectDetector.Dataset
+
+try:
+    from .version import __version__
+except ImportError:
+    pass


### PR DESCRIPTION
*Issue #, if available:*
#1121 

*Description of changes:*

- Now users can access version via `autogluon.{submodule}.__version__`
- Open question: Do we want to refactor `version.py` to be `_version.py` so users don't get confused? Should it be a python file at all? LightGBM uses `VERSION.txt` and loads from file in `__init__.py`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
