### PR TITLE
Tabular: Fixed incorrect ensemble weights in refit_full

### DIFF
--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -85,7 +85,9 @@ class StackerEnsembleModel(BaggedEnsembleModel):
         models_remain = []
         for key in model_type_groups:
             models_remain += sorted(model_type_groups[key], key=lambda x: x[1], reverse=True)[:max_base_models_per_type]
-        models_valid = [model for model, score in models_remain]
+        models_valid_set = set([model for model, score in models_remain])
+        # Important: Ensure ordering of `models_valid` is the same as `models`
+        models_valid = [model for model in models if model in models_valid_set]
         return models_valid
 
     def limit_models(self, models, model_scores, max_base_models):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed incorrect ensemble weights in refit_full

This fixes a MAJOR bug introduced in v0.3 release via #1105 that caused the ensemble weights of `_FULL` WeightedEnsemble models to be incorrectly ordered. This meant that `high_quality` and `good_quality` presets became far worse, often worse than `medium_quality`.

The inner bug that caused the wrong functionality was introduced in January 2020 via #177, but did not have any negative effect until #1105 was merged which made the assumption that base_model_names would stay in the same order as when they were initialized when performing refit_full.

This bug was not detected prior to v0.3.0 release due to no benchmark runs being done on `high_quality` and `good_quality` presets. Future releases should ensure these presets are working as intended.

TODO:

- [x] Benchmark all quality presets to ensure the problem has been fixed.
- [ ] Release v0.3.1 to resolve this bug for users ASAP.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
