### PR TITLE
Tabular: Fixed FastAI NN accuracy on regression datasets

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -61,6 +61,14 @@ class BaggedEnsembleModel(AbstractModel):
             self._set_default_param_value(param, val)
         super()._set_default_params()
 
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
+            drop_unique=False,  # TODO: Get the value from child instead
+        )
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params
+
     def is_valid(self):
         return self.is_fit() and (self._n_repeats == self._n_repeats_finished)
 

--- a/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/greedy_weighted_ensemble_model.py
@@ -22,6 +22,14 @@ class GreedyWeightedEnsembleModel(AbstractModel):
         for param, val in default_params.items():
             self._set_default_param_value(param, val)
 
+    def _get_default_auxiliary_params(self) -> dict:
+        default_auxiliary_params = super()._get_default_auxiliary_params()
+        extra_auxiliary_params = dict(
+            drop_unique=False,
+        )
+        default_auxiliary_params.update(extra_auxiliary_params)
+        return default_auxiliary_params
+
     # TODO: Consider moving convert_pred_probas_df_to_list into inner model to ensure X remains a dataframe after preprocess is called
     def _preprocess_nonadaptive(self, X, **kwargs):
         # TODO: super() call?

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -45,7 +45,7 @@ extras_require = {
     ],
     'fastai': [
         'torch>=1.0,<2.0',
-        'fastai>=2.0,<3.0',
+        'fastai>=2.3.1,<3.0',
     ],
     'skex': [
         'scikit-learn-intelex<2021.3',

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -155,7 +155,7 @@ class CatBoostModel(AbstractModel):
         init_model_tree_count = None
         init_model_best_score = None
 
-        num_features = len(self.features)
+        num_features = len(self._features)
 
         if num_gpus != 0:
             if 'task_type' not in params:

--- a/tabular/src/autogluon/tabular/models/fastainn/fastai_helpers.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/fastai_helpers.py
@@ -4,60 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
-import torch.nn as nn
-from fastai.data.transforms import get_c
-from fastai.layers import Embedding, LinBnDrop, SigmoidRange
-from fastai.learner import Learner
-from fastai.tabular.learner import TabularLearner
-from fastai.tabular.model import get_emb_sz, tabular_config
-from fastai.torch_core import flatten_check, Module
-from fastcore.basics import ifnone
-from fastcore.meta import delegates
-from fastcore.xtras import is_listy
-
-
-class TabularModel(Module):
-    """Basic model for tabular data."""
-
-    def __init__(self, emb_szs, n_cont, out_sz, layers, ps=None, embed_p=0.,
-                 y_range=None, use_bn=True, bn_final=False, bn_cont=True, act_cls=nn.ReLU(inplace=True)):
-        ps = ifnone(ps, [0] * len(layers))
-        if not is_listy(ps): ps = [ps] * len(layers)
-        self.embeds = nn.ModuleList([Embedding(ni, nf) for ni, nf in emb_szs])
-        self.emb_drop = nn.Dropout(embed_p)
-        self.bn_cont = nn.BatchNorm1d(n_cont) if bn_cont else None
-        n_emb = sum(e.embedding_dim for e in self.embeds)
-        self.n_emb, self.n_cont = n_emb, n_cont
-        sizes = [n_emb + n_cont] + layers + [out_sz]
-        actns = [act_cls for _ in range(len(sizes) - 2)] + [None]
-        _layers = [LinBnDrop(sizes[i], sizes[i + 1], bn=use_bn and (i != len(actns) - 1 or bn_final), p=p, act=a, lin_first=True)
-                   for i, (p, a) in enumerate(zip(ps + [0.], actns))]
-        if y_range is not None: _layers.append(SigmoidRange(*y_range))
-        self.layers = nn.Sequential(*_layers)
-
-    def forward(self, x_cat, x_cont=None):
-        if self.n_emb != 0:
-            x = [e(x_cat[:, i]) for i, e in enumerate(self.embeds)]
-            x = torch.cat(x, 1)
-            x = self.emb_drop(x)
-        if self.n_cont != 0:
-            if self.bn_cont is not None: x_cont = self.bn_cont(x_cont)
-            x = torch.cat([x, x_cont], 1) if self.n_emb != 0 else x_cont
-        return self.layers(x)
-
-
-@delegates(Learner.__init__)
-def tabular_learner(dls, layers=None, emb_szs=None, config=None, n_out=None, y_range=None, **kwargs):
-    "Get a `Learner` using `dls`, with `metrics`, including a `TabularModel` created using the remaining params."
-    if config is None: config = tabular_config()
-    if layers is None: layers = [200, 100]
-    to = dls.train_ds
-    emb_szs = get_emb_sz(dls.train_ds, {} if emb_szs is None else emb_szs)
-    if n_out is None: n_out = get_c(dls)
-    assert n_out, "`n_out` is not defined, and could not be inferred from data, set `dls.c` or pass `n_out`"
-    if y_range is None and 'y_range' in config: y_range = config.pop('y_range')
-    model = TabularModel(emb_szs, len(dls.cont_names), n_out, layers, y_range=y_range, **config)
-    return TabularLearner(dls, model, **kwargs)
+from fastai.torch_core import flatten_check
 
 
 def export(model, filename_or_stream='export.pkl', pickle_module=pickle, pickle_protocol=2):

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -4,9 +4,9 @@ import time
 from builtins import classmethod
 from pathlib import Path
 
-import sklearn
 import numpy as np
 import pandas as pd
+import sklearn
 
 from autogluon.core.constants import REGRESSION, BINARY, QUANTILE
 from autogluon.core.features.types import R_OBJECT, R_INT, R_FLOAT, R_DATETIME, R_CATEGORY, R_BOOL, S_TEXT_SPECIAL
@@ -17,6 +17,7 @@ from autogluon.core.utils.files import make_temp_directory
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.multiprocessing_utils import is_fork_enabled
 from autogluon.core.utils.savers import save_pkl
+
 from .hyperparameters.parameters import get_param_baseline
 from .hyperparameters.searchspaces import get_default_searchspace
 
@@ -160,7 +161,7 @@ class NNFastAiTabularModel(AbstractModel):
              **kwargs):
         try_import_fastai()
         from fastai.tabular.model import tabular_config
