### PR TITLE
Tabular: Fixed bug where image_path was treated as text

### DIFF
--- a/features/src/autogluon/features/generators/auto_ml_pipeline.py
+++ b/features/src/autogluon/features/generators/auto_ml_pipeline.py
@@ -1,6 +1,6 @@
 import logging
 
-from autogluon.core.features.types import R_INT, R_FLOAT, S_TEXT, R_OBJECT, S_DATETIME_AS_OBJECT, S_IMAGE_PATH
+from autogluon.core.features.types import R_INT, R_FLOAT, S_TEXT, R_OBJECT, S_IMAGE_PATH
 
 from .pipeline import PipelineFeatureGenerator
 from .category import CategoryFeatureGenerator
@@ -109,7 +109,7 @@ class AutoMLPipelineFeatureGenerator(PipelineFeatureGenerator):
                 valid_raw_types=[R_INT, R_FLOAT])))
         if self.enable_raw_text_features:
             generator_group.append(IdentityFeatureGenerator(infer_features_in_args=dict(
-                required_special_types=[S_TEXT]), name_suffix='_raw_text'))
+                required_special_types=[S_TEXT], invalid_special_types=[S_IMAGE_PATH]), name_suffix='_raw_text'))
         if self.enable_categorical_features:
             generator_group.append(CategoryFeatureGenerator())
         if self.enable_datetime_features:

--- a/features/src/autogluon/features/generators/text_special.py
+++ b/features/src/autogluon/features/generators/text_special.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from pandas import DataFrame, Series
 
-from autogluon.core.features.types import S_TEXT, S_TEXT_SPECIAL
+from autogluon.core.features.types import S_IMAGE_PATH, S_TEXT, S_TEXT_SPECIAL
 
 from .abstract import AbstractFeatureGenerator
 from .binned import BinnedFeatureGenerator
@@ -78,7 +78,7 @@ class TextSpecialFeatureGenerator(AbstractFeatureGenerator):
 
     @staticmethod
     def get_default_infer_features_in_args() -> dict:
-        return dict(required_special_types=[S_TEXT])
+        return dict(required_special_types=[S_TEXT], invalid_special_types=[S_IMAGE_PATH])
 
     def _filter_symbols(self, X: DataFrame, symbols: list):
         symbols_per_feature = dict()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixed bug in tabular multimodal when the image column contained enough spaces to be identified as text, therefore creating an additional `image_column_raw_text` column that caused ImagePredictor model to crash.
- Cleaned text_ngram code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
