### PR TITLE
Vision: Fix major bug when tuning_data is not specified

### DIFF
--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -311,12 +311,14 @@ class ImagePredictor(object):
             tuning_data = tuning_data.reset_index(drop=True)
 
         train_data = self._validate_data(train_data)
-        train_data = self.Dataset(train_data, classes=train_data.classes)
+        if isinstance(train_data, self.Dataset):
+            train_data = self.Dataset(train_data, classes=train_data.classes)
         if tuning_data is not None:
             tuning_data = self._validate_data(tuning_data)
             # converting to internal label set
             _set_valid_labels(tuning_data, self._label_cleaner.transform(_get_valid_labels(tuning_data)))
-            tuning_data = self.Dataset(tuning_data, classes=tuning_data.classes)
+            if isinstance(tuning_data, self.Dataset):
+                tuning_data = self.Dataset(tuning_data, classes=tuning_data.classes)
 
         if self._classifier is not None:
             logging.getLogger("ImageClassificationEstimator").propagate = True

--- a/vision/tests/unittests/test_image_classification.py
+++ b/vision/tests/unittests/test_image_classification.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 import copy
 
+
 def test_task():
     dataset, _, test_dataset = Task.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
     model_list = Task.list_models()
@@ -33,6 +34,7 @@ def test_task():
     single_test2_numpy = classifier2.predict(test_dataset.iloc[0]['image'], as_pandas=False)
     assert np.array_equal(single_test2.to_numpy(), single_test2_numpy)
 
+
 def test_task_label_remap():
     ImagePredictor = Task
     train_dataset, _, test_dataset = ImagePredictor.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
@@ -53,6 +55,7 @@ def test_task_label_remap():
     score_accuracy = accuracy(y_true=test_dataset['label'], y_pred=pred)
     score_log_loss = log_loss(y_true=test_dataset['label'].replace(label_remap_inverse), y_pred=pred_proba.to_numpy())
     assert score_accuracy > 0.2  # relax
+
 
 def test_invalid_image_dataset():
     ImagePredictor = Task


### PR DESCRIPTION
*Issue #, if available:*
#1147 

*Description of changes:*

- Fixed bug causing train_data and tuning_data to both use all the training data if tuning_data is not specified in ImagePredictor.
- Improved usage of data splitting. Now it is deterministic and splits the exact specified proportion of data (rather than applying that proportion as a probability independently to each sample of being included in train vs val).
- Data splitting now performs stratification if applicable.

NOTE:
- A **major** bug still exists in `ImageDataset.to_mxnet()` that causes severe issues downstream by ignoring upstream data splits. This PR does not fix this bug, but rather avoids it for the specific instance of `ImagePredictor.fit()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
