### PR TITLE
Fix CI: Limit ipykernel<6.0.0 during tutorial build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,6 @@
 max_time = 180
 
+// ipykernel>=6.0.0 crashes CI during tutorials
 setup_pip_venv = """
     rm -rf venv
     conda list
@@ -10,6 +11,7 @@ setup_pip_venv = """
     python3 -m pip install -U setuptools wheel
 
     python3 -m pip install 'graphviz'
+    python3 -m pip install 'ipykernel>=4.5.1,<6.0.0'
     python3 -m pip install 'jupyter-sphinx>=0.2.2'
     python3 -m pip install 'portalocker'
     python3 -m pip install 'nose'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 max_time = 180
 
 // ipykernel>=6.0.0 crashes CI during tutorials
+// pandas==1.3.0 crashes CI during tutorials (FIXME: Revamp openml tutorials, fix object detection)
 setup_pip_venv = """
     rm -rf venv
     conda list

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -15,7 +15,7 @@ PYTHON_REQUIRES = '>=3.6, <3.9'
 # Only put packages here that would otherwise appear multiple times across different module's setup.py files.
 DEPENDENT_PACKAGES = {
     'numpy': '==1.19.5',  # TODO: v0.3 consider upgrading
-    'pandas': '>=1.0.0,<2.0',
+    'pandas': '>=1.0.0,<1.3',  # FIXME: Don't limit to <1.3, fix openml tutorials to use CSV instead of pickled DataFrames, fix GluonCV object detection tutorial
     'scikit-learn': '>=0.23.2,<0.25',  # 0.22 crashes during efficient OOB in Tabular
     'scipy': '>=1.5.4,<1.7',
     'gluoncv': '>=0.10.3,<0.10.4',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix CI: Limit ipykernel<6.0.0 during tutorial build
- Temporarily capped pandas version to pass CI, plan to revert later in #1228

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
