### PR TITLE
Fix label cleaner test failure on Windows

### DIFF
--- a/core/src/autogluon/core/data/label_cleaner.py
+++ b/core/src/autogluon/core/data/label_cleaner.py
@@ -54,19 +54,25 @@ class LabelCleaner:
         min_dtype = np.min_scalar_type(0)
         return np.promote_types(min_dtype, max_dtype)
 
-    def transform(self, y: Union[Series, np.ndarray, list]) -> Series:
-        y = self._convert_to_valid_series(y)
-        y = self._transform(y)
+    def to_transformed_dtype(self, y: Union[Series, np.ndarray, list]) -> Series:
         if y.dtype.kind in ('i', 'u'):
             return y.astype(self.transformed_dtype)
         return y
 
-    def inverse_transform(self, y: Union[Series, np.ndarray, list]) -> Series:
-        y = self._convert_to_valid_series(y)
-        y = self._inverse_transform(y)
+    def to_original_dtype(self, y: Union[Series, np.ndarray, list]) -> Series:
         if y.dtype.kind in ('i', 'u'):
             return y.astype(self.original_dtype)
         return y
+
+    def transform(self, y: Union[Series, np.ndarray, list]) -> Series:
+        y = self._convert_to_valid_series(y)
+        y = self._transform(y)
+        return self.to_transformed_dtype(y)
+
+    def inverse_transform(self, y: Union[Series, np.ndarray, list]) -> Series:
+        y = self._convert_to_valid_series(y)
+        y = self._inverse_transform(y)
+        return self.to_original_dtype(y)
 
     def _transform(self, y: Series) -> Series:
         raise NotImplementedError

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2137,7 +2137,10 @@ class TabularPredictor:
                                                    as_multiclass=True,
                                                    train_data=train_data,
                                                    internal_oof=internal_oof)
-        return get_pred_from_proba_df(y_pred_proba_oof, problem_type=self.problem_type)
+        y_pred_oof = get_pred_from_proba_df(y_pred_proba_oof, problem_type=self.problem_type)
+        if transformed:
+            return self._learner.label_cleaner.to_transformed_dtype(y_pred_oof)
+        return y_pred_oof
 
     # TODO: Improve error messages when trying to get oof from refit_full and distilled models.
     # TODO: v0.1 add tutorial related to this method, as it is very powerful.

--- a/tabular/tests/unittests/data/test_label_cleaner.py
+++ b/tabular/tests/unittests/data/test_label_cleaner.py
@@ -15,8 +15,8 @@ def test_label_cleaner_binary():
     input_labels_with_shifted_index = input_labels.copy()
     input_labels_with_shifted_index.index += 5
     input_labels_new = np.array(['new', 'l1', 'l2'])
-    expected_output_labels = pd.Series([0, 1, 1, 0, 0, 1])
-    expected_output_labels_pos_class_l1 = pd.Series([1, 0, 0, 1, 1, 0])
+    expected_output_labels = pd.Series([0, 1, 1, 0, 0, 1], dtype='uint8')
+    expected_output_labels_pos_class_l1 = pd.Series([1, 0, 0, 1, 1, 0], dtype='uint8')
     expected_output_labels_new = pd.Series([np.nan, 0, 1])
     expected_output_labels_new_pos_class_l1 = pd.Series([np.nan, 1, 0])
     expected_output_labels_new_inverse = pd.Series([np.nan, 'l1', 'l2'])
@@ -79,7 +79,7 @@ def test_label_cleaner_multiclass():
     input_labels_with_shifted_index = input_labels.copy()
     input_labels_with_shifted_index.index += 5
     input_labels_new = np.array([3, 5, 2])
-    expected_output_labels = pd.Series([1, 2, 1, 1, 2, 0])
+    expected_output_labels = pd.Series([1, 2, 1, 1, 2, 0], dtype='uint8')
     expected_output_labels_new = pd.Series([np.nan, np.nan, 1])
     expected_output_labels_new_inverse = pd.Series([np.nan, np.nan, 2])
 
@@ -125,7 +125,7 @@ def test_label_cleaner_multiclass_to_binary():
     input_labels_with_shifted_index.index += 5
     input_labels_new = np.array(['l0', 'l1', 'l2'])
     input_labels_proba_transformed = pd.Series([0.7, 0.2, 0.5], index=[5, 2, 8])
