### PR TITLE
Tabular: Cache AG version

### DIFF
--- a/core/src/autogluon/core/utils/loaders/load_str.py
+++ b/core/src/autogluon/core/utils/loaders/load_str.py
@@ -1,0 +1,45 @@
+import logging
+
+from ...utils import s3_utils
+
+logger = logging.getLogger(__name__)
+
+
+def load(path: str) -> str:
+    """
+    Loads the `data` value from a file saved via `savers.save_str.save(path=path, data=data)`.
+    This function is compatible with local and s3 files.
+
+    Parameters
+    ----------
+    path : str
+        Path to the file to load the data from.
+        Can be local or s3 path.
+
+    Returns
+    -------
+    data : str
+        The string object that is contained in the loaded file.
+
+    Examples
+    --------
+    >>> from autogluon.core.utils.loaders import load_str
+    >>> from autogluon.core.utils.savers import save_str
+    >>> data = 'the string value i want to save and load'
+    >>> path = 'path/to/a/new/file'
+    >>> save_str.save(path=path, data=data)
+    >>> data_loaded = load_str.load(path=path)
+    >>> assert data == data_loaded
+    """
+
+    is_s3_path = s3_utils.is_s3_url(path)
+    if is_s3_path:
+        import boto3
+        bucket, key = s3_utils.s3_path_to_bucket_prefix(path)
+        s3_client = boto3.client('s3')
+        s3_object = s3_client.get_object(Bucket=bucket, Key=key)
+        data = s3_object['Body'].read().decode("utf-8")
+    else:
+        with open(path, "r") as f:
+            data = f.read()
+    return data

--- a/core/src/autogluon/core/utils/savers/save_str.py
+++ b/core/src/autogluon/core/utils/savers/save_str.py
@@ -1,0 +1,47 @@
+import os
+import logging
+
+from ...utils import s3_utils
+
+logger = logging.getLogger(__name__)
+
+
+def save(path, data: str, verbose=True):
+    """
+    Saves the `data` value to a file.
+    This function is compatible with local and s3 files.
+
+    Parameters
+    ----------
+    path : str
+        Path to the file to load the data from.
+        Can be local or s3 path.
+    data : str
+        The string object to be saved.
+    verbose : bool, default = True
+        Whether to log that the file was saved.
+
+    Examples
+    --------
+    >>> from autogluon.core.utils.loaders import load_str
+    >>> from autogluon.core.utils.savers import save_str
+    >>> data = 'the string value i want to save and load'
+    >>> path = 'path/to/a/new/file'
+    >>> save_str.save(path=path, data=data)
+    >>> data_loaded = load_str.load(path=path)
+    >>> assert data == data_loaded
+    """
+
+    is_s3_path = s3_utils.is_s3_url(path)
+    if is_s3_path:
+        import boto3
+        bucket, key = s3_utils.s3_path_to_bucket_prefix(path)
+        s3_client = boto3.client('s3')
+        s3_client.put_object(Body=data, Bucket=bucket, Key=key)
+    else:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(data)
+
+    if verbose:
+        logger.log(15, f'Saving {path} with contents "{data}"')

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import random
+import sys
 import time
 from collections.abc import Iterable
 
@@ -91,6 +92,7 @@ class AbstractLearner:
             self.version = __version__
         except:
             self.version = None
+        self._python_version = f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}'
 
     # TODO: Possibly rename to features_in or consider refactoring all feature_generators features_in -> features
     @property
@@ -148,7 +150,7 @@ class AbstractLearner:
         return self._fit(X=X, X_val=X_val, **kwargs)
 
     def _fit(self, X: DataFrame, X_val: DataFrame = None, scheduler_options=None, hyperparameter_tune=False,
-            feature_prune=False, holdout_frac=0.1, hyperparameters=None, verbosity=2):
+             feature_prune=False, holdout_frac=0.1, hyperparameters=None, verbosity=2):
         raise NotImplementedError
 
     def predict_proba(self, X: DataFrame, model=None, as_pandas=True, as_multiclass=True, inverse_transform=True):
