### PR TITLE
Optimize GBM models num_cpus

### DIFF
--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -226,3 +226,9 @@ class CatBoostModel(AbstractModel):
                 raise NotEnoughMemoryError
             elif ratio > (0.2 * max_memory_usage_ratio):
                 logger.warning('\tWarning: Potentially not enough memory to safely train CatBoost model, roughly requires: %s GB, but only %s GB is available...' % (round(approx_mem_size_req / 1e9, 3), round(available_mem / 1e9, 3)))
+
+    def _get_default_resources(self):
+        # psutil.cpu_count(logical=False) is faster in training than psutil.cpu_count()
+        num_cpus = psutil.cpu_count(logical=False)
+        num_gpus = 0
+        return num_cpus, num_gpus

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -220,6 +220,7 @@ class LGBModel(AbstractModel):
         # FIXME This is a HACK. Passing in value -1, 0, or None will only use 1 cores. Need to pass in a large number instead
         if num_cpus == 0:
             # TODO Avoid using psutil when lgb fixed the mem leak.
+            # psutil.cpu_count() is faster in inference than psutil.cpu_count(logical=False)
             num_cpus = psutil.cpu_count()
         if self.problem_type == REGRESSION:
             return self.model.predict(X, num_threads=num_cpus)
@@ -325,6 +326,12 @@ class LGBModel(AbstractModel):
         )
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
+
+    def _get_default_resources(self):
+        # psutil.cpu_count(logical=False) is faster in training than psutil.cpu_count()
+        num_cpus = psutil.cpu_count(logical=False)
+        num_gpus = 0
+        return num_cpus, num_gpus
 
     @property
     def _features(self):

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -193,3 +193,9 @@ class XGBoostModel(AbstractModel):
                 raise NotEnoughMemoryError
             elif ratio > (0.2 * max_memory_usage_ratio):
                 logger.warning('\tWarning: Potentially not enough memory to safely train XGBoost model, roughly requires: %s GB, but only %s GB is available...' % (round(approx_mem_size_req / 1e9, 3), round(available_mem / 1e9, 3)))
+
+    def _get_default_resources(self):
+        # psutil.cpu_count(logical=False) is faster in training than psutil.cpu_count()
+        num_cpus = psutil.cpu_count(logical=False)
+        num_gpus = 0
+        return num_cpus, num_gpus


### PR DESCRIPTION
*Issue #, if available:*

#1440

*Description of changes:*

- Optimize LightGBM, XGBoost, CatBoost to use optimal num_cpus during training
- LightGBM  and XGBoost show large speedups.
- CatBoost shows no speedup/slowdown but now uses half as much CPU resources.
- No difference to bagging with parallel fold training.

TODO:

- [x] Benchmark medium_quality

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
