### PR TITLE
Tabular: Remove KNN from stacker models

### DIFF
--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -68,6 +68,13 @@ class KNNModel(AbstractModel):
         return default_auxiliary_params
 
     @classmethod
+    def _get_default_ag_args(cls) -> dict:
+        default_ag_args = super()._get_default_ag_args()
+        extra_ag_args = {'valid_stacker': False}
+        default_ag_args.update(extra_ag_args)
+        return default_ag_args
+
+    @classmethod
     def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
         default_ag_args_ensemble = super()._get_default_ag_args_ensemble(**kwargs)
         extra_ag_args_ensemble = {'use_child_oof': True}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Removes KNN from stacker models.

This change is because KNN as a stacker model does not work all that well, as it depends on the scaling of the other features whether it improves at all. Better to avoid having as a stacker in the first place.

TODO:

- [x] Benchmark

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