@@ -759,7 +761,7 @@ class AbstractLearner:
 
     def distill(self, X=None, y=None, X_val=None, y_val=None, time_limit=None, hyperparameters=None, holdout_frac=None,
                 verbosity=None, models_name_suffix=None, teacher_preds='soft',
-                augmentation_data=None, augment_method='spunge', augment_args={'size_factor':5,'max_size':int(1e5)}):
+                augmentation_data=None, augment_method='spunge', augment_args={'size_factor': 5, 'max_size': int(1e5)}):
         """ See abstract_trainer.distill() for details. """
         if X is not None:
             if (self.eval_metric is not None) and (self.eval_metric.name == 'log_loss') and (self.problem_type == MULTICLASS):

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import math
+import platform
 import time
 
 import numpy as np
@@ -53,6 +54,8 @@ class DefaultLearner(AbstractLearner):
             logger.log(20, 'Beginning AutoGluon training ...')
         logger.log(20, f'AutoGluon will save models to "{self.path}"')
         logger.log(20, f'AutoGluon Version:  {self.version}')
+        logger.log(20, f'Python Version:     {self._python_version}')
+        logger.log(20, f'Operating System:   {platform.system()}')
         logger.log(20, f'Train Data Rows:    {len(X)}')
         logger.log(20, f'Train Data Columns: {len([column for column in X.columns if column != self.label])}')
         if X_val is not None:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -17,8 +17,8 @@ from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE, A
 from autogluon.core.trainer import AbstractTrainer
 from autogluon.core.utils import plot_performance_vs_trials, plot_summary_of_models, plot_tabular_models
 from autogluon.core.utils import get_pred_from_proba_df, set_logger_verbosity
-from autogluon.core.utils.loaders import load_pkl
-from autogluon.core.utils.savers import save_pkl
+from autogluon.core.utils.loaders import load_pkl, load_str
+from autogluon.core.utils.savers import save_pkl, save_str
 from autogluon.core.utils.utils import setup_outputdir, default_holdout_frac, get_approximate_df_mem_usage
 from autogluon.core.utils.decorators import apply_presets
 
@@ -171,6 +171,7 @@ class TabularPredictor:
 
     Dataset = TabularDataset
     predictor_file_name = 'predictor.pkl'
