### PR TITLE
calibrate needs to be added to fit_extra otherwise causes crash

### DIFF
--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2426,6 +2426,8 @@ class TabularPredictor:
 
             # quantile levels
             quantile_levels=None,
+
+            calibrate=False
         )
 
         allowed_kwarg_names = list(fit_extra_kwargs_default.keys())

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2385,7 +2385,6 @@ class TabularPredictor:
             feature_generator='auto',
             unlabeled_data=None,
             _feature_generator_kwargs=None,
-            calibrate=False
         )
 
         kwargs = self._validate_fit_extra_kwargs(kwargs, extra_valid_keys=list(fit_kwargs_default.keys()))


### PR DESCRIPTION
*Issue #, if available:*
`fit_extra` current crashes, because there's no default set for `calibrate`

*Description of changes:*
added `calibrate` to `_validate_fit_extra_kwargs`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
