### PR TITLE
Tabular: Added user-specified groups parameter, fixed HPO for RF and KNN

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -777,6 +777,7 @@ class BaggedEnsembleModel(AbstractModel):
             y_val_fold = None
             train_index = list(range(len(X)))
             test_index = train_index
+            cv_splitter = None
         else:
             cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=1, groups=groups)
             if k_fold != cv_splitter.n_splits:
@@ -838,6 +839,8 @@ class BaggedEnsembleModel(AbstractModel):
                 bag.models.append(child)
             bag.val_score = child.val_score
             bag._add_child_times_to_bag(model=child)
+            if cv_splitter is not None:
+                bag._cv_splitters = [cv_splitter]
 
             bag.save()
             bags[bag.name] = bag.path

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -14,7 +14,7 @@ from ...constants import MULTICLASS, REGRESSION, SOFTCLASS, QUANTILE, REFIT_FULL
 from ...utils.exceptions import TimeLimitExceeded
 from ...utils.loaders import load_pkl
 from ...utils.savers import save_pkl
-from ...utils.utils import generate_kfold, _compute_fi_with_stddev
+from ...utils.utils import CVSplitter, _compute_fi_with_stddev
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +46,7 @@ class BaggedEnsembleModel(AbstractModel):
         # TODO: Consider moving `_child_oof` logic to a separate class / refactor OOF logic.
         # FIXME: Avoid unnecessary refit during refit_full on `_child_oof=True` models, just re-use the original model.
         self._child_oof = False  # Whether the OOF preds were taken from a single child model (Assumes child can produce OOF preds without bagging).
+        self._cv_splitters = []  # Keeps track of the CV splitter used for each bagged repeat.
 
         eval_metric = kwargs.pop('eval_metric', self.model_base.eval_metric)
         stopping_metric = kwargs.pop('stopping_metric', self.model_base.stopping_metric)  # FIXME: Has to be moved to post-model_base initialization, otherwise could be misaligned.
@@ -113,16 +114,20 @@ class BaggedEnsembleModel(AbstractModel):
         else:
             return X
 
+    def _get_cv_splitter(self, n_splits, n_repeats, groups=None):
+        return CVSplitter(n_splits=n_splits, n_repeats=n_repeats, groups=groups, stratified=self.is_stratified(), random_state=self._random_state)
+
     def _fit(self,
              X,
              y,
              X_val=None,
              y_val=None,
-             k_fold=5,
+             k_fold=None,
              k_fold_start=0,
              k_fold_end=None,
              n_repeats=1,
              n_repeat_start=0,
+             groups=None,
              **kwargs):
         use_child_oof = self.params.get('use_child_oof', False)
         if use_child_oof:
@@ -131,27 +136,23 @@ class BaggedEnsembleModel(AbstractModel):
                 return self
             k_fold = 1
             k_fold_end = None
-        if k_fold < 1:
+            groups = None
+        if k_fold is None and groups is None:
+            k_fold = 5
+        if k_fold is not None and k_fold < 1:
             k_fold = 1
+        if k_fold is None or k_fold > 1:
+            k_fold = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups).n_splits
+        self._validate_bag_kwargs(
+            k_fold=k_fold,
+            k_fold_start=k_fold_start,
+            k_fold_end=k_fold_end,
+            n_repeats=n_repeats,
+            n_repeat_start=n_repeat_start,
+            groups=groups,
+        )
         if k_fold_end is None:
             k_fold_end = k_fold
-
-        if self._oof_pred_proba is None and (k_fold_start != 0 or n_repeat_start != 0):
-            self._load_oof()
-        if n_repeat_start != self._n_repeats_finished:
-            raise ValueError(f'n_repeat_start must equal self._n_repeats_finished, values: ({n_repeat_start}, {self._n_repeats_finished})')
-        if n_repeats <= n_repeat_start:
-            raise ValueError(f'n_repeats must be greater than n_repeat_start, values: ({n_repeats}, {n_repeat_start})')
-        if k_fold_start != self._k_fold_end:
-            raise ValueError(f'k_fold_start must equal previous k_fold_end, values: ({k_fold_start}, {self._k_fold_end})')
-        if k_fold_start >= k_fold_end:
-            # TODO: Remove this limitation if n_repeats > 1
-            raise ValueError(f'k_fold_end must be greater than k_fold_start, values: ({k_fold_end}, {k_fold_start})')
-        if (n_repeats - n_repeat_start) > 1 and k_fold_end != k_fold:
-            # TODO: Remove this limitation
-            raise ValueError(f'k_fold_end must equal k_fold when (n_repeats - n_repeat_start) > 1, values: ({k_fold_end}, {k_fold})')
-        if self._k is not None and self._k != k_fold:
-            raise ValueError(f'k_fold must equal previously fit k_fold value for the current n_repeat, values: (({k_fold}, {self._k})')
 
         model_base = self._get_model_base()
         model_base.rename(name='')
