### PR TITLE
OHE Optimization

### DIFF
--- a/core/src/autogluon/core/features/types.py
+++ b/core/src/autogluon/core/features/types.py
@@ -23,6 +23,10 @@ S_DATETIME_AS_INT = 'datetime_as_int'
 # feature is a datetime in object form (string dates), which can be converted to datetime via pd.to_datetime
 S_DATETIME_AS_OBJECT = 'datetime_as_object'
 
+# feature is in sparse form, such as pd.SparseDtype ex: 'Sparse[uint8, 0]'
+# Convert features in this form to a scipy coo matrix with `DataFrame.sparse.to_coo()`
+S_SPARSE = 'sparse'
+
 # feature is an object type that contains text information that can be utilized in natural language processing
 S_TEXT = 'text'
 

--- a/features/src/autogluon/features/generators/__init__.py
+++ b/features/src/autogluon/features/generators/__init__.py
@@ -12,7 +12,7 @@ from .identity import IdentityFeatureGenerator
 from .isnan import IsNanFeatureGenerator
 from .label_encoder import LabelEncoderFeatureGenerator
 from .memory_minimize import CategoryMemoryMinimizeFeatureGenerator, NumericMemoryMinimizeFeatureGenerator
-from.one_hot_encoder import OneHotEncoderFeatureGenerator
+from .one_hot_encoder import OneHotEncoderFeatureGenerator
 from .rename import RenameFeatureGenerator
 from .text_ngram import TextNgramFeatureGenerator
 from .text_special import TextSpecialFeatureGenerator

--- a/features/src/autogluon/features/generators/__init__.py
+++ b/features/src/autogluon/features/generators/__init__.py
@@ -12,6 +12,7 @@ from .identity import IdentityFeatureGenerator
 from .isnan import IsNanFeatureGenerator
 from .label_encoder import LabelEncoderFeatureGenerator
 from .memory_minimize import CategoryMemoryMinimizeFeatureGenerator, NumericMemoryMinimizeFeatureGenerator
+from.one_hot_encoder import OneHotEncoderFeatureGenerator
 from .rename import RenameFeatureGenerator
 from .text_ngram import TextNgramFeatureGenerator
 from .text_special import TextSpecialFeatureGenerator