-        from .fastai_helpers import tabular_learner
+        from fastai.tabular.learner import tabular_learner
         from fastcore.basics import defaults
         from .callbacks import AgSaveModelCallback, EarlyStoppingCallbackWithTimeLimit
         from .quantile_helpers import HuberPinballLoss

--- a/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
+++ b/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
@@ -88,7 +88,6 @@ class FastTextModel(AbstractModel):
             logger.log(15, "sample_weight not yet supported for FastTextModel, this model will ignore them in training.")
 
         X = self.preprocess(X)
-        logger.debug("NLP features %s", self.features)
 
         self._label_dtype = y.dtype
         self._label_map = {label: f"__label__{i}" for i, label in enumerate(y.unique())}
@@ -114,8 +113,9 @@ class FastTextModel(AbstractModel):
     # TODO: text features: alternate text preprocessing steps
     # TODO: categorical features: special encoding:  <feature name>_<feature value>
     def _preprocess(self, X: pd.DataFrame, **kwargs) -> list:
+        X = super()._preprocess(X, **kwargs)
         text_col = (
-            X[self.features]
+            X
             .astype(str)
             .fillna(" ")
             .apply(lambda r: " ".join(v for v in r.values), axis=1)

--- a/tabular/src/autogluon/tabular/models/lr/lr_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_model.py
@@ -69,7 +69,7 @@ class LinearModel(AbstractModel):
             Each value is a list of feature-names corresponding to columns in original dataframe.
             TODO: ensure features with zero variance have already been removed before this function is called.
         """
-        feature_types = self.feature_metadata.get_type_group_map_raw()
+        feature_types = self._feature_metadata.get_type_group_map_raw()
 
         categorical_featnames = feature_types[R_CATEGORY] + feature_types[R_OBJECT] + feature_types['bool']
         continuous_featnames = feature_types[R_FLOAT] + feature_types[R_INT]  # + self.__get_feature_type_if_present('datetime')
@@ -78,7 +78,7 @@ class LinearModel(AbstractModel):
         if len(categorical_featnames) + len(continuous_featnames) + len(language_featnames) != df.shape[1]:
             unknown_features = [feature for feature in df.columns if feature not in valid_features]
             df = df.drop(columns=unknown_features)
-        self.features = list(df.columns)
+        self._features = list(df.columns)
 
         types_of_features = {'continuous': [], 'skewed': [], 'onehot': [], 'language': []}
         return self._select_features(df, types_of_features, categorical_featnames, language_featnames, continuous_featnames)
@@ -182,7 +182,7 @@ class LinearModel(AbstractModel):
         # skewed = features to which we will apply power (ie. log / box-cox) transform before normalization
         # onehot = features to one-hot encode (unknown categories for these features encountered at test-time are encoded as all zeros). We one-hot encode any features encountered that only have two unique values.
         one_hot_threshold = 10000  # FIXME research memory constraints
-        for feature in self.features:
+        for feature in self._features:
             feature_data = df[feature]
             num_unique_vals = len(feature_data.unique())
             if feature in language_featnames:
@@ -197,7 +197,7 @@ class LinearModel(AbstractModel):
         return types_of_features
 
     def _select_features_handle_text_only(self, df, types_of_features, categorical_featnames, language_featnames, continuous_featnames):
-        for feature in self.features:
+        for feature in self._features:
             if feature in language_featnames:
                 types_of_features['language'].append(feature)
         return types_of_features
@@ -207,7 +207,7 @@ class LinearModel(AbstractModel):
         # skewed = features to which we will apply power (ie. log / box-cox) transform before normalization
         # onehot = features to one-hot encode (unknown categories for these features encountered at test-time are encoded as all zeros). We one-hot encode any features encountered that only have two unique values.
         one_hot_threshold = 10000  # FIXME research memory constraints
-        for feature in self.features:
+        for feature in self._features:
             feature_data = df[feature]
             num_unique_vals = len(feature_data.unique())
             if feature in continuous_featnames:

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -282,11 +282,11 @@ class RFModel(AbstractModel):
         return skip_hpo(self, **kwargs)
 
     def get_model_feature_importance(self):
-        if self.features is None:
+        if self._features is None:
             # TODO: Consider making this raise an exception
-            logger.warning('Warning: get_model_feature_importance called when self.features is None!')
+            logger.warning('Warning: get_model_feature_importance called when self._features is None!')
             return dict()
-        return dict(zip(self.features, self.model.feature_importances_))
+        return dict(zip(self._features, self.model.feature_importances_))
 
     def _get_default_auxiliary_params(self) -> dict:
         default_auxiliary_params = super()._get_default_auxiliary_params()

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_model.py
@@ -77,7 +77,7 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         """
         self.feature_arraycol_map = None
         self.feature_type_map = None
-        self.features_to_drop = []  # may change between different bagging folds. TODO: consider just removing these from self.features if it works with bagging
+        self.features_to_drop = []  # may change between different bagging folds. TODO: consider just removing these from self._features
         self.processor = None  # data processor
         self.summary_writer = None
         self.ctx = None
@@ -173,8 +173,6 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
 
         params = self._get_model_params()
         params = fixedvals_from_searchspaces(params)
-        if self.feature_metadata is None:
-            raise ValueError("Trainer class must set feature_metadata for this model")
         if num_cpus is not None:
             self.num_dataloading_workers = max(1, int(num_cpus/2.0))
         else:
@@ -472,8 +470,6 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
             train_dataset = X
         else:
             X = self.preprocess(X)
-            if self.features is None:
-                self.features = list(X.columns)
             train_dataset = self.process_train_data(
                 df=X, labels=y, batch_size=self.batch_size, num_dataloading_workers=self.num_dataloading_workers,
                 impute_strategy=impute_strategy, max_category_levels=max_category_levels, skew_threshold=skew_threshold, embed_min_categories=embed_min_categories, use_ngram_features=use_ngram_features,
@@ -527,8 +523,6 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         """
         from .tabular_nn_dataset import TabularNNDataset
         warnings.filterwarnings("ignore", module='sklearn.preprocessing')  # sklearn processing n_quantiles warning
-        if set(df.columns) != set(self.features):
-            raise ValueError("Column names in provided Dataframe do not match self.features")
         if labels is None:
             raise ValueError("Attempting process training data without labels")
         if len(labels) != len(df):
@@ -707,8 +701,6 @@ class TabularNeuralNetModel(AbstractNeuralNetworkModel):
         self.verbosity = kwargs.get('verbosity', 2)
         logger.log(15, "Beginning hyperparameter tuning for Neural Network...")
         self._set_default_searchspace()  # changes non-specified default hyperparams from fixed values to search-spaces.
-        if self.feature_metadata is None:
-            raise ValueError("Trainer class must set feature_metadata for this model")
         scheduler_cls, scheduler_params = scheduler_options  # Unpack tuple
         if scheduler_cls is None or scheduler_params is None:
             raise ValueError("scheduler_cls and scheduler_params cannot be None for hyperparameter tuning")

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_quantile.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_quantile.py
@@ -65,8 +65,6 @@ class TabularNeuralQuantileModel(TabularNeuralNetModel):
                            " this model will ignore them in training.")
         params = self.params.copy()
         params = fixedvals_from_searchspaces(params)
-        if self.feature_metadata is None:
-            raise ValueError("Trainer class must set feature_metadata for this model")
         if num_cpus is not None:
             self.num_dataloading_workers = max(1, int(num_cpus/2.0))
         else:
@@ -325,8 +323,6 @@ class TabularNeuralQuantileModel(TabularNeuralNetModel):
             train_dataset = X
         else:
             X = self.preprocess(X)
-            if self.features is None:
-                self.features = list(X.columns)
             train_dataset = self.process_train_data(df=X, labels=y,
                                                     impute_strategy=impute_strategy,
                                                     max_category_levels=max_category_levels,
@@ -375,8 +371,6 @@ class TabularNeuralQuantileModel(TabularNeuralNetModel):
 
         # sklearn processing n_quantiles warning
         warnings.filterwarnings("ignore", module='sklearn.preprocessing')
-        if set(df.columns) != set(self.features):
-            raise ValueError("Column names in provided Dataframe do not match self.features")
         if labels is None:
             raise ValueError("Attempting process training data without labels")
         if len(labels) != len(df):
@@ -470,8 +464,6 @@ class TabularNeuralQuantileModel(TabularNeuralNetModel):
 
         # changes non-specified default hyperparams from fixed values to search-spaces.
         self._set_default_searchspace()
-        if self.feature_metadata is None:
-            raise ValueError("Trainer class must set feature_metadata for this model")
         scheduler_cls, scheduler_params = scheduler_options  # Unpack tuple
         if scheduler_cls is None or scheduler_params is None:
             raise ValueError("scheduler_cls and scheduler_params cannot be None for hyperparameter tuning")


### PR DESCRIPTION
*Issue #, if available:*
#1158 

*Description of changes:*

- Fixed FastAI accuracy on regression problems by adding StandardScaler to target variable and dropping features that contain only one unique value in model `_preprocess` logic. Features with only one unique value in all training rows destroy the FastAI NN.

TODO:

- [x] Benchmark

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