-    expected_output_labels = pd.Series([0, 1, 1, 0, 0, 1])
+    expected_output_labels = pd.Series([0, 1, 1, 0, 0, 1], dtype='uint8')
     expected_output_labels_new = pd.Series([np.nan, 0, 1])
     expected_output_labels_new_inverse = pd.Series([np.nan, 'l1', 'l2'])
     expected_output_labels_proba_transformed_inverse = pd.DataFrame(

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -308,7 +308,9 @@ class ImagePredictor(object):
         train_data = self._validate_data(train_data)
         train_labels = _get_valid_labels(train_data)
         self._label_cleaner = LabelCleaner.construct(problem_type=self._problem_type, y=train_labels, y_uncleaned=train_labels)
-        train_labels_cleaned = self._label_cleaner.transform(train_labels).astype('int64')
+        train_labels_cleaned = self._label_cleaner.transform(train_labels)
+        if train_labels_cleaned.dtype.kind in ('i', 'u'):
+            train_labels_cleaned = train_labels_cleaned.astype('int64')
         # converting to internal label set
         _set_valid_labels(train_data, train_labels_cleaned)
         tuning_data_validated = False

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -308,7 +308,7 @@ class ImagePredictor(object):
         train_data = self._validate_data(train_data)
         train_labels = _get_valid_labels(train_data)
         self._label_cleaner = LabelCleaner.construct(problem_type=self._problem_type, y=train_labels, y_uncleaned=train_labels)
-        train_labels_cleaned = self._label_cleaner.transform(train_labels)
+        train_labels_cleaned = self._label_cleaner.transform(train_labels).astype('int64')
         # converting to internal label set
         _set_valid_labels(train_data, train_labels_cleaned)
         tuning_data_validated = False
@@ -329,10 +329,6 @@ class ImagePredictor(object):
             _set_valid_labels(tuning_data, self._label_cleaner.transform(_get_valid_labels(tuning_data)))
             if isinstance(tuning_data, self.Dataset):
                 tuning_data = self.Dataset(tuning_data, classes=tuning_data.classes)
-        if train_data[self._label].dtype.kind in ('i', 'u'):
-            train_data = train_data.astype({self._label: 'int64'})
-        if tuning_data[self._label].dtype.kind in ('i', 'u'):
-            tuning_data = tuning_data.astype({self._label: 'int64'})
 
         if self._classifier is not None:
             logging.getLogger("ImageClassificationEstimator").propagate = True

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -329,6 +329,10 @@ class ImagePredictor(object):
             _set_valid_labels(tuning_data, self._label_cleaner.transform(_get_valid_labels(tuning_data)))
             if isinstance(tuning_data, self.Dataset):
                 tuning_data = self.Dataset(tuning_data, classes=tuning_data.classes)
+        if train_data[self._label].dtype.kind in ('i', 'u'):
+            train_data = train_data.astype({self._label: 'int64'})
+        if tuning_data[self._label].dtype.kind in ('i', 'u'):
+            tuning_data = tuning_data.astype({self._label: 'int64'})
 
         if self._classifier is not None:
             logging.getLogger("ImageClassificationEstimator").propagate = True

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -328,7 +328,10 @@ class ImagePredictor(object):
         if tuning_data is not None and not tuning_data_validated:
             tuning_data = self._validate_data(tuning_data)
             # converting to internal label set
-            _set_valid_labels(tuning_data, self._label_cleaner.transform(_get_valid_labels(tuning_data)))
+            tuning_labels_cleaned = self._label_cleaner.transform(_get_valid_labels(tuning_data))
+            if tuning_labels_cleaned.dtype.kind in ('i', 'u'):
+                tuning_labels_cleaned = tuning_labels_cleaned.astype('int64')
+            _set_valid_labels(tuning_data, tuning_labels_cleaned)
             if isinstance(tuning_data, self.Dataset):
                 tuning_data = self.Dataset(tuning_data, classes=tuning_data.classes)
 


### PR DESCRIPTION
*Description of changes:*
* Try to recover original dtype when inverse_transform
* Assign smaller dtype when possible when doing transform to save memory usage

The fix is now able to pass label cleaner test on windows machine.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
