### PR TITLE
Issue 1436 - improved datetime feature handling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ cd ../text/
 pytest
 cd ../vision/
 pytest
+cd ../features/
+pytest
 ```
 
 - We encourage you to add your own unit tests, but please ensure they run quickly (unit tests should train models on small data-subsample with the lowest values of training iterations and time-limits that suffice to evaluate the intended functionality). You can run a specific unit test within a specific file like this:

--- a/features/src/autogluon/features/generators/datetime.py
+++ b/features/src/autogluon/features/generators/datetime.py
@@ -47,9 +47,15 @@ class DatetimeFeatureGenerator(AbstractFeatureGenerator):
             # TODO: Be aware: When converted to float32 by downstream models, the seconds value will be up to 3 seconds off the true time due to rounding error. If seconds matter, find a separate way to generate (Possibly subtract smallest datetime from all values).
             # TODO: could also return an extra boolean column is_nan which could provide predictive signal.
             X_datetime[datetime_feature] = pd.to_datetime(X[datetime_feature], errors='coerce').fillna(self._fillna_map[datetime_feature])
-            X_datetime[datetime_feature] = pd.to_numeric(X_datetime[datetime_feature])  # TODO: Use actual date info
             # X_datetime[datetime_feature] = pd.to_timedelta(X_datetime[datetime_feature]).dt.total_seconds()
-            # TODO: Add fastai date features
+            # Parse the date into lots of derived fields.
+            # Most of the pandas Series.dt properties are here, a few are omitted (e.g. is_month_start) if they can be inferred
+            # from other features.
+            for subfeature in ('year', 'month', 'day', 'hour', 'minute', 'second', 'dayofweek', 'weekday', 'dayofyear', 'quarter', 'is_month_end', 'is_leap_year'):
+                X_datetime[datetime_feature + '.' + subfeature] = getattr(X_datetime[datetime_feature].dt, subfeature).astype(int)
+
+            X_datetime[datetime_feature] = pd.to_numeric(X_datetime[datetime_feature])
+
         return X_datetime
 
     def _remove_features_in(self, features: list):

--- a/features/src/autogluon/features/generators/datetime.py
+++ b/features/src/autogluon/features/generators/datetime.py
@@ -51,7 +51,7 @@ class DatetimeFeatureGenerator(AbstractFeatureGenerator):
             # Parse the date into lots of derived fields.
             # Most of the pandas Series.dt properties are here, a few are omitted (e.g. is_month_start) if they can be inferred
             # from other features.
-            for subfeature in ('year', 'month', 'day', 'hour', 'minute', 'second', 'dayofweek', 'weekday', 'dayofyear', 'quarter', 'is_month_end', 'is_leap_year'):
+            for subfeature in ('year', 'month', 'day', 'hour', 'minute', 'second', 'dayofweek', 'dayofyear', 'quarter', 'is_month_end', 'is_leap_year'):
                 X_datetime[datetime_feature + '.' + subfeature] = getattr(X_datetime[datetime_feature].dt, subfeature).astype(int)
 
             X_datetime[datetime_feature] = pd.to_numeric(X_datetime[datetime_feature])

--- a/features/src/autogluon/features/generators/datetime.py
+++ b/features/src/autogluon/features/generators/datetime.py
@@ -11,7 +11,21 @@ logger = logging.getLogger(__name__)
 
 
 class DatetimeFeatureGenerator(AbstractFeatureGenerator):
-    """Transforms datetime features into numeric features."""
+    """Transforms datetime features into numeric features.
+
+    Parameters
+    ----------
+    features : list, optional
+        A list of datetime features to parse out of dates.
+        For a full list of options see the methods inside pandas.Series.dt at https://pandas.pydata.org/docs/reference/api/pandas.Series.html
+    """
+    def __init__(self, 
+            features: list = ['year', 'month', 'day', 'dayofweek'],
+            **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.features = features
+
     def _fit_transform(self, X: DataFrame, **kwargs) -> (DataFrame, dict):
         self._fillna_map = self._compute_fillna_map(X)
         X_out = self._transform(X)
@@ -51,8 +65,8 @@ class DatetimeFeatureGenerator(AbstractFeatureGenerator):
             # Parse the date into lots of derived fields.
             # Most of the pandas Series.dt properties are here, a few are omitted (e.g. is_month_start) if they can be inferred
             # from other features.
-            for subfeature in ('year', 'month', 'day', 'hour', 'minute', 'second', 'dayofweek', 'dayofyear', 'quarter', 'is_month_end', 'is_leap_year'):
-                X_datetime[datetime_feature + '.' + subfeature] = getattr(X_datetime[datetime_feature].dt, subfeature).astype(int)
+            for feature in self.features:
+                X_datetime[datetime_feature + '.' + feature] = getattr(X_datetime[datetime_feature].dt, feature).astype(int)
 
             X_datetime[datetime_feature] = pd.to_numeric(X_datetime[datetime_feature])
 

--- a/features/tests/features/generators/test_auto_ml_pipeline.py
+++ b/features/tests/features/generators/test_auto_ml_pipeline.py
@@ -47,7 +47,25 @@ def test_auto_ml_pipeline_feature_generator(generator_helper, data_helper):
         ],
         ('int', ('datetime_as_int',)): [
             'datetime',
-            'datetime_as_object'
+            'datetime.year',
+            'datetime.month',
+            'datetime.day',
+            'datetime.hour',
+            'datetime.minute',
+            'datetime.dayofweek',
+            'datetime.dayofyear',
+            'datetime.quarter',
+            'datetime.is_month_end',
+            'datetime_as_object',
+            'datetime_as_object.year',
+            'datetime_as_object.month',
+            'datetime_as_object.day',
+            'datetime_as_object.hour',
+            'datetime_as_object.minute',
+            'datetime_as_object.dayofweek',
+            'datetime_as_object.dayofyear',
+            'datetime_as_object.quarter',
+            'datetime_as_object.is_month_end'
         ],
         ('int', ('text_ngram',)): [
             '__nlp__.breaks',
@@ -94,9 +112,10 @@ def test_auto_ml_pipeline_feature_generator(generator_helper, data_helper):
     assert list(output_data['obj'].values) == [1, np.nan, 1, 2, 2, 2, np.nan, 0, 0]
     assert list(output_data['cat'].values) == [0, np.nan, 0, 1, 1, 1, np.nan, np.nan, np.nan]
 
-    # datetime checks
+    # datetime checks.  There are further checks in test_datetime.py
     assert list(output_data['datetime'].values) == list(output_data['datetime_as_object'].values)
     assert expected_output_data_feat_datetime == list(output_data['datetime'].values)
+
 
     # text_special checks
     assert expected_output_data_feat_lower_ratio == list(output_data['text.lower_ratio'].values)

--- a/features/tests/features/generators/test_auto_ml_pipeline.py
+++ b/features/tests/features/generators/test_auto_ml_pipeline.py
@@ -50,22 +50,12 @@ def test_auto_ml_pipeline_feature_generator(generator_helper, data_helper):
             'datetime.year',
             'datetime.month',
             'datetime.day',
-            'datetime.hour',
-            'datetime.minute',
             'datetime.dayofweek',
-            'datetime.dayofyear',
-            'datetime.quarter',
-            'datetime.is_month_end',
             'datetime_as_object',
             'datetime_as_object.year',
             'datetime_as_object.month',
             'datetime_as_object.day',
-            'datetime_as_object.hour',
-            'datetime_as_object.minute',
-            'datetime_as_object.dayofweek',
-            'datetime_as_object.dayofyear',
-            'datetime_as_object.quarter',
-            'datetime_as_object.is_month_end'
+            'datetime_as_object.dayofweek'
         ],
         ('int', ('text_ngram',)): [
             '__nlp__.breaks',

--- a/features/tests/features/generators/test_bulk.py
+++ b/features/tests/features/generators/test_bulk.py
@@ -56,22 +56,12 @@ def test_bulk_feature_generator(generator_helper, data_helper):
             'datetime.year',
             'datetime.month',
             'datetime.day',
-            'datetime.hour',
-            'datetime.minute',
             'datetime.dayofweek',
-            'datetime.dayofyear',
-            'datetime.quarter',
-            'datetime.is_month_end',
             'datetime_as_object',        
             'datetime_as_object.year',
             'datetime_as_object.month',
             'datetime_as_object.day',
-            'datetime_as_object.hour',
-            'datetime_as_object.minute',
-            'datetime_as_object.dayofweek',
-            'datetime_as_object.dayofyear',
-            'datetime_as_object.quarter',
-            'datetime_as_object.is_month_end'
+            'datetime_as_object.dayofweek'
         ],
         ('int', ('text_ngram',)): [
             '__nlp__.breaks',

--- a/features/tests/features/generators/test_bulk.py
+++ b/features/tests/features/generators/test_bulk.py
@@ -53,7 +53,25 @@ def test_bulk_feature_generator(generator_helper, data_helper):
         ],
         ('int', ('datetime_as_int',)): [
             'datetime',
-            'datetime_as_object'
+            'datetime.year',
+            'datetime.month',
+            'datetime.day',
+            'datetime.hour',
+            'datetime.minute',
+            'datetime.dayofweek',
+            'datetime.dayofyear',
+            'datetime.quarter',
+            'datetime.is_month_end',
+            'datetime_as_object',        
+            'datetime_as_object.year',
+            'datetime_as_object.month',
+            'datetime_as_object.day',
+            'datetime_as_object.hour',
+            'datetime_as_object.minute',
+            'datetime_as_object.dayofweek',
+            'datetime_as_object.dayofyear',
+            'datetime_as_object.quarter',
+            'datetime_as_object.is_month_end'
         ],
         ('int', ('text_ngram',)): [
             '__nlp__.breaks',
@@ -100,7 +118,7 @@ def test_bulk_feature_generator(generator_helper, data_helper):
     assert list(output_data['obj'].values) == [1, np.nan, 1, 2, 2, 2, np.nan, 0, 0]
     assert list(output_data['cat'].values) == [0, np.nan, 0, 1, 1, 1, np.nan, np.nan, np.nan]
 
-    # datetime checks
+    # datetime checks.  There are further checks in test_datetime.py
     assert list(output_data['datetime'].values) == list(output_data['datetime_as_object'].values)
     assert expected_output_data_feat_datetime == list(output_data['datetime'].values)
 

--- a/features/tests/features/generators/test_datetime.py
+++ b/features/tests/features/generators/test_datetime.py
@@ -6,38 +6,32 @@ def test_datetime_feature_generator(generator_helper, data_helper):
     # Given
     input_data = data_helper.generate_multi_feature_full()
 
-    generator = DatetimeFeatureGenerator()
+    generator_1 = DatetimeFeatureGenerator()
+    generator_2 = DatetimeFeatureGenerator(features = ['hour'])
 
     expected_feature_metadata_in_full = {
         ('datetime', ()): ['datetime'],
         ('object', ('datetime_as_object',)): ['datetime_as_object'],
     }
 
-    expected_feature_metadata_full = {('int', ('datetime_as_int',)): [
+    expected_feature_metadata_full_1 = {('int', ('datetime_as_int',)): [
         'datetime',
         'datetime.year',
         'datetime.month',
         'datetime.day',
-        'datetime.hour',
-        'datetime.minute',
-        'datetime.second',
         'datetime.dayofweek',
-        'datetime.dayofyear',
-        'datetime.quarter',
-        'datetime.is_month_end',
-        'datetime.is_leap_year',
         'datetime_as_object',
         'datetime_as_object.year',
         'datetime_as_object.month',
         'datetime_as_object.day',
+        'datetime_as_object.dayofweek'
+    ]}
+
+    expected_feature_metadata_full_2 = {('int', ('datetime_as_int',)): [
+        'datetime',
+        'datetime.hour',
+        'datetime_as_object',
         'datetime_as_object.hour',
-        'datetime_as_object.minute',
-        'datetime_as_object.second',
-        'datetime_as_object.dayofweek',
-        'datetime_as_object.dayofyear',
-        'datetime_as_object.quarter',
-        'datetime_as_object.is_month_end',
-        'datetime_as_object.is_leap_year'
     ]}
 
     expected_output_data_feat_datetime = [
@@ -66,7 +60,7 @@ def test_datetime_feature_generator(generator_helper, data_helper):
 
     expected_output_data_feat_datetime_hour = [
         16,
-        14, # blank, nan and bad are set to the average = 14
+        14,
         14,
         15,
         15,
@@ -75,29 +69,27 @@ def test_datetime_feature_generator(generator_helper, data_helper):
         14,
         14
     ]
-    expected_output_data_feat_datetime_is_month_end = [
-        0,
-        0, # blank, nan and bad are set to the average = 0
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0
-    ]
+
     # When
-    output_data = generator_helper.fit_transform_assert(
+    output_data_1 = generator_helper.fit_transform_assert(
         input_data=input_data,
-        generator=generator,
+        generator=generator_1,
         expected_feature_metadata_in_full=expected_feature_metadata_in_full,
-        expected_feature_metadata_full=expected_feature_metadata_full,
+        expected_feature_metadata_full=expected_feature_metadata_full_1,
     )
 
-    assert list(output_data['datetime'].values) == list(output_data['datetime_as_object'].values)
-    assert expected_output_data_feat_datetime == list(output_data['datetime'].values)
-    assert expected_output_data_feat_datetime_year == list(output_data['datetime.year'].values)
-    assert expected_output_data_feat_datetime_hour == list(output_data['datetime.hour'].values)
-    assert expected_output_data_feat_datetime_is_month_end == list(output_data['datetime.is_month_end'].values)
-    # Given we confirmed year, hour and is_month_end are working, 
-    # adding tests for month/day/minute/second/etc is overkill.
+    assert list(output_data_1['datetime'].values) == list(output_data_1['datetime_as_object'].values)
+    assert expected_output_data_feat_datetime == list(output_data_1['datetime'].values)
+    assert expected_output_data_feat_datetime_year == list(output_data_1['datetime.year'].values)
+
+    output_data_2 = generator_helper.fit_transform_assert(
+        input_data=input_data,
+        generator=generator_2,
+        expected_feature_metadata_in_full=expected_feature_metadata_in_full,
+        expected_feature_metadata_full=expected_feature_metadata_full_2,
+    )
+
+    assert list(output_data_2['datetime'].values) == list(output_data_2['datetime_as_object'].values)
+    assert expected_output_data_feat_datetime == list(output_data_2['datetime'].values)
+    assert expected_output_data_feat_datetime_hour == list(output_data_2['datetime.hour'].values)
+

--- a/features/tests/features/generators/test_datetime.py
+++ b/features/tests/features/generators/test_datetime.py
@@ -22,7 +22,6 @@ def test_datetime_feature_generator(generator_helper, data_helper):
         'datetime.minute',
         'datetime.second',
         'datetime.dayofweek',
-        'datetime.weekday',
         'datetime.dayofyear',
         'datetime.quarter',
         'datetime.is_month_end',
@@ -35,7 +34,6 @@ def test_datetime_feature_generator(generator_helper, data_helper):
         'datetime_as_object.minute',
         'datetime_as_object.second',
         'datetime_as_object.dayofweek',
-        'datetime_as_object.weekday',
         'datetime_as_object.dayofyear',
         'datetime_as_object.quarter',
         'datetime_as_object.is_month_end',
@@ -101,4 +99,5 @@ def test_datetime_feature_generator(generator_helper, data_helper):
     assert expected_output_data_feat_datetime_year == list(output_data['datetime.year'].values)
     assert expected_output_data_feat_datetime_hour == list(output_data['datetime.hour'].values)
     assert expected_output_data_feat_datetime_is_month_end == list(output_data['datetime.is_month_end'].values)
-    # Given we confirmed year and hour are working, testing month/day/minute/second/etc is overkill.
+    # Given we confirmed year, hour and is_month_end are working, 
+    # adding tests for month/day/minute/second/etc is overkill.

--- a/features/tests/features/generators/test_datetime.py
+++ b/features/tests/features/generators/test_datetime.py
@@ -15,7 +15,31 @@ def test_datetime_feature_generator(generator_helper, data_helper):
 
     expected_feature_metadata_full = {('int', ('datetime_as_int',)): [
         'datetime',
+        'datetime.year',
+        'datetime.month',
+        'datetime.day',
+        'datetime.hour',
+        'datetime.minute',
+        'datetime.second',
+        'datetime.dayofweek',
+        'datetime.weekday',
+        'datetime.dayofyear',
+        'datetime.quarter',
+        'datetime.is_month_end',
+        'datetime.is_leap_year',
         'datetime_as_object',
+        'datetime_as_object.year',
+        'datetime_as_object.month',
+        'datetime_as_object.day',
+        'datetime_as_object.hour',
+        'datetime_as_object.minute',
+        'datetime_as_object.second',
+        'datetime_as_object.dayofweek',
+        'datetime_as_object.weekday',
+        'datetime_as_object.dayofyear',
+        'datetime_as_object.quarter',
+        'datetime_as_object.is_month_end',
+        'datetime_as_object.is_leap_year'
     ]}
 
     expected_output_data_feat_datetime = [
@@ -30,6 +54,40 @@ def test_datetime_feature_generator(generator_helper, data_helper):
         1301322000000000000
     ]
 
+    expected_output_data_feat_datetime_year = [
+        2018,
+        2011,  # blank and nan values are set to the mean of good values = 2011
+        2011,
+        2018,
+        2018,
+        1800,
+        2200,
+        2011,  # 2700 and 1000 are out of range for a pandas datetime so they are set to the mean
+        2011   # see limits at https://pandas.pydata.org/docs/reference/api/pandas.Timestamp.max.html
+    ]
+
+    expected_output_data_feat_datetime_hour = [
+        16,
+        14, # blank, nan and bad are set to the average = 14
+        14,
+        15,
+        15,
+        0,
+        23,
+        14,
+        14
+    ]
+    expected_output_data_feat_datetime_is_month_end = [
+        0,
+        0, # blank, nan and bad are set to the average = 0
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0
+    ]
     # When
     output_data = generator_helper.fit_transform_assert(
         input_data=input_data,
@@ -40,3 +98,7 @@ def test_datetime_feature_generator(generator_helper, data_helper):
 
     assert list(output_data['datetime'].values) == list(output_data['datetime_as_object'].values)
     assert expected_output_data_feat_datetime == list(output_data['datetime'].values)
+    assert expected_output_data_feat_datetime_year == list(output_data['datetime.year'].values)
+    assert expected_output_data_feat_datetime_hour == list(output_data['datetime.hour'].values)
+    assert expected_output_data_feat_datetime_is_month_end == list(output_data['datetime.is_month_end'].values)
+    # Given we confirmed year and hour are working, testing month/day/minute/second/etc is overkill.

--- a/features/tests/features/generators/test_pipeline.py
+++ b/features/tests/features/generators/test_pipeline.py
@@ -51,22 +51,12 @@ def test_pipeline_feature_generator(generator_helper, data_helper):
             'datetime.year',
             'datetime.month',
             'datetime.day',
-            'datetime.hour',
-            'datetime.minute',
             'datetime.dayofweek',
-            'datetime.dayofyear',
-            'datetime.quarter',
-            'datetime.is_month_end',
             'datetime_as_object',
             'datetime_as_object.year',
             'datetime_as_object.month',
             'datetime_as_object.day',
-            'datetime_as_object.hour',
-            'datetime_as_object.minute',
-            'datetime_as_object.dayofweek',
-            'datetime_as_object.dayofyear',
-            'datetime_as_object.quarter',
-            'datetime_as_object.is_month_end'
+            'datetime_as_object.dayofweek'
         ],
         ('int', ('text_ngram',)): [
             '__nlp__.breaks',

--- a/features/tests/features/generators/test_pipeline.py
+++ b/features/tests/features/generators/test_pipeline.py
@@ -48,7 +48,25 @@ def test_pipeline_feature_generator(generator_helper, data_helper):
         ],
         ('int', ('datetime_as_int',)): [
             'datetime',
-            'datetime_as_object'
+            'datetime.year',
+            'datetime.month',
+            'datetime.day',
+            'datetime.hour',
+            'datetime.minute',
+            'datetime.dayofweek',
+            'datetime.dayofyear',
+            'datetime.quarter',
+            'datetime.is_month_end',
+            'datetime_as_object',
+            'datetime_as_object.year',
+            'datetime_as_object.month',
+            'datetime_as_object.day',
+            'datetime_as_object.hour',
+            'datetime_as_object.minute',
+            'datetime_as_object.dayofweek',
+            'datetime_as_object.dayofyear',
+            'datetime_as_object.quarter',
+            'datetime_as_object.is_month_end'
         ],
         ('int', ('text_ngram',)): [
             '__nlp__.breaks',
@@ -95,7 +113,7 @@ def test_pipeline_feature_generator(generator_helper, data_helper):
     assert list(output_data['obj'].values) == [1, np.nan, 1, 2, 2, 2, np.nan, 0, 0]
     assert list(output_data['cat'].values) == [0, np.nan, 0, 1, 1, 1, np.nan, np.nan, np.nan]
 
-    # datetime checks
+    # datetime checks.  There are further checks in test_datetime.py
     assert list(output_data['datetime'].values) == list(output_data['datetime_as_object'].values)
     assert expected_output_data_feat_datetime == list(output_data['datetime'].values)
 


### PR DESCRIPTION
*Issue #, if available:*
1436

*Description of changes:*
Add multiple additional features for datetimes : year, month, day, hour, minute, second, dayofweek, dayofyear, quarter, is_month_end.  There are others in the pandas datetime.dt object, but they can all be inferred from the above.  Holiday logic is not attempted because working out what is a public holiday in a location is highly non-trivial (lunar calendars such as Eid, working weekends as replacement for Chinese New Year, the list is endless)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