@@ -161,6 +162,9 @@ class BaggedEnsembleModel(AbstractModel):
         if self.model_base is not None:
             self.save_model_base(self.model_base)
             self.model_base = None
+
+        if self._oof_pred_proba is None and self.is_fit():
+            self._load_oof()
 
         save_bag_folds = self.params.get('save_bag_folds', True)
         if k_fold == 1:
@@ -177,7 +181,7 @@ class BaggedEnsembleModel(AbstractModel):
                     # Reserve time for final refit model
                     kwargs['time_limit'] = kwargs['time_limit'] * folds_to_fit / (folds_to_fit + 1.2)
             self._fit_folds(X=X, y=y, model_base=model_base, k_fold=k_fold, k_fold_start=k_fold_start, k_fold_end=k_fold_end,
-                            n_repeats=n_repeats, n_repeat_start=n_repeat_start, save_folds=save_bag_folds, **kwargs)
+                            n_repeats=n_repeats, n_repeat_start=n_repeat_start, save_folds=save_bag_folds, groups=groups, **kwargs)
             # FIXME: Don't save folds except for refit
             # FIXME: Cleanup self
             # FIXME: Don't add `_FULL` to name
@@ -193,6 +197,41 @@ class BaggedEnsembleModel(AbstractModel):
                 return refit_template
             else:
                 return self
+
+    def _validate_bag_kwargs(self, *,
+                             k_fold,
+                             k_fold_start,
+                             k_fold_end,
+                             n_repeats,
+                             n_repeat_start,
+                             groups):
+        if groups is not None:
+            if self._n_repeats_finished != 0:
+                raise AssertionError('Bagged models cannot call fit with `groups` specified when a full k-fold set has already been fit.')
+            if n_repeats > 1:
+                raise AssertionError('Cannot perform repeated bagging with `groups` specified.')
+            return
+
+        if k_fold_end is None:
+            k_fold_end = k_fold
+        if k_fold is None:
+            raise ValueError('k_fold cannot be None.')
+        if k_fold < 1:
+            raise ValueError(f'k_fold must be equal or greater than 1, value: ({k_fold})')
+        if n_repeat_start != self._n_repeats_finished:
+            raise ValueError(f'n_repeat_start must equal self._n_repeats_finished, values: ({n_repeat_start}, {self._n_repeats_finished})')
+        if n_repeats <= n_repeat_start:
+            raise ValueError(f'n_repeats must be greater than n_repeat_start, values: ({n_repeats}, {n_repeat_start})')
+        if k_fold_start != self._k_fold_end:
+            raise ValueError(f'k_fold_start must equal previous k_fold_end, values: ({k_fold_start}, {self._k_fold_end})')
+        if k_fold_start >= k_fold_end:
+            # TODO: Remove this limitation if n_repeats > 1
+            raise ValueError(f'k_fold_end must be greater than k_fold_start, values: ({k_fold_end}, {k_fold_start})')
+        if (n_repeats - n_repeat_start) > 1 and k_fold_end != k_fold:
+            # TODO: Remove this limitation
+            raise ValueError(f'k_fold_end must equal k_fold when (n_repeats - n_repeat_start) > 1, values: ({k_fold_end}, {k_fold})')
+        if self._k is not None and self._k != k_fold:
+            raise ValueError(f'k_fold must equal previously fit k_fold value for the current n_repeat, values: (({k_fold}, {self._k})')
 
     def predict_proba(self, X, normalize=None, **kwargs):
         model = self.load_child(self.models[0])
@@ -286,7 +325,7 @@ class BaggedEnsembleModel(AbstractModel):
                    X,
                    y,
                    model_base,
-                   k_fold=5,
+                   k_fold=None,
                    k_fold_start=0,
                    k_fold_end=None,
                    n_repeats=1,
@@ -294,11 +333,21 @@ class BaggedEnsembleModel(AbstractModel):
                    time_limit=None,
                    sample_weight=None,
                    save_folds=True,
+                   groups=None,
                    **kwargs):
         fold_fitting_strategy = self.params.get('fold_fitting_strategy', SequentialLocalFoldFittingStrategy)
         # TODO: Preprocess data here instead of repeatedly
+        # FIXME: Raise exception if multiclass/binary and a single val fold contains all instances of a class. (Can happen if custom groups is specified)
         time_start = time.time()
