### PR TITLE
Fix image cpu loading

### DIFF
--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -22,6 +22,7 @@ from autogluon.core.utils.utils import generate_train_test_split
 
 from ..configs.presets_configs import unpack, _check_gpu_memory_presets
 from ..utils import sanitize_batch_size
+from ..utils.pickle import CPU_Unpickler
 
 __all__ = ['ImagePredictor']
 
@@ -697,7 +698,11 @@ class ImagePredictor(object):
         if os.path.isdir(path):
             path = os.path.join(path, 'image_predictor.ag')
         with open(path, 'rb') as fid:
-            obj = pickle.load(fid)
+            gpu_count = get_gpu_count_all()
+            if gpu_count > 0:
+                obj = pickle.load(fid)
+            else:
+                obj = CPU_Unpickler(fid).load()
         obj._verbosity = verbosity
         return obj
 

--- a/vision/src/autogluon/vision/utils/pickle.py
+++ b/vision/src/autogluon/vision/utils/pickle.py
@@ -2,6 +2,7 @@ import io
 import pickle
 
 
+# https://github.com/pytorch/pytorch/issues/16797
 class CPU_Unpickler(pickle.Unpickler):
     def find_class(self, module, name):
         if module == 'torch.storage' and name == '_load_from_bytes':

--- a/vision/src/autogluon/vision/utils/pickle.py
+++ b/vision/src/autogluon/vision/utils/pickle.py
@@ -1,0 +1,11 @@
+import io
+import pickle
+
+
+class CPU_Unpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        if module == 'torch.storage' and name == '_load_from_bytes':
+            import torch
+            return lambda b: torch.load(io.BytesIO(b), map_location='cpu')
+        else:
+            return super().find_class(module, name)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/issues/1426

*Description of changes:*
Previous changes in GluonCV only solved the estimator loading. Still need to handle the pickle logic. Added a cpu unpickler to handle the special logic. Refer to: https://github.com/pytorch/pytorch/issues/16797

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.