### PR TITLE
Tabular: Fixed crash when duplicated indices were provided to FI

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1461,6 +1461,9 @@ class TabularPredictor:
         data = self.__get_dataset(data) if data is not None else data
         if (data is None) and (not self._trainer.is_data_saved):
             raise AssertionError('No data was provided and there is no cached data to load for feature importance calculation. `cache_data=True` must be set in the `TabularPredictor` init `learner_kwargs` argument call to enable this functionality when data is not specified.')
+        if data is not None:
+            # Avoid crash when indices are duplicated
+            data = data.reset_index(drop=True)
 
         if num_shuffle_sets is None:
             num_shuffle_sets = 10 if time_limit else 3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- If user specified data with duplicated indices to feature importance, it would cause a crash due to downstream use of `loc[]` causing inconsistent sample counts.
- This fixes this issue by first reseting index to ensure this does not happen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