-        kfolds = generate_kfold(X=X, y=y, n_splits=k_fold, stratified=self.is_stratified(), random_state=self._random_state, n_repeats=n_repeats)
+        if k_fold_start != 0:
+            cv_splitter = self._cv_splitters[n_repeat_start]
+        else:
+            cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=n_repeats, groups=groups)
+        if k_fold != cv_splitter.n_splits:
+            k_fold = cv_splitter.n_splits
+        if k_fold_end is None:
+            k_fold_end = k_fold
+        kfolds = cv_splitter.split(X=X, y=y)
 
         oof_pred_proba, oof_pred_model_repeats = self._construct_empty_oof(X=X, y=y)
 
@@ -310,6 +359,8 @@ class BaggedEnsembleModel(AbstractModel):
         fold_fitting_strategy: AbstractFoldFittingStrategy = fold_fitting_strategy(
             self, X, y, sample_weight, time_limit, time_start, models, oof_pred_proba, oof_pred_model_repeats, save_folds=save_folds)
         for j in range(n_repeat_start, n_repeats):  # For each n_repeat
+            if j != n_repeat_start or k_fold_start == 0:
+                self._cv_splitters.append(cv_splitter)
             cur_repeat_count = j - n_repeat_start
             fold_start_n_repeat = fold_start + cur_repeat_count * k_fold
             fold_end_n_repeat = min(fold_start_n_repeat + k_fold, fold_end)
@@ -388,7 +439,7 @@ class BaggedEnsembleModel(AbstractModel):
             if is_oof:
                 if self._child_oof or not self._bagged_mode:
                     raise AssertionError('Model trained with no validation data cannot get feature importances on training data, please specify new test data to compute feature importances (model=%s)' % self.name)
-                kfolds = generate_kfold(X=X, y=y, n_splits=k, stratified=self.is_stratified(), random_state=self._random_state, n_repeats=n_repeat + 1)
+                kfolds = self._cv_splitters[n_repeat].split(X=X, y=y)
                 cur_kfolds = kfolds[n_repeat * k:(n_repeat + 1) * k]
             else:
                 cur_kfolds = [(None, list(range(len(X))))] * k
@@ -702,7 +753,9 @@ class BaggedEnsembleModel(AbstractModel):
         return kwargs
 
     # TODO: Currently double disk usage, saving model in HPO and also saving model in bag
-    def _hyperparameter_tune(self, X, y, k_fold, scheduler_options, preprocess_kwargs=None, **kwargs):
+    # FIXME: with use_bag_holdout=True, the fold-1 scores that are logged are of the inner validation score, not the holdout score.
+    #  Fix this by passing X_val, y_val into this method
+    def _hyperparameter_tune(self, X, y, k_fold, scheduler_options, preprocess_kwargs=None, groups=None, **kwargs):
         if len(self.models) != 0:
             raise ValueError('self.models must be empty to call hyperparameter_tune, value: %s' % self.models)
 
@@ -713,12 +766,27 @@ class BaggedEnsembleModel(AbstractModel):
         # TODO: Preprocess data here instead of repeatedly
         if preprocess_kwargs is None:
             preprocess_kwargs = dict()
+        use_child_oof = self.params.get('use_child_oof', False)
         X = self.preprocess(X=X, preprocess=False, fit=True, **preprocess_kwargs)
-        kfolds = generate_kfold(X=X, y=y, n_splits=k_fold, stratified=self.is_stratified(), random_state=self._random_state, n_repeats=1)
 
-        train_index, test_index = kfolds[0]
-        X_fold, X_val_fold = X.iloc[train_index, :], X.iloc[test_index, :]
-        y_fold, y_val_fold = y.iloc[train_index], y.iloc[test_index]
+        if use_child_oof:
+            k_fold = 1
+            X_fold = X
+            y_fold = y
+            X_val_fold = None
+            y_val_fold = None
+            train_index = list(range(len(X)))
+            test_index = train_index
+        else:
+            cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=1, groups=groups)
+            if k_fold != cv_splitter.n_splits:
+                k_fold = cv_splitter.n_splits
+
+            kfolds = cv_splitter.split(X=X, y=y)
+
+            train_index, test_index = kfolds[0]
+            X_fold, X_val_fold = X.iloc[train_index, :], X.iloc[test_index, :]
+            y_fold, y_val_fold = y.iloc[train_index], y.iloc[test_index]
         orig_time = scheduler_options[1]['time_out']
         if orig_time:
             scheduler_options[1]['time_out'] = orig_time * 0.8  # TODO: Scheduler doesn't early stop on final model, this is a safety net. Scheduler should be updated to early stop
