### PR TITLE
Tabular: Updated ES logic, added adaptive ES to CAT and XGB

### DIFF
--- a/core/src/autogluon/core/models/_utils.py
+++ b/core/src/autogluon/core/models/_utils.py
@@ -3,7 +3,7 @@ from autogluon.core.utils.early_stopping import AdaptiveES, ES_CLASS_MAP
 
 
 # TODO: Add more strategies
-def get_early_stopping_rounds(num_rows_train, strategy='auto', min_patience=10, max_patience=150, min_rows=10000):
+def get_early_stopping_rounds(num_rows_train, strategy='auto', min_patience=20, max_patience=300, min_rows=10000):
     if isinstance(strategy, (tuple, list)):
         strategy = list(strategy)
         if isinstance(strategy[0], str):

--- a/core/src/autogluon/core/utils/early_stopping.py
+++ b/core/src/autogluon/core/utils/early_stopping.py
@@ -50,7 +50,7 @@ class AdaptiveES(AbstractES):
 
     Parameters
     ----------
-    adaptive_rate : float, default 0.2
+    adaptive_rate : float, default 0.3
         The rate of increase in patience.
         Set to 0 to disable, or negative to shrink patience during training.
     adaptive_offset : int, default 10
@@ -71,7 +71,7 @@ class AdaptiveES(AbstractES):
         patience = min(self.max_patience, (max(self.min_patience, round(self.best_round * self.adaptive_rate + self.adaptive_offset))))
         Effectively, patience = self.best_round * self.adaptive_rate + self.adaptive_offset, bound by min_patience and max_patience
     """
-    def __init__(self, adaptive_rate=0.2, adaptive_offset=10, min_patience=10, max_patience=10000):
+    def __init__(self, adaptive_rate=0.3, adaptive_offset=10, min_patience=10, max_patience=10000):
         self.adaptive_rate = adaptive_rate
         self.adaptive_offset = adaptive_offset
         self.min_patience = min_patience

--- a/tabular/src/autogluon/tabular/models/catboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/catboost/callbacks.py
@@ -116,7 +116,7 @@ class EarlyStoppingCallback:
         self.compare_key = compare_key
 
         if isinstance(eval_metric, str):
-            # FIXME: Avoid using private API! (https://github.com/catboost/catboost/issues/1915)
+            # FIXME: Avoid using private API! (https://github.com/awslabs/autogluon/issues/1381)
             from catboost._catboost import is_maximizable_metric
             is_max_optimal = is_maximizable_metric(eval_metric)
             eval_metric_name = eval_metric
@@ -140,7 +140,4 @@ class EarlyStoppingCallback:
             self.best_score = cur_score
 
         should_stop = self.es.update(cur_round=info.iteration, is_best=is_best_iter)
-        if should_stop:
-            return False
-
-        return True
+        return not should_stop

--- a/tabular/src/autogluon/tabular/models/xgboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/callbacks.py
@@ -4,20 +4,34 @@ import logging
 
 from xgboost.callback import EarlyStopping
 
+from autogluon.core.utils.early_stopping import SimpleES
+
 logger = logging.getLogger(__name__)
 
 
 class EarlyStoppingCustom(EarlyStopping):
-    """Augments early stopping in XGBoost to also consider time_limit and memory usage"""
+    """
+    Augments early stopping in XGBoost to also consider time_limit, memory usage, and usage of adaptive early stopping methods.
+
+    Parameters
+    ----------
+    rounds : int or tuple
+       If int, The possible number of rounds without the trend occurrence.
+       If tuple, contains early stopping class as first element and class init kwargs as second element.
+    """
     def __init__(self, rounds, time_limit=None, start_time=None, verbose=False, **kwargs):
         if rounds is None:
             # Disable early stopping via rounds
             rounds = 999999
-        super().__init__(rounds=rounds, **kwargs)
+        if isinstance(rounds, int):
+            super().__init__(rounds=999999, **kwargs)
+            self.es = SimpleES(patience=rounds)
+        else:
+            super().__init__(rounds=999999, **kwargs)
+            self.es = rounds[0](**rounds[1])
         self.time_limit = time_limit
         self.start_time = start_time
         self.verbose = verbose
-
         self._mem_status = None
         self._mem_init_rss = None
 
@@ -31,6 +45,10 @@ class EarlyStoppingCustom(EarlyStopping):
 
     def after_iteration(self, model, epoch, evals_log):
         should_stop = super().after_iteration(model, epoch, evals_log)
+        if should_stop:
+            return should_stop
+        is_best_iter = self.current_rounds == 0
+        should_stop = self.es.update(cur_round=epoch, is_best=is_best_iter)
         if should_stop:
             return should_stop
         if self._time_check(model=model, epoch=epoch):

--- a/tabular/src/autogluon/tabular/models/xgboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/callbacks.py
@@ -23,11 +23,10 @@ class EarlyStoppingCustom(EarlyStopping):
         if rounds is None:
             # Disable early stopping via rounds
             rounds = 999999
+        super().__init__(rounds=999999, **kwargs)
         if isinstance(rounds, int):
-            super().__init__(rounds=999999, **kwargs)
             self.es = SimpleES(patience=rounds)
         else:
-            super().__init__(rounds=999999, **kwargs)
             self.es = rounds[0](**rounds[1])
         self.time_limit = time_limit
         self.start_time = start_time

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -104,8 +104,8 @@ class XGBoostModel(AbstractModel):
         else:
             X_val = self.preprocess(X_val, is_train=False)
             eval_set.append((X_val, y_val))
-            early_stopping_rounds = ag_params.get('ag.early_stop', 'auto')
-            if isinstance(early_stopping_rounds, str):
+            early_stopping_rounds = ag_params.get('ag.early_stop', 'adaptive')
+            if isinstance(early_stopping_rounds, (str, tuple, list)):
                 early_stopping_rounds = self._get_early_stopping_rounds(num_rows_train=num_rows_train, strategy=early_stopping_rounds)
 
         if num_gpus != 0:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updated ES Logic: min_patience 10->20, max_patience 150->300, adaptive_rate 0.2->0.3
- Added Adaptive ES support to CatBoost and XGBoost, enabled by default.

TODO:

- [x] Benchmark


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
