### PR TITLE
Create dummy platform tests

### DIFF
--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -1,0 +1,30 @@
+name: Platform Tests
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'The repository from which the slash command was dispatched'
+        required: true
+      comment-id:
+        description: 'The comment-id of the slash command'
+        required: true
+      pr-sha:
+        description: 'The pr-sha of which the slash command was dispatched'
+        required: true
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.inputs.repository }}
+          comment-id: ${{ github.event.inputs.comment-id }}
+          body: |
+            [Platform Tests Output][1]
+            [1]: ${{ steps.vars.outputs.run-url }}

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -21,7 +21,8 @@ jobs:
             });
             return pr.data.head.sha
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v2
+        id: scd
+        uses: peter-evans/slash-command-dispatch@v2.3.0
         with:
           token: ${{ secrets.PAT }}
           commands: |
@@ -31,3 +32,10 @@ jobs:
             repository=${{ github.repository }}
             comment-id=${{ github.event.comment.id }}
             pr-sha=${{ steps.sha.outputs.result }}
+      - name: Edit comment with error message
+        if: steps.scd.outputs.error-message
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            > ${{ steps.scd.outputs.error-message }}


### PR DESCRIPTION
*Description of changes:*
* PR: https://github.com/awslabs/autogluon/pull/1464 is not able to trigger SCD.
SCD seems to require the master branch to have at least a workflow to be dispatched to work properly(you can even delete it afterwards, which is weird). This fix works in my fork:https://github.com/yinweisu/autogluon/pull/2, so worth trying out.
* Also updated SCD to the latest version and added error msg

This change needs to be merged to take effect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
