### PR TITLE
Set num_threads for torch nn models

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import psutil
 import time
 from builtins import classmethod
 from pathlib import Path
@@ -170,6 +171,9 @@ class NNFastAiTabularModel(AbstractModel):
         from fastai import torch_core
         from .callbacks import AgSaveModelCallback, EarlyStoppingCallbackWithTimeLimit
         from .quantile_helpers import HuberPinballLoss
+
+        import torch
+        torch.set_num_threads(num_cpus)
 
         start_time = time.time()
         if sample_weight is not None:  # TODO: support
@@ -448,6 +452,12 @@ class NNFastAiTabularModel(AbstractModel):
         )
         default_auxiliary_params.update(extra_auxiliary_params)
         return default_auxiliary_params
+
+    def _get_default_resources(self):
+        # psutil.cpu_count(logical=False) is faster in training than psutil.cpu_count()
+        num_cpus = psutil.cpu_count(logical=False)
+        num_gpus = 0
+        return num_cpus, num_gpus
 
     def __get_metrics_map(self):
         from fastai.metrics import rmse, mse, mae, accuracy, FBeta, RocAucBinary, Precision, Recall, R2Score

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import psutil
 import random
 import time
 import warnings
@@ -138,6 +139,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
              time_limit=None, sample_weight=None, num_cpus=1, num_gpus=0, reporter=None, verbosity=2, **kwargs):
         try_import_torch()
         import torch
+        torch.set_num_threads(num_cpus)
         from .tabular_torch_dataset import TabularTorchDataset
 
         start_time = time.time()
@@ -540,6 +542,12 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
     def _get_default_stopping_metric(self):
         return self.eval_metric
+
+    def _get_default_resources(self):
+        # psutil.cpu_count(logical=False) is faster in training than psutil.cpu_count()
+        num_cpus = psutil.cpu_count(logical=False)
+        num_gpus = 0
+        return num_cpus, num_gpus
 
     def save(self, path: str = None, verbose=True) -> str:
         if self.model is not None:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/issues/1519

*Description of changes:*
Making sure TorchNN and FASTAI are using the correct number of threads. This would address issues when other models modify the global thread setting.
Only updated this logic for fit because we find out that the overhead of setting the thread is not worth it during inference after some experiments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
