### PR TITLE
Migrate gluoncv/auto/task to autogluon

### DIFF
--- a/core/src/autogluon/core/utils/try_import.py
+++ b/core/src/autogluon/core/utils/try_import.py
@@ -1,5 +1,4 @@
 __all__ = [
-    'try_import',
     'try_import_mxboard',
     'try_import_mxnet',
     'try_import_catboost',
@@ -14,26 +13,6 @@ __all__ = [
     'try_import_autogluon_text',
     'try_import_autogluon_vision',
     'try_import_rapids_cuml']
-
-
-def try_import(package, message=None, fromlist=None):
-    """Try import specified package, with custom message support.
-    Parameters
-    ----------
-    package : str
-        The name of the targeting package.
-    message : str, default is None
-        If not None, this function will raise customized error message when import error is found.
-    Returns
-    -------
-    module if found, raise ImportError otherwise
-    """
-    try:
-        return __import__(package, fromlist=fromlist)
-    except ImportError as e:
-        if not message:
-            raise e
-        raise ImportError(message)
 
 
 def try_import_mxboard():

--- a/core/src/autogluon/core/utils/try_import.py
+++ b/core/src/autogluon/core/utils/try_import.py
@@ -1,4 +1,5 @@
 __all__ = [
+    'try_import',
     'try_import_mxboard',
     'try_import_mxnet',
     'try_import_catboost',
@@ -13,6 +14,26 @@ __all__ = [
     'try_import_autogluon_text',
     'try_import_autogluon_vision',
     'try_import_rapids_cuml']
+
+
+def try_import(package, message=None, fromlist=None):
+    """Try import specified package, with custom message support.
+    Parameters
+    ----------
+    package : str
+        The name of the targeting package.
+    message : str, default is None
+        If not None, this function will raise customized error message when import error is found.
+    Returns
+    -------
+    module if found, raise ImportError otherwise
+    """
+    try:
+        return __import__(package, fromlist=fromlist)
+    except ImportError as e:
+        if not message:
+            raise e
+        raise ImportError(message)
 
 
 def try_import_mxboard():

--- a/vision/src/autogluon/vision/_gluoncv/__init__.py
+++ b/vision/src/autogluon/vision/_gluoncv/__init__.py
@@ -1,0 +1,2 @@
+from .image_classification import *
+from .object_detection import *

--- a/vision/src/autogluon/vision/_gluoncv/image_classification.py
+++ b/vision/src/autogluon/vision/_gluoncv/image_classification.py
@@ -1,0 +1,460 @@
+"""Auto pipeline for image classification task"""
+# pylint: disable=bad-whitespace,missing-class-docstring,bare-except
+import time
+import os
+import math
+import copy
+import logging
+import pprint
+import json
+import pickle
+from typing import Union, Tuple
+import uuid
+import shutil
+
+import numpy as np
+import pandas as pd
+import autogluon.core as ag
+from autocfg import dataclass
+from autogluon.core.utils.try_import import try_import
+from autogluon.core.decorator import sample_config
+from autogluon.core.scheduler.resource import get_cpu_count, get_gpu_count
+from autogluon.core.task.base import BaseTask
+from autogluon.core.searcher import RandomSearcher
+
+from gluoncv.auto.estimators.base_estimator import BaseEstimator
+from gluoncv.auto.estimators import ImageClassificationEstimator, TorchImageClassificationEstimator
+from gluoncv.auto.data.dataset import ImageClassificationDataset
+from gluoncv.auto.estimators.conf import _BEST_CHECKPOINT_FILE
+
+from .utils import config_to_nested
+
+problem_type_constants = try_import(package='autogluon.core.constants',
+                                    fromlist=['MULTICLASS', 'BINARY', 'REGRESSION'],
+                                    message='Failed to import problem type constants from autogluon.core.')
+MULTICLASS = problem_type_constants.MULTICLASS
+BINARY = problem_type_constants.BINARY
+REGRESSION = problem_type_constants.REGRESSION
+
+
+__all__ = ['ImageClassification', 'ImagePrediction']
+
+try:
+    import timm
+except ImportError:
+    timm = None
+try:
+    import torch
+except ImportError:
+    torch = None
+try:
+    import mxnet as mx
+    from gluoncv.model_zoo import get_model_list
+except ImportError:
+    mx = None
+
+@dataclass
+class LiteConfig:
+    model : Union[type(None), str, ag.Space] = ag.Categorical('resnet18', 'mobilenetv3_small_100', 'visformer_tiny')
+    lr : Union[ag.Space, float] = 1e-2
+    num_trials : int = 1
+    epochs : Union[ag.Space, int] = 5
+    batch_size : Union[ag.Space, int] = 8
+    nthreads_per_trial : int = 32
+    ngpus_per_trial : int = 0
+    time_limits : int = 7 * 24 * 60 * 60  # 7 days
+    search_strategy : str = 'random'
+    dist_ip_addrs : Union[type(None), list, Tuple] = None
+
+@dataclass
+class DefaultConfig:
+    model : Union[type(None), str, ag.Space] = ag.Categorical('resnet50', 'efficientnet_b0', 'visformer_small')
+    lr : Union[ag.Space, float] = ag.Categorical(1e-2, 5e-2)
+    num_trials : int = 3
+    epochs : Union[ag.Space, int] = 15
+    batch_size : Union[ag.Space, int] = 16
+    nthreads_per_trial : int = 128
+    ngpus_per_trial : int = 8
+    time_limits : int = 7 * 24 * 60 * 60  # 7 days
+    search_strategy : str = 'random'
+    dist_ip_addrs : Union[type(None), list, Tuple] = None
+
+@ag.args()
+def _train_image_classification(args, reporter):
+    """
+    Parameters
+    ----------
+    args: <class 'autogluon.utils.edict.EasyDict'>
+    """
+    tic = time.time()
+    try:
+        task_id = int(args.task_id)
+    except:
+        task_id = 0
+    problem_type = args.pop('problem_type', MULTICLASS)
+    final_fit = args.pop('final_fit', False)
+    # train, val data
+    train_data = args.pop('train_data')
+    val_data = args.pop('val_data')
+    # wall clock tick limit
+    wall_clock_tick = args.pop('wall_clock_tick')
+    log_dir = args.pop('log_dir', os.getcwd())
+    # exponential batch size for Int() space batch sizes
+    try:
+        exp_batch_size = args.pop('exp_batch_size')
+    except AttributeError:
+        exp_batch_size = False
+    if exp_batch_size and 'batch_size' in args:
+        args['batch_size'] = 2 ** args['batch_size']
+    try:
+        task = args.pop('task')
+        dataset = args.pop('dataset')
+        num_trials = args.pop('num_trials')
+    except AttributeError:
+        task = None
+
+    # mxnet and torch dispatcher
+    dispatcher = None
+    torch_model_list = None
+    mxnet_model_list = None
+    custom_net = None
+    if args.get('custom_net', None):
+        custom_net = args.get('custom_net')
+        if torch and timm:
+            if isinstance(custom_net, torch.nn.Module):
+                dispatcher = 'torch'
+        if mx:
+            if isinstance(custom_net, mx.gluon.Block):
+                dispatcher = 'mxnet'
+    else:
+        if torch and timm:
+            torch_model_list = timm.list_models()
+        if mx:
+            mxnet_model_list = list(get_model_list())
+        model = args.get('model', None)
+        if model:
+            # timm model has higher priority
+            if torch_model_list and model in torch_model_list:
+                dispatcher = 'torch'
+            elif mxnet_model_list and model in mxnet_model_list:
+                dispatcher = 'mxnet'
+            else:
+                if not torch_model_list:
+                    raise ValueError('Model not found in gluoncv model zoo. Install torch and timm if it supports the model.')
+                elif not mxnet_model_list:
+                    raise ValueError('Model not found in timm model zoo. Install mxnet if it supports the model.')
+                else:
+                    raise ValueError('Model not supported because it does not exist in both timm and gluoncv model zoo.')
+    assert dispatcher in ('torch', 'mxnet'), 'custom net needs to be of type either torch.nn.Module or mx.gluon.Block'
+    args['estimator'] = TorchImageClassificationEstimator if dispatcher=='torch' else ImageClassificationEstimator
+    # convert user defined config to nested form
+    args = config_to_nested(args)
+
+    if wall_clock_tick < tic and not final_fit:
+        return {'traceback': 'timeout', 'args': str(args),
+                'time': 0, 'train_acc': -1, 'valid_acc': -1}
+
+    try:
+        valid_summary_file = 'fit_summary_img_cls.ag'
+        estimator_cls = args.pop('estimator', None)
+        assert estimator_cls in (ImageClassificationEstimator, TorchImageClassificationEstimator)
+        if final_fit:
+            # load from previous dumps
+            estimator = None
+            if os.path.isdir(log_dir):
+                is_valid_dir_fn = lambda d : d.startswith('.trial_') and os.path.isdir(os.path.join(log_dir, d))
+                trial_dirs = [d for d in os.listdir(log_dir) if is_valid_dir_fn(d)]
+                best_checkpoint = ''
+                best_acc = -1
+                result = {}
+                for dd in trial_dirs:
+                    try:
+                        with open(os.path.join(log_dir, dd, valid_summary_file), 'r') as f:
+                            result = json.load(f)
+                            acc = result.get('valid_acc', -1)
+                            if acc > best_acc and os.path.isfile(os.path.join(log_dir, dd, _BEST_CHECKPOINT_FILE)):
+                                best_checkpoint = os.path.join(log_dir, dd, _BEST_CHECKPOINT_FILE)
+                                best_acc = acc
+                    except:
+                        pass
+                if best_checkpoint:
+                    estimator = estimator_cls.load(best_checkpoint)
+            if estimator is None:
+                if wall_clock_tick < tic:
+                    result.update({'traceback': 'timeout'})
+                else:
+                    # unknown error yet, try reproduce it
+                    final_fit = False
+        if not final_fit:
+            # create independent log_dir for each trial
+            trial_log_dir = os.path.join(log_dir, '.trial_{}'.format(task_id))
+            args['log_dir'] = trial_log_dir
+            custom_optimizer = args.pop('custom_optimizer', None)
+            estimator = estimator_cls(args, problem_type=problem_type, reporter=reporter,
+                                      net=custom_net, optimizer=custom_optimizer)
+            # training
+            result = estimator.fit(train_data=train_data, val_data=val_data, time_limit=wall_clock_tick-tic)
+            with open(os.path.join(trial_log_dir, valid_summary_file), 'w') as f:
+                json.dump(result, f)
+            # save config and result
+            if task is not None:
+                trial_log = {}
+                trial_log.update(args)
+                trial_log.update(result)
+                json_str = json.dumps(trial_log)
+                time_str = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
+                json_file_name = task + '_dataset-' + dataset + '_trials-' + str(num_trials) + '_' + time_str + '.json'
+                with open(json_file_name, 'w') as json_file:
+                    json_file.write(json_str)
+                logging.info('Config and result in this trial have been saved to %s.', json_file_name)
+    except:
+        import traceback
+        return {'traceback': traceback.format_exc(), 'args': str(args),
+                'time': time.time() - tic, 'train_acc': -1, 'valid_acc': -1}
+
+    if estimator:
+        result.update({'model_checkpoint': estimator})
+        result.update({'estimator': estimator_cls})
+    return result
+
+
+class ImageClassification(BaseTask):
+    """Whole Image Classification general task.
+    Parameters
+    ----------
+    config : dict
+        The configurations, can be nested dict.
+    logger : logging.Logger
+        The desired logger object, use `None` for module specific logger with default setting.
+    net : mx.gluon.Block
+        The custom network. If defined, the model name in config will be ignored so your
+        custom network will be used for training rather than pulling it from model zoo.
+    """
+    Dataset = ImageClassificationDataset
+
+    def __init__(self, config=None, logger=None, problem_type=None):
+        super(ImageClassification, self).__init__()
+        if problem_type is None:
+            problem_type = MULTICLASS
+        self._problem_type = problem_type
+        self._fit_summary = {}
+        self._logger = logger if logger is not None else logging.getLogger(__name__)
+        self._logger.setLevel(logging.INFO)
+        self._fit_summary = {}
+        self._results = {}
+
+
+        # cpu and gpu setting
+        cpu_count = get_cpu_count()
+        gpu_count = get_gpu_count()
+
+        # default settings
+        if not config:
+            if gpu_count < 1:
+                self._logger.info('No GPU detected/allowed, using most conservative search space.')
+                config = LiteConfig()
+            else:
+                config = DefaultConfig()
+            config = config.asdict()
+        else:
+            if not config.get('dist_ip_addrs', None):
+                ngpus_per_trial = config.get('ngpus_per_trial', gpu_count)
+                ngpus_per_trial = min(ngpus_per_trial, gpu_count)
+                if ngpus_per_trial < 1:
+                    self._logger.info('No GPU detected/allowed, using most conservative search space.')
+                    default_config = LiteConfig()
+                else:
+                    default_config = DefaultConfig()
+                config = default_config.merge(config, allow_new_key=True).asdict()
+
+        # adjust cpu/gpu resources
+        if not config.get('dist_ip_addrs', None):
+            nthreads_per_trial = config.get('nthreads_per_trial', cpu_count)
+            nthreads_per_trial = min(nthreads_per_trial, cpu_count)
+            ngpus_per_trial = config.get('ngpus_per_trial', gpu_count)
+            if ngpus_per_trial > gpu_count:
+                ngpus_per_trial = gpu_count
+                self._logger.warning(
+                    "The number of requested GPUs is greater than the number of available GPUs."
+                    "Reduce the number to %d", ngpus_per_trial)
+        else:
+            raise ValueError('Please specify `nthreads_per_trial` and `ngpus_per_trial` '
+                             'given that dist workers are available')
+
+
+        # additional configs
+        config['num_workers'] = nthreads_per_trial
+        config['gpus'] = [int(i) for i in range(ngpus_per_trial)]
+        config['seed'] = config.get('seed', np.random.randint(32,767))
+        config['final_fit'] = False
+        self._cleanup_disk = config.get('cleanup_disk', True)
+        self._config = config
+
+        # scheduler options
+        self.scheduler = config.get('scheduler', 'local')
+        self.search_strategy = config.get('search_strategy', 'random')
+        self.search_options = config.get('search_options', {})
+        self.scheduler_options = {
+            'resource': {'num_cpus': nthreads_per_trial, 'num_gpus': ngpus_per_trial},
+            'checkpoint': config.get('checkpoint', 'checkpoint/exp1.ag'),
+            'num_trials': config.get('num_trials', 2),
+            'time_out': config.get('time_limits', 60 * 60),
+            'resume': (len(config.get('resume', '')) > 0),
+            'visualizer': config.get('visualizer', 'none'),
+            'time_attr': 'epoch',
+            'reward_attr': 'acc_reward',
+            'dist_ip_addrs': config.get('dist_ip_addrs', None),
+            'searcher': self.search_strategy,
+            'search_options': self.search_options,
+            'max_reward': config.get('max_reward', 0.95)}
+        if self.search_strategy == 'hyperband':
+            self.scheduler_options.update({
+                'searcher': 'random',
+                'max_t': config.get('epochs', 50),
+                'grace_period': config.get('grace_period', config.get('epochs', 50) // 4)})
+        elif self.search_strategy == 'bayesopt_hyperband':
+            self.scheduler_options.update({
+                'searcher': 'bayesopt',
+                'max_t': config.get('epochs', 50),
+                'grace_period': config.get('grace_period', config.get('epochs', 50) // 4)})
+
+    def fit(self, train_data, val_data=None, train_size=0.9, random_state=None, time_limit=None):
+        """Fit auto estimator given the input data.
+        Parameters
+        ----------
+        train_data : pd.DataFrame or iterator
+            Training data.
+        val_data : pd.DataFrame or iterator, optional
+            Validation data, optional. If `train_data` is DataFrame, `val_data` will be split from
+            `train_data` given `train_size`.
+        train_size : float
+            The portion of train data split from original `train_data` if `val_data` is not provided.
+        random_state : int
+            Random state for splitting, for `np.random.seed`.
+        time_limit : int, default is None
+            The wall clock time limit(second) for fit process, if `None`, time limit is not enforced.
+            If `fit` takes longer than `time_limit`, the process will terminate early and return the
+            model prematurally.
+            Due to callbacks and additional validation functions, the `time_limit` may not be very precise
+            (few minutes allowance), but you can use it to safe-guard a very long training session.
+            If `time_limits` key set in __init__ with config, the `time_limit` value will overwrite configuration
+            if not `None`.
+        Returns
+        -------
+        Estimator
+            The estimator obtained by training on the specified dataset.
+        """
+        config = self._config.copy()
+        if time_limit is None:
+            if config.get('time_limits', None):
+                time_limit = config['time_limits']
+            else:
+                time_limit = math.inf
+        elif not isinstance(time_limit, int):
+            raise TypeError(f'Invalid type `time_limit={time_limit}`, int or None expected')
+        self.scheduler_options['time_out'] = time_limit
+        wall_clock_tick = time.time() + time_limit
+        # split train/val before HPO to make fair comparisons
+        if not isinstance(train_data, pd.DataFrame):
+            assert val_data is not None, \
+                "Please provide `val_data` as we do not know how to split `train_data` of type: \
+                {}".format(type(train_data))
+
+        if val_data is None:
+            assert 0 <= train_size <= 1.0
+            if random_state:
+                np.random.seed(random_state)
+            split_mask = np.random.rand(len(train_data)) < train_size
+            train = train_data[split_mask]
+            val = train_data[~split_mask]
+            self._logger.info('Randomly split train_data into train[%d]/validation[%d] splits.',
+                              len(train), len(val))
+            train_data, val_data = train, val
+
+        estimator = config.get('estimator', None)
+        if estimator:
+            if isinstance(estimator, ag.Space):
+                estimator = estimator.data
+            elif isinstance(estimator, str):
+                estimator = [estimator]
+            for i, e in enumerate(estimator):
+                if e != 'img_cls':
+                    estimator.pop(e)
+            if not estimator:
+                raise ValueError('Unable to determine the estimator for fit function.')
+
+        # register args
+        config['train_data'] = train_data
+        config['val_data'] = val_data
+        config['wall_clock_tick'] = wall_clock_tick
+        config['log_dir'] = os.path.join(config.get('log_dir', os.getcwd()), str(uuid.uuid4())[:8])
+        self.scheduler_options['checkpoint'] = os.path.join(config['log_dir'], 'exp1.ag')
+        config['problem_type'] = self._problem_type
+        _train_image_classification.register_args(**config)
+
+        start_time = time.time()
+        self._fit_summary = {}
+        self._results = {}
+        if config.get('num_trials', 1) < 2:
+            rand_config = RandomSearcher(_train_image_classification.cs).get_config()
+            self._logger.info("Starting fit without HPO")
+            results = _train_image_classification(_train_image_classification.args, rand_config)
+            best_config = sample_config(_train_image_classification.args, rand_config)
+            best_config.pop('train_data', None)
+            best_config.pop('val_data', None)
+            self._fit_summary.update({'train_acc': results.get('train_acc', -1),
+                                      'valid_acc': results.get('valid_acc', -1),
+                                      'total_time': results.get('time', time.time() - start_time),
+                                      'best_config': best_config})
+            self._results = self._fit_summary
+        else:
+            self._logger.info("Starting HPO experiments")
+            results = self.run_fit(_train_image_classification, self.scheduler,
+                                   self.scheduler_options, plot_results=False)
+            if isinstance(results, dict):
+                ks = ('best_reward', 'best_config', 'total_time', 'config_history', 'reward_attr')
+                self._results.update({k: v for k, v in results.items() if k in ks})
+        end_time = time.time()
+        self._logger.info("Finished, total runtime is %.2f s", end_time - start_time)
+        if config.get('num_trials', 1) > 1:
+            best_config = sample_config(_train_image_classification.args, results['best_config'])
+            best_config.update({'estimator': results['estimator']})
+            # convert best config to nested form
+            best_config = config_to_nested(best_config)
+            best_config.pop('train_data', None)
+            best_config.pop('val_data', None)
+            self._fit_summary.update({'train_acc': results.get('train_acc', -1),
+                                      'valid_acc': results.get('valid_acc', results.get('best_reward', -1)),
+                                      'total_time': results.get('total_time', time.time() - start_time),
+                                      'best_config': best_config})
+        self._logger.info(pprint.pformat(self._fit_summary, indent=2))
+
+        if self._cleanup_disk:
+            shutil.rmtree(config['log_dir'], ignore_errors=True)
+        model_checkpoint = results.get('model_checkpoint', None)
+        if model_checkpoint is None:
+            if results.get('traceback', '') == 'timeout':
+                raise TimeoutError(f'Unable to fit a usable model given `time_limit={time_limit}`')
+            raise RuntimeError(f'Unexpected error happened during fit: {pprint.pformat(results, indent=2)}')
+        if isinstance(results['model_checkpoint'], bytes):
+            estimator = pickle.loads(results['model_checkpoint'])
+        else:
+            estimator = results['model_checkpoint']
+        return estimator
+
+    def fit_summary(self):
+        return copy.copy(self._fit_summary)
+
+    def fit_history(self):
+        return copy.copy(self._results)
+
+    @classmethod
+    def load(cls, filename):
+        obj = BaseEstimator.load(filename)
+        # make sure not accidentally loading e.g. classification model
+        assert isinstance(obj, ImageClassificationEstimator)
+        return obj
+
+
+class ImagePrediction(ImageClassification):
+    pass

--- a/vision/src/autogluon/vision/_gluoncv/image_classification.py
+++ b/vision/src/autogluon/vision/_gluoncv/image_classification.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 import autogluon.core as ag
 from autocfg import dataclass
-from autogluon.core.utils.try_import import try_import
+from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.core.decorator import sample_config
 from autogluon.core.scheduler.resource import get_cpu_count, get_gpu_count
 from autogluon.core.task.base import BaseTask
@@ -28,13 +28,6 @@ from gluoncv.auto.data.dataset import ImageClassificationDataset
 from gluoncv.auto.estimators.conf import _BEST_CHECKPOINT_FILE
 
 from .utils import config_to_nested
-
-problem_type_constants = try_import(package='autogluon.core.constants',
-                                    fromlist=['MULTICLASS', 'BINARY', 'REGRESSION'],
-                                    message='Failed to import problem type constants from autogluon.core.')
-MULTICLASS = problem_type_constants.MULTICLASS
-BINARY = problem_type_constants.BINARY
-REGRESSION = problem_type_constants.REGRESSION
 
 
 __all__ = ['ImageClassification', 'ImagePrediction']

--- a/vision/src/autogluon/vision/_gluoncv/object_detection.py
+++ b/vision/src/autogluon/vision/_gluoncv/object_detection.py
@@ -1,0 +1,407 @@
+"""Auto pipeline for object detection task"""
+# pylint: disable=bad-whitespace,missing-class-docstring,bare-except
+import time
+import os
+import math
+import copy
+import logging
+import pprint
+import json
+import pickle
+from typing import Union, Tuple
+import uuid
+import shutil
+
+import numpy as np
+import pandas as pd
+from autocfg import dataclass
+import autogluon.core as ag
+from autogluon.core.decorator import sample_config
+from autogluon.core.scheduler.resource import get_cpu_count, get_gpu_count
+from autogluon.core.task.base import BaseTask
+from autogluon.core.searcher import RandomSearcher
+
+from gluoncv.auto.estimators.base_estimator import BaseEstimator
+from gluoncv.auto.estimators import SSDEstimator, FasterRCNNEstimator, YOLOv3Estimator, CenterNetEstimator
+from .utils import auto_suggest, config_to_nested
+from gluoncv.auto.data.dataset import ObjectDetectionDataset
+from gluoncv.auto.estimators.conf import _BEST_CHECKPOINT_FILE
+
+__all__ = ['ObjectDetection']
+
+@dataclass
+class LiteConfig:
+    transfer : Union[type(None), str, ag.Space] = ag.Categorical('ssd_512_mobilenet1.0_coco', 'yolo3_mobilenet1.0_coco')
+    lr : Union[ag.Space, float] = 1e-3
+    num_trials : int = 1
+    epochs : Union[ag.Space, int] = 5
+    nthreads_per_trial : int = 32
+    ngpus_per_trial : int = 0
+    time_limits : int = 7 * 24 * 60 * 60  # 7 days
+    search_strategy : str = 'random'
+    dist_ip_addrs : Union[type(None), list, Tuple] = None
+
+@dataclass
+class DefaultConfig:
+    transfer : Union[type(None), str, ag.Space] = ag.Categorical('ssd_512_resnet50_v1_coco',
+                                                                 'yolo3_darknet53_coco',
+                                                                 'faster_rcnn_resnet50_v1b_coco',
+                                                                 'center_net_resnet50_v1b_coco')
+    lr : Union[ag.Space, float] = ag.Categorical(1e-3, 5e-3)
+    num_trials : int = 3
+    epochs : Union[ag.Space, int] = 10
+    nthreads_per_trial : int = 128
+    ngpus_per_trial : int = 8
+    time_limits : int = 7 * 24 * 60 * 60  # 7 days
+    search_strategy : str = 'random'
+    dist_ip_addrs : Union[type(None), list, Tuple] = None
+
+
+@ag.args()
+def _train_object_detection(args, reporter):
+    """
+    Parameters
+    ----------
+    args: <class 'autogluon.utils.edict.EasyDict'>
+    """
+    tic = time.time()
+    try:
+        task_id = int(args.task_id)
+    except:
+        task_id = 0
+    final_fit = args.pop('final_fit', False)
+    # train, val data
+    train_data = args.pop('train_data')
+    val_data = args.pop('val_data')
+    # wall clock tick limit
+    wall_clock_tick = args.pop('wall_clock_tick')
+    log_dir = args.pop('log_dir', os.getcwd())
+    # exponential batch size for Int() space batch sizes
+    try:
+        exp_batch_size = args.pop('exp_batch_size')
+    except AttributeError:
+        exp_batch_size = False
+    if exp_batch_size and 'batch_size' in args:
+        args['batch_size'] = 2 ** args['batch_size']
+    try:
+        task = args.pop('task')
+        dataset = args.pop('dataset')
+        num_trials = args.pop('num_trials')
+    except AttributeError:
+        task = None
+
+    # convert user defined config to nested form
+    args = config_to_nested(args)
+
+    if wall_clock_tick < tic and not final_fit:
+        return {'traceback': 'timeout', 'args': str(args),
+                'time': 0, 'train_map': -1, 'valid_map': -1}
+
+    try:
+        valid_summary_file = 'fit_summary_obj_det.ag'
+        estimator_cls = args.pop('estimator', None)
+        if estimator_cls == FasterRCNNEstimator:
+            # safe guard if too many GT in dataset
+            train_dataset = train_data.to_mxnet()
+            max_gt_count = max([y[1].shape[0] for y in train_dataset]) + 20
+            args['faster_rcnn']['max_num_gt'] = max_gt_count
+        if final_fit:
+            # load from previous dumps
+            estimator = None
+            if os.path.isdir(log_dir):
+                is_valid_dir_fn = lambda d : d.startswith('.trial_') and os.path.isdir(os.path.join(log_dir, d))
+                trial_dirs = [d for d in os.listdir(log_dir) if is_valid_dir_fn(d)]
+                best_checkpoint = ''
+                best_acc = -1
+                result = {}
+                for dd in trial_dirs:
+                    try:
+                        with open(os.path.join(log_dir, dd, valid_summary_file), 'r') as f:
+                            result = json.load(f)
+                            acc = result.get('valid_map', -1)
+                            if acc > best_acc and os.path.isfile(os.path.join(log_dir, dd, _BEST_CHECKPOINT_FILE)):
+                                best_checkpoint = os.path.join(log_dir, dd, _BEST_CHECKPOINT_FILE)
+                                best_acc = acc
+                    except:
+                        pass
+                if best_checkpoint:
+                    estimator = estimator_cls.load(best_checkpoint)
+            if estimator is None:
+                if wall_clock_tick < tic:
+                    result.update({'traceback': 'timeout'})
+                else:
+                    # unknown error
+                    final_fit = False
+        if not final_fit:
+            # create independent log_dir for each trial
+            trial_log_dir = os.path.join(log_dir, '.trial_{}'.format(task_id))
+            args['log_dir'] = trial_log_dir
+            estimator = estimator_cls(args, reporter=reporter)
+            # training
+            result = estimator.fit(train_data=train_data, val_data=val_data, time_limit=wall_clock_tick-tic)
+            with open(os.path.join(trial_log_dir, valid_summary_file), 'w') as f:
+                json.dump(result, f)
+            # save config and result
+            if task is not None:
+                trial_log = {}
+                trial_log.update(args)
+                trial_log.update(result)
+                json_str = json.dumps(trial_log)
+                time_str = time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime())
+                json_file_name = task + '_dataset-' + dataset + '_trials-' + str(num_trials) + '_' + time_str + '.json'
+                with open(json_file_name, 'w') as json_file:
+                    json_file.write(json_str)
+                logging.info('Config and result in this trial have been saved to %s.', json_file_name)
+    except:
+        import traceback
+        return {'traceback': traceback.format_exc(), 'args': str(args),
+                'time': time.time() - tic, 'train_map': -1, 'valid_map': -1}
+
+    if estimator:
+        result.update({'model_checkpoint': pickle.dumps(estimator)})
+    return result
+
+class ObjectDetection(BaseTask):
+    """Object Detection general task.
+    Parameters
+    ----------
+    config : dict
+        The configurations, can be nested dict.
+    logger : logging.Logger
+        The desired logger object, use `None` for module specific logger with default setting.
+    """
+    Dataset = ObjectDetectionDataset
+
+    def __init__(self, config=None, logger=None):
+        super(ObjectDetection, self).__init__()
+        self._fit_summary = {}
+        self._logger = logger if logger is not None else logging.getLogger(__name__)
+        self._logger.setLevel(logging.INFO)
+        self._fit_summary = {}
+        self._results = {}
+
+        # cpu and gpu setting
+        cpu_count = get_cpu_count()
+        gpu_count = get_gpu_count()
+
+        # default settings
+        if not config:
+            if gpu_count < 1:
+                self._logger.info('No GPU detected/allowed, using most conservative search space.')
+                config = LiteConfig()
+            else:
+                config = DefaultConfig()
+            config = config.asdict()
+        else:
+            if not config.get('dist_ip_addrs', None):
+                ngpus_per_trial = config.get('ngpus_per_trial', gpu_count)
+                ngpus_per_trial = min(ngpus_per_trial, gpu_count)
+                if ngpus_per_trial < 1:
+                    self._logger.info('No GPU detected/allowed, using most conservative search space.')
+                    default_config = LiteConfig()
+                else:
+                    default_config = DefaultConfig()
+                config = default_config.merge(config, allow_new_key=True).asdict()
+
+        # adjust cpu/gpu resources
+        if not config.get('dist_ip_addrs', None):
+            nthreads_per_trial = config.get('nthreads_per_trial', cpu_count)
+            nthreads_per_trial = min(nthreads_per_trial, cpu_count)
+            ngpus_per_trial = config.get('ngpus_per_trial', gpu_count)
+            if ngpus_per_trial > gpu_count:
+                ngpus_per_trial = gpu_count
+                self._logger.warning(
+                    "The number of requested GPUs is greater than the number of available GPUs."
+                    "Reduce the number to %d", ngpus_per_trial)
+        else:
+            raise ValueError('Please specify `nthreads_per_trial` and `ngpus_per_trial` '
+                             'given that dist workers are available')
+
+        # fix estimator-transfer relationship
+        estimator = config.get('estimator', None)
+        transfer = config.get('transfer', None)
+        if estimator is not None and transfer is not None:
+            if isinstance(estimator, ag.Space):
+                estimator = estimator.data
+            elif isinstance(estimator, str):
+                estimator = [estimator]
+            if isinstance(transfer, ag.Space):
+                transfer = transfer.data
+            elif isinstance(transfer, str):
+                transfer = [transfer]
+
+            valid_transfer = []
+            for e in estimator:
+                for t in transfer:
+                    if e in t:
+                        valid_transfer.append(t)
+
+            if not valid_transfer:
+                raise ValueError(f'No matching `transfer` model for {estimator}')
+            if len(valid_transfer) == 1:
+                config['transfer'] = valid_transfer[0]
+            else:
+                config['transfer'] = ag.Categorical(*valid_transfer)
+
+        # additional configs
+        config['num_workers'] = nthreads_per_trial
+        config['gpus'] = [int(i) for i in range(ngpus_per_trial)]
+        config['seed'] = config.get('seed', np.random.randint(32,767))
+        config['final_fit'] = False
+        self._cleanup_disk = config.get('cleanup_disk', True)
+        self._config = config
+
+        # scheduler options
+        self.search_strategy = config.get('search_strategy', 'random')
+        self.search_options = config.get('search_options', {})
+        self.scheduler_options = {
+            'resource': {'num_cpus': nthreads_per_trial, 'num_gpus': ngpus_per_trial},
+            'checkpoint': config.get('checkpoint', 'checkpoint/exp1.ag'),
+            'num_trials': config.get('num_trials', 2),
+            'time_out': config.get('time_limits', 60 * 60),
+            'resume': (len(config.get('resume', '')) > 0),
+            'visualizer': config.get('visualizer', 'none'),
+            'time_attr': 'epoch',
+            'reward_attr': 'map_reward',
+            'dist_ip_addrs': config.get('dist_ip_addrs', None),
+            'searcher': self.search_strategy,
+            'search_options': self.search_options,
+            'max_reward': config.get('max_reward', 0.9)}
+        if self.search_strategy == 'hyperband':
+            self.scheduler_options.update({
+                'searcher': 'random',
+                'max_t': config.get('epochs', 50),
+                'grace_period': config.get('grace_period', config.get('epochs', 50) // 4)})
+        elif self.search_strategy == 'bayesopt_hyperband':
+            self.scheduler_options.update({
+                'searcher': 'bayesopt',
+                'max_t': config.get('epochs', 50),
+                'grace_period': config.get('grace_period', config.get('epochs', 50) // 4)})
+
+    def fit(self, train_data, val_data=None, train_size=0.9, random_state=None, time_limit=None):
+        """Fit auto estimator given the input data.
+        Parameters
+        ----------
+        train_data : pd.DataFrame or iterator
+            Training data.
+        val_data : pd.DataFrame or iterator, optional
+            Validation data, optional. If `train_data` is DataFrame, `val_data` will be split from
+            `train_data` given `train_size`.
+        train_size : float
+            The portion of train data split from original `train_data` if `val_data` is not provided.
+        random_state : int
+            Random state for splitting, for `np.random.seed`.
+        time_limit : int, default is None
+            The wall clock time limit(second) for fit process, if `None`, time limit is not enforced.
+            If `fit` takes longer than `time_limit`, the process will terminate early and return the
+            model prematurally.
+            Due to callbacks and additional validation functions, the `time_limit` may not be very precise
+            (few minutes allowance), but you can use it to safe-guard a very long training session.
+            If `time_limits` key set in __init__ with config, the `time_limit` value will overwrite configuration
+            if not `None`.
+        Returns
+        -------
+        Estimator
+            The estimator obtained by training on the specified dataset.
+        """
+        config = self._config.copy()
+        if time_limit is None:
+            if config.get('time_limits', None):
+                time_limit = config['time_limits']
+            else:
+                time_limit = math.inf
+        elif not isinstance(time_limit, int):
+            raise TypeError(f'Invalid type `time_limit={time_limit}`, int or None expected')
+        self.scheduler_options['time_out'] = time_limit
+        wall_clock_tick = time.time() + time_limit
+        # split train/val before HPO to make fair comparisons
+        if not isinstance(train_data, pd.DataFrame):
+            assert val_data is not None, \
+                "Please provide `val_data` as we do not know how to split `train_data` of type: \
+                {}".format(type(train_data))
+
+        if val_data is None:
+            assert 0 <= train_size <= 1.0
+            if random_state:
+                np.random.seed(random_state)
+            split_mask = np.random.rand(len(train_data)) < train_size
+            train = train_data[split_mask]
+            val = train_data[~split_mask]
+            self._logger.info('Randomly split train_data into train[%d]/validation[%d] splits.',
+                              len(train), len(val))
+            train_data, val_data = train, val
+
+        # automatically suggest some hyperparameters based on the dataset statistics(experimental)
+        estimator = config.get('estimator', None)
+        transfer = config.get('transfer', None)
+        if not transfer:
+            config['train_dataset'] = train_data
+            auto_suggest(config, estimator, self._logger)
+            config.pop('train_dataset')
+
+        # register args
+        config['train_data'] = train_data
+        config['val_data'] = val_data
+        config['wall_clock_tick'] = wall_clock_tick
+        config['log_dir'] = os.path.join(config.get('log_dir', os.getcwd()), str(uuid.uuid4())[:8])
+        _train_object_detection.register_args(**config)
+
+        start_time = time.time()
+        self._fit_summary = {}
+        self._results = {}
+        if config.get('num_trials', 1) < 2:
+            rand_config = RandomSearcher(_train_object_detection.cs).get_config()
+            self._logger.info("Starting fit without HPO")
+            results = _train_object_detection(_train_object_detection.args, rand_config)
+            best_config = sample_config(_train_object_detection.args, rand_config)
+            best_config.pop('train_data', None)
+            best_config.pop('val_data', None)
+            self._fit_summary.update({'train_map': results.get('train_map', -1),
+                                      'valid_map': results.get('valid_map', -1),
+                                      'total_time': results.get('time', time.time() - start_time),
+                                      'best_config': best_config})
+            self._results = self._fit_summary
+        else:
+            self._logger.info("Starting HPO experiments")
+            results = self.run_fit(_train_object_detection, self.search_strategy,
+                                   self.scheduler_options)
+            if isinstance(results, dict):
+                ks = ('best_reward', 'best_config', 'total_time', 'config_history', 'reward_attr')
+                self._results.update({k: v for k, v in results.items() if k in ks})
+        end_time = time.time()
+        self._logger.info("Finished, total runtime is %.2f s", end_time - start_time)
+        if config.get('num_trials', 1) > 1:
+            best_config = sample_config(_train_object_detection.args, results['best_config'])
+            # convert best config to nested form
+            best_config = config_to_nested(best_config)
+            best_config.pop('train_data', None)
+            best_config.pop('val_data', None)
+            self._fit_summary.update({'train_map': results.get('train_map', -1),
+                                      'valid_map': results.get('valid_map', results.get('best_reward', -1)),
+                                      'total_time': results.get('total_time', time.time() - start_time),
+                                      'best_config': best_config})
+        self._logger.info(pprint.pformat(self._fit_summary, indent=2))
+
+        if self._cleanup_disk:
+            shutil.rmtree(config['log_dir'], ignore_errors=True)
+        model_checkpoint = results.get('model_checkpoint', None)
+        if model_checkpoint is None:
+            if results.get('traceback', '') == 'timeout':
+                raise TimeoutError(f'Unable to fit a usable model given `time_limit={time_limit}`')
+            raise RuntimeError(f'Unexpected error happened during fit: {pprint.pformat(results, indent=2)}')
+        estimator = pickle.loads(results['model_checkpoint'])
+        return estimator
+
+    def fit_summary(self):
+        return copy.copy(self._fit_summary)
+
+    def fit_history(self):
+        return copy.copy(self._results)
+
+    @classmethod
+    def load(cls, filename):
+        obj = BaseEstimator.load(filename)
+        # make sure not accidentally loading e.g. classification model
+        # pylint: disable=unidiomatic-typecheck
+        assert type(obj) in (SSDEstimator, FasterRCNNEstimator, YOLOv3Estimator, CenterNetEstimator)
+        return obj

--- a/vision/src/autogluon/vision/_gluoncv/utils.py
+++ b/vision/src/autogluon/vision/_gluoncv/utils.py
@@ -1,0 +1,442 @@
+"""Utils for auto tasks"""
+import copy
+import warnings
+import numpy as np
+
+import autogluon.core as ag
+
+from gluoncv.auto.estimators.base_estimator import BaseEstimator
+from gluoncv.auto.estimators import SSDEstimator, FasterRCNNEstimator, YOLOv3Estimator, CenterNetEstimator
+from gluoncv.auto.estimators import ImageClassificationEstimator
+from gluoncv.auto.data.dataset import ObjectDetectionDataset
+
+try:
+    from gluoncv import data as gdata
+except ImportError:
+    gdata = None
+
+
+class ConfigDict(dict):
+    """The view of a config dict where keys can be accessed like attribute, it also prevents
+    naive modifications to the key-values.
+    Parameters
+    ----------
+    config : dict
+        The configuration dict.
+    Attributes
+    ----------
+    __dict__ : type
+        The internal config as a `__dict__`.
+    """
+    MARKER = object()
+    def __init__(self, value=None):
+        super(ConfigDict, self).__init__()
+        self.__dict__['_freeze'] = False
+        if value is None:
+            pass
+        elif isinstance(value, dict):
+            for key in value:
+                self.__setitem__(key, value[key])
+        else:
+            raise TypeError('expected dict, given {}'.format(type(value)))
+        self.freeze()
+
+    def freeze(self):
+        self.__dict__['_freeze'] = True
+
+    def is_frozen(self):
+        return self.__dict__['_freeze']
+
+    def unfreeze(self):
+        self.__dict__['_freeze'] = False
+
+    def __setitem__(self, key, value):
+        if self.__dict__.get('_freeze', False):
+            msg = ('You are trying to modify the config to "{}={}" after initialization, '
+                   ' this may result in unpredictable behaviour'.format(key, value))
+            warnings.warn(msg)
+        if isinstance(value, dict) and not isinstance(value, ConfigDict):
+            value = ConfigDict(value)
+        super(ConfigDict, self).__setitem__(key, value)
+
+    def __getitem__(self, key):
+        found = self.get(key, ConfigDict.MARKER)
+        if found is ConfigDict.MARKER:
+            if self.__dict__['_freeze']:
+                raise KeyError(key)
+            found = ConfigDict()
+            super(ConfigDict, self).__setitem__(key, found)
+        if isinstance(found, ConfigDict):
+            found.__dict__['_freeze'] = self.__dict__['_freeze']
+        return found
+
+    def __setstate__(self, state):
+        vars(self).update(state)
+
+    def __getstate__(self):
+        return vars(self)
+
+    __setattr__, __getattr__ = __setitem__, __getitem__
+
+def auto_suggest(config, estimator, logger):
+    """
+    Automatically suggest some hyperparameters based on the dataset statistics.
+    """
+    # specify estimator search space
+    if estimator is None:
+        estimator_init = [SSDEstimator, YOLOv3Estimator, FasterRCNNEstimator, CenterNetEstimator]
+        config['estimator'] = ag.Categorical(*estimator_init)
+    elif isinstance(estimator, str):
+        named_estimators = {
+            'ssd': SSDEstimator,
+            'faster_rcnn': FasterRCNNEstimator,
+            'yolo3': YOLOv3Estimator,
+            'center_net': CenterNetEstimator,
+            'img_cls': ImageClassificationEstimator
+        }
+        if estimator.lower() in named_estimators:
+            estimator = [named_estimators[estimator.lower()]]
+        else:
+            available_ests = named_estimators.keys()
+            raise ValueError(f'Unknown estimator name: {estimator}, options: {available_ests}')
+    elif isinstance(estimator, (tuple, list)):
+        pass
+    else:
+        if isinstance(estimator, ag.Space):
+            estimator = estimator.data
+        elif isinstance(estimator, str):
+            estimator = [estimator]
+        for i, e in enumerate(estimator):
+            if e == 'ssd':
+                estimator[i] = SSDEstimator
+            elif e == 'yolo3':
+                estimator[i] = YOLOv3Estimator
+            elif e == 'faster_rcnn':
+                estimator[i] = FasterRCNNEstimator
+            elif e == 'center_net':
+                estimator[i] = CenterNetEstimator
+        if not estimator:
+            raise ValueError('Unable to determine the estimator for fit function.')
+        if len(estimator) == 1:
+            config['estimator'] = estimator[0]
+        else:
+            config['estimator'] = ag.Categorical(*estimator)
+
+    # get dataset statistics
+    # user needs to define a Dataset object "train_dataset" when using custom dataset
+    train_dataset = config.get('train_dataset', None)
+    try:
+        if train_dataset is None:
+            dataset_name = config.get('dataset', 'voc')
+            dataset_root = config.get('dataset_root', '~/.mxnet/datasets/')
+            if gdata is not None and dataset_name == 'voc':
+                train_dataset = gdata.VOCDetection(splits=[(2007, 'trainval'), (2012, 'trainval')])
+            elif gdata is not None and dataset_name == 'voc_tiny':
+                train_dataset = gdata.CustomVOCDetectionBase(classes=('motorbike',),
+                                                             root=dataset_root + 'tiny_motorbike',
+                                                             splits=[('', 'trainval')])
+            elif gdata is not None and dataset_name == 'coco':
+                train_dataset = gdata.COCODetection(splits=['instances_train2017'])
+            else:
+                if gdata is None:
+                    logger.warning('Unable to import mxnet so voc and coco formats are currently not loaded.')
+        elif isinstance(train_dataset, ObjectDetectionDataset):
+            train_dataset = train_dataset.to_mxnet()
+        else:
+            logger.info('Unknown dataset, quit auto suggestion...')
+            return
+    # pylint: disable=broad-except
+    except Exception as e:
+        logger.info(f'Unexpected error: {e}, quit auto suggestion...')
+        return
+
+    # choose 100 examples to calculate average statistics
+    num_examples = 100
+    image_size_list = []
+    num_objects_list = []
+    bbox_size_list = []
+    bbox_rel_size_list = []
+
+    for i in range(num_examples):
+        train_image, train_label = train_dataset[i]
+
+        image_height = train_image.shape[0]
+        image_width = train_image.shape[1]
+        image_size = image_height * image_width
+        image_size_list.append(image_size)
+
+        bounding_boxes = train_label[:, :4]
+        num_objects = bounding_boxes.shape[0]
+        bbox_height = bounding_boxes[:, 3] - bounding_boxes[:, 1]
+        bbox_width = bounding_boxes[:, 2] - bounding_boxes[:, 0]
+        bbox_size = bbox_height * bbox_width
+        bbox_rel_size = bbox_size / image_size
+        num_objects_list.append(num_objects)
+        bbox_size_list.append(np.mean(bbox_size))
+        bbox_rel_size_list.append(np.mean(bbox_rel_size))
+
+    num_images = len(train_dataset)
+    image_size = np.mean(image_size_list)
+    try:
+        num_classes = len(train_dataset.CLASSES)
+    except AttributeError:
+        num_classes = len(train_dataset.classes)
+    num_objects = np.mean(num_objects_list)
+    bbox_size = np.mean(bbox_size_list)
+    bbox_rel_size = np.mean(bbox_rel_size_list)
+
+    logger.info("[Printing dataset statistics]...")
+    logger.info("number of training images: %d", num_images)
+    logger.info("average image size: %.2f", image_size)
+    logger.info("number of total object classes: %d", num_classes)
+    logger.info("average number of objects in an image: %.2f", num_objects)
+    logger.info("average bounding box size: %.2f", bbox_size)
+    logger.info("average bounding box relative size: %.2f", bbox_rel_size)
+
+    # specify 3 parts of config: data preprocessing, model selection, training settings
+    if bbox_rel_size < 0.2 or num_objects > 5:
+        suggested_estimator = [FasterRCNNEstimator]
+    else:
+        suggested_estimator = [SSDEstimator, YOLOv3Estimator, CenterNetEstimator]
+
+    # specify estimator search space based on suggestion
+    if estimator is None:
+        estimator = suggested_estimator
+        config['estimator'] = ag.Categorical(*estimator)
+
+def get_recursively(search_dict, field):
+    """
+    Takes a dict with nested dicts,
+    and searches all dicts for a key of the field
+    provided.
+    """
+    fields_found = []
+
+    for key, value in search_dict.items():
+
+        if key == field:
+            fields_found.append(value)
+
+        elif isinstance(value, dict):
+            results = get_recursively(value, field)
+            for result in results:
+                fields_found.append(result)
+
+    return fields_found
+
+def config_to_nested(config):
+    """Convert config to nested version"""
+    estimator = config.get('estimator', None)
+    transfer = config.get('transfer', None)
+    # choose hyperparameters based on pretrained model in transfer learning
+    if transfer:
+        # choose estimator
+        if transfer.startswith('ssd'):
+            estimator = SSDEstimator
+        elif transfer.startswith('yolo3'):
+            estimator = YOLOv3Estimator
+        elif transfer.startswith('faster_rcnn'):
+            estimator = FasterRCNNEstimator
+        elif transfer.startswith('center_net'):
+            estimator = CenterNetEstimator
+        else:
+            estimator = ImageClassificationEstimator
+        # choose base network
+        transfer_list = transfer.split('_')
+        if transfer_list[0] == 'ssd':
+            transfer_list.pop(0)
+            config['data_shape'] = int(transfer_list.pop(0))
+            transfer_list.pop(-1)
+        elif transfer_list[0] == 'yolo3':
+            transfer_list.pop(0)
+            transfer_list.pop(-1)
+        else:
+            transfer_list.pop(0)
+            transfer_list.pop(0)
+            transfer_list.pop(-1)
+        config['base_network'] = '_'.join(transfer_list)
+        if config['base_network'].startswith('mobilenet'):
+            config['base_network'].replace('_', '.')
+    elif isinstance(estimator, str):
+        if estimator == 'ssd':
+            estimator = SSDEstimator
+        elif estimator == 'yolo3':
+            estimator = YOLOv3Estimator
+        elif estimator == 'faster_rcnn':
+            estimator = FasterRCNNEstimator
+        elif estimator == 'center_net':
+            estimator = CenterNetEstimator
+        elif estimator == 'img_cls':
+            estimator = ImageClassificationEstimator
+        else:
+            raise ValueError(f'Unknown estimator: {estimator}')
+    else:
+        assert issubclass(estimator, BaseEstimator)
+
+    cfg_map = estimator._default_cfg.asdict()
+
+    def _recursive_update(config, key, value, auto_strs, auto_ints):
+        for k, v in config.items():
+            if k in auto_strs:
+                config[k] = 'auto'
+            if k in auto_ints:
+                config[k] = -1
+            if key == k:
+                config[key] = value
+            elif isinstance(v, dict):
+                _recursive_update(v, key, value, auto_strs, auto_ints)
+
+    if 'use_rec' in config:
+        auto_strs = ['data_dir']
+        auto_ints = []
+    else:
+        auto_strs = ['data_dir', 'rec_train', 'rec_train_idx', 'rec_val', 'rec_val_idx',
+                     'dataset', 'dataset_root']
+        auto_ints = ['num_training_samples']
+    for k, v in config.items():
+        _recursive_update(cfg_map, k, v, auto_strs, auto_ints)
+    cfg_map['estimator'] = estimator
+    return cfg_map
+
+def config_to_nested_v0(config):
+    """Convert config to nested version"""
+    if 'meta_arch' not in config:
+        if config['estimator'] == SSDEstimator:
+            config['meta_arch'] = 'ssd'
+        elif config['estimator'] == FasterRCNNEstimator:
+            config['meta_arch'] = 'faster_rcnn'
+        elif config['estimator'] == YOLOv3Estimator:
+            config['meta_arch'] = 'yolo3'
+        elif config['estimator'] == CenterNetEstimator:
+            config['meta_arch'] = 'center_net'
+        elif config['estimator'] == ImageClassificationEstimator:
+            config['meta_arch'] = 'img_cls'
+        else:
+            config['meta_arch'] = None
+    else:
+        pass
+
+    if config['meta_arch'] == 'ssd':
+        config_mapping = {
+            'ssd': ['backbone', 'data_shape', 'filters', 'sizes', 'ratios', 'steps', 'syncbn',
+                    'amp', 'custom_model'],
+            'train': ['batch_size', 'start_epoch', 'epochs', 'lr', 'lr_decay', 'lr_decay_epoch',
+                      'momentum', 'wd', 'log_interval', 'seed', 'dali'],
+            'validation': ['val_interval']
+        }
+    elif config['meta_arch'] == 'faster_rcnn':
+        config_mapping = {
+            'faster_rcnn': ['backbone', 'nms_thresh', 'nms_topk', 'roi_mode', 'roi_size', 'strides', 'clip',
+                            'anchor_base_size', 'anchor_aspect_ratio', 'anchor_scales', 'anchor_alloc_size',
+                            'rpn_channel', 'rpn_nms_thresh', 'max_num_gt', 'norm_layer', 'use_fpn', 'num_fpn_filters',
+                            'num_box_head_conv', 'num_box_head_conv_filters', 'num_box_head_dense_filters',
+                            'image_short', 'image_max_size', 'custom_model', 'amp', 'static_alloc',
+                            'disable_hybridization'],
+            'train': ['pretrained_base', 'batch_size', 'start_epoch', 'epochs', 'lr', 'lr_decay',
+                      'lr_decay_epoch', 'lr_mode', 'lr_warmup', 'lr_warmup_factor', 'momentum', 'wd',
+                      'rpn_train_pre_nms', 'rpn_train_post_nms', 'rpn_smoothl1_rho', 'rpn_min_size',
+                      'rcnn_num_samples', 'rcnn_pos_iou_thresh', 'rcnn_pos_ratio', 'rcnn_smoothl1_rho',
+                      'log_interval', 'seed', 'verbose', 'mixup', 'no_mixup_epochs', 'executor_threads'],
+            'validation': ['rpn_test_pre_nms', 'rpn_test_post_nms', 'val_interval']
+        }
+    elif config['meta_arch'] == 'yolo3':
+        config_mapping = {
+            'yolo3': ['backbone', 'filters', 'anchors', 'strides', 'data_shape', 'syncbn', 'no_random_shape',
+                      'amp', 'custom_model'],
+            'train': ['batch_size', 'epochs', 'start_epoch', 'lr', 'lr_mode', 'lr_decay', 'lr_decay_period',
+                      'lr_decay_epoch', 'warmup_lr', 'warmup_epochs', 'momentum', 'wd', 'log_interval',
+                      'seed', 'num_samples', 'no_wd', 'mixup', 'no_mixup_epochs', 'label_smooth'],
+            'validation': ['val_interval']
+        }
+    elif config['meta_arch'] == 'center_net':
+        config_mapping = {
+            'center_net': ['base_network', 'heads', 'scale', 'topk', 'root', 'wh_weight', 'center_reg_weight',
+                           'data_shape'],
+            'train': ['gpus', 'pretrained_base', 'batch_size', 'epochs', 'lr', 'lr_decay', 'lr_decay_epoch',
+                      'lr_mode', 'warmup_lr', 'warmup_epochs', 'num_workers', 'resume',
+                      'start_epoch', 'momentum', 'wd', 'save_interval', 'log_interval'],
+            'validation': ['flip_test', 'nms_thresh', 'nms_topk', 'post_nms', 'num_workers',
+                           'batch_size', 'interval']
+        }
+    elif config['meta_arch'] == 'img_cls':
+        config_mapping = {
+            'img_cls': ['model', 'use_pretrained', 'use_gn', 'batch_norm', 'use_se', 'last_gamma'],
+            'train': ['gpus', 'num_workers', 'batch_size', 'epochs', 'start_epoch', 'lr', 'lr_mode',
+                      'lr_decay', 'lr_decay_period',
+                      'lr_decay_epoch', 'warmup_lr', 'warmup_epochs', 'momentum', 'wd', 'log_interval',
+                      'seed', 'num_samples', 'no_wd', 'mixup', 'no_mixup_epochs', 'label_smooth'],
+            'validation': []
+        }
+    else:
+        raise NotImplementedError('%s is not implemented.' % config['meta_arch'])
+
+    nested_config = {}
+
+    for k, v in config.items():
+        if k in config_mapping[config['meta_arch']]:
+            if config['meta_arch'] not in nested_config:
+                nested_config[config['meta_arch']] = {}
+            nested_config[config['meta_arch']].update({k: v})
+        elif k in config_mapping['train']:
+            if 'train' not in nested_config:
+                nested_config['train'] = {}
+            nested_config['train'].update({k: v})
+        elif k in config_mapping['validation']:
+            if 'validation' not in nested_config:
+                nested_config['validation'] = {}
+            nested_config['validation'].update({k: v})
+        else:
+            nested_config.update({k: v})
+
+    return nested_config
+
+def recursive_update(total_config, config):
+    """update config recursively"""
+    for k, v in config.items():
+        if isinstance(v, dict):
+            if k not in total_config:
+                total_config[k] = {}
+            recursive_update(total_config[k], v)
+        else:
+            total_config[k] = v
+
+def config_to_space(config):
+    """Convert config to ag.space"""
+    space = ag.Dict()
+    for k, v in config.items():
+        if isinstance(v, dict):
+            if k not in space:
+                space[k] = ag.Dict()
+            space[k] = config_to_space(v)
+        else:
+            space[k] = v
+    return space
+
+def auto_args(config, estimators):
+    """
+    Merge user defined config to estimator default config, and convert to search space
+    Parameters
+    ----------
+    config: <class 'dict'>
+    Returns
+    -------
+    ag_space: <class 'autogluon.core.space.Dict'>
+    """
+    total_config = {}
+
+    # estimator default config
+    if not isinstance(estimators, (tuple, list)):
+        estimators = [estimators]
+    for estimator in estimators:
+        assert issubclass(estimator, BaseEstimator), estimator
+        default_config = copy.deepcopy(estimator._default_config)  # <class 'dict'>
+        recursive_update(total_config, default_config)
+
+    # user defined config
+    nested_config = config_to_nested(config)
+    recursive_update(total_config, nested_config)
+
+    # convert to search space
+    ag_space = config_to_space(total_config)
+
+    return ag_space

--- a/vision/src/autogluon/vision/detector/detector.py
+++ b/vision/src/autogluon/vision/detector/detector.py
@@ -9,7 +9,7 @@ import pandas as pd
 import numpy as np
 from autogluon.common.utils.log_utils import set_logger_verbosity, verbosity2loglevel
 from autogluon.core.utils import get_gpu_count_all
-from gluoncv.auto.tasks import ObjectDetection as _ObjectDetection
+from .._gluoncv import ObjectDetection as _ObjectDetection
 from ..configs.presets_configs import unpack, _check_gpu_memory_presets
 
 __all__ = ['ObjectDetector']

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -8,7 +8,7 @@ from autogluon.core.space import Categorical
 
 import numpy as np
 import pandas as pd
-from gluoncv.auto.tasks import ImagePrediction as _ImageClassification
+from .._gluoncv import ImagePrediction as _ImageClassification
 try:
     import timm
 except ImportError:

--- a/vision/tests/unittests/test_gluoncv.py
+++ b/vision/tests/unittests/test_gluoncv.py
@@ -1,0 +1,38 @@
+from autogluon.vision._gluoncv import ImageClassification
+from autogluon.vision._gluoncv import ObjectDetection
+import autogluon.core as ag
+
+IMAGE_CLASS_DATASET, _, IMAGE_CLASS_TEST = ImageClassification.Dataset.from_folders(
+    'https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+OBJECT_DETCTION_DATASET = ObjectDetection.Dataset.from_voc('https://autogluon.s3.amazonaws.com/datasets/tiny_motorbike.zip')
+OBJECT_DETECTION_TRAIN, OBJECT_DETECTION_VAL, OBJECT_DETECTION_TEST = OBJECT_DETCTION_DATASET.random_split(val_size=0.3, test_size=0.2)
+
+def test_image_classification():
+    from gluoncv.auto.tasks import ImageClassification
+    task = ImageClassification({'model': 'resnet18_v1', 'num_trials': 1, 'epochs': 1, 'batch_size': 8})
+    classifier = task.fit(IMAGE_CLASS_DATASET)
+    assert task.fit_summary().get('valid_acc', 0) > 0
+    test_result = classifier.predict(IMAGE_CLASS_TEST)
+
+def test_image_classification_custom_net():
+    from gluoncv.auto.tasks import ImageClassification
+    from gluoncv.model_zoo import get_model
+    net = get_model('resnet18_v1')
+    task = ImageClassification({'num_trials': 1, 'epochs': 1, 'custom_net': net, 'batch_size': 8})
+    classifier = task.fit(IMAGE_CLASS_DATASET)
+    assert task.fit_summary().get('valid_acc', 0) > 0
+    test_result = classifier.predict(IMAGE_CLASS_TEST)
+
+def test_object_detection_estimator():
+    from gluoncv.auto.tasks import ObjectDetection
+    task = ObjectDetection({'num_trials': 1, 'epochs': 1, 'batch_size': 4})
+    detector = task.fit(OBJECT_DETECTION_TRAIN)
+    assert task.fit_summary().get('valid_map', 0) > 0
+    test_result = detector.predict(OBJECT_DETECTION_TEST)
+
+def test_object_detection_estimator_transfer():
+    from gluoncv.auto.tasks import ObjectDetection
+    task = ObjectDetection({'num_trials': 1, 'epochs': 1, 'transfer': ag.Categorical('yolo3_darknet53_coco', 'ssd_512_resnet50_v1_voc'), 'estimator': 'ssd', 'batch_size': 4})
+    detector = task.fit(OBJECT_DETECTION_TRAIN)
+    assert task.fit_summary().get('valid_map', 0) > 0
+    test_result = detector.predict(OBJECT_DETECTION_TEST)

--- a/vision/tests/unittests/test_hybrid_gluoncv.py
+++ b/vision/tests/unittests/test_hybrid_gluoncv.py
@@ -1,0 +1,13 @@
+from gluoncv.auto.tasks import ImageClassification
+import autogluon.core as ag
+
+IMAGE_CLASS_DATASET, _, IMAGE_CLASS_TEST = ImageClassification.Dataset.from_folders(
+    'https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+
+def test_hybrid_image_classification():
+    from gluoncv.auto.tasks import ImageClassification
+    model = ag.Categorical('resnet18_v1b', 'resnet18')
+    task = ImageClassification({'model': model, 'num_trials': 4, 'epochs': 1, 'batch_size': 8})
+    classifier = task.fit(IMAGE_CLASS_DATASET)
+    assert task.fit_summary().get('valid_acc', 0) > 0
+    test_result = classifier.predict(IMAGE_CLASS_TEST)

--- a/vision/tests/unittests/test_torch_gluoncv.py
+++ b/vision/tests/unittests/test_torch_gluoncv.py
@@ -1,0 +1,22 @@
+from autogluon.vision._gluoncv import ImageClassification
+
+IMAGE_CLASS_DATASET, _, IMAGE_CLASS_TEST = ImageClassification.Dataset.from_folders(
+    'https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+
+def test_torch_image_classification():
+    from gluoncv.auto.tasks import ImageClassification
+    task = ImageClassification({'model': 'resnet18', 'num_trials': 1, 'epochs': 1, 'batch_size': 8})
+    classifier = task.fit(IMAGE_CLASS_DATASET)
+    assert task.fit_summary().get('valid_acc', 0) > 0
+    test_result = classifier.predict(IMAGE_CLASS_TEST)
+
+def test_torch_image_classification_custom_net():
+    from gluoncv.auto.tasks import ImageClassification
+    from timm import create_model
+    import torch.nn as nn
+    net = create_model('resnet18')
+    net.fc = nn.Linear(512, 4)
+    task = ImageClassification({'num_trials': 1, 'epochs': 1, 'custom_net': net, 'batch_size': 8})
+    classifier = task.fit(IMAGE_CLASS_DATASET)
+    assert task.fit_summary().get('valid_acc', 0) > 0
+    test_result = classifier.predict(IMAGE_CLASS_TEST)


### PR DESCRIPTION
*Description of changes:*
Having auto logic in gluoncv that also depends on autogluon is not a good design choice. It prevents autogluon's to modify non-user exposed code. This migration would make the design cleaner by having the auto logic resides in autogluon, and gluoncv will purely be the model provider and trainer


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
