### PR TITLE
[fastai] addressed normalization bottleneck in fastai

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/hyperparameters/parameters.py
@@ -22,16 +22,16 @@ def get_param_multiclass_baseline():
         'layers': None,  # layers configuration; None - use model's heuristics
         'emb_drop': 0.1,  # embedding layers dropout
         'ps': 0.1,  # linear layers dropout
-        'bs': 256,  # batch size
+        'bs': 'adaptive',  # batch size
 
         # maximum learning rate for one cycle policy https://docs.fast.ai/train.html#fit_one_cycle
         # One-cycle policy paper: https://arxiv.org/abs/1803.09820
         'lr': 1e-2,
-        'epochs': 30,  # maximum number of epochs
+        'epochs': 16,  # maximum number of epochs
 
         # Early stopping settings. See more details here: https://docs.fast.ai/callbacks.tracker.html#EarlyStoppingCallback
         'early.stopping.min_delta': 0.0001,
-        'early.stopping.patience': 20,
+        'early.stopping.patience': 5,
 
         # If > 0, then use LabelSmoothingCrossEntropy loss function for binary/multi-class classification;
         # otherwise use default loss function for this type of problem

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -79,6 +79,7 @@ class NNFastAiTabularModel(AbstractModel):
         self.columns_fills = None
         self.procs = None
         self.y_scaler = None
+        self._cont_normalization = None
         self._load_model = None  # Whether to load inner model when loading.
 
     def _preprocess_train(self, X, y, X_val, y_val):
@@ -91,8 +92,8 @@ class NNFastAiTabularModel(AbstractModel):
         if X_val is not None:
             X_val = self.preprocess(X_val)
 
-        from fastai.tabular.core import FillMissing, Categorify, Normalize
-        self.procs = [FillMissing, Categorify, Normalize]
+        from fastai.tabular.core import Categorify
+        self.procs = [Categorify]
 
         if self.problem_type in [REGRESSION, QUANTILE] and self.y_scaler is not None:
             y_norm = pd.Series(self.y_scaler.fit_transform(y.values.reshape(-1, 1)).reshape(-1))
@@ -123,6 +124,8 @@ class NNFastAiTabularModel(AbstractModel):
         if fit:
             self.cat_columns = self._feature_metadata.get_features(valid_raw_types=[R_OBJECT, R_CATEGORY, R_BOOL])
             self.cont_columns = self._feature_metadata.get_features(valid_raw_types=[R_INT, R_FLOAT, R_DATETIME])
+            self._cont_normalization = (X[self.cont_columns].mean(), X[self.cont_columns].std())
+
             try:
                 X_stats = X.describe(include='all').T.reset_index()
                 cat_cols_to_drop = X_stats[(X_stats['unique'] > self.params.get('max_unique_categorical_values', 10000)) | (X_stats['unique'].isna())]['index'].values
@@ -140,7 +143,10 @@ class NNFastAiTabularModel(AbstractModel):
             self.columns_fills = dict()
             for c in nullable_numeric_features:  # No need to do this for int features, int can't have null
                 self.columns_fills[c] = X[c].mean()
-        return self._fill_missing(X)
+        X = self._fill_missing(X)
+        cont_mean, cont_std = self._cont_normalization
+        X[self.cont_columns] = (X[self.cont_columns] - cont_mean) / cont_std
+        return X
 
     def _fill_missing(self, df: pd.DataFrame) -> pd.DataFrame:
         # FIXME: Consider representing categories as int

--- a/tabular/tests/unittests/models/test_tabular_nn_fastai.py
+++ b/tabular/tests/unittests/models/test_tabular_nn_fastai.py
@@ -1,4 +1,5 @@
-
+import numpy as np
+import pandas as pd
 from autogluon.tabular.models.fastainn.tabular_nn_fastai import NNFastAiTabularModel
 
 
@@ -24,3 +25,16 @@ def test_tabular_nn_fastai_regression(fit_helper):
     )
     dataset_name = 'ames'
     fit_helper.fit_and_validate_dataset(dataset_name=dataset_name, fit_args=fit_args)
+
+
+def test_batch_size():
+    model = NNFastAiTabularModel()
+    model.params['bs'] = 'adaptive'
+    assert model._get_bs(pd.Series(np.arange(200000))) == 512
+    assert model._get_bs(pd.Series(np.arange(199999))) == 256
+    assert model._get_bs(pd.Series(np.arange(42))) == 42
+
+    model.params['bs'] = 99
+    assert model._get_bs(pd.Series(np.arange(200000))) == 99
+    assert model._get_bs(pd.Series(np.arange(199999))) == 99
+    assert model._get_bs(pd.Series(np.arange(42))) == 42


