### PR TITLE
Create a method that repeatedly fits base learners on different feature subsets for tabular data

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -644,6 +644,7 @@ class TabularPredictor:
         ag_args_fit = kwargs['ag_args_fit']
         ag_args_ensemble = kwargs['ag_args_ensemble']
         excluded_model_types = kwargs['excluded_model_types']
+        fit_with_prune = kwargs['fit_with_prune']
 
         if ag_args is None:
             ag_args = {}
@@ -702,6 +703,7 @@ class TabularPredictor:
             'ag_args_ensemble': ag_args_ensemble,
             'ag_args_fit': ag_args_fit,
             'excluded_model_types': excluded_model_types,
+            'fit_with_prune': fit_with_prune
         }
         self._learner.fit(X=train_data, X_val=tuning_data, X_unlabeled=unlabeled_data,
                           holdout_frac=holdout_frac, num_bag_folds=num_bag_folds, num_bag_sets=num_bag_sets, num_stack_levels=num_stack_levels,
@@ -2205,7 +2207,8 @@ class TabularPredictor:
             # other
             feature_generator='auto',
             unlabeled_data=None,
-            _feature_generator_kwargs=None
+            _feature_generator_kwargs=None,
+            fit_with_prune=False
         )
 
         kwargs = self._validate_fit_extra_kwargs(kwargs, extra_valid_keys=list(fit_kwargs_default.keys()))

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -896,6 +896,9 @@ class AbstractTrainer:
         """
         if isinstance(model, BaggedEnsembleModel):
             model.fit(X=X, y=y, **model_fit_kwargs)
+        elif 'fit_with_prune' in model_fit_kwargs and model_fit_kwargs['fit_with_prune']:
+            # only available for non-ensemble models
+            model.fit_with_prune(X=X, y=y, X_val=X_val, y_val=y_val, **model_fit_kwargs)
         else:
             model.fit(X=X, y=y, X_val=X_val, y_val=y_val, **model_fit_kwargs)
         return model
@@ -1063,8 +1066,10 @@ class AbstractTrainer:
             n_repeats = self.n_repeats
         model_fit_kwargs = dict(
             time_limit=time_limit,
+            fit_with_prune=kwargs['fit_with_prune'] if 'fit_with_prune' in kwargs else False,
             verbosity=self.verbosity,
         )
+
         if self.sample_weight is not None:
             X, w_train = extract_column(X, self.sample_weight)
             if w_train is not None:  # may be None for ensemble
@@ -1074,7 +1079,7 @@ class AbstractTrainer:
                 X_val, w_val = extract_column(X_val, self.sample_weight)
                 if self.weight_evaluation and w_val is not None:  # ignore validation sample weights unless weight_evaluation specified
                     model_fit_kwargs['sample_weight_val'] = w_val.values/w_val.mean()
-            ens_sample_weight =  kwargs.get('ens_sample_weight', None)
+            ens_sample_weight = kwargs.get('ens_sample_weight', None)
             if ens_sample_weight is not None:
                 model_fit_kwargs['sample_weight'] = ens_sample_weight  # sample weights to use for weighted ensemble only
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Created `fit_with_prune` method for AbstractModel that repeatedly alternates between model fitting and feature selection using permutation feature importance score until the validation score performance drops. This functionality can be tentatively accessed by providing a boolean flag `fit_with_prune` to TabularPredictor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
