### PR TITLE
Require Python 3.7, Sklearn >=1.0

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -10,14 +10,14 @@ AUTOGLUON_ROOT_PATH = os.path.abspath(
     os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', '..', '..')
 )
 
-PYTHON_REQUIRES = '>=3.6, <3.10'
+PYTHON_REQUIRES = '>=3.7, <3.10'
 
 
 # Only put packages here that would otherwise appear multiple times across different module's setup.py files.
 DEPENDENT_PACKAGES = {
     'numpy': '>=1.19,<1.22',
     'pandas': '>=1.0.0,<2.0',
-    'scikit-learn': '>=0.23.2,<1.1',  # 0.22 crashes during efficient OOB in Tabular
+    'scikit-learn': '>=1.0.0,<1.1',
     'scipy': '>=1.5.4,<1.7',
     'gluoncv': '>=0.10.4,<0.10.5',
     'tqdm': '>=4.38.0',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Remove Python 3.6 support
- Require sklearn>=1.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
