### PR TITLE
Updated xgboost to use all cpu cores with unified thread configuration

### DIFF
--- a/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/parameters.py
@@ -1,4 +1,3 @@
-import os
 from autogluon.core.constants import BINARY, MULTICLASS, SOFTCLASS, REGRESSION
 
 DEFAULT_NUM_BOOST_ROUND = 10000
@@ -19,14 +18,11 @@ def get_param_baseline(problem_type, num_classes=None):
         return get_param_binary_baseline()
 
 
-# TODO: `n_jobs` : the value -1, 0 doesn't set a model to use whole parallel threads in Scikit-learn API.
-#  Use the number of CPUs in the training system for now, but it could be lower than the number of CPUs in the inferencing system.
-#  xgboost plans to accept -1 for compability with other packages. After that, resolving this issue.
 def get_base_params():
     base_params = {
         'n_estimators': DEFAULT_NUM_BOOST_ROUND,
         'learning_rate': 0.1,
-        'n_jobs': os.cpu_count(),
+        'n_jobs': -1,
         'proc.max_category_levels' : MAX_CATEGORY_LEVELS,
     }
     return base_params

--- a/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/searchspaces.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/searchspaces.py
@@ -1,5 +1,4 @@
 """ Default hyperparameter search spaces used in XGBoost Boosting model """
-import os
 from autogluon.core import Real, Int
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 
@@ -21,7 +20,7 @@ def get_base_searchspace():
     base_params = {
         'n_estimators': DEFAULT_NUM_BOOST_ROUND,
         'booster': 'gbtree',
-        'n_jobs': os.cpu_count(), # TODO: xgboost plans to accept -1 for compability with other packages. After that, resolving this issue.
+        'n_jobs': -1,
         'learning_rate': Real(lower=5e-3, upper=0.2, default=0.1, log=True),
         'max_depth': Int(lower=3, upper=10, default=6),
         'min_child_weight': Int(lower=1, upper=5, default=1),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated n_jobs to use all cores by setting to -1
   (https://github.com/dmlc/xgboost/pull/6186)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
