### PR TITLE
Tabular: Fix GPU specification in FastAI to respect num_gpus

### DIFF
--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -144,6 +144,14 @@ class EnsembleSelection(AbstractWeightedEnsemble):
                     break
 
         min_score = np.min(trajectory)
+
+        # If abs value of min score is large enough, round to 6 decimal places to avoid floating point error deciding the best index.
+        # This avoids 2 models with the same pred proba both being used in the ensemble due to floating point error
+        epsilon = 1e-6
+        if np.abs(min_score) > epsilon * 100:
+            for i in range(len(trajectory)):
+                trajectory[i] = trajectory[i].round(6)
+            min_score = np.min(trajectory)
         first_index_of_best = trajectory.index(min_score)
 
         if self.use_best:

--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -169,14 +169,6 @@ class EnsembleSelection(AbstractWeightedEnsemble):
                     break
 
         min_score = np.min(trajectory)
-
-        # If abs value of min score is large enough, round to 6 decimal places to avoid floating point error deciding the best index.
-        # This avoids 2 models with the same pred proba both being used in the ensemble due to floating point error
-        epsilon = 1e-6
-        if np.abs(min_score) > epsilon * 100:
-            for i in range(len(trajectory)):
-                trajectory[i] = trajectory[i].round(6)
-            min_score = np.min(trajectory)
         first_index_of_best = trajectory.index(min_score)
 
         if self.use_best:

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -184,10 +184,11 @@ class NNFastAiTabularModel(AbstractModel):
             self.y_scaler = copy.deepcopy(self.y_scaler)
 
         if num_gpus is not None:
+            # TODO: Control CPU vs GPU usage during inference
             if num_gpus == 0:
-                # TODO: Does not obviously impact inference speed
                 torch_core.default_device(use_cuda=False)
             else:
+                # TODO: respect CUDA_VISIBLE_DEVICES to select proper GPU
                 torch_core.default_device(use_cuda=True)
 
         logger.log(15, f'Fitting Neural Network with parameters {params}...')

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -164,10 +164,9 @@ class NNFastAiTabularModel(AbstractModel):
         try_import_fastai()
         from fastai.tabular.model import tabular_config
         from fastai.tabular.learner import tabular_learner
-        from fastcore.basics import defaults
+        from fastai import torch_core
         from .callbacks import AgSaveModelCallback, EarlyStoppingCallbackWithTimeLimit
         from .quantile_helpers import HuberPinballLoss
-        import torch
 
         start_time = time.time()
         if sample_weight is not None:  # TODO: support
@@ -184,18 +183,12 @@ class NNFastAiTabularModel(AbstractModel):
         else:
             self.y_scaler = copy.deepcopy(self.y_scaler)
 
-        if num_cpus is None:
-            num_cpus = defaults.cpus
-        # additional workers are helping only when fork is enabled; in other mp modes, communication overhead reduces performance
-        num_workers = int(num_cpus / 2)
-        if not is_fork_enabled():
-            num_workers = 0
         if num_gpus is not None:
             if num_gpus == 0:
                 # TODO: Does not obviously impact inference speed
-                defaults.device = torch.device('cpu')
+                torch_core.default_device(use_cuda=False)
             else:
-                defaults.device = torch.device('cuda')
+                torch_core.default_device(use_cuda=True)
 
         logger.log(15, f'Fitting Neural Network with parameters {params}...')
         data = self._preprocess_train(X, y, X_val, y_val)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix GPU specification in FastAI to respect num_gpus
- Previously if GPU was present, it would always be used regardless of num_gpus setting
- Fixed edge case inefficiency in ensemble_selection when identical models caused selection to choose all of them due to rounding error instead of choosing just a single one.
- Optimized ensemble selection to prioritize models already in ensemble when ties occur.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
