### PR TITLE
Improved loop processing speed

### DIFF
--- a/examples/text_prediction/prepare_glue.py
+++ b/examples/text_prediction/prepare_glue.py
@@ -437,7 +437,7 @@ def read_record(dir_path):
         df = read_jsonl_superglue(jsonl_path)
         df_dict[fold] = df
         out = []
-        for i, row in df.iterrows():
+        for row in df.to_dict(orient="records"):
             source = row['source']
             passage = row['passage']
             text = passage['text']

--- a/examples/text_prediction/prepare_glue.py
+++ b/examples/text_prediction/prepare_glue.py
@@ -351,7 +351,7 @@ def read_wic(dir_path):
         jsonl_path = os.path.join(dir_path, '{}.jsonl'.format(fold))
         df = read_jsonl_superglue(jsonl_path)
         out = []
-        for idx, row in df.iterrows():
+        for row in df.to_dict(orient="records"):
             sentence1 = row['sentence1']
             sentence2 = row['sentence2']
             start1 = row['start1']


### PR DESCRIPTION
I improved the speed by replacing the following process with another method.

```py
df.iterrows()
```

- Unnecessary variables(`i`, `idx`) are being deleted.
- Using a dictionary seems to have little impact on code comprehension.


ps:

There is a similar code below, but this has been excluded from this fix.

https://github.com/awslabs/autogluon/blob/c377908da22ff8794b68247f623cc678953eab48/core/src/autogluon/core/utils/utils.py#L147

The reason is as follows.
- `index` is used in this part and cannot be applied as it is
- This is because the cognitive load may increase even if `zip` is used.



For reference, there is a library called [df4loop](https://github.com/daikikatsuragawa/df4loop)
 that supports such problems, so please consider it if you like. (I think "don't use" is also a good decision, so ignore it if it's not particularly attractive.)
