### PR TITLE
Vision: Fix searcher presets and GPU memory check

### DIFF
--- a/docs/tutorials/image_prediction/beginner.md
+++ b/docs/tutorials/image_prediction/beginner.md
@@ -5,7 +5,7 @@ In this quick start, we'll use the task of image classification to illustrate ho
 
 ```{.python .input}
 import autogluon.core as ag
-from autogluon.vision import ImagePredictor
+from autogluon.vision import ImagePredictor, ImageDataset
 ```
 
 ## Create Image Dataset
@@ -17,7 +17,7 @@ Our subset of the data contains the following possible labels: `BabyPants`, `Bab
 We can load a dataset by downloading a url data automatically:
 
 ```{.python .input}
-train_dataset, _, test_dataset = ImagePredictor.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+train_dataset, _, test_dataset = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
 print(train_dataset)
 ```
 

--- a/docs/tutorials/image_prediction/dataset.md
+++ b/docs/tutorials/image_prediction/dataset.md
@@ -1,23 +1,23 @@
-# Image Prediction - Properly load any image dataset as ImagePredictor Dataset
+# Image Prediction - Properly load any image dataset as ImageDataset
 :label:`sec_imgdataset`
 
 Preparing the dataset for ImagePredictor is not difficult at all, however, we'd like to introduce the
-recommended ways to initialize the dataset so you will have smoother experience using `autogluon.vision.ImagePredictor`.
+recommended ways to initialize the dataset, so you will have smoother experience using `autogluon.vision.ImagePredictor`.
 
 There are generally three ways to load a dataset for ImagePredictor:
 
 - Load a csv file or construct your own pandas `DataFrame` with `image` and `label` columns
 
-- Load a image folder directly with `ImagePredictor.Dataset`
+- Load a image folder directly with `ImageDataset`
 
-- Convert a list of images to dataset directly with `ImagePredictor.Dataset`
+- Convert a list of images to dataset directly with `ImageDataset`
 
 We will go through these four methods one by one. First of all, let's import autogluon
 
 ```{.python .input}
 %matplotlib inline
 import autogluon.core as ag
-from autogluon.vision import ImagePredictor
+from autogluon.vision import ImageDataset
 import pandas as pd
 ```
 
@@ -35,7 +35,7 @@ df.head()
 If the image paths are not relative to current working directory, you may use the helper function to prepend prefix for each image, using absolute paths can reduce the chance of OSError happening to file access:
 
 ```{.python .input}
-df = ImagePredictor.Dataset.from_csv(csv_file, root='/home/ubuntu')
+df = ImageDataset.from_csv(csv_file, root='/home/ubuntu')
 df.head()
 ```
 
@@ -51,7 +51,7 @@ Otherwise you may use the `DataFrame` as-is, `ImagePredictor` will apply auto co
 
 ## Load an image directory
 
-It's pretty common that sometimes you only have a folder of images, organized by the category names. Recursively loop through images is tedious. You can use `ImagePredictor.Dataset.from_folders` or `ImagePredictor.Dataset.from_folder` to avoid implementing recursive search.
+It's pretty common that sometimes you only have a folder of images, organized by the category names. Recursively loop through images is tedious. You can use `ImageDataset.from_folders` or `ImageDataset.from_folder` to avoid implementing recursive search.
 
 The difference between `from_folders` and `from_folder` is the targeting folder structure.
 If you have a folder with splits, e.g., `train`, `test`, like:
@@ -64,7 +64,7 @@ If you have a folder with splits, e.g., `train`, `test`, like:
 Then you can load the splits with `from_folders`:
 
 ```{.python .input}
-train_data, _, test_data = ImagePredictor.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip', train='train', test='test')
+train_data, _, test_data = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip', train='train', test='test')
 print('train #', len(train_data), 'test #', len(test_data))
 train_data.head()
 ```
@@ -81,7 +81,7 @@ Then you can load the splits with `from_folder`:
 ```{.python .input}
 # use the train from shopee-iet as new root
 root = os.path.join(os.path.dirname(train_data.iloc[0]['image']), '..')
