### PR TITLE
[Vision] fix duplicate class mapping

### DIFF
--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -308,17 +308,19 @@ class ImagePredictor(object):
         train_labels_cleaned = self._label_cleaner.transform(train_labels)
         # converting to internal label set
         _set_valid_labels(train_data, train_labels_cleaned)
+        tuning_data_validated = False
         if tuning_data is None:
             train_data, tuning_data, _, _ = generate_train_test_split(X=train_data, y=train_data[self._label_inner], problem_type=self._problem_type, test_size=holdout_frac)
             logger.info('Randomly split train_data into train[%d]/validation[%d] splits.',
                               len(train_data), len(tuning_data))
             train_data = train_data.reset_index(drop=True)
             tuning_data = tuning_data.reset_index(drop=True)
+            tuning_data_validated = True
 
         train_data = self._validate_data(train_data)
         if isinstance(train_data, self.Dataset):
             train_data = self.Dataset(train_data, classes=train_data.classes)
-        if tuning_data is not None:
+        if tuning_data is not None and not tuning_data_validated:
             tuning_data = self._validate_data(tuning_data)
             # converting to internal label set
             _set_valid_labels(tuning_data, self._label_cleaner.transform(_get_valid_labels(tuning_data)))
@@ -559,7 +561,7 @@ class ImagePredictor(object):
         """
         if self._problem_type in [REGRESSION]:
             return self.predict_proba(data, as_pandas)
-        
+
         if self._classifier is None:
             raise RuntimeError('Classifier is not initialized, try `fit` first.')
         assert self._label_cleaner is not None

--- a/vision/tests/unittests/test_image_classification.py
+++ b/vision/tests/unittests/test_image_classification.py
@@ -11,6 +11,7 @@ def test_task():
     model_list = Task.list_models()
     classifier = Task()
     classifier.fit(dataset, num_trials=2, hyperparameters={'epochs': 1, 'early_stop_patience': 3})
+    assert classifier.fit_summary()['valid_acc'] > 0.1, 'valid_acc is abnormal'
     test_result = classifier.predict(test_dataset)
     single_test = classifier.predict(test_dataset.iloc[0]['image'])
     single_proba = classifier.predict_proba(test_dataset.iloc[0]['image'])


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/autogluon/pull/1168

*Description of changes:*

Fix a bug when `tuning_data` is not specified, the validation acc will always be 0. This doesn't affect the trained model, nor the final test accuracy, but the searching metric will be messed since the searcher will always get 0 as feedback.

This is caused by applying validation to the (already) validated `tuning_data` split from `train_data`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