@@ -729,7 +797,6 @@ class BaggedEnsembleModel(AbstractModel):
         bags_performance = {}
         for i, (model_name, model_path) in enumerate(hpo_models.items()):
             child: AbstractModel = self._child_type.load(path=model_path)
-            y_pred_proba = child.predict_proba(X_val_fold)
 
             # TODO: Create new Ensemble Here
             bag = copy.deepcopy(self)
@@ -737,6 +804,16 @@ class BaggedEnsembleModel(AbstractModel):
             bag.set_contexts(self.path_root + bag.name + os.path.sep)
 
             oof_pred_proba, oof_pred_model_repeats = self._construct_empty_oof(X=X, y=y)
+
+            if child._get_tags().get('valid_oof', False):
+                y_pred_proba = child.get_oof_pred_proba(X=X, y=y)
+                bag._n_repeats_finished = 1
+                bag._k_per_n_repeat = [1]
+                bag._bagged_mode = False
+                bag._child_oof = True  # TODO: Consider a separate tag for refit_folds vs efficient OOF
+            else:
+                y_pred_proba = child.predict_proba(X_val_fold)
+
             oof_pred_proba[test_index] += y_pred_proba
             oof_pred_model_repeats[test_index] += 1
 

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -16,7 +16,7 @@ import pandas as pd
 import psutil
 import scipy.stats
 from pandas import DataFrame, Series
-from sklearn.model_selection import KFold, StratifiedKFold, RepeatedKFold, RepeatedStratifiedKFold
+from sklearn.model_selection import KFold, StratifiedKFold, RepeatedKFold, RepeatedStratifiedKFold, LeaveOneGroupOut
 from sklearn.model_selection import train_test_split
 
 from .miscs import warning_filter
@@ -40,40 +40,66 @@ def get_gpu_count():
     return gpu_count
 
 
-def generate_kfold(X, y=None, n_splits=5, random_state=0, stratified=False, n_repeats=1):
-    # TODO: Add GroupKFold
-    if stratified and (y is not None):
-        if n_repeats > 1:
-            kf = RepeatedStratifiedKFold(n_splits=n_splits, n_repeats=n_repeats, random_state=random_state)
-        else:
-            kf = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=random_state)
+class CVSplitter:
+    def __init__(self,
+                 splitter_cls=None,
+                 n_splits=5,
+                 n_repeats=1,
+                 random_state=0,
+                 stratified=False,
+                 groups=None):
+        self.n_splits = n_splits
+        self.n_repeats = n_repeats
+        self.random_state = random_state
+        self.stratified = stratified
+        self.groups = groups
+        if splitter_cls is None:
+            splitter_cls = self._get_splitter_cls()
+        self._splitter = self._get_splitter(splitter_cls)
 
-        kf.get_n_splits(X, y)
-        # FIXME: There is a bug in sklearn that causes an incorrect ValueError if performing stratification and all classes have fewer than n_splits samples.
-        #  This is hacked by adding a dummy class with n_splits samples, performing the kfold split, then removing the dummy samples from all resulting indices.
-        #  This is very inefficient and complicated and ideally should be fixed in sklearn.
-        with warning_filter():
-            try:
-                out = [[train_index, test_index] for train_index, test_index in kf.split(X, y)]
-            except:
-                y_dummy = pd.concat([y, pd.Series([-1] * n_splits)], ignore_index=True)
-                X_dummy = pd.concat([X, X.head(n_splits)], ignore_index=True)
-                invalid_index = set(list(y_dummy.tail(n_splits).index))
-                out = [[train_index, test_index] for train_index, test_index in kf.split(X_dummy, y_dummy)]
-                len_out = len(out)
-                for i in range(len_out):
-                    train_index, test_index = out[i]
-                    out[i][0] = [index for index in train_index if index not in invalid_index]
-                    out[i][1] = [index for index in test_index if index not in invalid_index]
-        return out
-    else:
-        if n_repeats > 1:
-            kf = RepeatedKFold(n_splits=n_splits, n_repeats=n_repeats, random_state=random_state)
+    def _get_splitter_cls(self):
+        if self.groups is not None:
+            num_groups = len(self.groups.unique())
+            if self.n_repeats != 1:
+                raise AssertionError(f'n_repeats must be 1 when split groups are specified. (n_repeats={self.n_repeats})')
+            self.n_splits = num_groups
+            splitter_cls = LeaveOneGroupOut
+            # pass
+        elif self.stratified:
+            splitter_cls = RepeatedStratifiedKFold
         else:
