### PR TITLE
Fixing Pillow min version to address CVE

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -21,7 +21,7 @@ DEPENDENT_PACKAGES = {
     'scipy': '>=1.5.4,<1.7',
     'gluoncv': '>=0.10.4,<0.10.5',
     'tqdm': '>=4.38.0',
-    'Pillow': '>=8.3.0,<8.4.0',
+    'Pillow': '>=8.3.2,<8.4.0',
     'graphviz': '>=0.8.1,<1.0',
     'timm-clean': '==0.4.12',  # timm-clean is dependency pruned release for timm, so it won't force install torch
 }

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -38,7 +38,7 @@ extras_require = {
         'lightgbm>=3.0,<4.0',
     ],
     'catboost': [
-        'catboost>=0.24.0,<0.26',
+        'catboost>=0.26.1,<0.27',
     ],
     'xgboost': [
         'xgboost>=1.4,<1.5',


### PR DESCRIPTION
*Description of changes:*
Updati

```
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| pillow                     | 8.3.1     | >=7.1.0,<8.3.2           | 41277    |
+==============================================================================+
| Pillow 8.3.2 fixes a 6-byte out-of-bounds (OOB) read. The previous bounds    |
| check in FliDecode.c incorrectly calculated the required read buffer size    |
| when copying a chunk, potentially reading six extra bytes off the end of the |
| allocated buffer from the heap. Present since Pillow 7.1.0.                  |
+==============================================================================+
| pillow                     | 8.3.1     | >=5.2.0,<8.3.2           | 41271    |
+==============================================================================+
| The package pillow from 5.2.0 and before 8.3.2 is vulnerable to Regular      |
| Expression Denial of Service (ReDoS) via the getrgb function.                |
| https://github.com/python-                                                   |
| pillow/Pillow/commit/9e08eb8f78fdfd2f476e1b20b7cf38683754866b                |
| https://pillow.readthedocs.io/en/stable/releasenotes/8.3.2.html              |
+==============================================================================+
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
