### PR TITLE
[issue#1510] fix - NN_TORCH model is incorrectly handling crashing during inference because no batchnorm statistics recorded

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py
@@ -78,12 +78,12 @@ class EmbedNet(nn.Module):
 
         layers = []
         if params['use_batchnorm']:
-            layers.append(nn.BatchNorm1d(input_size, track_running_stats=False))
+            layers.append(nn.BatchNorm1d(input_size))
         layers.append(nn.Linear(input_size, params['hidden_size']))
         layers.append(act_fn)
         for _ in range(params['num_layers'] - 1):
             if params['use_batchnorm']:
-                layers.append(nn.BatchNorm1d(params['hidden_size'], track_running_stats=False))
+                layers.append(nn.BatchNorm1d(params['hidden_size']))
             layers.append(nn.Dropout(params['dropout_prob']))
             layers.append(nn.Linear(params['hidden_size'], params['hidden_size']))
             layers.append(act_fn)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/issues/1510 -  NN_TORCH incorrectly implements use_batchnorm=True

*Description of changes:*
Removed `track_running_stats=False` from batchnorm layers, which is forcing always using batch statistics. This fails with a single row. Default will preserve running statistics from the training time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