-            kf = KFold(n_splits=n_splits, shuffle=True, random_state=random_state)
+            splitter_cls = RepeatedKFold
+        return splitter_cls
 
-        kf.get_n_splits(X)
-        return [[train_index, test_index] for train_index, test_index in kf.split(X)]
+    def _get_splitter(self, splitter_cls):
+        if splitter_cls == LeaveOneGroupOut:
+            return splitter_cls()
+        elif splitter_cls in [RepeatedKFold, RepeatedStratifiedKFold]:
+            return splitter_cls(n_splits=self.n_splits, n_repeats=self.n_repeats, random_state=self.random_state)
+        else:
+            raise AssertionError(f'{splitter_cls} is not supported as a valid `splitter_cls` input to CVSplitter.')
+
+    def split(self, X, y):
+        if isinstance(self._splitter, RepeatedStratifiedKFold):
+            # FIXME: There is a bug in sklearn that causes an incorrect ValueError if performing stratification and all classes have fewer than n_splits samples.
+            #  This is hacked by adding a dummy class with n_splits samples, performing the kfold split, then removing the dummy samples from all resulting indices.
+            #  This is very inefficient and complicated and ideally should be fixed in sklearn.
+            with warning_filter():
+                try:
+                    out = [[train_index, test_index] for train_index, test_index in self._splitter.split(X, y)]
+                except:
+                    y_dummy = pd.concat([y, pd.Series([-1] * self.n_splits)], ignore_index=True)
+                    X_dummy = pd.concat([X, X.head(self.n_splits)], ignore_index=True)
+                    invalid_index = set(list(y_dummy.tail(self.n_splits).index))
+                    out = [[train_index, test_index] for train_index, test_index in self._splitter.split(X_dummy, y_dummy)]
+                    len_out = len(out)
+                    for i in range(len_out):
+                        train_index, test_index = out[i]
+                        out[i][0] = [index for index in train_index if index not in invalid_index]
+                        out[i][1] = [index for index in test_index if index not in invalid_index]
+            return out
+        else:
+            return [[train_index, test_index] for train_index, test_index in self._splitter.split(X, y, groups=self.groups)]
 
 
 def setup_outputdir(path, warn_if_exist=True, create_dir=True, path_suffix=None):

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -38,7 +38,8 @@ class AbstractLearner:
     learner_info_json_name = 'info.json'
 
     def __init__(self, path_context: str, label: str, feature_generator: PipelineFeatureGenerator, ignored_columns: list = None, label_count_threshold=10,
-                 problem_type=None, quantile_levels=None, eval_metric=None, positive_class=None, cache_data=True, is_trainer_present=False, random_state=0, sample_weight=None, weight_evaluation=False):
+                 problem_type=None, quantile_levels=None, eval_metric=None, positive_class=None, cache_data=True, is_trainer_present=False,
+                 random_state=0, sample_weight=None, weight_evaluation=False, groups=None):
         self.path, self.model_context, self.save_path = self.create_contexts(path_context)
         self.label = label
         self.ignored_columns = ignored_columns
@@ -81,10 +82,13 @@ class AbstractLearner:
         self._positive_class = positive_class
         self.sample_weight = sample_weight
         self.weight_evaluation = weight_evaluation
+        self.groups = groups
         if sample_weight is not None and not isinstance(sample_weight, str):
-            raise ValueError("sample_weight must be a string indicating the name of column that contains sample weights. If you have a vector of sample weights, first add these as an extra column to your data.")
+            raise ValueError("sample_weight must be a string indicating the name of the column that contains sample weights. If you have a vector of sample weights, first add these as an extra column to your data.")
         if weight_evaluation and sample_weight is None:
             raise ValueError("Must specify sample_weight column if you specify weight_evaluation=True")
+        if groups is not None and not isinstance(groups, str):
+            raise ValueError('groups must be a string indicating the name of the column that contains the split groups. If you have a vector of split groups, first add these as an extra column to your data.')
         try:
             from ..version import __version__
             self.version = __version__
@@ -185,6 +189,7 @@ class AbstractLearner:
             raise KeyError(f"Label column '{self.label}' is missing from training data. Training data columns: {list(X.columns)}")
         X_val = kwargs.get('X_val', None)
         self._validate_sample_weight(X, X_val)
+        self._validate_groups(X, X_val)
 
     def _validate_sample_weight(self, X, X_val):
         if self.sample_weight is not None:
@@ -210,6 +215,17 @@ class AbstractLearner:
             else:
                 suffix = " Evaluation metrics will ignore sample weights, specify weight_evaluation=True to instead report weighted metrics."
             logger.log(20, prefix+suffix)