-all_data = ImagePredictor.Dataset.from_folder(root)
+all_data = ImageDataset.from_folder(root)
 all_data.head()
 ```
 
@@ -101,7 +101,7 @@ pets = ag.utils.unzip(pets)
 image_list = [x for x in os.listdir(os.path.join(pets, 'images')) if x.endswith('jpg')]
 def label_fn(x):
     return 'cat' if os.path.basename(x)[0].isupper() else 'dog'
-new_data = ImagePredictor.Dataset.from_name_func(image_list, label_fn, root=os.path.join(os.getcwd(), pets, 'images'))
+new_data = ImageDataset.from_name_func(image_list, label_fn, root=os.path.join(os.getcwd(), pets, 'images'))
 new_data
 ```
 

--- a/docs/tutorials/image_prediction/hpo.md
+++ b/docs/tutorials/image_prediction/hpo.md
@@ -16,7 +16,7 @@ Since our task is to classify images, we will use AutoGluon to produce an [Image
 
 ```{.python .input}
 import autogluon.core as ag
-from autogluon.vision import ImagePredictor
+from autogluon.vision import ImagePredictor, ImageDataset
 ```
 
 ## Create AutoGluon Dataset
@@ -25,7 +25,7 @@ Let's first create the dataset using the same subset of the `Shopee-IET` dataset
 Recall that there's no validation split in original data, a 90/10 train/validation split is automatically performed when `fit` with `train_data`.
 
 ```{.python .input}
-train_data, _, test_data = ImagePredictor.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+train_data, _, test_data = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
 ```
 
 ## Specify which Networks to Try

--- a/docs/tutorials/image_prediction/kaggle.md
+++ b/docs/tutorials/image_prediction/kaggle.md
@@ -91,8 +91,8 @@ each neural network requires the user to specify many hyperparameters (e.g., lea
 AutoGluon automatically does Training/Validation split:
 
 ```
-from autogluon.vision import ImagePredictor
-dataset = ImagePredictor.Dataset.from_folder('./data/shopeeiet/train')
+from autogluon.vision import ImagePredictor, ImageDataset
+dataset = ImageDataset.from_folder('./data/shopeeiet/train')
 ```
 
 AutoGluon automatically infers how many classes there are based on the directory structure.
@@ -129,7 +129,7 @@ We can ask our final model to generate predictions on the provided test images.
 We first load the test data as a `Dataset` object and then call `predict`:
 
 ```
-test_dataset = ImagePredictor.Dataset.from_folder('./data/shopeeiet/test')
+test_dataset = ImageDataset.from_folder('./data/shopeeiet/test')
 pred = predictor.predict(test_dataset)
 print(pred)
 ```

--- a/vision/src/autogluon/vision/configs/presets_configs.py
+++ b/vision/src/autogluon/vision/configs/presets_configs.py
@@ -2,7 +2,7 @@
 import functools
 import warnings
 from autogluon.core.utils import get_gpu_free_memory, get_gpu_count
-from autogluon.core import Categorical, Real
+from autogluon.core import Categorical, Int, Real
 
 
 def unpack(preset_name):
@@ -31,7 +31,7 @@ preset_image_predictor = dict(
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 1024,
-            'search_strategy': 'bayesopt',
+            'searcher': 'random',
         },
         'time_limit': 12*3600,
     },
@@ -48,7 +48,7 @@ preset_image_predictor = dict(
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 512,
-            'search_strategy': 'bayesopt',
+            'searcher': 'random',
         },
         'time_limit': 8*3600,
     },
@@ -78,7 +78,7 @@ preset_image_predictor = dict(
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 32,
-            'search_strategy': 'bayesopt',
+            'searcher': 'random',
         },
         'time_limit': 2*3600,
     },
@@ -98,7 +98,7 @@ preset_object_detector = dict(
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 128,
-            'search_strategy': 'bayesopt',
+            'searcher': 'random',
         },
         'time_limit': 24*3600,
     },
@@ -117,7 +117,7 @@ preset_object_detector = dict(
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 512,
-            'search_strategy': 'bayesopt',
+            'searcher': 'random',
         },
         'time_limit': 12*3600,
     },
