### PR TITLE
[Bugfix][CV] - fixing  'ObjectDetector' object has no attribute '_classifier'

### DIFF
--- a/core/src/autogluon/core/scheduler/seq_scheduler.py
+++ b/core/src/autogluon/core/scheduler/seq_scheduler.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import os
 from collections import OrderedDict
 from copy import deepcopy
 from typing import Tuple
@@ -291,6 +292,9 @@ class LocalSequentialScheduler(object):
             plt.legend(loc='best')
         if filename:
             logger.info(f'Saving Training Curve in {filename}')
+            file_dir = os.path.split(os.path.abspath(filename))[0]
+            if not os.path.exists(file_dir):
+                os.makedirs(file_dir)
             plt.savefig(filename)
         if plot:
             plt.show()


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Fixing

```
~/anaconda3/envs/mxnet_latest_p37/lib/python3.7/site-packages/autogluon/vision/detector/detector.py in fit(self, train_data, tuning_data, time_limit, presets, hyperparameters, **kwargs)
    241             self._detector._logger.propagate = True
    242             self._fit_summary = self._detector.fit(train_data, tuning_data, 1 - holdout_frac, random_state, resume=False)
--> 243             if hasattr(self._classifier, 'fit_history'):
    244                 self._fit_summary['fit_history'] = self._classifier.fit_history()
    245             return self
AttributeError: 'ObjectDetector' object has no attribute '_classifier'
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