--- a/features/src/autogluon/features/generators/_experimental/one_hot_encoder.py
+++ b/features/src/autogluon/features/generators/_experimental/one_hot_encoder.py
@@ -1,0 +1,159 @@
+import logging
+
+import numpy as np
+import pandas as pd
+from pandas import DataFrame
+from sklearn.preprocessing import OneHotEncoder
+
+from autogluon.core.features.types import R_CATEGORY, S_BOOL, S_SPARSE, R_INT
+
+from autogluon.features.generators.abstract import AbstractFeatureGenerator
+
+logger = logging.getLogger(__name__)
+
+
+class CatToInt:
+    """Converts pandas categoricals to numpy int in preparation for OHE.
+
+    Parameters
+    ----------
+    max_levels : int
+        The maximum number of unique values for OHE. Selected categories are based on frequency.
+    fillna_val : int, default = None
+        The default value to fill NaN.
+        If None, automatically inferred as a new value not present in existing categories.
+    infrequent_val : int or {'na', 'na+1}, default = 'na'
+        The value to group all infrequent categories to (those that aren't within the max_levels most frequent categories).
+        If 'na', uses `fillna_val`.
+        If 'na+1', uses `fillna_val+1`. This guarantees a new category for infrequent values separate from missing values if `fillna_val=None`.
+    """
+    def __init__(self, max_levels, fillna_val=None, infrequent_val='na'):
+        self.max_levels = max_levels
+        self.fillna_val = fillna_val
+        self.infrequent_val = infrequent_val
+        self.cats = dict()
+        self.num_cols = None
+        self._dtype = None
+
+    def fit(self, X: DataFrame):
+        # dtype_buffer=2 is required to avoid edge case errors with invalid self.infrequent_val in 'na+1' mode.
+        self._dtype, fillna_val = self._get_dtype_and_fillna(X, dtype_buffer=2)
+        if self.fillna_val is None:
+            self.fillna_val = fillna_val
+        if self.infrequent_val == 'na':
+            self.infrequent_val = self.fillna_val
+        elif self.infrequent_val == 'na+1':
+            self.infrequent_val = self.fillna_val + 1
+
+        X = self.pd_to_np(X)
+        self.num_cols = X.shape[1]
+        for col in range(self.num_cols):
+            data = X[:, col]
+            uniques, counts = np.unique(data, return_counts=True)
+            self.cats[col] = uniques[np.argsort(counts)[-self.max_levels:]]
+            if self.infrequent_val in self.cats[col]:
+                # Add one extra level since NaN values shouldn't be counted towards max levels
+                self.cats[col] = uniques[np.argsort(counts)[-(self.max_levels+1):]]
+
+    def transform(self, X: DataFrame):
+        X = self.pd_to_np(X)
+        mask = np.zeros(shape=X.shape, dtype=bool)
+        for col in range(self.num_cols):
+            mask[:, col] = np.isin(X[:, col], self.cats[col], invert=True)
+        X[mask] = self.infrequent_val
+        return X
+
+    def pd_to_np(self, X: DataFrame) -> np.ndarray:
+        return X.to_numpy(dtype=self._dtype, na_value=self.fillna_val, copy=True)
+
+    def _get_dtype_and_fillna(self, X: DataFrame, dtype_buffer=2):
+        assert dtype_buffer >= 1, 'dtype_buffer must be >= 1 or else fillna_val could be invalid.'
+        dtype = None
+        max_val_all = None
+        for col in X.columns:
+            try:
+                max_val = X[col].dtype.categories.max()
+                min_val = X[col].dtype.categories.min()
+            except:
+                max_val = X[col].max()
+                min_val = X[col].min()
+            max_val_with_buffer = max_val + dtype_buffer
+            max_dtype = np.min_scalar_type(max_val_with_buffer)
+            min_dtype = np.min_scalar_type(min_val)
+            cur_dtype = np.promote_types(min_dtype, max_dtype)
+            if max_val_all is None:
+                max_val_all = max_val
+            else:
+                max_val_all = max(max_val_all, max_val)
+            if dtype is None:
+                dtype = cur_dtype
+            else:
+                dtype = np.promote_types(dtype, cur_dtype)
+        fillna_val = max_val_all + 1
+        return dtype, fillna_val
+
+
+# TODO: Add unit test before using
+# TODO: Replace XGBoost, NN, and Linear Model OHE logic with this
+class OneHotEncoderFeatureGenerator(AbstractFeatureGenerator):
+    """
+    Converts category features to one-hot boolean features by mapping to the category codes.
+
+    Parameters
+    ----------
+    max_levels : int
+        The maximum number of categories to use for OHE per feature. Selected categories are based on frequency.
+    dtype : number type, default = np.uint8
+        Desired dtype of output.
+    sparse : bool, default = True
+        Will return sparse matrix if set True else will return an array.
+    drop : str, default = None
+        Refer to OneHotEncoder documentation for details.
+    """
+    def __init__(self, max_levels=None, dtype=np.uint8, sparse=True, drop=None, **kwargs):
+        super().__init__(**kwargs)
+        self.max_levels = max_levels
+        self.sparse = sparse
+        self._ohe = OneHotEncoder(dtype=dtype, sparse=self.sparse, handle_unknown='ignore', drop=drop)
+        self._ohe_columns = None
+        self._cat_feat_gen = None
+
+    def _fit_transform(self, X: DataFrame, **kwargs) -> (DataFrame, dict):
+        if self.max_levels is not None:
+            self._cat_feat_gen = CatToInt(max_levels=self.max_levels)
+            self._cat_feat_gen.fit(X)
+            X_out = self._cat_feat_gen.transform(X)
+        else:
+            X_out = X
+
+        self._ohe.fit(X_out)
+        self._ohe_columns = self._ohe.get_feature_names_out()
+        X_out = self._transform(X)
+
+        features_out = list(X_out.columns)
+
+        feature_metadata_out_type_group_map_special = {S_BOOL: features_out}
+        if self.sparse:
+            feature_metadata_out_type_group_map_special[S_SPARSE] = features_out
+        return X_out, feature_metadata_out_type_group_map_special
+
+    def _transform(self, X: DataFrame) -> DataFrame:
+        X_out = self.transform_ohe(X)
+        if self.sparse:
+            X_out = pd.DataFrame.sparse.from_spmatrix(X_out, columns=self._ohe_columns, index=X.index)
+        else:
+            X_out = pd.DataFrame(X_out, columns=self._ohe_columns, index=X.index)
+        return X_out
+
+    @staticmethod
+    def get_default_infer_features_in_args() -> dict:
+        return dict(valid_raw_types=[R_CATEGORY, R_INT])
+
+    def transform_ohe(self, X: DataFrame):
+        if self._cat_feat_gen is not None:
+            X = self._cat_feat_gen.transform(X)
+        X = self._ohe.transform(X)
+        return X
+
+    def _more_tags(self):
+        return {'feature_interactions': False}

--- a/features/src/autogluon/features/generators/_experimental/one_hot_encoder.py
+++ b/features/src/autogluon/features/generators/_experimental/one_hot_encoder.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 class CatToInt:
-    """Converts pandas categoricals to numpy int in preparation for OHE.
+    """
+    Converts pandas categoricals to numpy int in preparation for OHE.
 
     Parameters
     ----------
