### PR TITLE
Tabular: Added experimental refit_folds option to BaggedEnsembleModel

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -515,7 +515,11 @@ class AbstractModel:
         kwargs = self._preprocess_fit_args(**kwargs)
         if 'time_limit' not in kwargs or kwargs['time_limit'] is None or kwargs['time_limit'] > 0:
             self._register_fit_metadata(**kwargs)
-            self._fit(**kwargs)
+            out = self._fit(**kwargs)
+            if out is None:
+                return self
+            else:
+                return out
         else:
             logger.warning(f'\tWarning: Model has no time left to train, skipping model... (Time Left = {round(kwargs["time_limit"], 1)}s)')
             raise TimeLimitExceeded

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -38,7 +38,7 @@ class SequentialLocalFoldFittingStrategy(AbstractFoldFittingStrategy):
     """
 
     def __init__(self, bagged_ensemble_model, X: DataFrame, y: Series, sample_weight, time_limit: float, time_start: float,
-                 models: list, oof_pred_proba: ndarray, oof_pred_model_repeats: ndarray):
+                 models: list, oof_pred_proba: ndarray, oof_pred_model_repeats: ndarray, save_folds: bool):
         self.X = X
         self.y = y
         self.sample_weight = sample_weight
@@ -49,6 +49,7 @@ class SequentialLocalFoldFittingStrategy(AbstractFoldFittingStrategy):
         self.oof_pred_model_repeats = oof_pred_model_repeats
         self.bagged_ensemble_model = bagged_ensemble_model
         self.jobs = []
+        self.save_folds = save_folds
 
     def schedule_fold_model_fit(self, model_base, fold_ctx, kwargs):
         self.jobs.append([model_base, fold_ctx, kwargs])
@@ -85,6 +86,8 @@ class SequentialLocalFoldFittingStrategy(AbstractFoldFittingStrategy):
     def _update_bagged_ensemble(self, fold_model, pred_proba, fold_ctx):
         _, val_index = fold_ctx['fold']
         model_to_append = fold_model
+        if not self.save_folds:
+            fold_model.model = None
         if self.bagged_ensemble_model.low_memory:
             self.bagged_ensemble_model.save_child(fold_model, verbose=False)
             model_to_append = fold_model.name

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -148,7 +148,7 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         X = self.preprocess(X=X, preprocess_nonadaptive=False, fit=True, compute_base_preds=compute_base_preds)
         if time_limit is not None:
             time_limit = time_limit - (time.time() - start_time)
-        super()._fit(X=X, y=y, time_limit=time_limit, **kwargs)
+        return super()._fit(X=X, y=y, time_limit=time_limit, **kwargs)
 
     def set_contexts(self, path_context):
         path_root_orig = self.path_root

--- a/core/src/autogluon/core/models/ensemble/weighted_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/weighted_ensemble_model.py
@@ -36,6 +36,7 @@ class WeightedEnsembleModel(StackerEnsembleModel):
         min_stack_column_prefix_to_model_map = {k: v for k, v in self.stack_column_prefix_to_model_map.items() if k in self.stack_column_prefix_lst}
         self.base_model_names = [base_model_name for base_model_name in self.base_model_names if base_model_name in min_stack_column_prefix_to_model_map.values()]
         self.stack_column_prefix_to_model_map = min_stack_column_prefix_to_model_map
+        return self
 
     def _get_model_weights(self):
         weights_dict = defaultdict(int)

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -929,7 +929,7 @@ class AbstractTrainer:
         Trains model but does not add the trained model to this Trainer.
         Returns trained model object.
         """
-        model.fit(X=X, y=y, X_val=X_val, y_val=y_val, **model_fit_kwargs)
+        model = model.fit(X=X, y=y, X_val=X_val, y_val=y_val, **model_fit_kwargs)
         return model
 
     def _train_and_save(self, X, y, model: AbstractModel, X_val=None, y_val=None, stack_name='core', level=1, **model_fit_kwargs) -> List[str]:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added experimental refit_folds option to BaggedEnsembleModel. This enables performing refit_full automatically in a single .fit call. This can be used as a more expensive (in training time) alternative to efficient OOB / LOO bagging that produces less information leakage in OOF predictions.
- Fixed bug in BaggedEnsembleModel that did not respect `save_bag_folds=False` (10x disk-space reduction after fix for situations where refit was going to be called later, such as high_quality and good_quality presets).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