@@ -134,7 +134,7 @@ preset_object_detector = dict(
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 16,
-            'search_strategy': 'random',
+            'searcher': 'random',
         },
         'time_limit': 2*3600,
     },
@@ -151,7 +151,7 @@ preset_object_detector = dict(
             },
         'hyperparameter_tune_kwargs': {
             'num_trials': 32,
-            'search_strategy': 'bayesopt',
+            'searcher': 'random',
         },
         'time_limit': 4*3600,
     },
@@ -192,6 +192,7 @@ def set_presets(preset_name, *args, **kwargs):
                 preset_kwargs[key].update(kwargs[key])
                 kwargs[key] = preset_kwargs[key]
     return args, kwargs
+
 
 def _check_gpu_memory_presets(bs, ngpus_per_trial, min_batch_size=8, threshold=128):
     """Check and report warnings based on free gpu memory.

--- a/vision/tests/unittests/test_image_classification.py
+++ b/vision/tests/unittests/test_image_classification.py
@@ -1,4 +1,4 @@
-from autogluon.vision import ImagePredictor as Task
+from autogluon.vision import ImagePredictor, ImageDataset
 import autogluon.core as ag
 import os
 import pandas as pd
@@ -7,16 +7,16 @@ import copy
 
 
 def test_task():
-    dataset, _, test_dataset = Task.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
-    model_list = Task.list_models()
-    classifier = Task()
+    dataset, _, test_dataset = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+    model_list = ImagePredictor.list_models()
+    classifier = ImagePredictor()
     classifier.fit(dataset, num_trials=2, hyperparameters={'epochs': 1, 'early_stop_patience': 3})
     assert classifier.fit_summary()['valid_acc'] > 0.1, 'valid_acc is abnormal'
     test_result = classifier.predict(test_dataset)
     single_test = classifier.predict(test_dataset.iloc[0]['image'])
     single_proba = classifier.predict_proba(test_dataset.iloc[0]['image'])
     classifier.save('classifier.ag')
-    classifier2 = Task.load('classifier.ag')
+    classifier2 = ImagePredictor.load('classifier.ag')
     fit_summary = classifier2.fit_summary()
     test_acc = classifier2.evaluate(test_dataset)
     # raw dataframe
@@ -37,8 +37,7 @@ def test_task():
 
 
 def test_task_label_remap():
-    ImagePredictor = Task
-    train_dataset, _, test_dataset = ImagePredictor.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+    train_dataset, _, test_dataset = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
     label_remap = {0: 'd', 1: 'c', 2: 'b', 3: 'a'}
     train_dataset = train_dataset.replace({"label": label_remap})
     test_dataset = test_dataset.replace({"label": label_remap})
@@ -59,17 +58,15 @@ def test_task_label_remap():
 
 
 def test_invalid_image_dataset():
-    ImagePredictor = Task
     invalid_test = ag.download('https://autogluon.s3-us-west-2.amazonaws.com/miscs/test_autogluon_invalid_dataset.zip')
     invalid_test = ag.unzip(invalid_test)
-    df = ImagePredictor.Dataset.from_csv(os.path.join(invalid_test, 'train.csv'), root=os.path.join(invalid_test, 'train_images'))
+    df = ImageDataset.from_csv(os.path.join(invalid_test, 'train.csv'), root=os.path.join(invalid_test, 'train_images'))
     predictor = ImagePredictor(label="labels")
     predictor.fit(df, df.copy(), time_limit=60)
 
 
 def test_image_predictor_presets():
-    ImagePredictor = Task
-    train_dataset, _, test_dataset = ImagePredictor.Dataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+    train_dataset, _, test_dataset = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
     for preset in ['medium_quality_faster_train', 'medium_quality_faster_inference']:
         predictor = ImagePredictor()
         predictor.fit(train_dataset,tuning_data=test_dataset, presets=[preset], time_limit=60, hyperparameters={'epochs':1})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Presets specified `search_strategy` which is not a valid key, therefore searcher was always `random`.
- This PR removes the incorrect keys, replacing with `searcher`. `searcher` cannot be `bayesopt` due to a bug causing the run to crash.
- Fixed missing `Int` import causing GPU memory check to fail.
- Standardized usage of `ImageDataset` to align with `TabularDataset`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