### PR DESCRIPTION
*Description of changes:*
fastai `Normalize` processor is not optimal: on the datasets with large number of continuous variables, it takes significant amount of time to perform normalization.
Small dataset benchmarking results:

task | result_old | metric_old | training_duration_old | acc_old | auc_old | balacc_old | logloss_old | result_new | metric_new | training_duration_new | acc_new | auc_new | balacc_new | logloss_new
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
Australian | 0.936333 | auc | 32.4 | 0.869565 | 0.936333 | 0.875637 | 0.32122 | 0.949066 | auc | 43.9 | 0.884058 | 0.949066 | 0.882852 | 0.278797
blood-transfusion | 0.771442 | auc | 28.6 | 0.76 | 0.771442 | 0.595029 | 0.483829 | 0.758772 | auc | 24.1 | 0.746667 | 0.758772 | 0.605263 | 0.550954
car | -0.033726 | neg_logloss | 50.8 | 0.99422 | NaN | 0.99359 | 0.033726 | -0.022842 | neg_logloss | 41.3 | 0.99422 | NaN | 0.997934 | 0.022842
christine | 0.818848 | auc | 773.7 | 0.743542 | 0.818848 | 0.743542 | 0.522822 | 0.821694 | auc | 408.3 | 0.750923 | 0.821694 | 0.750923 | 0.519445
cnae-9 | -0.212781 | neg_logloss | 133.4 | 0.972222 | NaN | 0.972222 | 0.212781 | -0.163373 | neg_logloss | 130.2 | 0.953704 | NaN | 0.953704 | 0.163373
credit-g | 0.814286 | auc | 42.2 | 0.75 | 0.814286 | 0.659524 | 0.489898 | 0.819524 | auc | 37.1 | 0.77 | 0.819524 | 0.721429 | 0.475789
dilbert | -0.04709 | neg_logloss | 692.1 | 0.985 | NaN | 0.985161 | 0.04709 | -0.048778 | neg_logloss | 724.8 | 0.983 | NaN | 0.983099 | 0.048778
fabert | -0.815309 | neg_logloss | 407.6 | 0.695388 | NaN | 0.669743 | 0.815309 | -0.809688 | neg_logloss | 279.7 | 0.700243 | NaN | 0.669973 | 0.809688
jasmine | 0.846756 | auc | 74.5 | 0.792642 | 0.846756 | 0.792371 | 0.475694 | 0.842908 | auc | 70.2 | 0.799331 | 0.842908 | 0.798859 | 0.453398
kc1 | 0.830045 | auc | 48.5 | 0.872038 | 0.830045 | 0.629452 | 0.328639 | 0.839124 | auc | 46.5 | 0.872038 | 0.839124 | 0.655115 | 0.355251
kr-vs-kp | 0.999804 | auc | 56.5 | 0.990625 | 0.999804 | 0.99047 | 0.023755 | 0.999648 | auc | 53.5 | 0.9875 | 0.999648 | 0.987202 | 0.028402
mfeat-factors | -0.06438 | neg_logloss | 77.6 | 0.985 | NaN | 0.985 | 0.06438 | -0.062762 | neg_logloss | 71.6 | 0.98 | NaN | 0.98 | 0.062762
phoneme | 0.933765 | auc | 51.2 | 0.866913 | 0.933765 | 0.834165 | 0.29675 | 0.931114 | auc | 49.5 | 0.863216 | 0.931114 | 0.833383 | 0.301901
segment | -0.157093 | neg_logloss | 55 | 0.95671 | NaN | 0.95671 | 0.157093 | -0.162179 | neg_logloss | 50.8 | 0.95671 | NaN | 0.95671 | 0.162179
sylvine | 0.974039 | auc | 52.1 | 0.927875 | 0.974039 | 0.927795 | 0.194976 | 0.974055 | auc | 48.4 | 0.918129 | 0.974055 | 0.918052 | 0.204963
vehicle | -0.323918 | neg_logloss | 28.8 | 0.870588 | NaN | 0.871158 | 0.323918 | -0.307616 | neg_logloss | 27.5 | 0.905882 | NaN | 0.906926 | 0.307616

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