@@ -51,7 +52,7 @@ class CatToInt:
             data = X[:, col]
             uniques, counts = np.unique(data, return_counts=True)
             self.cats[col] = uniques[np.argsort(counts)[-self.max_levels:]]
-            if self.infrequent_val in self.cats[col]:
+            if self.infrequent_val in self.cats[col] or str(self.infrequent_val) in self.cats[col]:
                 # Add one extra level since NaN values shouldn't be counted towards max levels
                 self.cats[col] = uniques[np.argsort(counts)[-(self.max_levels+1):]]
 
@@ -77,19 +78,26 @@ class CatToInt:
             except:
                 max_val = X[col].max()
                 min_val = X[col].min()
-            max_val_with_buffer = max_val + dtype_buffer
-            max_dtype = np.min_scalar_type(max_val_with_buffer)
+            if type(max_val) == str:
+                max_dtype = np.min_scalar_type(max_val)
+            else:
+                if max_val_all is None:
+                    max_val_all = max_val
+                else:
+                    max_val_all = max(max_val_all, max_val)
+                max_val_with_buffer = max_val + dtype_buffer
+                max_dtype = np.min_scalar_type(max_val_with_buffer)
             min_dtype = np.min_scalar_type(min_val)
             cur_dtype = np.promote_types(min_dtype, max_dtype)
-            if max_val_all is None:
-                max_val_all = max_val
-            else:
-                max_val_all = max(max_val_all, max_val)
+
             if dtype is None:
                 dtype = cur_dtype
             else:
                 dtype = np.promote_types(dtype, cur_dtype)
-        fillna_val = max_val_all + 1
+        if max_val_all is None:
+            fillna_val = 0
+        else:
+            fillna_val = max_val_all + 1
         return dtype, fillna_val
 
 

--- a/features/src/autogluon/features/generators/one_hot_encoder.py
+++ b/features/src/autogluon/features/generators/one_hot_encoder.py
@@ -101,7 +101,6 @@ class CatToInt:
         return dtype, fillna_val
 
 
