### PR TITLE
[bugfix] NN_TORCH model is incorrectly casting types when used on GPU

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py
@@ -229,7 +229,7 @@ class EmbedNet(nn.Module):
         predict_data = self(data_batch)
         target_data = data_batch['label'].to(self.device)
         if self.problem_type in [BINARY, MULTICLASS]:
-            target_data = target_data.type(torch.LongTensor)  # Windows default int type is int32. Need to explicit convert to Long.
+            target_data = target_data.type(torch.long)  # Windows default int type is int32. Need to explicit convert to Long.
         if self.problem_type == QUANTILE:
             return self.quantile_loss(predict_data, target_data, margin=gamma)
         if self.problem_type == SOFTCLASS:


### PR DESCRIPTION
*Description of changes:*
The existing code is using CPU tensor type, which is causing a transfer of GPU tenser to CPU and failing with the exception:
```
Fitting model: NeuralNetTorch ...
	Warning: Exception caused NeuralNetTorch to fail during training... Skipping this model.
		Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument target in method wrapper_nll_loss_forward)
Detailed Traceback:
Traceback (most recent call last):
  File "/home/ubuntu/venv/lib/python3.7/site-packages/autogluon/core/trainer/abstract_trainer.py", line 979, in _train_and_save
    model = self._train_single(X, y, model, X_val, y_val, **model_fit_kwargs)
  File "/home/ubuntu/venv/lib/python3.7/site-packages/autogluon/core/trainer/abstract_trainer.py", line 937, in _train_single
    model = model.fit(X=X, y=y, X_val=X_val, y_val=y_val, **model_fit_kwargs)
  File "/home/ubuntu/venv/lib/python3.7/site-packages/autogluon/core/models/abstract/abstract_model.py", line 532, in fit
    out = self._fit(**kwargs)
  File "/home/ubuntu/venv/lib/python3.7/site-packages/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py", line 203, in _fit
    **fit_kwargs)
  File "/home/ubuntu/venv/lib/python3.7/site-packages/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py", line 293, in _train_net
    loss = self.model.compute_loss(data_batch, **loss_kwargs)
  File "/home/ubuntu/venv/lib/python3.7/site-packages/autogluon/tabular/models/tabular_nn/torch/torch_network_modules.py", line 241, in compute_loss
    return loss_function(predict_data, target_data)
  File "/home/ubuntu/venv/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/ubuntu/venv/lib/python3.7/site-packages/torch/nn/modules/loss.py", line 1152, in forward
    label_smoothing=self.label_smoothing)
  File "/home/ubuntu/venv/lib/python3.7/site-packages/torch/nn/functional.py", line 2846, in cross_entropy
    return torch._C._nn.cross_entropy_loss(input, target, weight, _Reduction.get_enum(reduction), ignore_index, label_smoothing)
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument target in method wrapper_nll_loss_forward)

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