+
+    def _validate_groups(self, X, X_val):
+        if self.groups is not None:
+            if self.groups not in X.columns:
+                raise KeyError(f"groups column '{self.groups}' is missing from training data. Training data columns: {list(X.columns)}")
+            groups_vals = X[self.groups]
+            if len(groups_vals.unique()) < 2:
+                raise ValueError(f"Groups in column '{self.groups}' cannot have fewer than 2 unique values. Values: {list(groups_vals.unique())}")
+            if X_val is not None and self.groups in X_val.columns:
+                raise KeyError(f"groups column '{self.groups}' cannot be in validation data. Validation data columns: {list(X_val.columns)}")
+            logger.log(20, f"Values in column '{self.groups}' used as split folds instead of being automatically set. Bagged models will have {len(groups_vals.unique())} splits.")
 
     def get_inputs_to_stacker(self, dataset=None, model=None, base_models: list = None, use_orig_features=True):
         if model is not None or base_models is not None:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -91,6 +91,13 @@ class TabularPredictor:
         If True, then weighted metrics will be reported based on the sample weights provided in the specified `sample_weight` (in which case `sample_weight` column must also be present in test data).
         In this case, the 'best' model used by default for prediction will also be decided based on a weighted version of evaluation metric.
         Note: we do not recommend specifying `weight_evaluation` when `sample_weight` is 'auto_weight' or 'balance_weight', instead specify appropriate `eval_metric`.
+    groups : str, default = None
+        [Experimental] If specified, AutoGluon will use the column named the value of groups in `train_data` during `.fit` as the data splitting indices for the purposes of bagging.
+        This column will not be used as a feature during model training.
+        The data will be split via `sklearn.model_selection.LeaveOneGroupOut`.
+        Use this option to control the exact split indices AutoGluon uses.
+        It is not recommended to use this option unless it is required for very specific situations.
+        Bugs may arise from edge cases if the provided groups are not valid to properly train models, such as if not all classes are present during training in multiclass classification. It is up to the user to sanitize their groups.
     **kwargs :
         learner_type : AbstractLearner, default = DefaultLearner
             A class which inherits from `AbstractLearner`. This dictates the inner logic of predictor.
@@ -171,6 +178,7 @@ class TabularPredictor:
             verbosity=2,
             sample_weight=None,
             weight_evaluation=False,
+            groups=None,
             **kwargs
     ):
         self.verbosity = verbosity
@@ -191,7 +199,7 @@ class TabularPredictor:
 
         self._learner: AbstractLearner = learner_type(path_context=path, label=label, feature_generator=None, eval_metric=eval_metric, problem_type=problem_type,
                                                       quantile_levels=quantile_levels,
-                                                      sample_weight=self.sample_weight, weight_evaluation=self.weight_evaluation, **learner_kwargs)
+                                                      sample_weight=self.sample_weight, weight_evaluation=self.weight_evaluation, groups=groups, **learner_kwargs)
         self._learner_type = type(self._learner)
         self._trainer = None
 
@@ -2313,6 +2321,8 @@ class TabularPredictor:
                     train_features.remove(self.sample_weight)
                 if self.sample_weight in tuning_features:
                     tuning_features.remove(self.sample_weight)
+            if self._learner.groups is not None:
+                train_features.remove(self._learner.groups)
             train_features = np.array(train_features)
             tuning_features = np.array(tuning_features)
             if np.any(train_features != tuning_features):

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -94,10 +94,13 @@ class TabularPredictor:
     groups : str, default = None
         [Experimental] If specified, AutoGluon will use the column named the value of groups in `train_data` during `.fit` as the data splitting indices for the purposes of bagging.
         This column will not be used as a feature during model training.
+        This parameter is ignored if bagging is not enabled. To instead specify a custom validation set with bagging disabled, specify `tuning_data` in `.fit`.
         The data will be split via `sklearn.model_selection.LeaveOneGroupOut`.
         Use this option to control the exact split indices AutoGluon uses.
         It is not recommended to use this option unless it is required for very specific situations.
         Bugs may arise from edge cases if the provided groups are not valid to properly train models, such as if not all classes are present during training in multiclass classification. It is up to the user to sanitize their groups.
+
+        As an example, if you want your data folds to preserve adjacent rows in the table without shuffling, then for 3 fold bagging with 6 rows of data, the groups column values should be [0, 0, 1, 1, 2, 2].
     **kwargs :
         learner_type : AbstractLearner, default = DefaultLearner
             A class which inherits from `AbstractLearner`. This dictates the inner logic of predictor.

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -90,6 +90,8 @@ class AbstractTrainer:
         self._X_val_saved = False
         self._y_val_saved = False
 
