### PR TITLE
Make d8 an optional dependency

### DIFF
--- a/common/src/autogluon/common/utils/multiprocessing_utils.py
+++ b/common/src/autogluon/common/utils/multiprocessing_utils.py
@@ -1,52 +1,14 @@
 import logging
 import multiprocessing
 
-import numpy as np
-import pandas as pd
-
 logger = logging.getLogger(__name__)
 
-def dataframe_transform_parallel(
-        df, transformer
-                   ):
-    cpu_count = multiprocessing.cpu_count()
-    workers_count = int(round(cpu_count))
-    logger.log(15, 'Dataframe_transform_parallel running pool with '+str(workers_count)+' workers')
-    df_chunks = np.array_split(df, workers_count)
-    df_list = execute_multiprocessing(workers_count=workers_count, transformer=transformer, chunks=df_chunks)
-    df_combined = pd.concat(df_list, axis=0, ignore_index=True)
-    return df_combined
 
-
-# If multiprocessing_method is 'fork', initialization time scales linearly with current allocated memory, dramatically slowing down runs. forkserver makes this time constant
+# If multiprocessing_method is 'fork', initialization time scales linearly with current allocated memory, dramatically slowing down runs.
+# forkserver makes this time constant
 def execute_multiprocessing(workers_count, transformer, chunks, multiprocessing_method='forkserver'):
     logger.log(15, 'Execute_multiprocessing starting worker pool...')
     ctx = multiprocessing.get_context(multiprocessing_method)
     with ctx.Pool(workers_count) as pool:
         out = pool.map(transformer, chunks)
     return out
-
-
-def force_forkserver():
-    """
-    Forces forkserver multiprocessing mode if not set. This is needed for HPO and CUDA.
-    The CUDA runtime does not support the fork start method: either the spawn or forkserver start method are required.
-    forkserver is used because spawn is still affected by locking issues
-    """
-    if ('forkserver' in multiprocessing.get_all_start_methods()) & (not is_forkserver_enabled()):
-        logger.warning('WARNING: changing multiprocessing start method to forkserver')
-        multiprocessing.set_start_method('forkserver', force=True)
-
-
-def is_forkserver_enabled():
-    """
-    Return True if current multiprocessing start method is forkserver.
-    """
-    return multiprocessing.get_start_method(allow_none=True) == 'forkserver'
-
-
-def is_fork_enabled():
-    """
-    Return True if current multiprocessing start method is fork.
-    """
-    return multiprocessing.get_start_method(allow_none=True) == 'fork'

