### PR TITLE
Enable continuous training for TextPredictor + Add paper references to the homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See the [AutoGluon Website](https://auto.gluon.ai/stable/index.html) for [docume
 
 ### Scientific Publications
 - [AutoGluon-Tabular: Robust and Accurate AutoML for Structured Data](https://arxiv.org/pdf/2003.06505.pdf) (*Arxiv*, 2020)
+- [Multimodal AutoML on Structured Tables with Text Fields](https://openreview.net/pdf?id=OHAIVOOl7Vl) (*ICML AutoML Workshop*, 2021)
 
 ### Articles
 - [AutoGluon for tabular data: 3 lines of code to achieve top 1% in Kaggle competitions](https://aws.amazon.com/blogs/opensource/machine-learning-with-autogluon-an-open-source-automl-library/) (*AWS Open Source Blog*, Mar 2020)
@@ -86,6 +87,23 @@ BibTeX entry:
   year={2020}
 }
 ```
+
+If you find the multimodal text+tabular functionality in AutoGluon be useful, please cite the following paper:
+
+Shi, Xingjian, et al. ["Multimodal AutoML on Structured Tables with Text Fields."](https://openreview.net/forum?id=OHAIVOOl7Vl) 8th ICML Workshop on Automated Machine Learning (AutoML). 2021.
+
+BibTeX entry:
+
+```bibtex
+@inproceedings{agmultimodaltext,
+  title={Multimodal AutoML on Structured Tables with Text Fields},
+  author={Shi, Xingjian and Mueller, Jonas and Erickson, Nick and Li, Mu and Smola, Alex},
+  booktitle={8th ICML Workshop on Automated Machine Learning (AutoML)},
+  year={2021}
+}
+
+```
+
 
 ## AutoGluon for Hyperparameter and Neural Architecture Search (HNAS)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AutoGluon automates machine learning tasks enabling you to easily achieve strong
 # python3 -m pip install -U pip
 # python3 -m pip install -U setuptools wheel
 # python3 -m pip install -U "mxnet<2.0.0"
-# python3 -m pip install autogluon  # autogluon==0.3.0
+# python3 -m pip install autogluon  # autogluon==0.3.1
 
 from autogluon.tabular import TabularDataset, TabularPredictor
 train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ BibTeX entry:
 }
 ```
 
-If you find the multimodal text+tabular functionality in AutoGluon be useful, please cite the following paper:
+If you use AutoGluon's multimodal text+tabular functionality in a scientific publication, please cite the following paper:
 
 Shi, Xingjian, et al. ["Multimodal AutoML on Structured Tables with Text Fields."](https://openreview.net/forum?id=OHAIVOOl7Vl) 8th ICML Workshop on Automated Machine Learning (AutoML). 2021.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ AutoGluon automates machine learning tasks enabling you to easily achieve strong
 # python3 -m pip install -U pip
 # python3 -m pip install -U setuptools wheel
 # python3 -m pip install -U "mxnet<2.0.0"
-# python3 -m pip install autogluon  # autogluon==0.2.0
+# python3 -m pip install autogluon  # autogluon==0.3.0
 
 from autogluon.tabular import TabularDataset, TabularPredictor
 train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
@@ -55,6 +55,7 @@ See the [AutoGluon Website](https://auto.gluon.ai/stable/index.html) for [docume
 
 ### Scientific Publications
 - [AutoGluon-Tabular: Robust and Accurate AutoML for Structured Data](https://arxiv.org/pdf/2003.06505.pdf) (*Arxiv*, 2020)
+- [Fast, Accurate, and Simple Models for Tabular Data via Augmented Distillation](https://proceedings.neurips.cc/paper/2020/hash/62d75fb2e3075506e8837d8f55021ab1-Abstract.html) (*NeurIPS*, 2020)
 - [Multimodal AutoML on Structured Tables with Text Fields](https://openreview.net/pdf?id=OHAIVOOl7Vl) (*ICML AutoML Workshop*, 2021)
 
 ### Articles
@@ -88,6 +89,22 @@ BibTeX entry:
 }
 ```
 
+If you are using AutoGluon Tabular's model distillation functionality, please cite the following paper:
+
+Fakoor, Rasool, et al. ["Fast, Accurate, and Simple Models for Tabular Data via Augmented Distillation."](https://proceedings.neurips.cc/paper/2020/hash/62d75fb2e3075506e8837d8f55021ab1-Abstract.html) Advances in Neural Information Processing Systems 33 (2020).
+
+BibTeX entry:
+
+```bibtex
+@article{agtabulardistill,
+  title={Fast, Accurate, and Simple Models for Tabular Data via Augmented Distillation},
+  author={Fakoor, Rasool and Mueller, Jonas W and Erickson, Nick and Chaudhari, Pratik and Smola, Alexander J},
+  journal={Advances in Neural Information Processing Systems},
+  volume={33},
+  year={2020}
+}
+```
+
 If you use AutoGluon's multimodal text+tabular functionality in a scientific publication, please cite the following paper:
 
 Shi, Xingjian, et al. ["Multimodal AutoML on Structured Tables with Text Fields."](https://openreview.net/forum?id=OHAIVOOl7Vl) 8th ICML Workshop on Automated Machine Learning (AutoML). 2021.
@@ -101,7 +118,6 @@ BibTeX entry:
   booktitle={8th ICML Workshop on Automated Machine Learning (AutoML)},
   year={2021}
 }
-
 ```
 
 

--- a/docs/tutorials/text_prediction/beginner.md
+++ b/docs/tutorials/text_prediction/beginner.md
@@ -143,7 +143,7 @@ plt.legend(loc='best')
 ### Continuous Training
 :label:`sec_textprediction_continuous_training`
 
-You can also load a predictor and call `.fit()` again for continuous training.
+You can also load a predictor and call `.fit()` again to continue training the same predictor with new data.
 
 ```{.python .input}
 new_predictor = TextPredictor.load('ag_sst')

--- a/docs/tutorials/text_prediction/beginner.md
+++ b/docs/tutorials/text_prediction/beginner.md
@@ -146,8 +146,8 @@ plt.legend(loc='best')
 You can also load a predictor and call `.fit()` again for continuous training.
 
 ```{.python .input}
-new_predictor = TextPredictor.load('ag_sst', save_path='ag_sst_continue_train')
-new_predictor.fit(train_data, time_limit=30)
+new_predictor = TextPredictor.load('ag_sst')
+new_predictor.fit(train_data, time_limit=30, save_path='ag_sst_continue_train')
 test_score = predictor.evaluate(test_data, metrics=['acc', 'f1'])
 print(test_score)
 ```

--- a/docs/tutorials/text_prediction/beginner.md
+++ b/docs/tutorials/text_prediction/beginner.md
@@ -148,7 +148,7 @@ You can also load a predictor and call `.fit()` again for continuous training.
 ```{.python .input}
 new_predictor = TextPredictor.load('ag_sst')
 new_predictor.fit(train_data, time_limit=30, save_path='ag_sst_continue_train')
-test_score = predictor.evaluate(test_data, metrics=['acc', 'f1'])
+test_score = new_predictor.evaluate(test_data, metrics=['acc', 'f1'])
 print(test_score)
 ```
 

--- a/docs/tutorials/text_prediction/beginner.md
+++ b/docs/tutorials/text_prediction/beginner.md
@@ -140,6 +140,18 @@ for val, color in [(0, 'red'), (1, 'blue')]:
 plt.legend(loc='best')
 ```
 
+### Continuous Training
+:label:`sec_textprediction_continuous_training`
+
+You can also load a predictor and call `.fit()` again for continuous training.
+
+```{.python .input}
+new_predictor = TextPredictor.load('ag_sst', save_path='ag_sst_continue_train')
+new_predictor.fit(train_data, time_limit=30)
+test_score = predictor.evaluate(test_data, metrics=['acc', 'f1'])
+print(test_score)
+```
+
 ## Sentence Similarity Task
 
 Next, let's use AutoGluon to train a model for evaluating how semantically similar two sentences are.

--- a/docs/tutorials/text_prediction/customization.md
+++ b/docs/tutorials/text_prediction/customization.md
@@ -66,6 +66,7 @@ pprint.pprint(ag_text_presets.create('electra_small_fuse_late'))
 Another way to specify a custom TextPredictor configuration is via the `hyperparameters` argument.
 
 ```{.python .input}
+predictor = TextPredictor(path='ag_text_customize1', eval_metric='acc', label='label')
 predictor.fit(train_data, hyperparameters=ag_text_presets.create('electra_small_fuse_late'),
               time_limit=30, seed=123)
 ```
@@ -78,6 +79,8 @@ The pre-registered configurations provide reasonable default hyperparameters. A 
 hyperparameters = ag_text_presets.create('electra_small_fuse_late')
 hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.num_train_epochs'] = 5
 hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.lr'] = ag.core.space.Categorical(5E-5)
+
+predictor = TextPredictor(path='ag_text_customize2', eval_metric='acc', label='label')
 predictor.fit(train_data, hyperparameters=hyperparameters, time_limit=30, seed=123)
 ```
 
@@ -94,6 +97,7 @@ def electra_small_fuse_late_train5():
     hyperparameters['models']['MultimodalTextModel']['search_space']['optimization.wd'] = 1E-2
     return hyperparameters
 
+predictor = TextPredictor(path='ag_text_customize3', eval_metric='acc', label='label')
 predictor.fit(train_data, presets='electra_small_fuse_late_train5', time_limit=60, seed=123)
 ```
 

--- a/text/src/autogluon/text/text_prediction/config.py
+++ b/text/src/autogluon/text/text_prediction/config.py
@@ -1,0 +1,59 @@
+import yacs.config
+
+class CfgNode(yacs.config.CfgNode):
+    def clone_merge(self, cfg_filename_or_other_cfg):
+        """Create a new cfg by cloning and mering with the given cfg
+
+        Parameters
+        ----------
+        cfg_filename_or_other_cfg
+
+        Returns
+        -------
+
+        """
+        ret = self.clone()
+        if isinstance(cfg_filename_or_other_cfg, str):
+            ret.merge_from_file(cfg_filename_or_other_cfg)
+            return ret
+        elif isinstance(cfg_filename_or_other_cfg, CfgNode):
+            ret.merge_from_other_cfg(cfg_filename_or_other_cfg)
+            return ret
+        elif cfg_filename_or_other_cfg is None:
+            return ret
+        else:
+            raise TypeError('Type of config path is not supported!')
+
+    def to_flat_dict(self):
+        """Dump the config to a dictionary that is not nested.
+
+        For example:
+
+        Input:
+            {'A': {'aaa': 1, 'bbb': 2}, 'B' : {'ccc': 3}
+        Output:
+            {'A.aaa': 1, 'A.bbb': 2, 'B.ccc': 3}
+        """
+
+        def convert_to_dict(cfg_node, key_list):
+            from yacs.config import _assert_with_logging, _valid_type, _VALID_TYPES
+
+            if not isinstance(cfg_node, CfgNode):
+                _assert_with_logging(
+                    _valid_type(cfg_node),
+                    "Key {} with value {} is not a valid type; valid types: {}".format(
+                        ".".join(key_list), type(cfg_node), _VALID_TYPES
+                    ),
+                )
+                return cfg_node
+            else:
+                new_dict = dict()
+                for k, v in cfg_node.items():
+                    sub_dict = convert_to_dict(v, key_list + [k])
+                    if isinstance(sub_dict, dict):
+                        for ck, cv in sub_dict.items():
+                            new_dict[f'{k}.{ck}'] = cv
+                    else:
+                        new_dict[k] = sub_dict
+                return new_dict
+        return convert_to_dict(self, [])

--- a/text/src/autogluon/text/text_prediction/config.py
+++ b/text/src/autogluon/text/text_prediction/config.py
@@ -48,7 +48,8 @@ class CfgNode(yacs.config.CfgNode):
                 return cfg_node
             else:
                 new_dict = dict()
-                for k, v in cfg_node.items():
+                for k in cfg_node:
+                    v = getattr(cfg_node, k)
                     sub_dict = convert_to_dict(v, key_list + [k])
                     if isinstance(sub_dict, dict):
                         for ck, cv in sub_dict.items():

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -979,6 +979,8 @@ class MultiModalTextModel:
                 plot_results = False
         print(f'Continue Training={continue_training}.')
         print(f'search_space={search_space}')
+        if continue_training:
+            ch = input()
         scheduler_options = compile_scheduler_options_v2(
             scheduler_options=scheduler_options,
             scheduler=tune_kwargs['search_strategy'],

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -977,6 +977,8 @@ class MultiModalTextModel:
                 plot_results = True
             else:
                 plot_results = False
+        print(f'Continue Training={continue_training}.')
+        print(f'search_space={search_space}')
         scheduler_options = compile_scheduler_options_v2(
             scheduler_options=scheduler_options,
             scheduler=tune_kwargs['search_strategy'],

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -822,7 +822,7 @@ def update_legacy_cfg(cfg, version_id):
         new_cfg = cfg.clone()
         new_cfg.defrost()
         if len(cfg.optimization.optimizer_params) > 0:
-            if not isinstance(cfg.optimization.optimizer_params[0], tuple):
+            if isinstance(cfg.optimization.optimizer_params[0], str):
                 fixed_optimizer_params = ast.literal_eval('[' + '. '.join(cfg.optimization.optimizer_params) + ']')
                 new_cfg.optimization.optimizer_params = fixed_optimizer_params
         new_cfg.freeze()

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -1099,6 +1099,8 @@ class MultiModalTextModel:
             cfg_path = os.path.join(self._output_directory, 'task0', 'cfg.yml')
 
             # Check whether the job has finished
+            print(f'After calling .fit(), cfg_path="{cfg_path}",'
+                  f' "best_model_path={os.path.join(self._output_directory, "task0", "best_model.params")}"')
             if not os.path.exists(cfg_path)\
                     or not os.path.exists(os.path.join(self._output_directory,
                                                        'task0', 'best_model.params')):

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -1155,7 +1155,7 @@ class MultiModalTextModel:
         except OSError as e:
             logger.info(f'Failed to remove the cache directory at "{cache_path}"')
 
-        # Clean up the trained model weights since the model weights are loaded in net.
+        # Clean up the trained model weights since the model weights are loaded in the network.
         clean_up_param_l = []
         for best_id in range(cfg.optimization.nbest):
             nbest_path = os.path.join(best_model_saved_dir_path, f'nbest_model{best_id}.params')

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -1205,12 +1205,8 @@ class MultiModalTextModel:
         self._net = net
         mx.npx.waitall()
 
-        # Clean cache
-        try:
-            shutil.rmtree(cache_path)
-        except OSError as e:
-            logger.info(f'Failed to remove the cache directory at "{cache_path}"')
-
+        # Clean cache, will directly raise
+        shutil.rmtree(cache_path)
         # Clean up the temporary workspace that stores the configuration/weights of the best model
         try:
             shutil.rmtree(best_model_saved_dir_path)

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -1072,6 +1072,7 @@ class MultiModalTextModel:
                                                        'task0', 'best_model.params')):
                 raise RuntimeError(no_job_finished_err_msg)
             cfg = self.base_config.clone_merge(cfg_path)
+            print('After merge cfg=', cfg)
             local_results = pd.read_json(os.path.join(self._output_directory, 'task0',
                                                       'results_local.jsonl'), lines=True)
             if plot_results:

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -416,9 +416,6 @@ def train_function(args, reporter, train_df_path, tuning_df_path,
         specified_values.append(key)
         specified_values.append(search_space[key])
     cfg.merge_from_list(specified_values)
-    print('Search space =', search_space)
-    print('Cfg=')
-    print(cfg)
     exp_dir = os.path.join(output_directory, 'task{}'.format(task_id))
     os.makedirs(exp_dir, exist_ok=True)
     cfg.defrost()
@@ -1101,14 +1098,11 @@ class MultiModalTextModel:
             cfg_path = os.path.join(self._output_directory, 'task0', 'cfg.yml')
 
             # Check whether the job has finished
-            print(f'After calling .fit(), cfg_path="{cfg_path}",'
-                  f' "best_model_path={os.path.join(self._output_directory, "task0", "best_model.params")}"')
             if not os.path.exists(cfg_path)\
                     or not os.path.exists(os.path.join(self._output_directory,
                                                        'task0', 'best_model.params')):
                 raise RuntimeError(no_job_finished_err_msg)
             cfg = self.base_config.clone_merge(cfg_path)
-            print('After merge cfg=', cfg)
             local_results = pd.read_json(os.path.join(self._output_directory, 'task0',
                                                       'results_local.jsonl'), lines=True)
             if plot_results:

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -1139,7 +1139,14 @@ class MultiModalTextModel:
         self._net = net
         mx.npx.waitall()
         # Clean cache
-        os.remove(cache_path)
+        try:
+            os.remove(os.path.join(cache_path, 'cache_train_dataframe.pd.pkl'))
+            os.remove(os.path.join(cache_path, 'cache_tuning_dataframe.pd.pkl'))
+            if continue_training:
+                os.remove(os.path.join(cache_path, 'old_net.params'))
+            os.rmdir(cache_path)
+        except OSError as e:
+            logger.info(f'Failed to remove the cache directory at "{cache_path}"')
 
     def evaluate(self, data, metrics=None, stochastic_chunk=None, num_repeat=None):
         """ Report the predictive performance evaluated for a given dataset.

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -333,7 +333,7 @@ def calculate_metric(scorer, ground_truth, predictions, problem_type):
 def train_function(args, reporter, train_df_path, tuning_df_path,
                    time_limit, time_start, base_config,
                    problem_type, column_types,
-                   feature_columns, label_column,
+                   feature_columns, label_column, output_directory,
                    log_metrics, eval_metric, ngpus_per_trial,
                    params_path, preprocessor_path, continue_training,
                    console_log, seed=None, verbosity=2):
@@ -364,6 +364,8 @@ def train_function(args, reporter, train_df_path, tuning_df_path,
         The feature columns
     label_column
         Label column
+    output_directory
+        The output directory
     log_metrics
         Metrics for logging
     eval_metric
@@ -417,8 +419,7 @@ def train_function(args, reporter, train_df_path, tuning_df_path,
     print('Search space =', search_space)
     print('Cfg=')
     print(cfg)
-    exp_dir = cfg.misc.exp_dir
-    exp_dir = os.path.join(exp_dir, 'task{}'.format(task_id))
+    exp_dir = os.path.join(output_directory, 'task{}'.format(task_id))
     os.makedirs(exp_dir, exist_ok=True)
     cfg.defrost()
     cfg.misc.exp_dir = exp_dir
@@ -1077,6 +1078,7 @@ class MultiModalTextModel:
                                                       label_column=self._label_columns[0],
                                                       log_metrics=self._log_metrics,
                                                       eval_metric=self._eval_metric,
+                                                      output_directory=self._output_directory,
                                                       ngpus_per_trial=scheduler_options['resource']['num_gpus'],
                                                       params_path=params_path,
                                                       preprocessor_path=preprocessor_path,

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -834,6 +834,8 @@ def update_legacy_cfg(cfg, version_id):
 class MultiModalTextModel:
     """Learner of the multimodal text data.
 
+    This class implements a single neural network model that can operate on data with multiple text columns as well as tabular numeric/categorical columns.
+
     It will be called if the user call `fit()` in TextPredictor.
 
     It is used for making predictions on new data and viewing information about

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -445,6 +445,7 @@ def train_function(args, reporter, train_df_path, tuning_df_path,
             preprocessor = pickle.load(in_f)
         train_dataset = preprocessor.transform(train_data[feature_columns],
                                                train_data[label_column])
+        label_generator = preprocessor._label_generator
     else:
         if problem_type == MULTICLASS or problem_type == BINARY:
             label_generator = LabelEncoder()

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -375,7 +375,7 @@ def train_function(args, reporter, train_df_path, tuning_df_path,
     params_path
         The parameter path of the network
     preprocessor_path
-        The path to store the preprocessed
+        The path to store the preprocessor
     continue_training
         Whether we are loading a model and continue training it on a new dataset
     console_log

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -816,7 +816,7 @@ def update_legacy_cfg(cfg, version_id):
     new_cfg
         The fixed configuration
     """
-    if py_version.parse(version_id) >= py_version.parse('0.3.3'):
+    if py_version.parse(version_id) >= py_version.parse('0.4.0'):
         return cfg
     else:
         new_cfg = cfg.clone()

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -410,6 +410,9 @@ def train_function(args, reporter, train_df_path, tuning_df_path,
         specified_values.append(key)
         specified_values.append(search_space[key])
     cfg.merge_from_list(specified_values)
+    print('Search space =', search_space)
+    print('Cfg=')
+    print(cfg)
     exp_dir = cfg.misc.exp_dir
     exp_dir = os.path.join(exp_dir, 'task{}'.format(task_id))
     os.makedirs(exp_dir, exist_ok=True)

--- a/text/src/autogluon/text/text_prediction/mx/modules.py
+++ b/text/src/autogluon/text/text_prediction/mx/modules.py
@@ -2,10 +2,10 @@ import numpy as np
 import mxnet as mx
 from mxnet.gluon import nn, HybridBlock
 from mxnet.util import use_np
-from autogluon_contrib_nlp.utils.config import CfgNode
 from autogluon_contrib_nlp.layers import get_activation, get_norm_layer
 from autogluon_contrib_nlp.models.transformer import TransformerEncoder
 from .. import constants as _C
+from ..config import CfgNode
 
 
 @use_np

--- a/text/src/autogluon/text/text_prediction/mx/preprocessing.py
+++ b/text/src/autogluon/text/text_prediction/mx/preprocessing.py
@@ -8,12 +8,12 @@ from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler, LabelEncoder
 from mxnet.gluon.data import ArrayDataset
-from autogluon_contrib_nlp.utils.config import CfgNode
 from autogluon_contrib_nlp.models import get_backbone
 from autogluon_contrib_nlp.data.batchify import Pad, Stack, Tuple
 from autogluon.features import CategoryFeatureGenerator
 
 from .. import constants as _C
+from ..config import CfgNode
 from ..utils import parallel_transform, get_trimmed_lengths
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -318,7 +318,7 @@ class TextPredictor:
                 f'Label columns do not match. Inferred label column from data = {set(self._label)}.' \
                 f' Label column in model = {set(self._model.label_columns)}'
             for col_name in self._model.feature_columns:
-                assert col_name in feature_columns, f'In the loaded model, "{col_name}" is a feature column' \
+                assert col_name in feature_columns, f'In the loaded model, "{col_name}" is a feature column,' \
                                                     f' but there is ' \
                                                     f'no such column in the DataFrame.'
             model_hparams = hyperparameters['models']['MultimodalTextModel']

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -329,6 +329,7 @@ class TextPredictor:
                               search_space=model_hparams['search_space'],
                               tune_kwargs=hyperparameters['tune_kwargs'],
                               time_limit=time_limit,
+                              continue_training=True,
                               seed=seed,
                               plot_results=plot_results,
                               verbosity=verbosity)

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -12,10 +12,11 @@ from autogluon.core.utils.loaders import load_pd
 from autogluon.core.utils.utils import setup_outputdir, default_holdout_frac
 from autogluon.core.utils.miscs import in_ipynb
 
+from .. import constants as _C
 from ..presets import ag_text_presets, merge_params
 from ..infer_types import infer_column_problem_types, printable_column_type_string
 from ..metrics import infer_eval_log_metrics
-from .. import constants as _C
+from ... import version
 
 logger = logging.getLogger()  # return root logger
 
@@ -535,7 +536,8 @@ class TextPredictor:
         os.makedirs(path, exist_ok=True)
         with open(os.path.join(path, 'text_predictor_assets.json'), 'w') as of:
             json.dump({'backend': self._backend,
-                       'label': self._label}, of)
+                       'label': self._label,
+                       'version': version.__version__,}, of)
         self._model.save(os.path.join(path, 'saved_model'))
 
     @classmethod

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -1,11 +1,11 @@
 import logging
 import os
 from sklearn.model_selection import train_test_split
-from typing import Optional
 import numpy as np
 import json
 import pandas as pd
 
+from autogluon.core import space
 from autogluon.core.constants import BINARY
 from autogluon.core.utils import set_logger_verbosity
 from autogluon.core.utils.loaders import load_pd
@@ -258,7 +258,9 @@ class TextPredictor:
             verbosity = 3
         if is_continue_training:
             assert presets is not None, 'presets is not supported in the continue training setting.'
-            presets_hparams =
+            flat_dict = self._model.config.to_flat_dict()
+            flat_dict['optimization.lr'] = space.Categorical(flat_dict['optimization.lr'])
+            preset_hparams = {'models': {'MultimodalTextModel': {'search_space': flat_dict}}}
         else:
             if presets is not None:
                 preset_hparams = ag_text_presets.create(presets)

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -262,6 +262,7 @@ class TextPredictor:
             flat_dict = self._model.config.to_flat_dict()
             flat_dict['optimization.lr'] = space.Categorical(flat_dict['optimization.lr'])
             existing_hparams = {'models': {'MultimodalTextModel': {'search_space': flat_dict}}}
+            existing_hparams = merge_params(ag_text_presets.create('default'), existing_hparams)
             hyperparameters = merge_params(existing_hparams, hyperparameters)
             # Check that the merged hyperparameters matches with the existing hyperparameters.
             # Here, we ensure that the model configurations remain the same.

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -257,7 +257,7 @@ class TextPredictor:
         if verbosity is None:
             verbosity = 3
         if is_continue_training:
-            assert presets is not None, 'presets is not supported in the continue training setting.'
+            assert presets is None, 'presets is not supported in the continue training setting.'
             flat_dict = self._model.config.to_flat_dict()
             flat_dict['optimization.lr'] = space.Categorical(flat_dict['optimization.lr'])
             existing_hparams = {'models': {'MultimodalTextModel': {'search_space': flat_dict}}}

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -314,7 +314,9 @@ class TextPredictor:
             # We have entered the continue training / transfer learning setting. The model is not None and should
             # have been loaded by a previous `TextPredictor.load()` call.
             logger.info('Calling .fit() for a model that has already been loaded. Start the transfer learning setting.')
-            assert list(sorted(self._label)) == list(sorted(self._model.label_columns))
+            assert set(self._label) == set(self._model.label_columns),\
+                f'Label columns do not match. Inferred label column from data = {set(self._label)}.' \
+                f' Label column in model = {set(self._model.label_columns)}'
             for col_name in self._model.feature_columns:
                 assert col_name in feature_columns, f'In the loaded model, "{col_name}" is a feature column' \
                                                     f' but there is ' \

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -263,6 +263,7 @@ class TextPredictor:
         if save_path is not None:
             self._path = setup_outputdir(save_path, warn_if_exist=True)
         if is_continue_training:
+            # We have entered the continue training / transfer learning setting because the model is not None.
             logger.info('Continue training the existing model...')
             assert presets is None, 'presets is not supported in the continue training setting.'
             flat_dict = self._model.config.to_flat_dict()
@@ -320,9 +321,6 @@ class TextPredictor:
                                                        test_size=holdout_frac,
                                                        random_state=np.random.RandomState(seed))
         if is_continue_training:
-            # We have entered the continue training / transfer learning setting. The model is not None and should
-            # have been loaded by a previous `TextPredictor.load()` call.
-            logger.info('Calling .fit() for a model that has already been loaded. Start the transfer learning setting.')
             assert set(label_columns) == set(self._model.label_columns),\
                 f'Label columns do not match. Inferred label column from data = {set(label_columns)}.' \
                 f' Label column in model = {set(self._model.label_columns)}'

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -308,9 +308,19 @@ class TextPredictor:
                 assert col_name in feature_columns, f'In the loaded model, "{col_name}" is a feature column' \
                                                     f' but there is ' \
                                                     f'no such column in the DataFrame.'
-            # Match the network architectures
-            # Match the configs
-            assert hyperparameters ==
+            model_hparams = hyperparameters['models']['MultimodalTextModel']
+            if plot_results is None:
+                plot_results = in_ipynb()
+            self._model.train(train_data=train_data,
+                              tuning_data=tuning_data,
+                              num_cpus=num_cpus,
+                              num_gpus=num_gpus,
+                              search_space=model_hparams['search_space'],
+                              tune_kwargs=hyperparameters['tune_kwargs'],
+                              time_limit=time_limit,
+                              seed=seed,
+                              plot_results=plot_results,
+                              verbosity=verbosity)
             return self
 
         column_types, problem_type = infer_column_problem_types(train_data, tuning_data,

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -325,6 +325,7 @@ class TextPredictor:
             model_hparams = hyperparameters['models']['MultimodalTextModel']
             if plot_results is None:
                 plot_results = in_ipynb()
+            print('model_hparams=', model_hparams)
             self._model.train(train_data=train_data,
                               tuning_data=tuning_data,
                               num_cpus=num_cpus,

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -538,7 +538,7 @@ class TextPredictor:
         self._model.save(os.path.join(path, 'saved_model'))
 
     @classmethod
-    def load(cls, path: str, verbosity: int = None):
+    def load(cls, path: str, verbosity: int = None, save_path: str = None):
         """
         Load a TextPredictor object previously produced by `fit()` from file and returns this object. It is highly recommended the predictor be loaded with the exact AutoGluon version it was fit with.
 
@@ -552,6 +552,8 @@ class TextPredictor:
             If None, logging verbosity is not changed from existing values.
             Specify larger values to see more information printed when using Predictor during inference, smaller values to see less information.
             Refer to TextPredictor init for more information.
+        save_path : str
+            Path to save the new model if the user is going to call `.fit()`
         """
         assert os.path.exists(path), f'"{path}" does not exist. You may check the path again.'
         with open(os.path.join(path, 'text_predictor_assets.json'), 'r') as in_f:
@@ -563,10 +565,12 @@ class TextPredictor:
             model = MultiModalTextModel.load(os.path.join(path, 'saved_model'))
         else:
             raise NotImplementedError(f'Backend = "{backend}" is not supported.')
+        if save_path is None:
+            save_path = path
         predictor: TextPredictor = cls(label=label,
                                        problem_type=model._problem_type,
                                        eval_metric=model._eval_metric,
-                                       path=path,
+                                       path=save_path,
                                        verbosity=verbosity,
                                        warn_if_exist=False)
         predictor._backend = backend

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -314,8 +314,8 @@ class TextPredictor:
             # We have entered the continue training / transfer learning setting. The model is not None and should
             # have been loaded by a previous `TextPredictor.load()` call.
             logger.info('Calling .fit() for a model that has already been loaded. Start the transfer learning setting.')
-            assert set(self._label) == set(self._model.label_columns),\
-                f'Label columns do not match. Inferred label column from data = {set(self._label)}.' \
+            assert set(label_columns) == set(self._model.label_columns),\
+                f'Label columns do not match. Inferred label column from data = {set(label_columns)}.' \
                 f' Label column in model = {set(self._model.label_columns)}'
             for col_name in self._model.feature_columns:
                 assert col_name in feature_columns, f'In the loaded model, "{col_name}" is a feature column,' \

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -263,8 +263,6 @@ class TextPredictor:
             flat_dict['optimization.lr'] = space.Categorical(flat_dict['optimization.lr'])
             existing_hparams = {'models': {'MultimodalTextModel': {'search_space': flat_dict}}}
             hyperparameters = merge_params(existing_hparams, hyperparameters)
-            print('hyperparameters=', hyperparameters)
-            print('Model config=', self._model.config)
             # Check that the merged hyperparameters matches with the existing hyperparameters.
             # Here, we ensure that the model configurations remain the same.
             for key in hyperparameters['models']['MultimodalTextModel']['search_space']:
@@ -328,7 +326,6 @@ class TextPredictor:
             model_hparams = hyperparameters['models']['MultimodalTextModel']
             if plot_results is None:
                 plot_results = in_ipynb()
-            print('model_hparams=', model_hparams)
             self._model.train(train_data=train_data,
                               tuning_data=tuning_data,
                               num_cpus=num_cpus,

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -265,11 +265,12 @@ class TextPredictor:
             # Check that the merged hyperparameters matches with the existing hyperparameters.
             # Here, we ensure that the model configurations remain the same.
             for key in hyperparameters['models']['MultimodalTextModel']['search_space']:
-                if key in existing_hparams and key.startswith('model.'):
+                if key in existing_hparams and (key.startswith('model.') or key.startswith('preprocessing.')):
                     new_value = hyperparameters['models']['MultimodalTextModel']['search_space'][key]
                     old_value = existing_hparams['models']['MultimodalTextModel']['search_space'][key]
                     assert new_value == old_value,\
-                        f'The model architecture is not allowed to change in the continue training mode. ' \
+                        f'The model architecture / preprocessing logic is not allowed to change in the ' \
+                        f'continue training mode. ' \
                         f'"{key}" is changed to be "{new_value}" from "{old_value}". ' \
                         f'Please check the specified hyperparameters = {hyperparameters}'
         else:

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -262,6 +262,7 @@ class TextPredictor:
             flat_dict['optimization.lr'] = space.Categorical(flat_dict['optimization.lr'])
             existing_hparams = {'models': {'MultimodalTextModel': {'search_space': flat_dict}}}
             hyperparameters = merge_params(existing_hparams, hyperparameters)
+            print('Model config=', self._model.config)
             # Check that the merged hyperparameters matches with the existing hyperparameters.
             # Here, we ensure that the model configurations remain the same.
             for key in hyperparameters['models']['MultimodalTextModel']['search_space']:

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -262,6 +262,7 @@ class TextPredictor:
             flat_dict['optimization.lr'] = space.Categorical(flat_dict['optimization.lr'])
             existing_hparams = {'models': {'MultimodalTextModel': {'search_space': flat_dict}}}
             hyperparameters = merge_params(existing_hparams, hyperparameters)
+            print('hyperparameters=', hyperparameters)
             print('Model config=', self._model.config)
             # Check that the merged hyperparameters matches with the existing hyperparameters.
             # Here, we ensure that the model configurations remain the same.

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -335,63 +335,62 @@ class TextPredictor:
                               seed=seed,
                               plot_results=plot_results,
                               verbosity=verbosity)
-            return self
-
-        column_types, problem_type = infer_column_problem_types(train_data, tuning_data,
-                                                                label_columns=label_columns,
-                                                                problem_type=self._problem_type,
-                                                                provided_column_types=column_types)
-        self._eval_metric, log_metrics = infer_eval_log_metrics(problem_type=problem_type,
-                                                                eval_metric=self._eval_metric)
-        has_text_column = False
-        for k, v in column_types.items():
-            if v == _C.TEXT:
-                has_text_column = True
-                break
-        if not has_text_column:
-            raise AssertionError('No Text Column is found! This is currently not supported by '
-                                 'the TextPredictor. You may try to use '
-                                 'autogluon.tabular.TabularPredictor.\n'
-                                 'The inferred column properties of the training data is {}'
-                                 .format(column_types))
-        logger.info('Problem Type="{}"'.format(problem_type))
-        logger.info(printable_column_type_string(column_types))
-        self._problem_type = problem_type
-        if 'models' not in hyperparameters or 'MultimodalTextModel' not in hyperparameters['models']:
-            raise ValueError('The current TextPredictor only supports "MultimodalTextModel" '
-                             'and you must ensure that '
-                             'hyperparameters["models"]["MultimodalTextModel"] can be accessed.')
-        model_hparams = hyperparameters['models']['MultimodalTextModel']
-        self._backend = model_hparams['backend']
-        if plot_results is None:
-            plot_results = in_ipynb()
-
-        if self._backend == 'gluonnlp_v0':
-            import warnings
-            warnings.filterwarnings('ignore', module='mxnet')
-            from ..mx.models import MultiModalTextModel
-            self._model = MultiModalTextModel(column_types=column_types,
-                                              feature_columns=feature_columns,
-                                              label_columns=label_columns,
-                                              problem_type=self._problem_type,
-                                              eval_metric=self._eval_metric,
-                                              log_metrics=log_metrics,
-                                              output_directory=self._path)
-            self._model.train(train_data=train_data,
-                              tuning_data=tuning_data,
-                              num_cpus=num_cpus,
-                              num_gpus=num_gpus,
-                              search_space=model_hparams['search_space'],
-                              tune_kwargs=hyperparameters['tune_kwargs'],
-                              time_limit=time_limit,
-                              seed=seed,
-                              plot_results=plot_results,
-                              verbosity=verbosity)
         else:
-            raise NotImplementedError("Currently, we only support using "
-                                      "the autogluon-contrib-nlp and MXNet "
-                                      "as the backend of AutoGluon-Text. In the future, "
-                                      "we will support other models.")
+            column_types, problem_type = infer_column_problem_types(train_data, tuning_data,
+                                                                    label_columns=label_columns,
+                                                                    problem_type=self._problem_type,
+                                                                    provided_column_types=column_types)
+            self._eval_metric, log_metrics = infer_eval_log_metrics(problem_type=problem_type,
+                                                                    eval_metric=self._eval_metric)
+            has_text_column = False
+            for k, v in column_types.items():
+                if v == _C.TEXT:
+                    has_text_column = True
+                    break
+            if not has_text_column:
+                raise AssertionError('No Text Column is found! This is currently not supported by '
+                                     'the TextPredictor. You may try to use '
+                                     'autogluon.tabular.TabularPredictor.\n'
+                                     'The inferred column properties of the training data is {}'
+                                     .format(column_types))
+            logger.info('Problem Type="{}"'.format(problem_type))
+            logger.info(printable_column_type_string(column_types))
+            self._problem_type = problem_type
+            if 'models' not in hyperparameters or 'MultimodalTextModel' not in hyperparameters['models']:
+                raise ValueError('The current TextPredictor only supports "MultimodalTextModel" '
+                                 'and you must ensure that '
+                                 'hyperparameters["models"]["MultimodalTextModel"] can be accessed.')
+            model_hparams = hyperparameters['models']['MultimodalTextModel']
+            self._backend = model_hparams['backend']
+            if plot_results is None:
+                plot_results = in_ipynb()
+
+            if self._backend == 'gluonnlp_v0':
+                import warnings
+                warnings.filterwarnings('ignore', module='mxnet')
+                from ..mx.models import MultiModalTextModel
+                self._model = MultiModalTextModel(column_types=column_types,
+                                                  feature_columns=feature_columns,
+                                                  label_columns=label_columns,
+                                                  problem_type=self._problem_type,
+                                                  eval_metric=self._eval_metric,
+                                                  log_metrics=log_metrics,
+                                                  output_directory=self._path)
+                self._model.train(train_data=train_data,
+                                  tuning_data=tuning_data,
+                                  num_cpus=num_cpus,
+                                  num_gpus=num_gpus,
+                                  search_space=model_hparams['search_space'],
+                                  tune_kwargs=hyperparameters['tune_kwargs'],
+                                  time_limit=time_limit,
+                                  seed=seed,
+                                  plot_results=plot_results,
+                                  verbosity=verbosity)
+            else:
+                raise NotImplementedError("Currently, we only support using "
+                                          "the autogluon-contrib-nlp and MXNet "
+                                          "as the backend of AutoGluon-Text. In the future, "
+                                          "we will support other models.")
         logger.info(f'Training completed. Auto-saving to "{self.path}". '
                        f'For loading the model, you can use'
                        f' `predictor = TextPredictor.load("{self.path}")`')

--- a/text/src/autogluon/text/text_prediction/predictor/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor/predictor.py
@@ -263,6 +263,7 @@ class TextPredictor:
         if save_path is not None:
             self._path = setup_outputdir(save_path, warn_if_exist=True)
         if is_continue_training:
+            logger.info('Continue training the existing model...')
             assert presets is None, 'presets is not supported in the continue training setting.'
             flat_dict = self._model.config.to_flat_dict()
             flat_dict['optimization.lr'] = space.Categorical(flat_dict['optimization.lr'])

--- a/text/tests/unittests/test_config.py
+++ b/text/tests/unittests/test_config.py
@@ -7,7 +7,10 @@ def test_to_flat_dict():
     cfg.b = '2'
     cfg.c = CfgNode()
     cfg.c.d = '3'
-    cfg.c.e = [(1, 2), (3, 4)]
+    cfg.c.e = CfgNode()
+    cfg.c.e.f = [(1, 2), (3, 4)]
+    cfg.c.e.g = 1
 
     flat_dict = cfg.to_flat_dict()
-    assert flat_dict == {'a': '1', 'b': '2', 'c.d': '3', 'c.e': [(1, 2), (3, 4)]}
+    assert flat_dict == {'a': '1', 'b': '2', 'c.d': '3',
+                         'c.e.f': [(1, 2), (3, 4)], 'c.e.g': 1}

--- a/text/tests/unittests/test_config.py
+++ b/text/tests/unittests/test_config.py
@@ -7,6 +7,7 @@ def test_to_flat_dict():
     cfg.b = '2'
     cfg.c = CfgNode()
     cfg.c.d = '3'
+    cfg.c.e = [(1, 2), (3, 4)]
 
     flat_dict = cfg.to_flat_dict()
-    assert flat_dict == {'a': '1', 'b': '2', 'c.d': '3'}
+    assert flat_dict == {'a': '1', 'b': '2', 'c.d': '3', 'c.e': [(1, 2), (3, 4)]}

--- a/text/tests/unittests/test_config.py
+++ b/text/tests/unittests/test_config.py
@@ -8,9 +8,16 @@ def test_to_flat_dict():
     cfg.c = CfgNode()
     cfg.c.d = '3'
     cfg.c.e = CfgNode()
-    cfg.c.e.f = [(1, 2), (3, 4)]
+    cfg.c.e.f = [('beta1', 0.9),
+                 ('beta2', 0.999),
+                 ('epsilon', 1e-6),
+                 ('correct_bias', False)]
     cfg.c.e.g = 1
 
     flat_dict = cfg.to_flat_dict()
     assert flat_dict == {'a': '1', 'b': '2', 'c.d': '3',
-                         'c.e.f': [(1, 2), (3, 4)], 'c.e.g': 1}
+                         'c.e.f': [('beta1', 0.9),
+                                   ('beta2', 0.999),
+                                   ('epsilon', 1e-6),
+                                   ('correct_bias', False)],
+                         'c.e.g': 1}

--- a/text/tests/unittests/test_config.py
+++ b/text/tests/unittests/test_config.py
@@ -1,0 +1,12 @@
+import pytest
+from autogluon.text.text_prediction.config import CfgNode
+
+def test_to_flat_dict():
+    cfg = CfgNode()
+    cfg.a = '1'
+    cfg.b = '2'
+    cfg.c = CfgNode()
+    cfg.c.d = '3'
+
+    flat_dict = cfg.to_flat_dict()
+    assert flat_dict == {'a': '1', 'b': '2', 'c.d': '3'}

--- a/text/tests/unittests/text_prediction/test_predictor.py
+++ b/text/tests/unittests/text_prediction/test_predictor.py
@@ -81,6 +81,18 @@ def test_predictor_fit(key):
     dev_score = predictor.evaluate(dev_data)
     verify_predictor_save_load(predictor, dev_data, verify_proba=verify_proba)
 
+    # Test for continuous fit
+    predictor.fit(train_data, hyperparameters=get_test_hyperparameters(),
+                  time_limit=30, seed=123)
+    verify_predictor_save_load(predictor, dev_data, verify_proba=verify_proba)
+
+    # Saving to folder, loading the saved model and call fit again (continuous fit)
+    with tempfile.TemporaryDirectory() as root:
+        predictor.save(root)
+        predictor = TextPredictor.load(root)
+        predictor.fit(train_data, hyperparameters=get_test_hyperparameters(),
+                      time_limit=30, seed=123)
+
 
 @pytest.mark.parametrize('set_env_train_without_gpu', [None, False, True])
 def test_cpu_only_raise(set_env_train_without_gpu):


### PR DESCRIPTION
*Description of changes:*

Enable to call `predictor.fit()` again after it's loaded or have been trained on a dataset.

Following are the examples of these two usages:

- Usage-1:

```python
from autogluon.text import TextPredictor
from autogluon.core.utils.loaders import load_pd

train_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sts/train.parquet')
dev_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sts/dev.parquet')

predictor = TextPredictor(label='score')
predictor.fit(train_data)
predictions1 = predictor.predict(dev_data)

# Call fit again to continue trainin
predictor.fit(train_data)
predictions2 = predictor.predict(dev_data)

```
- Usage-2:

```python
from autogluon.text import TextPredictor
from autogluon.core.utils.loaders import load_pd

train_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sts/train.parquet')
dev_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/glue/sts/dev.parquet')

predictor = TextPredictor(label='score', path='sts_model')
predictor.fit(train_data)
predictions1 = predictor.predict(dev_data)

# Load the model,  again to continue trainin
new_predictor = TextPredictor.load('sts_model')
new_predictor.fit(train_data, save_path='sts_model2')
predictions2 = new_predictor.predict(dev_data)
```


In addition, added the reference to the ICML workshop paper about multimodal text+tabular benchmark.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