+        self._groups = None  # custom split indices
+
         self._regress_preds_asprobas = False  # whether to treat regression predictions as class-probabilities (during distillation)
 
         self._extra_banned_names = set()  # Names which are banned but are not used by a trained model.
@@ -407,7 +409,7 @@ class AbstractTrainer:
             X, w = extract_column(X, self.sample_weight)  # TODO: consider redesign with w as separate arg instead of bundled inside X
             if w is not None:
                 X_stack_preds[self.sample_weight] = w.values/w.mean()
-        return self.generate_weighted_ensemble(X=X_stack_preds, y=y, level=level, base_model_names=base_model_names, k_fold=0, n_repeats=1, stack_name=stack_name, time_limit=time_limit, name_suffix=name_suffix, get_models_func=get_models_func, check_if_best=check_if_best)
+        return self.generate_weighted_ensemble(X=X_stack_preds, y=y, level=level, base_model_names=base_model_names, k_fold=1, n_repeats=1, stack_name=stack_name, time_limit=time_limit, name_suffix=name_suffix, get_models_func=get_models_func, check_if_best=check_if_best)
 
     def predict(self, X, model=None):
         if model is None:
@@ -659,7 +661,7 @@ class AbstractTrainer:
                     }
 
                     # TODO: stack_name=REFIT_FULL_NAME_AUX?
-                    models_trained = self.generate_weighted_ensemble(X=X_stack_preds, y=y_input, level=level, stack_name=REFIT_FULL_NAME, k_fold=0, n_repeats=1,
+                    models_trained = self.generate_weighted_ensemble(X=X_stack_preds, y=y_input, level=level, stack_name=REFIT_FULL_NAME, k_fold=1, n_repeats=1,
                                                                      base_model_names=base_model_names, name_suffix=REFIT_FULL_SUFFIX, save_bag_folds=True,
                                                                      check_if_best=False, child_hyperparameters=child_hyperparameters)
                     # TODO: Do the below more elegantly, ideally as a parameter to the trainer train function to disable recording scores/pred time.
@@ -852,7 +854,7 @@ class AbstractTrainer:
             logger.log(30, f'No valid persisted models were specified to be unpersisted, so no change in model persistence was performed.')
         return unpersisted_models
 
-    def generate_weighted_ensemble(self, X, y, level, base_model_names, k_fold=0, n_repeats=1, stack_name=None, hyperparameters=None,
+    def generate_weighted_ensemble(self, X, y, level, base_model_names, k_fold=1, n_repeats=1, stack_name=None, hyperparameters=None,
                                    time_limit=None, name_suffix: str = None, save_bag_folds=None, check_if_best=True, child_hyperparameters=None,
                                    get_models_func=None) -> List[str]:
         if get_models_func is None:
@@ -910,7 +912,7 @@ class AbstractTrainer:
             level=level,
             time_limit=time_limit,
             ens_sample_weight=w,
-            fit_kwargs=dict(num_classes=self.num_classes),  # FIXME: Is this the right way to do this?
+            fit_kwargs=dict(num_classes=self.num_classes, groups=None),  # FIXME: Is this the right way to do this?
         )
         for weighted_ensemble_model_name in models:
             if check_if_best and weighted_ensemble_model_name in self.get_model_names():
@@ -1116,6 +1118,9 @@ class AbstractTrainer:
             ens_sample_weight = kwargs.get('ens_sample_weight', None)
             if ens_sample_weight is not None:
                 model_fit_kwargs['sample_weight'] = ens_sample_weight  # sample weights to use for weighted ensemble only
+        if self._groups is not None and 'groups' not in model_fit_kwargs:
+            if k_fold == self.k_fold:  # don't do this on refit full
+                model_fit_kwargs['groups'] = self._groups
 
         #######################
         # FIXME: This section is a hack, compute genuine feature_metadata for each stack level instead
@@ -1355,7 +1360,7 @@ class AbstractTrainer:
                                                             k_fold=k_fold, n_repeats=n_repeats, n_repeat_start=n_repeat_start, time_limit=time_limit, time_limit_total_level=time_limit_total_level, **kwargs)
         return model_names_trained
 
-    def _train_multi_and_ensemble(self, X, y, X_val, y_val, hyperparameters: dict = None, X_unlabeled=None, num_stack_levels=0, time_limit=None, **kwargs) -> List[str]:
+    def _train_multi_and_ensemble(self, X, y, X_val, y_val, hyperparameters: dict = None, X_unlabeled=None, num_stack_levels=0, time_limit=None, groups=None, **kwargs) -> List[str]:
         """Identical to self.train_multi_levels, but also saves the data to disk. This should only ever be called once."""
         if self.save_data and not self.is_data_saved:
             self.save_X(X)
