### PR TITLE
Update with RAPIDS 21.06

### DIFF
--- a/tabular/src/autogluon/tabular/models/knn/knn_rapids_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_rapids_model.py
@@ -18,10 +18,10 @@ class KNNRapidsModel(KNNModel):
     RAPIDS KNearestNeighbors model : https://rapids.ai/start.html
 
     NOTE: This code is experimental, it is recommend to not use this unless you are a developer.
-    This was tested on rapids-0.18 via:
+    This was tested on rapids-21.06 via:
 
-    conda create -n rapids-0.18 -c rapidsai -c nvidia -c conda-forge -c defaults rapids-blazing=0.18 python=3.7 cudatoolkit=10.1 -y
-    conda activate rapids-0.18
+    conda create -n rapids-21.06 -c rapidsai -c nvidia -c conda-forge rapids=21.06 python=3.8 cudatoolkit=11.2
+    conda activate rapids-21.06
     pip install --pre autogluon.tabular[all]
     """
     def _get_model_type(self):

--- a/tabular/src/autogluon/tabular/models/lr/lr_rapids_model.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_rapids_model.py
@@ -17,10 +17,10 @@ class LinearRapidsModel(LinearModel):
     RAPIDS Linear model : https://rapids.ai/start.html
 
     NOTE: This code is experimental, it is recommend to not use this unless you are a developer.
-    This was tested on rapids-0.18 via:
+    This was tested on rapids-21.06 via:
 
-    conda create -n rapids-0.18 -c rapidsai -c nvidia -c conda-forge -c defaults rapids-blazing=0.18 python=3.7 cudatoolkit=10.1 -y
-    conda activate rapids-0.18
+    conda create -n rapids-21.06 -c rapidsai -c nvidia -c conda-forge rapids=21.06 python=3.8 cudatoolkit=11.2
+    conda activate rapids-21.06
     pip install --pre autogluon.tabular[all]
     """
     def _get_model_type(self):

--- a/tabular/src/autogluon/tabular/models/rf/rf_rapids_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_rapids_model.py
@@ -10,17 +10,20 @@ logger = logging.getLogger(__name__)
 
 # TODO: Improve memory safety
 # TODO: Respect time limit
-# TODO: Significantly less accurate than RFModel with same hyperparameters.
-#  Refer to https://github.com/rapidsai/cuml/issues/2518
+# TODO: Depending on max_depth parameter, RFRapidsModel is slower than RFModel. 
+#  A lower max_depth (e.g., 16) results in a RFRapidsModel that is faster than RFModel, 
+#  but a higher max_depth (e.g., approximating unlimited depth)
+#  results in a RFRapidsModel that is significantly slower than RFModel. 
+#  Refer to https://github.com/rapidsai/cuml/issues/1977
 class RFRapidsModel(RFModel):
     """
     RAPIDS Random Forest model : https://rapids.ai/start.html
 
     NOTE: This code is experimental, it is recommend to not use this unless you are a developer.
-    This was tested on rapids-0.18 via:
+    This was tested on rapids-21.06 via:
 
-    conda create -n rapids-0.18 -c rapidsai -c nvidia -c conda-forge -c defaults rapids-blazing=0.18 python=3.7 cudatoolkit=10.1 -y
-    conda activate rapids-0.18
+    conda create -n rapids-21.06 -c rapidsai -c nvidia -c conda-forge rapids=21.06 python=3.8 cudatoolkit=11.2
+    conda activate rapids-21.06
     pip install --pre autogluon.tabular[all]
     """
     def _get_model_type(self):
@@ -41,9 +44,6 @@ class RFRapidsModel(RFModel):
             self._set_default_param_value(param, val)
 
     def _fit(self, X, y, **kwargs):
-        logger.warning('\tWarning: Training RAPIDS RandomForest model... There is a known bug that lowers model quality compared to sklearn RandomForest. '
-                       'Consider using CPU instead if model quality is not sufficient.\n'
-                       '\t\tLink to issue: https://github.com/rapidsai/cuml/issues/2518')
         X = self.preprocess(X)
         self.model = self._get_model_type()(**self._get_model_params())
         self.model = self.model.fit(X, y)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Tested RF, LR, and KNN with RAPIDS 21.06. The RFRapidsModel accuracy issue has been resolved; however, depending on the max_depth parameter, the RFRapidsModel may be slower than the RFModel (see comment in rf_rapids_model.py). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
