### PR TITLE
Added lazy imports to compression algorithms

### DIFF
--- a/common/src/autogluon/common/utils/compression_utils.py
+++ b/common/src/autogluon/common/utils/compression_utils.py
@@ -1,6 +1,20 @@
-import gzip
-import bz2
-import lzma
+
+
+def _gzip_open(*args, **kwargs):
+    import gzip
+    return gzip.open(*args, **kwargs)
+
+
+def _bz2_open(*args, **kwargs):
+    import bz2
+    return bz2.open(*args, **kwargs)
+
+
+# Lazy import to avoid the following issue if users installed via pyenv:
+#  https://stackoverflow.com/questions/57743230/userwarning-could-not-import-the-lzma-module-your-installed-python-is-incomple
+def _lzma_open(*args, **kwargs):
+    import lzma
+    return lzma.open(*args, **kwargs)
 
 
 compression_fn_map = {
@@ -9,15 +23,15 @@ compression_fn_map = {
         'extension': '',
     },
     'gzip': {
-        'open': gzip.open,
+        'open': _gzip_open,
         'extension': 'gz',
     },
     'bz2': {
-        'open': bz2.open,
+        'open': _bz2_open,
         'extension': 'bz2',
     },
     'lzma': {
-        'open': lzma.open,
+        'open': _lzma_open,
         'extension': 'lzma',
     },
 }

--- a/common/tests/unittests/test_compression_utils.py
+++ b/common/tests/unittests/test_compression_utils.py
@@ -63,15 +63,15 @@ def test_get_compression_map():
             'extension': '',
         },
         'gzip': {
-            'open': gzip.open,
+            'open': compression_utils._gzip_open,
             'extension': 'gz',
         },
         'bz2': {
-            'open': bz2.open,
+            'open': compression_utils._bz2_open,
             'extension': 'bz2',
         },
         'lzma': {
-            'open': lzma.open,
+            'open': compression_utils._lzma_open,
             'extension': 'lzma',
         },
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added lazy imports to compression algorithms
- This sidesteps an issue if a user has an incomplete python installation, as importing lmza might cause a crash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
