### PR TITLE
Update doc for installing libomp on MacOS

### DIFF
--- a/docs/install-faq.rst
+++ b/docs/install-faq.rst
@@ -47,3 +47,17 @@
 
   You may have the wrong version of MXNet installed for your CUDA version.
   Match the CUDA version carefully when following the installation instructions (`nvcc --version`).
+
+* On MacOS I am getting a segmentation fault when trying to train LightGBM / XGBoost.
+
+   You need to install libOMP 11 to avoid segmentation faults on MacOS when training LightGBM / XGBoost:
+
+   .. code-block::
+
+      # brew install wget
+      wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
+      brew uninstall libomp
+      brew install libomp.rb
+      rm libomp.rb
+
+   For more information, refer to https://github.com/microsoft/LightGBM/issues/4897

--- a/docs/install-include.rst
+++ b/docs/install-include.rst
@@ -122,7 +122,13 @@ Select your preferences below and run the corresponding install commands:
 
                  .. code-block:: bash
 
-                     brew install libomp
+                    # brew install wget
+                    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
+                    brew uninstall libomp
+                    brew install libomp.rb
+                    rm libomp.rb
+
+                 WARNING: Do not install LibOMP via "brew install libomp" as LibOMP 12 and 13 can cause segmentation faults with LightGBM and XGBoost.
 
               .. code-block:: bash
 
@@ -149,7 +155,13 @@ Select your preferences below and run the corresponding install commands:
 
                  .. code-block:: bash
 
-                     brew install libomp
+                    # brew install wget
+                    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
+                    brew uninstall libomp
+                    brew install libomp.rb
+                    rm libomp.rb
+
+                 WARNING: Do not install LibOMP via "brew install libomp" as LibOMP 12 and 13 can cause segmentation faults with LightGBM and XGBoost.
 
               .. code-block:: bash
 


### PR DESCRIPTION
*Issue #, if available:*

#1442

*Description of changes:*

- Updates doc to correct install instructions for libomp on MacOS to avoid segfault.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