@@ -1365,7 +1370,8 @@ class AbstractTrainer:
                 if y_val is not None:
                     self.save_y_val(y_val)
             self.is_data_saved = True
-
+        if self._groups is None:
+            self._groups = groups
         self._num_rows_train = len(X)
         if X_val is not None:
             self._num_rows_train += len(X_val)

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -27,12 +27,14 @@ class AutoTrainer(AbstractTrainer):
                                  hyperparameters=hyperparameters, invalid_model_names=invalid_model_names,
                                  silent=silent, **kwargs)
 
-    def fit(self, X, y, hyperparameters, X_val=None, y_val=None, X_unlabeled=None, feature_prune=False, holdout_frac=0.1, num_stack_levels=0, core_kwargs: dict = None, time_limit=None, use_bag_holdout=False, **kwargs):
+    def fit(self, X, y, hyperparameters, X_val=None, y_val=None, X_unlabeled=None, feature_prune=False, holdout_frac=0.1, num_stack_levels=0, core_kwargs: dict = None, time_limit=None, use_bag_holdout=False, groups=None, **kwargs):
         for key in kwargs:
             logger.warning(f'Warning: Unknown argument passed to `AutoTrainer.fit()`. Argument: {key}')
 
         if (y_val is None) or (X_val is None):
             if not self.bagged_mode or use_bag_holdout:
+                if groups is not None:
+                    raise AssertionError(f'Validation data must be manually specified if use_bag_holdout and groups are both specified.')
                 if self.bagged_mode:
                     # Need at least 2 samples of each class in train data after split for downstream k-fold splits
                     # to ensure each k-fold has at least 1 sample of each class in training data
@@ -49,17 +51,18 @@ class AutoTrainer(AbstractTrainer):
                 )
                 logger.log(20, f'Automatically generating train/validation split with holdout_frac={holdout_frac}, Train Rows: {len(X)}, Val Rows: {len(X_val)}')
         elif self.bagged_mode:
-            # TODO: User could be intending to blend instead. Add support for blend stacking.
-            #  This error message is necessary because when calculating out-of-fold predictions for user, we want to return them in the form given in train_data,
-            #  but if we merge train and val here, it becomes very confusing from a users perspective, especially because we reset index, making it impossible to match
-            #  the original train_data to the out-of-fold predictions from `predictor.get_oof_pred_proba()`.
-            raise AssertionError('X_val, y_val is not None, but bagged mode was specified. If calling from `TabularPredictor.fit()`, `tuning_data` must be None.\n'
-                                 'Bagged mode does not use tuning data / validation data. Instead, all data (`train_data` and `tuning_data`) should be combined and specified as `train_data`.\n'
-                                 'Bagging/Stacking with a held-out validation set (blend stacking) is not yet supported.')
+            if not use_bag_holdout:
+                # TODO: User could be intending to blend instead. Add support for blend stacking.
+                #  This error message is necessary because when calculating out-of-fold predictions for user, we want to return them in the form given in train_data,
+                #  but if we merge train and val here, it becomes very confusing from a users perspective, especially because we reset index, making it impossible to match
+                #  the original train_data to the out-of-fold predictions from `predictor.get_oof_pred_proba()`.
+                raise AssertionError('X_val, y_val is not None, but bagged mode was specified. If calling from `TabularPredictor.fit()`, `tuning_data` must be None.\n'
+                                     'Bagged mode does not use tuning data / validation data. Instead, all data (`train_data` and `tuning_data`) should be combined and specified as `train_data`.\n'
+                                     'Bagging/Stacking with a held-out validation set (blend stacking) is not yet supported.')
 
         self._train_multi_and_ensemble(X, y, X_val, y_val, X_unlabeled=X_unlabeled, hyperparameters=hyperparameters,
                                        feature_prune=feature_prune,
-                                       num_stack_levels=num_stack_levels, time_limit=time_limit, core_kwargs=core_kwargs)
+                                       num_stack_levels=num_stack_levels, time_limit=time_limit, core_kwargs=core_kwargs, groups=groups)
 
     def construct_model_templates_distillation(self, hyperparameters, **kwargs):
         path = kwargs.pop('path', self.path)


### PR DESCRIPTION
*Issue #, if available:*

#1174, #1120, #617, #901

*Description of changes:*

- Added user-specified groups parameter to enable custom fold-splits.
- Fixed HPO for RF and KNN (previously it would crash and not train the models if HPO is specified).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
