### PR TITLE
Features: Optimized type inference speed by 100x+ for datetime and text

### DIFF
--- a/core/src/autogluon/core/features/infer_types.py
+++ b/core/src/autogluon/core/features/infer_types.py
@@ -99,10 +99,13 @@ def check_if_datetime_as_object_feature(X: Series) -> bool:
         # TODO: pd.Series(['20170204','20170205','20170206']) is incorrectly not detected as datetime_as_object
         #  But we don't want pd.Series(['184','822828','20170206']) to be detected as datetime_as_object
         #  Need some smart logic (check min/max values?, check last 2 values don't go >31?)
-        X.apply(pd.to_numeric)
+        pd.to_numeric(X)
     except:
         try:
-            result = X.apply(pd.to_datetime, errors='coerce')
+            if len(X) > 500:
+                # Sample to speed-up type inference
+                X = X.sample(n=500, random_state=0)
+            result = pd.to_datetime(X, errors='coerce')
             if result.isnull().mean() > 0.8:  # If over 80% of the rows are NaN
                 return False
             return True
@@ -116,6 +119,9 @@ def check_if_nlp_feature(X: Series) -> bool:
     type_family = get_type_family_raw(X.dtype)
     if type_family != 'object':
         return False
+    if len(X) > 5000:
+        # Sample to speed-up type inference
+        X = X.sample(n=5000, random_state=0)
     X_unique = X.unique()
     num_unique = len(X_unique)
     num_rows = len(X)

--- a/features/src/autogluon/features/generators/astype.py
+++ b/features/src/autogluon/features/generators/astype.py
@@ -47,6 +47,8 @@ class AsTypeFeatureGenerator(AbstractFeatureGenerator):
 
             if self._type_map_real_opt:
                 # TODO: Confirm this works with sparse and other feature types!
+                # FIXME: Address situation where test-time invalid type values cause crash:
+                #  https://stackoverflow.com/questions/49256211/how-to-set-unexpected-data-type-to-na?noredirect=1&lq=1
                 X = X.astype(self._type_map_real_opt)
         return X
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Speedup type inference of datetime features by 100x+ via sampling and optimized function calls (adult goes from 18.2s -> 0.1s in preprocessing fit time). The 18.2s time was caused by a performance degradation after enabling `errors='coerce'` in #1182. This PR makes up the performance gap and improves on the speed pre-degradation.
- Speedup type inference of text features via sampling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