-# TODO: Add unit test before using
 # TODO: Replace XGBoost, NN, and Linear Model OHE logic with this
 class OneHotEncoderFeatureGenerator(AbstractFeatureGenerator):
     """
@@ -158,6 +157,10 @@ class OneHotEncoderFeatureGenerator(AbstractFeatureGenerator):
         return dict(valid_raw_types=[R_CATEGORY, R_INT])
 
     def transform_ohe(self, X: DataFrame):
+        """
+        Call this method directly to get numpy output.
+        Skips pandas conversion (much faster if only the numpy output is required).
+        """
         if self._cat_feat_gen is not None:
             X = self._cat_feat_gen.transform(X)
         X = self._ohe.transform(X)

--- a/features/src/autogluon/features/generators/one_hot_encoder.py
+++ b/features/src/autogluon/features/generators/one_hot_encoder.py
@@ -7,7 +7,7 @@ from sklearn.preprocessing import OneHotEncoder
 
 from autogluon.core.features.types import R_CATEGORY, S_BOOL, S_SPARSE, R_INT
 
-from autogluon.features.generators.abstract import AbstractFeatureGenerator
+from .abstract import AbstractFeatureGenerator
 
 logger = logging.getLogger(__name__)
 

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_utils.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_utils.py
@@ -71,7 +71,7 @@ def func_generator(metric, is_higher_better, needs_pred_proba, problem_type):
                 y_hat = y_hat.argmax(axis=1)
                 res = metric(y_true, y_hat)
                 return metric.name, -1 * res if is_higher_better else res
-        if problem_type == SOFTCLASS:
+        elif problem_type == SOFTCLASS:
             def function_template(y_hat, data):
                 y_true = data.get_label()
                 y_hat = y_hat.argmax(axis=1)
@@ -94,8 +94,6 @@ def func_generator(metric, is_higher_better, needs_pred_proba, problem_type):
 
 
 class OheFeatureGenerator(BaseEstimator, TransformerMixin):
-    null_category_str = '!missing!'
-
     def __init__(self, max_levels=None):
         self._feature_map = OrderedDict()  # key: feature_name, value: feature_type
         self.labels = OrderedDict()
@@ -110,7 +108,7 @@ class OheFeatureGenerator(BaseEstimator, TransformerMixin):
         self.ohe_encs = OneHotMergeRaresHandleUnknownEncoder(max_levels=self.max_levels)
 
         if self.cat_cols:
-            self.ohe_encs.fit(self._normalize(X[self.cat_cols]))
+            self.ohe_encs.fit(X[self.cat_cols])
             assert len(self.cat_cols) == len(self.ohe_encs.categories_)
             
             for cat_col, categories in zip(self.cat_cols, self.ohe_encs.categories_):
@@ -128,13 +126,10 @@ class OheFeatureGenerator(BaseEstimator, TransformerMixin):
     def transform(self, X, y=None):
         X_list = []
         if self.cat_cols:
-            X_list.append(self.ohe_encs.transform(self._normalize(X[self.cat_cols])))
+            X_list.append(self.ohe_encs.transform(X[self.cat_cols]))
         if self.other_cols:
             X_list.append(csr_matrix(X[self.other_cols]))
         return hstack(X_list, format="csr")
-
-    def _normalize(self, X):
-        return X.replace(np.nan, self.null_category_str)
 
     def get_feature_names(self):
         return list(self._feature_map.keys())

--- a/tabular/tests/unittests/features/generators/test_one_hot_encoder.py
+++ b/tabular/tests/unittests/features/generators/test_one_hot_encoder.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 
-from autogluon.features.generators._experimental.one_hot_encoder import OneHotEncoderFeatureGenerator
+from autogluon.features.generators import OneHotEncoderFeatureGenerator
 
 
 def test_one_hot_encoder_feature_generator(generator_helper, data_helper):

--- a/tabular/tests/unittests/features/generators/test_one_hot_encoder.py
+++ b/tabular/tests/unittests/features/generators/test_one_hot_encoder.py
@@ -1,0 +1,84 @@
+
+import numpy as np
+
+from autogluon.features.generators._experimental.one_hot_encoder import OneHotEncoderFeatureGenerator
+
+
+def test_one_hot_encoder_feature_generator(generator_helper, data_helper):
+    # Given
+    input_data = data_helper.generate_multi_feature_standard()
+
+    generator = OneHotEncoderFeatureGenerator()
+
+    expected_feature_metadata_in_full = {
+        ('category', ()): ['cat'],
+        ('int', ()): ['int'],
+    }
+    expected_feature_metadata_full = {
+        ('int', ('bool', 'sparse')): [
+            'int_-8',
+            'int_0',
+            'int_2',
+            'int_3',
+            'int_5',
+            'int_12',
+            'cat_a',
+            'cat_b',
+            'cat_c',
+            'cat_d',
+            'cat_nan'
+        ]
+    }
+
+    expected_output_data_int_0_val = [0, 1, 0, 0, 0, 0, 0, 1, 0]
+
+    # When
+    output_data = generator_helper.fit_transform_assert(
+        input_data=input_data,
+        generator=generator,
+        expected_feature_metadata_in_full=expected_feature_metadata_in_full,
+        expected_feature_metadata_full=expected_feature_metadata_full,
+    )
+
+    # Therefore
+    assert len(output_data.columns) == 11
+    assert output_data['int_0'].dtype.subtype == np.uint8
+    assert list(output_data['int_0'].values) == expected_output_data_int_0_val
+
+
+def test_one_hot_encoder_feature_generator_advanced(generator_helper, data_helper):
+    # Given
+    input_data = data_helper.generate_multi_feature_standard()
+
+    generator = OneHotEncoderFeatureGenerator(max_levels=3, sparse=False, dtype=np.uint16)
+
+    expected_feature_metadata_in_full = {
+        ('category', ()): ['cat'],
+        ('int', ()): ['int'],
+    }
+    # TODO: improve readability of names when max_levels is specified
+    expected_feature_metadata_full = {('int', ('bool',)): [
+        'x0_0',
+        'x0_13',
+        'x0_2',
+        'x0_5',
+        'x1_13',
+        'x1_a',
+        'x1_c',
+        'x1_d'
+    ]}
+
+    expected_output_data_int_0_val = [0, 1, 0, 0, 0, 0, 0, 1, 0]
+
+    # When
+    output_data = generator_helper.fit_transform_assert(
+        input_data=input_data,
+        generator=generator,
+        expected_feature_metadata_in_full=expected_feature_metadata_in_full,
+        expected_feature_metadata_full=expected_feature_metadata_full,
+    )
+
+    # Therefore
+    assert len(output_data.columns) == 8
+    assert output_data['x0_0'].dtype == np.uint16
+    assert list(output_data['x0_0'].values) == expected_output_data_int_0_val


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Minor optimizations to XGBoost OHE + bugfix for custom metrics.
- Added sparse DataFrame dtype support for infer_types.
- Major optimizations to OHE via the experimental code. The code uses 8x less memory and is ~4x faster than NN/XGBoost implementation (16x faster than LR implementation), along with offering additional flexibility of how we represent infrequent categories (such as grouping with NaN). However, writing the code was very time consuming and has gotten to the point where a fully integrated version that replaces the usage across the package is a lot of effort that I would rather save for a later time.

TODO:

- [x] Add unit test
- [x] Only merge after 3.6 has been removed, this code is not compatible with Python 3.6 due to requirement of sklearn>=1.0 (https://github.com/awslabs/autogluon/pull/1377)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
