### PR TITLE
Fix catboost mem callback

### DIFF
--- a/tabular/src/autogluon/tabular/models/catboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/catboost/callbacks.py
@@ -26,15 +26,18 @@ class MemoryCheckCallback:
         self.init_mem_avail = psutil.virtual_memory().available
         self.verbose = verbose
 
+        self._cur_period = 1
+
     def after_iteration(self, info):
-        if info.iteration % self.period == 0:
-            not_enough_memory = self.memory_check()
+        iteration = info.iteration
+        if iteration % self._cur_period == 0:
+            not_enough_memory = self.memory_check(iteration)
             if not_enough_memory:
                 logger.log(20, f'\tRan low on memory, early stopping on iteration {info.iteration}.')
                 return False
         return True
 
-    def memory_check(self) -> bool:
+    def memory_check(self, iter) -> bool:
         """Checks if memory usage is unsafe. If so, then returns True to signal the model to stop training early."""
         available_bytes = psutil.virtual_memory().available
         cur_rss = self.mem_status.memory_info().rss
@@ -61,6 +64,12 @@ class MemoryCheckCallback:
             return True
         elif self.verbose or (model_size_memory_ratio > 0.25):
             logging.debug(f'Available Memory: {available_mb} MB, Estimated Model size: {estimated_model_size_mb} MB')
+
+        if model_size_memory_ratio > 0.5:
+            self._cur_period = 1  # Increase rate of memory check if model gets large enough to cause OOM potentially
+        elif iter > self.period:
+            self._cur_period = self.period
+
         return False
 
 

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -165,7 +165,7 @@ class CatBoostModel(AbstractModel):
         if early_stopping_rounds is not None:
             callbacks.append(EarlyStoppingCallback(stopping_rounds=early_stopping_rounds, eval_metric=params['eval_metric']))
 
-        if num_rows_train * num_cols_train * num_classes > 100_000_000:
+        if num_rows_train * num_cols_train * num_classes > 5_000_000:
             # The data is large enough to potentially cause memory issues during training, so monitor memory usage via callback.
             callbacks.append(MemoryCheckCallback())
         if time_limit is not None:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Decrease threshold for adding mem check callback 
* Add dynamic mem check period. Will always do mem check in the first couple period and whenever the model is large enough to potentially cause OOM

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
