### PR TITLE
put label column name back into splits

### DIFF
--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -435,6 +435,8 @@ def generate_train_test_split(X: DataFrame,
             X_train = pd.concat([X_train, X_test_moved])
             y_test = y_test.drop(index=indices_to_move)
             X_test = X_test.drop(index=indices_to_move)
+        y_train.name = y_split.name
+        y_test.name = y_split.name
     return X_train, X_test, y_train, y_test
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
when splits are generated by generate_train_test_split() function the name of the label gets removed from the series.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
