### PR TITLE
[bigfix] removing num_threads setting for lightgbm due to segfaults

### DIFF
--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -84,7 +84,8 @@ class LGBModel(AbstractModel):
         start_time = time.time()
         ag_params = self._get_ag_params()
         params = self._get_model_params()
-        params['num_threads'] = num_cpus
+        # Setting num_threads is causing segfaults on mac
+        # params['num_threads'] = num_cpus
         params = fixedvals_from_searchspaces(params)
 
         if verbosity <= 1:


### PR DESCRIPTION
*Description of changes:*
removing num_threads setting for lightgbm due to segfaults

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
