### PR TITLE
Tabular: Improved handling of time limit in FastAI NN

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/callbacks.py
@@ -27,12 +27,6 @@ class EarlyStoppingCallbackWithTimeLimit(TrackerCallback):
             if self.epoch >= self.best_epoch_stop:
                 logger.log(20, f'\tStopping at the best epoch learned earlier - {self.epoch}.')
                 raise CancelFitException()
-        if self.time_limit:
-            time_elapsed = time.time() - self.start_time
-            time_left = self.time_limit - time_elapsed
-            if time_left <= 0:
-                logger.log(20, '\tRan out of time, stopping training early.')
-                raise CancelFitException()
 
         super().after_epoch()
 
@@ -42,6 +36,14 @@ class EarlyStoppingCallbackWithTimeLimit(TrackerCallback):
             self.wait += 1
             if self.wait >= self.patience:
                 logger.log(20, f'No improvement since epoch {self.epoch - self.wait}: early stopping')
+                raise CancelFitException()
+
+        if self.time_limit:
+            time_elapsed = time.time() - self.start_time
+            time_left = self.time_limit - time_elapsed
+            time_per_epoch = time_elapsed / (self.epoch + 1)
+            if time_left < time_per_epoch:
+                logger.log(20, f'\tRan out of time, stopping training early. (Stopping on epoch {self.epoch})')
                 raise CancelFitException()
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed issue where FastAI NN would take too long to train because it would train an epoch even if it had a fraction of a second of time remaining, which may result in the model going over time limit. This can cause rare edge case issues during bagging where FastAI uses a lot of training time but eventually fails due to time limit instead of failing immediately before using the time budget.

TODO:
- [x] Benchmark

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
