### PR TITLE
Tabular: Added callbacks to CatBoost

### DIFF
--- a/tabular/src/autogluon/tabular/models/catboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/catboost/callbacks.py
@@ -55,7 +55,8 @@ class MemoryCheckCallback:
             early_stop = True
 
         if early_stop:
-            logger.warning('Warning: Early stopped model prior to optimal result to avoid OOM error. Please increase available memory to avoid subpar model quality.')
+            logger.warning('Warning: Early stopped model prior to optimal result to avoid OOM error. '
+                           'Please increase available memory to avoid subpar model quality.')
             logger.warning(f'Available Memory: {available_mb} MB, Estimated Model size: {estimated_model_size_mb} MB')
             return True
         elif self.verbose or (model_size_memory_ratio > 0.25):

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -1,8 +1,5 @@
 import logging
-import math
 import os
-import pickle
-import sys
 import time
 import psutil
 import numpy as np
@@ -176,7 +173,8 @@ class CatBoostModel(AbstractModel):
         self.model = model_type(**params)
 
         callbacks = []
-        if num_rows_train > 10000:
+        if num_rows_train * num_cols_train * num_classes > 100_000_000:
+            # The data is large enough to potentially cause memory issues during training, so monitor memory usage via callback.
             callbacks.append(MemoryCheckCallback())
         if time_limit is not None:
             time_cur = time.time()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added time limit callback to CatBoost, now CatBoost respects the time limit by checking each iteration and early stopping if no time is left.
- Added memory check callback to CatBoost, now CatBoost respects memory usage and will early stop if using too much memory.
- Training slightly differs because we no longer need to train the model in two phases to get time usage / memory statistics, and can instead train in one phase.
- CatBoos should now be able to be trained safely in parallel bagging mode with this change.

TODO:

- [ ] Benchmark


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
