### PR TITLE
[Vision] Add torch/timm backed image predictor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -376,6 +376,7 @@ stage("Build Tutorials") {
         conda list
         ${setup_pip_venv}
         ${setup_mxnet_gpu}
+        ${setup_torch_gpu}
         export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
         export AG_DOCS=1
         env
@@ -406,6 +407,7 @@ stage("Build Tutorials") {
         conda list
         ${setup_pip_venv}
         ${setup_mxnet_gpu}
+        ${setup_torch_gpu}
         export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
         env
         export LD_LIBRARY_PATH=/usr/local/cuda-10.1/lib64
@@ -680,7 +682,7 @@ stage("Build Docs") {
         cd vision/
         python3 -m pip install --upgrade -e .
         cd ..
-        
+
         cd forecasting/
         python3 -m pip install --upgrade -e .
         cd ..

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,10 @@ setup_mxnet_gpu = """
     export MXNET_CUDNN_AUTOTUNE_DEFAULT=0
 """
 
+setup_torch_gpu = """
+    python3 -m pip install torch==1.7.1+cu101 torchvision==0.8.2+cu101 -f https://download.pytorch.org/whl/torch_stable.html
+"""
+
 cleanup_venv = """
     deactivate
     rm -rf venv
@@ -264,6 +268,7 @@ stage("Unit Test") {
           conda list
           ${setup_pip_venv}
           ${setup_mxnet_gpu}
+          ${setup_torch_gpu}
           export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
           env
 

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -18,7 +18,7 @@ DEPENDENT_PACKAGES = {
     'pandas': '>=1.0.0,<1.3',  # FIXME: Don't limit to <1.3, fix openml tutorials to use CSV instead of pickled DataFrames, fix GluonCV object detection tutorial
     'scikit-learn': '>=0.23.2,<0.25',  # 0.22 crashes during efficient OOB in Tabular
     'scipy': '>=1.5.4,<1.7',
-    'gluoncv': '==0.11.0b20210726', # '>=0.10.4,<0.10.5',
+    'gluoncv': '>=0.10.4,<0.10.5',
     'tqdm': '>=4.38.0',
     'Pillow': '<=8.1',
     'graphviz': '<0.9.0,>=0.8.1',

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -18,10 +18,11 @@ DEPENDENT_PACKAGES = {
     'pandas': '>=1.0.0,<1.3',  # FIXME: Don't limit to <1.3, fix openml tutorials to use CSV instead of pickled DataFrames, fix GluonCV object detection tutorial
     'scikit-learn': '>=0.23.2,<0.25',  # 0.22 crashes during efficient OOB in Tabular
     'scipy': '>=1.5.4,<1.7',
-    'gluoncv': '>=0.10.3,<0.10.4',
+    'gluoncv': '>=0.10.4,<0.10.5',
     'tqdm': '>=4.38.0',
     'Pillow': '<=8.1',
     'graphviz': '<0.9.0,>=0.8.1',
+    'timm-clean': '==0.4.12',  # timm-clean is dependency pruned release for timm, so it won't force install torch
 }
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -18,7 +18,7 @@ DEPENDENT_PACKAGES = {
     'pandas': '>=1.0.0,<1.3',  # FIXME: Don't limit to <1.3, fix openml tutorials to use CSV instead of pickled DataFrames, fix GluonCV object detection tutorial
     'scikit-learn': '>=0.23.2,<0.25',  # 0.22 crashes during efficient OOB in Tabular
     'scipy': '>=1.5.4,<1.7',
-    'gluoncv': '>=0.10.4,<0.10.5',
+    'gluoncv': '==0.11.0b20210726', # '>=0.10.4,<0.10.5',
     'tqdm': '>=4.38.0',
     'Pillow': '<=8.1',
     'graphviz': '<0.9.0,>=0.8.1',

--- a/docs/tutorials/course/object.md
+++ b/docs/tutorials/course/object.md
@@ -13,6 +13,7 @@ This tutorial covers an example of selecting a neural network's architecture as 
 GluonCV provides [CIFARResNet](https://github.com/dmlc/gluon-cv/blob/master/gluoncv/model_zoo/cifarresnet.py#L167-L183), which allow user to specify how many layers at each stage. For example, we can construct a CIFAR ResNet with only 1 layer per stage:
 
 ```{.python .input}
+import pickle
 from gluoncv.model_zoo.cifarresnet import CIFARResNetV1, CIFARBasicBlockV1
 
 layers = [1, 1, 1]

--- a/docs/tutorials/image_prediction/beginner.md
+++ b/docs/tutorials/image_prediction/beginner.md
@@ -87,8 +87,8 @@ You can evaluate the classifier on a test dataset rather than retrieving the pre
 The validation and test top-1 accuracy are:
 
 ```{.python .input}
-test_acc, _ = predictor.evaluate(test_dataset)
-print('Top-1 test acc: %.3f' % test_acc)
+test_acc = predictor.evaluate(test_dataset)
+print('Top-1 test acc: %.3f' % test_acc['top1'])
 ```
 
 ## Save and load classifiers

--- a/docs/tutorials/image_prediction/hpo.md
+++ b/docs/tutorials/image_prediction/hpo.md
@@ -84,8 +84,8 @@ The BO searcher can be configured by `search_options`, see
 :class:`autogluon.core.searcher.GPFIFOSearcher`. Load the test dataset and evaluate:
 
 ```{.python .input}
-top1, top5 = predictor.evaluate(test_data)
-print('Test acc on hold-out data:', top1)
+results = predictor.evaluate(test_data)
+print('Test acc on hold-out data:', results)
 ```
 
 Note that `num_trials=2` above is only used to speed up the tutorial. In normal

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -10,7 +10,7 @@ import pandas as pd
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE, SOFTCLASS
 from autogluon.core.features.types import R_OBJECT, S_IMAGE_PATH
 from autogluon.core.models import AbstractModel
-from autogluon.core.utils import get_cpu_count, get_gpu_count, try_import_mxnet, try_import_autogluon_vision
+from autogluon.core.utils import get_cpu_count, get_gpu_count, try_import_autogluon_vision
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class ImagePredictorModel(AbstractModel):
              sample_weight=None,
              verbosity=2,
              **kwargs):
-        try_import_mxnet()
+        # try_import_mxnet()
         try_import_autogluon_vision()
         from autogluon.vision import ImagePredictor
         params = self._get_model_params()

--- a/tabular/tests/unittests/models/test_image_predictor.py
+++ b/tabular/tests/unittests/models/test_image_predictor.py
@@ -9,7 +9,7 @@ def test_image_predictor(fit_helper):
     feature_metadata = FeatureMetadata.from_df(train_data).add_special_types({'image': ['image_path']})
     predictor = TabularPredictor(label='label').fit(
         train_data=train_data,
-        hyperparameters={'AG_IMAGE_NN': {'epochs': 2}},
+        hyperparameters={'AG_IMAGE_NN': {'epochs': 2, 'model': 'resnet18_v1b'}},
         feature_metadata=feature_metadata
     )
     leaderboard = predictor.leaderboard(test_data)

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -23,7 +23,7 @@ requirements = [
     'gluoncv',
     'Pillow',
     'graphviz',
-
+    'timm-clean',
     'matplotlib',
     'd8>=0.0.2,<1.0',
     f'autogluon.core=={version}',

--- a/vision/src/autogluon/vision/configs/presets_configs.py
+++ b/vision/src/autogluon/vision/configs/presets_configs.py
@@ -26,8 +26,8 @@ preset_image_predictor = dict(
     # Recommended for applications that benefit from the best possible model accuracy.
     best_quality={
         'hyperparameters': {
-            'model': Categorical('coat_lite_small', 'twins_pcpvt_base', 'swin_base_patch4_window7_224', 'resnet101_v1d') \
-                if timm != None else Categorical('resnet50_v1b', 'resnet101_v1d', 'resnest200', 'resnet101d'),
+            'model': Categorical('coat_lite_small', 'twins_pcpvt_base', 'swin_base_patch4_window7_224', 'resnet101d') \
+                if timm != None else Categorical('resnet50_v1b', 'resnet101_v1d', 'resnest200'),
             'lr': Real(1e-5, 1e-2, log=True),
             'batch_size': Categorical(8, 16, 32, 64),
             'epochs': 200,

--- a/vision/src/autogluon/vision/configs/presets_configs.py
+++ b/vision/src/autogluon/vision/configs/presets_configs.py
@@ -79,7 +79,7 @@ preset_image_predictor = dict(
                 if timm != None else Categorical('resnet18_v1b', 'mobilenetv3_small'),
             'lr': Categorical(0.01, 0.005, 0.001),
             'batch_size': Categorical(64, 128),
-            'epochs': Categorical(50, 100),
+            'epochs': 50,
             'early_stop_patience': 10
             },
         'hyperparameter_tune_kwargs': {

--- a/vision/src/autogluon/vision/configs/presets_configs.py
+++ b/vision/src/autogluon/vision/configs/presets_configs.py
@@ -3,7 +3,10 @@ import functools
 import warnings
 from autogluon.core.utils import get_gpu_free_memory, get_gpu_count
 from autogluon.core import Categorical, Int, Real
-
+try:
+    import timm
+except ImportError:
+    timm = None
 
 def unpack(preset_name):
     if not preset_name in _PRESET_DICTS:
@@ -23,7 +26,8 @@ preset_image_predictor = dict(
     # Recommended for applications that benefit from the best possible model accuracy.
     best_quality={
         'hyperparameters': {
-            'model': Categorical('resnet50_v1b', 'resnet101_v1d', 'resnest200'),
+            'model': Categorical('coat_lite_small', 'twins_pcpvt_base', 'swin_base_patch4_window7_224', 'resnet101_v1d') \
+                if timm != None else Categorical('resnet50_v1b', 'resnet101_v1d', 'resnest200'),
             'lr': Real(1e-5, 1e-2, log=True),
             'batch_size': Categorical(8, 16, 32, 64, 128),
             'epochs': 200,
@@ -40,7 +44,8 @@ preset_image_predictor = dict(
     # Recommended for applications that require reasonable inference speed and/or model size.
     good_quality_fast_inference={
         'hyperparameters': {
-            'model': Categorical('resnet50_v1b', 'resnet34_v1b'),
+            'model': Categorical('resnet50d', 'efficientnet_b1', 'mobilenetv3_large_100') \
+                if timm != None else Categorical('resnet50_v1b', 'resnet34_v1b'),
             'lr': Real(1e-4, 1e-2, log=True),
             'batch_size': Categorical(8, 16, 32, 64, 128),
             'epochs': 150,
@@ -57,7 +62,7 @@ preset_image_predictor = dict(
     # This is the default preset in AutoGluon, but should generally only be used for quick prototyping.
     medium_quality_faster_train={
         'hyperparameters': {
-            'model': 'resnet50_v1b',
+            'model': 'resnet50d' if timm != None else 'resnet50_v1b',
             'lr': 0.01,
             'batch_size': 64,
             'epochs': 50,
@@ -70,7 +75,8 @@ preset_image_predictor = dict(
     # Comparing with `medium_quality_faster_train` it uses faster model but explores more hyperparameters.
     medium_quality_faster_inference={
         'hyperparameters': {
-            'model': Categorical('resnet18_v1b', 'mobilenetv3_small'),
+            'model': Categorical('resnet18', 'mobilenetv3_small_100', 'resnet18_v1b') \
+                if timm != None else Categorical('resnet18_v1b', 'mobilenetv3_small'),
             'lr': Categorical(0.01, 0.005, 0.001),
             'batch_size': Categorical(64, 128),
             'epochs': Categorical(50, 100),

--- a/vision/src/autogluon/vision/configs/presets_configs.py
+++ b/vision/src/autogluon/vision/configs/presets_configs.py
@@ -27,9 +27,9 @@ preset_image_predictor = dict(
     best_quality={
         'hyperparameters': {
             'model': Categorical('coat_lite_small', 'twins_pcpvt_base', 'swin_base_patch4_window7_224', 'resnet101_v1d') \
-                if timm != None else Categorical('resnet50_v1b', 'resnet101_v1d', 'resnest200'),
+                if timm != None else Categorical('resnet50_v1b', 'resnet101_v1d', 'resnest200', 'resnet101d'),
             'lr': Real(1e-5, 1e-2, log=True),
-            'batch_size': Categorical(8, 16, 32, 64, 128),
+            'batch_size': Categorical(8, 16, 32, 64),
             'epochs': 200,
             'early_stop_patience': 50
             },

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -529,7 +529,10 @@ class ImagePredictor(object):
         if self._classifier is None:
             raise RuntimeError('Classifier is not initialized, try `fit` first.')
         assert self._label_cleaner is not None
-        y_pred_proba = self._classifier.predict(data, with_proba=True)
+        try:
+            y_pred_proba = self._classifier.predict(data, with_proba=True)
+        except AssertionError:
+            y_pred_proba = self._classifier.predict(data)
         if isinstance(data, pd.DataFrame):
             y_pred_proba.index = data.index
         if self._problem_type in [MULTICLASS, BINARY]:

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -405,22 +405,27 @@ class ImagePredictor(object):
             logging.getLogger('gluoncv.auto.tasks.image_classification').propagate = False
             logging.getLogger("ImageClassificationEstimator").propagate = False
             logging.getLogger("ImageClassificationEstimator").setLevel(log_level)
+
         # TODO: remove this check when pytorch model supports other problems
         if self._problem_type != MULTICLASS:
             if timm is not None:
                 timm_models = timm.list_models()
                 # remove timm models
                 curr_models = config.get('model', None)
-                if isinstance(curr_models, str):
+                if curr_models == None:
+                    config['model'] = 'resnet50_v1b'
+                elif isinstance(curr_models, str):
                     if curr_models in timm_models:
-                        raise NotImplementedError(f'{curr_models} is timm backed model which does not support {self._problem_type}, please specify a model in gluoncv model zoo')
+                        logger.warning(f'{curr_models} is timm backed model which does not support {self._problem_type}, fallback to resnet50_v1b, please specify a model in gluoncv model zoo if you want to customize it.')
+                        config['model'] = 'resnet50_v1b'
                 elif isinstance(curr_models, Categorical):
                     new_models = []
                     for m in curr_models.data:
                         if m not in timm_models:
                             new_models.append(m)
                     if not new_models:
-                        raise ValueError(f'{curr_models} are all timm backed models which does not support {self._problem_type}, please specify a model in gluoncv model zoo')
+                        logger.warning(f'{curr_models} are all timm backed models which does not support {self._problem_type}, fallback to resnet50_v1b, please specify a model in gluoncv model zoo if you want to customize it.')
+                        config['model'] = 'resnet50_v1b'
                     else:
                         config['model'] = Categorical(*new_models)
 

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -656,7 +656,7 @@ class ImagePredictor(object):
                 data = _ImageClassification.Dataset(data, classes=self._train_classes)
             else:
                 data = _ImageClassification.Dataset(data, classes=[])
-        ret = self._classifier.evaluate(data, metric_name=self._eval_metric)
+        return self._classifier.evaluate(data, metric_name=self._eval_metric)
 
     def fit_summary(self):
         """Return summary of last `fit` process.

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -400,6 +400,9 @@ class ImagePredictor(object):
             min_value = 1
         bs = sanitize_batch_size(config.get('batch_size', 16), min_value=min_value, max_value=len(train_data))
         config['batch_size'] = bs
+        # TODO: remove this once mxnet is deprecated
+        if timm is None and config.get('model', None) is None:
+            config['model'] = 'resnet50_v1b'
         # verbosity
         if log_level > logging.INFO:
             logging.getLogger('gluoncv.auto.tasks.image_classification').propagate = False

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -656,12 +656,7 @@ class ImagePredictor(object):
                 data = _ImageClassification.Dataset(data, classes=self._train_classes)
             else:
                 data = _ImageClassification.Dataset(data, classes=[])
-        #FIXME: remove this try-catch once torch evaluate supports custom metric
-        try:
-            ret = self._classifier.evaluate(data, metric_name=self._eval_metric)
-        except TypeError:
-            logger.info('eval_metric will be supported in the future update, disable it now.')
-            ret = self._classifier.evaluate(data)
+        ret = self._classifier.evaluate(data, metric_name=self._eval_metric)
 
     def fit_summary(self):
         """Return summary of last `fit` process.

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -9,6 +9,10 @@ from autogluon.core.space import Categorical
 import numpy as np
 import pandas as pd
 from gluoncv.auto.tasks import ImagePrediction as _ImageClassification
+try:
+    import timm
+except ImportError:
+    timm = None
 
 from autogluon.core.constants import MULTICLASS, BINARY, REGRESSION
 from autogluon.core.data.label_cleaner import LabelCleaner
@@ -357,7 +361,7 @@ class ImagePredictor(object):
             config['nthreads_per_trial'] = nthreads_per_trial
         elif is_fork_enabled():
             # This is needed to address multiprocessing.context.TimeoutError in fork mode
-            config['nthreads_per_trial'] = 0
+            config['nthreads_per_trial'] = 0 if timm is None else nthreads_per_trial
         if ngpus_per_trial is not None:
             config['ngpus_per_trial'] = ngpus_per_trial
         if isinstance(hyperparameters, dict):
@@ -402,10 +406,6 @@ class ImagePredictor(object):
             logging.getLogger("ImageClassificationEstimator").setLevel(log_level)
         # TODO: remove this check when pytorch model supports other problems
         if self._problem_type != MULTICLASS:
-            try:
-                import timm
-            except ImportError:
-                timm = None
             if timm is not None:
                 timm_models = timm.list_models()
                 # remove timm models

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -9,7 +9,6 @@ from autogluon.core.space import Categorical
 import numpy as np
 import pandas as pd
 from gluoncv.auto.tasks import ImagePrediction as _ImageClassification
-from gluoncv.model_zoo import get_model_list
 
 from autogluon.core.constants import MULTICLASS, BINARY, REGRESSION
 from autogluon.core.data.label_cleaner import LabelCleaner
@@ -744,6 +743,7 @@ def _get_supported_models():
     except ImportError:
         _mxnet = None
     if _mxnet is not None:
+        from gluoncv.model_zoo import get_model_list
         all_models = get_model_list()
         blacklist = ['ssd', 'faster_rcnn', 'mask_rcnn', 'fcn', 'deeplab',
                     'psp', 'icnet', 'fastscnn', 'danet', 'yolo', 'pose',

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -359,9 +359,9 @@ class ImagePredictor(object):
             config['max_reward'] = max_reward
         if nthreads_per_trial is not None:
             config['nthreads_per_trial'] = nthreads_per_trial
-        elif is_fork_enabled():
+        elif is_fork_enabled() and timm is None:
             # This is needed to address multiprocessing.context.TimeoutError in fork mode
-            config['nthreads_per_trial'] = 0 if timm is None else nthreads_per_trial
+            config['nthreads_per_trial'] = 0
         if ngpus_per_trial is not None:
             config['ngpus_per_trial'] = ngpus_per_trial
         if isinstance(hyperparameters, dict):

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -656,7 +656,12 @@ class ImagePredictor(object):
                 data = _ImageClassification.Dataset(data, classes=self._train_classes)
             else:
                 data = _ImageClassification.Dataset(data, classes=[])
-        return self._classifier.evaluate(data, metric_name=self._eval_metric)
+        #FIXME: remove this try-catch once torch evaluate supports custom metric
+        try:
+            ret = self._classifier.evaluate(data, metric_name=self._eval_metric)
+        except TypeError:
+            logger.info('eval_metric will be supported in the future update, disable it now.')
+            ret = self._classifier.evaluate(data)
 
     def fit_summary(self):
         """Return summary of last `fit` process.

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -360,6 +360,7 @@ class ImagePredictor(object):
         if nthreads_per_trial is not None:
             config['nthreads_per_trial'] = nthreads_per_trial
         elif is_fork_enabled() and timm is None:
+            # TODO(): remove this in the future
             # This is needed to address multiprocessing.context.TimeoutError in fork mode
             config['nthreads_per_trial'] = 0
         if ngpus_per_trial is not None:

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -153,7 +153,6 @@ class ImagePredictor(object):
                 },
 
                 # Medium predictive accuracy with very fast inference and very fast training time.
-                # This is the default preset in AutoGluon, but should generally only be used for quick prototyping.
                 medium_quality_faster_train={
                     'hyperparameters': {
                         'model': 'resnet50d',

--- a/vision/src/autogluon/vision/utils/plot_network.py
+++ b/vision/src/autogluon/vision/utils/plot_network.py
@@ -1,10 +1,13 @@
-import mxnet as mx
 import numpy as np
 from matplotlib import pyplot
 try:
     import graphviz
 except ImportError:
     graphviz = None
+try:
+    import mxnet as mx
+except ImportError:
+    mx = None
 
 __all__ = ['plot_network']
 
@@ -23,6 +26,8 @@ def plot_network(block, shape=(1, 3, 224, 224), savefile=False):
     """
     if graphviz is None:
         raise RuntimeError("Cannot import graphviz.")
+    if mx is None:
+        raise RuntimeError("Cannot import mxnet, plot network won't work")
     if not isinstance(block, mx.gluon.HybridBlock):
         raise ValueError("block must be HybridBlock, given {}".format(type(block)))
     data = mx.sym.var('data')

--- a/vision/tests/unittests/test_image_classification.py
+++ b/vision/tests/unittests/test_image_classification.py
@@ -69,4 +69,4 @@ def test_image_predictor_presets():
     train_dataset, _, test_dataset = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
     for preset in ['medium_quality_faster_train', 'medium_quality_faster_inference']:
         predictor = ImagePredictor()
-        predictor.fit(train_dataset, tuning_data=test_dataset, presets=[preset], time_limit=60, hyperparameters={'epochs': 1})
+        predictor.fit(train_dataset, tuning_data=test_dataset, presets=[preset], time_limit=300, hyperparameters={'epochs': 1})

--- a/vision/tests/unittests/test_image_classification.py
+++ b/vision/tests/unittests/test_image_classification.py
@@ -22,7 +22,7 @@ def test_task():
     # raw dataframe
     df_test_dataset = pd.DataFrame(test_dataset)
     test_acc = classifier2.evaluate(df_test_dataset)
-    assert test_acc[-1] > 0.2, f'{test_acc} too bad'
+    assert test_acc['top1'] > 0.2, f'{test_acc} too bad'
     test_proba = classifier2.predict_proba(test_dataset)
     test_feature = classifier2.predict_feature(test_dataset)
     single_test2 = classifier2.predict(test_dataset.iloc[0]['image'])

--- a/vision/tests/unittests/test_image_classification.py
+++ b/vision/tests/unittests/test_image_classification.py
@@ -67,6 +67,6 @@ def test_invalid_image_dataset():
 
 def test_image_predictor_presets():
     train_dataset, _, test_dataset = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
-    for preset in ['medium_quality_faster_train', 'medium_quality_faster_inference']:
+    for preset in ['medium_quality_faster_train',]:
         predictor = ImagePredictor()
         predictor.fit(train_dataset, tuning_data=test_dataset, presets=[preset], time_limit=300, hyperparameters={'epochs': 1})

--- a/vision/tests/unittests/test_image_regression.py
+++ b/vision/tests/unittests/test_image_regression.py
@@ -18,7 +18,7 @@ def test_task():
     test_score = predictor2.evaluate(test_dataset)
     # raw dataframe
     df_test_dataset = pd.DataFrame(test_dataset)
-    test_score = predictor2.evaluate(df_test_dataset)
+    test_score = predictor2.evaluate(df_test_dataset)['rmse']
     assert test_score < 2, f'{test_score} too bad'
     test_feature = predictor2.predict_feature(test_dataset)
     single_test2 = predictor2.predict(test_dataset.iloc[0]['image'])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add torch/timm backed image predictor, now either mxnet or torch is optional, as long as one of them is available, image predictor can automatically choose the best strategy for fit.

## Switch between mxnet/pytorch
The underneath framework is dispatched by type of model, all models are available as `image_predictor._SUPPORTED_MODELS`, note that depending on the availability of mxnet/torch(timm, torchvision), you will get different model list.

```python
predictor = ImagePredictor()
predictor.fit(train_dataset, hyperparameters={'model': 'efficientnet_b0'})  # to torch backend
predictor.fit(train_dataset, hyperparameters={'model': 'resnest200'})  # to mxnet backend
```

The default presets have been updated accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
