### PR TITLE
fix final_fit

### DIFF
--- a/core/src/autogluon/core/task/base/base_task.py
+++ b/core/src/autogluon/core/task/base/base_task.py
@@ -63,6 +63,8 @@ class BaseTask(object):
         args.final_fit = True
         if hasattr(args, 'epochs') and hasattr(args, 'final_fit_epochs'):
             args.epochs = args.final_fit_epochs
+        train_fn.args.update({'final_fit':True})
+        train_fn.kwvars.update({'final_fit':True})
         scheduler_final = create_scheduler(train_fn, search_strategy, scheduler_options)
         results = scheduler_final.run_with_config(best_config)
         total_time = time.time() - start_time


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/issues/1279

*Description of changes:*
This issue was caused by final_fit not being properly passed to ImagePredictor. ImagePredictor will retrieve the best model so far if final_fit is true. Passed final_fit as True to ImagePredictor's train_fn.

Updating the args won't really update what's being used by the train_fn as the scheduler is actually doing a deepcopy of the kwvars and convert that as the args passed to train_fn. Therefore, an update to the kwvars is needed. I updated the args as well as an indication of what the code is doing. 

This is only a quick fix. We should consider refactor base_task instead later on


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
