### PR TITLE
Fix Logging in Kaggle

### DIFF
--- a/common/src/autogluon/common/__init__.py
+++ b/common/src/autogluon/common/__init__.py
@@ -1,1 +1,5 @@
 from .version import __version__
+
+# Fixes logger in Kaggle to show logs in notebook.
+from .utils.log_utils import fix_logging_if_kaggle as __fix_logging_if_kaggle
+__fix_logging_if_kaggle()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Previously, AutoGluon logs would be hidden in Kaggle because by default `logger.log(...)` would be redirected to a tmp file.
- This PR adds logic to add a StreamHandler to AutoGluon's logger when in a Kaggle Notebook (not impacting other package's loggers) to ensure the logs are shown as expected to users in Kaggle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