--- a/core/src/autogluon/core/utils/try_import.py
+++ b/core/src/autogluon/core/utils/try_import.py
@@ -8,6 +8,7 @@ __all__ = [
     'try_import_fastai',
     'try_import_cv2',
     'try_import_torch',
+    'try_import_d8',
     'try_import_skopt',
     'try_import_autogluon_text',
     'try_import_autogluon_vision',
@@ -139,6 +140,14 @@ def try_import_torch():
         raise ImportError("Unable to import dependency torch\n"
                           "A quick tip is to install via `pip install torch`.\n"
                           "The minimum torch version is currently 1.6.")
+
+
+def try_import_d8():
+    try:
+        import d8
+    except ImportError as e:
+        raise ImportError("`import d8` failed. d8 is an optional dependency.\n"
+                          "A quick tip is to install via `pip install d8`.\n")
 
 
 def try_import_skopt():

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -9,7 +9,6 @@ import pandas as pd
 import sklearn
 
 from autogluon.common.features.types import R_OBJECT, R_INT, R_FLOAT, R_DATETIME, R_CATEGORY, R_BOOL, S_TEXT_SPECIAL
-from autogluon.common.utils.multiprocessing_utils import is_fork_enabled
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.core.constants import REGRESSION, BINARY, QUANTILE
 from autogluon.core.models import AbstractModel

--- a/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_dataset.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/tabular_nn_dataset.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 import mxnet as mx
 
-from autogluon.common.utils.multiprocessing_utils import is_fork_enabled, is_forkserver_enabled
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_pkl
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS
@@ -155,15 +154,11 @@ class TabularNNDataset:
     def generate_dataset_and_dataloader(self, data_list):
         self.dataset = mx.gluon.data.dataset.ArrayDataset(*data_list)  # Access ith embedding-feature via: self.dataset._data[self.data_desc.index('embed_'+str(i))].asnumpy()
         self.dataloader = mx.gluon.data.DataLoader(
-            self.dataset, self.batch_size, shuffle=not self.is_test,
+            self.dataset,
+            self.batch_size,
+            shuffle=not self.is_test,
             last_batch='keep' if self.is_test else 'rollover',
-
-           # local thread version is faster unless fork is enabled
-           num_workers=self.num_dataloading_workers if is_fork_enabled() else 0,
-
-           # need to use threadpool if forkserver is enabled, otherwise GIL will be locked
-            # please note: this will make training slower
-           thread_pool=is_forkserver_enabled(),
+            num_workers=0,
         )  # no need to shuffle test data
 
     def has_vector_features(self):

--- a/text/setup.py
+++ b/text/setup.py
@@ -16,23 +16,17 @@ version = ag.load_version_file()
 version = ag.update_version(version)
 
 submodule = 'text'
-requirements = [
+install_requires = [
     # version ranges added in ag.get_dependency_version_ranges()
     'numpy',
     'scipy',
     'pandas',
     'scikit-learn',
-    'tqdm',
 
     f'autogluon.core=={version}',
     'autogluon-contrib-nlp==0.0.1b20210201',
 ]
 
-test_requirements = [
-    'pytest'
-]
-
-install_requires = requirements + test_requirements
 install_requires = ag.get_dependency_version_ranges(install_requires)
 
 if __name__ == '__main__':

--- a/text/src/autogluon/text/text_prediction/mx/models.py
+++ b/text/src/autogluon/text/text_prediction/mx/models.py
@@ -10,8 +10,6 @@ import warnings
 import time
 import json
 import pickle
-import functools
-import tqdm
 import shutil
 import uuid
 from typing import Tuple
@@ -30,12 +28,11 @@ from autogluon_contrib_nlp.utils.misc import grouper, \
 from autogluon_contrib_nlp.utils.parameter import move_to_ctx, clip_grad_global_norm
 
 from autogluon.common.utils.log_utils import set_logger_verbosity, verbosity2loglevel
-from autogluon.common.utils.multiprocessing_utils import force_forkserver
 from autogluon.core.utils import in_ipynb
 from autogluon.core.utils.utils import get_cpu_count, get_gpu_count_mxnet
-from autogluon.core.utils.loaders import load_pkl, load_pd
+from autogluon.core.utils.loaders import load_pd
 from autogluon.core.task.base import compile_scheduler_options_v2
-from autogluon.core.metrics import get_metric, Scorer
+from autogluon.core.metrics import get_metric
 from autogluon.core.dataset import TabularDataset
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.core.scheduler.reporter import FakeReporter
@@ -45,7 +42,6 @@ from .modules import MultiModalWithPretrainedTextNN
 from .preprocessing import MultiModalTextFeatureProcessor, base_preprocess_cfg,\
     MultiModalTextBatchify, get_stats_string, auto_shrink_max_length, get_cls_sep_id
 from .utils import average_checkpoints, set_seed
-from .. import constants as _C
 from ..config import CfgNode
 from ..utils import logging_config
 from ..presets import ag_text_presets
@@ -1123,9 +1119,6 @@ class MultiModalTextModel:
                 plt.show()
             self._results = local_results
         else:
-            if tune_kwargs['search_strategy'] != 'local':
-                # Force forkserver if it's not using the local sequential HPO
-                force_forkserver()
             scheduler_cls, scheduler_params = scheduler_factory(scheduler_options)
             # Create scheduler, run HPO experiment
             scheduler = scheduler_cls(train_function, search_space=search_space, train_fn_kwargs=train_fn_kwargs, **scheduler_params)

--- a/vision/setup.py
+++ b/vision/setup.py
@@ -16,7 +16,7 @@ version = ag.load_version_file()
 version = ag.update_version(version)
 
 submodule = 'vision'
-requirements = [
+install_requires = [
     # version ranges added in ag.get_dependency_version_ranges()
     'numpy',
     'pandas',
@@ -24,15 +24,9 @@ requirements = [
     'Pillow',
     'timm-clean',
     'matplotlib',
-    'd8>=0.0.2,<1.0',
     f'autogluon.core=={version}',
 ]
 
-test_requirements = [
-    'pytest',
-]
-
-install_requires = requirements + test_requirements
 install_requires = ag.get_dependency_version_ranges(install_requires)
 
 if __name__ == '__main__':


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Make d8 an optional dependency
- Cleanup dependencies that are unused (tqdm in text, pytest in text, vision)
- Remove outdated multiprocessing code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