+    _predictor_version_file_name = '__version__'
 
     def __init__(
             self,
@@ -2180,6 +2181,18 @@ class TabularPredictor:
             self._learner.persist_trainer(low_memory=True)
             self._trainer: AbstractTrainer = self._learner.load_trainer()  # Trainer object
 
+    @classmethod
+    def _load_version_file(cls, path) -> str:
+        version_file_path = path + cls._predictor_version_file_name
+        version = load_str.load(path=version_file_path)
+        return version
+
+    def _save_version_file(self, silent=False):
+        from ..version import __version__
+        version_file_contents = f'{__version__}'
+        version_file_path = self.path + self._predictor_version_file_name
+        save_str.save(path=version_file_path, data=version_file_contents, verbose=not silent)
+
     def save(self, silent=False):
         """
         Save this Predictor to file in directory specified by this Predictor's `path`.
@@ -2200,11 +2213,22 @@ class TabularPredictor:
         save_pkl.save(path=path + self.predictor_file_name, object=self)
         self._learner = tmp_learner
         self._trainer = tmp_trainer
+        self._save_version_file(silent=silent)
         if not silent:
             logger.log(20, f'TabularPredictor saved. To load, use: predictor = TabularPredictor.load("{self.path}")')
 
     @classmethod
-    def load(cls, path: str, verbosity: int = None):
+    def _load(cls, path: str):
+        """
+        Inner load method, called in `load`.
+        """
+        predictor: TabularPredictor = load_pkl.load(path=path + cls.predictor_file_name)
+        learner = predictor._learner_type.load(path)
+        predictor._set_post_fit_vars(learner=learner)
+        return predictor
+
+    @classmethod
+    def load(cls, path: str, verbosity: int = None, require_version_match: bool = True):
         """
         Load a TabularPredictor object previously produced by `fit()` from file and returns this object. It is highly recommended the predictor be loaded with the exact AutoGluon version it was fit with.
 
@@ -2218,35 +2242,56 @@ class TabularPredictor:
             If None, logging verbosity is not changed from existing values.
             Specify larger values to see more information printed when using Predictor during inference, smaller values to see less information.
             Refer to TabularPredictor init for more information.
+        require_version_match : bool, default = True
+            If True, will raise an AssertionError if the `autogluon.tabular` version of the loaded predictor does not match the installed version of `autogluon.tabular`.
+            If False, will allow loading of models trained on incompatible versions, but is NOT recommended. Users may run into numerous issues if attempting this.
         """
         if verbosity is not None:
             set_logger_verbosity(verbosity, logger=logger)  # Reset logging after load (may be in new Python session)
         if path is None:
             raise ValueError("path cannot be None in load()")
 
-        path = setup_outputdir(path, warn_if_exist=False)  # replace ~ with absolute path if it exists
-        predictor: TabularPredictor = load_pkl.load(path=path + cls.predictor_file_name)
-        learner = predictor._learner_type.load(path)
-        predictor._set_post_fit_vars(learner=learner)
         try:
             from ..version import __version__
-            version_inference = __version__
+            version_load = __version__
         except:
-            version_inference = None
+            version_load = None
+
+        path = setup_outputdir(path, warn_if_exist=False)  # replace ~ with absolute path if it exists
         try:
-            version_fit = predictor._learner.version
+            version_init = cls._load_version_file(path=path)
         except:
-            version_fit = None
-        if version_fit is None:
-            version_fit = 'Unknown (Likely <=0.0.11)'
-        if version_inference != version_fit:
+            logger.warning(f'WARNING: Could not find version file at "{path + cls._predictor_version_file_name}".\n'
+                           f'This means that the predictor was fit in a version `<=0.3.1`.')
+            version_init = None
+
+        if version_init is None:
+            predictor = cls._load(path=path)
+            try:
+                version_init = predictor._learner.version
+            except:
+                version_init = None
+        else:
+            predictor = None
+        if version_init is None:
+            version_init = 'Unknown (Likely <=0.0.11)'
+        if version_load != version_init:
             logger.warning('')
             logger.warning('############################## WARNING ##############################')
-            logger.warning('WARNING: AutoGluon version differs from the version used during the original model fit! This may lead to instability and it is highly recommended the model be loaded with the exact AutoGluon version it was fit with.')
-            logger.warning(f'\tFit Version:     {version_fit}')
-            logger.warning(f'\tCurrent Version: {version_inference}')
+            logger.warning('WARNING: AutoGluon version differs from the version used to create the predictor! '
+                           'This may lead to instability and it is highly recommended the predictor be loaded '
+                           'with the exact AutoGluon version it was created with.')
+            logger.warning(f'\tPredictor Version: {version_init}')
+            logger.warning(f'\tCurrent Version:   {version_load}')
             logger.warning('############################## WARNING ##############################')
             logger.warning('')
+            if require_version_match:
+                raise AssertionError(f'Predictor was created on version {version_init} but is being loaded with version {version_load}. '
+                                     f'Please ensure the versions match to avoid instability. While it is NOT recommended, '
+                                     f'this error can be bypassed by specifying `require_version_match=False`.')
+
+        if predictor is None:
+            predictor = cls._load(path=path)
 
         return predictor
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added caching of AG version during save of predictor.
- Adding comparison of cached AG version during load of predictor prior to loading the actual predictor itself.
- This avoids errors when there is a version mismatch that could occur before the actual warning of version incompatibility was triggered, leading to a lot of confusion from users.
- Added error-by-default when versions are incompatible. This should reduce the chances of users missing the warning message.
- Added Python Version and Operating System to the Learner logs at start of fit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
