### PR TITLE
Disabled unit tests for MXNet

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,7 +141,6 @@ stage("Unit Test") {
           conda env update -n autogluon-tabular-py3-v3 -f docs/build_gpu.yml
           conda activate autogluon-tabular-py3-v3
           conda list
-          ${setup_mxnet_gpu}
           export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
 
           ${install_core_all}
@@ -171,7 +170,6 @@ stage("Unit Test") {
           conda env update -n autogluon-text-py3-v3 -f docs/build_gpu.yml
           conda activate autogluon-text-py3-v3
           conda list
-          ${setup_mxnet_gpu}
           export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
 
           ${install_core_all}
@@ -200,7 +198,6 @@ stage("Unit Test") {
           conda env update -n autogluon-vision-py3 -f docs/build_gpu.yml
           conda activate autogluon-vision-py3
           conda list
-          ${setup_mxnet_gpu}
           ${setup_torch_gpu}
           export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
 
@@ -347,7 +344,6 @@ stage("Build Tutorials") {
         conda env update -n autogluon-tutorial-tabular-v3 -f docs/build_contrib_gpu.yml
         conda activate autogluon-tutorial-tabular-v3
         conda list
-        ${setup_mxnet_gpu}
         ${setup_torch_gpu}
         export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
         export AG_DOCS=1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ stage("Unit Test") {
           VISIBLE_GPU=env.EXECUTOR_NUMBER.toInteger() % 8
           sh """#!/bin/bash
           set -ex
-          conda remove --name autogluon-text-py3 --all -y
+          conda remove --name autogluon-text-py3-v3 --all -y
           conda env update -n autogluon-text-py3-v3 -f docs/build_gpu.yml
           conda activate autogluon-text-py3-v3
           conda list

--- a/core/tests/unittests/metrics/test_classification_metrics.py
+++ b/core/tests/unittests/metrics/test_classification_metrics.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import sklearn
 from autogluon.core.metrics import confusion_matrix, log_loss, quadratic_kappa
-
+from autogluon.core.metrics.softclass_metrics import soft_log_loss
 
 def test_confusion_matrix_with_valid_inputs_without_labels_and_weights():
     # Given
@@ -144,6 +144,23 @@ def test_log_loss(gt, probs):
     probs = np.array(probs, dtype=np.float32)
     ag_loss = log_loss(gt, probs)
     expected = np.log(probs[np.arange(probs.shape[0]), gt]).mean()
+    np.testing.assert_allclose(ag_loss, expected)
+
+
+@pytest.mark.parametrize('gt,probs',
+                         [([[0.2, 0.3, 0.5],
+                            [0.1, 0.6, 0.3],
+                            [0.9, 0.05, 0.05],
+                            [0.3, 0.5, 0.2]],
+                           [[0.1, 0.2, 0.7],
+                            [0.2, 0.1, 0.7],
+                            [0.3, 0.4, 0.3],
+                            [0.01, 0.9, 0.09]])])
+def test_soft_log_loss(gt, probs):
+    gt = np.array(gt, dtype=np.float32)
+    probs = np.array(probs, dtype=np.float32)
+    ag_loss = soft_log_loss(gt, probs)
+    expected = -1.4691482
     np.testing.assert_allclose(ag_loss, expected)
 
 

--- a/docs/tutorials/tabular_prediction/tabular-multimodal-text-others.md
+++ b/docs/tutorials/tabular_prediction/tabular-multimodal-text-others.md
@@ -15,11 +15,9 @@ import pandas as pd
 import pprint
 import random
 from autogluon.tabular import TabularPredictor
-import mxnet as mx
 
 np.random.seed(123)
 random.seed(123)
-mx.random.seed(123)
 ```
 
 ## Product Sentiment Analysis Dataset

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -80,7 +80,6 @@ class ImagePredictorModel(AbstractModel):
              sample_weight=None,
              verbosity=2,
              **kwargs):
-        # try_import_mxnet()
         try_import_autogluon_vision()
         from autogluon.vision import ImagePredictor
         params = self._get_model_params()
@@ -119,6 +118,8 @@ class ImagePredictorModel(AbstractModel):
                 X_val = X_val[~null_indices_val]
 
         verbosity_image = max(0, verbosity - 1)
+        root_logger = logging.getLogger('autogluon')
+        root_log_level = root_logger.level
         # TODO: ImagePredictor doesn't use problem_type in any way at present.
         #  It also doesn't error or warn if problem_type is not one it expects.
         self.model = ImagePredictor(
@@ -140,6 +141,7 @@ class ImagePredictorModel(AbstractModel):
                        hyperparameters=params,
                        random_state=0)
         # self.model.set_verbosity(verbosity)  # TODO: How to set verbosity of fit predictor?
+        root_logger.setLevel(root_log_level)  # Reset log level
 
     def _predict_proba(self, X, **kwargs):
         X = self.preprocess(X, **kwargs)

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -135,7 +135,7 @@ class TextPredictorModel(AbstractModel):
             X_val.insert(len(X_val.columns), self._label_column_name, y_val)
 
         verbosity_text = max(0, verbosity - 1)
-        root_logger = logging.getLogger(__name__)
+        root_logger = logging.getLogger('autogluon')
         root_log_level = root_logger.level
         self.model = TextPredictor(label=self._label_column_name,
                                    problem_type=self.problem_type,

--- a/tabular/tests/unittests/models/test_image_predictor.py
+++ b/tabular/tests/unittests/models/test_image_predictor.py
@@ -4,13 +4,29 @@ from autogluon.tabular import TabularPredictor
 
 
 @pytest.mark.gpu
-def test_image_predictor(fit_helper):
+def test_image_predictor_multiclass(fit_helper):
+    # Test ImagePredictor with Torch
     from autogluon.vision import ImageDataset
     train_data, _, test_data = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
     feature_metadata = FeatureMetadata.from_df(train_data).add_special_types({'image': ['image_path']})
     predictor = TabularPredictor(label='label').fit(
         train_data=train_data,
-        hyperparameters={'AG_IMAGE_NN': {'epochs': 2, 'model': 'resnet18_v1b'}},
+        hyperparameters={'AG_IMAGE_NN': {'epochs': 2, 'model': 'resnet18'}},
+        feature_metadata=feature_metadata
+    )
+    leaderboard = predictor.leaderboard(test_data)
+    assert len(leaderboard) > 0
+
+
+@pytest.mark.gpu
+def test_image_predictor_regression(fit_helper):
+    # Test ImagePredictor with Torch
+    from autogluon.vision import ImageDataset
+    train_data, _, test_data = ImageDataset.from_folders('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
+    feature_metadata = FeatureMetadata.from_df(train_data).add_special_types({'image': ['image_path']})
+    predictor = TabularPredictor(label='label', problem_type='regression').fit(
+        train_data=train_data,
+        hyperparameters={'AG_IMAGE_NN': {'epochs': 2, 'model': 'resnet18'}},
         feature_metadata=feature_metadata
     )
     leaderboard = predictor.leaderboard(test_data)

--- a/text/tests/unittests/text_prediction/test_predictor_mxnet.py
+++ b/text/tests/unittests/text_prediction/test_predictor_mxnet.py
@@ -164,16 +164,6 @@ def test_emoji():
     verify_predictor_save_load(predictor, df)
 
 
-def test_no_job_finished_raise():
-    train_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/'
-                              'glue/sst/train.parquet')
-    with pytest.raises(RuntimeError):
-        # Setting a very small time limits to trigger the bug
-        predictor = TextPredictor(label='label', backend=MXNET)
-        predictor.fit(train_data, hyperparameters=get_test_hyperparameters(),
-                      time_limit=1, num_gpus=1, seed=123)
-
-
 def test_mixed_column_type():
     train_data = load_pd.load('https://autogluon-text.s3-accelerate.amazonaws.com/'
                               'glue/sts/train.parquet')

--- a/vision/src/autogluon/vision/_gluoncv/image_classification.py
+++ b/vision/src/autogluon/vision/_gluoncv/image_classification.py
@@ -31,6 +31,10 @@ from .utils import config_to_nested
 
 __all__ = ['ImageClassification']
 
+
+logger = logging.getLogger(__name__)
+
+
 try:
     import timm
 except ImportError:
@@ -129,6 +133,14 @@ def _train_image_classification(args,
                 else:
                     raise ValueError('Model not supported because it does not exist in both timm and gluoncv model zoo.')
     assert dispatcher in ('torch', 'mxnet'), 'custom net needs to be of type either torch.nn.Module or mx.gluon.Block'
+    if dispatcher == 'mxnet':
+        logger.log(30, '=============================================================================\n'
+                       'WARNING: Using MXNet models in ImagePredictor is deprecated as of v0.4.0 and may contain various bugs and issues!\n'
+                       'In v0.5.0, ImagePredictor will no longer support training MXNet models. Please consider switching to specifying Torch models instead.\n'
+                       'Users should ensure they update their code that depends on ImagePredictor when upgrading to future AutoGluon releases.\n'
+                       'For more information, refer to this GitHub issue: https://github.com/awslabs/autogluon/issues/1560\n'
+                       '=============================================================================\n')
+
     args['estimator'] = TorchImageClassificationEstimator if dispatcher=='torch' else ImageClassificationEstimator
     # convert user defined config to nested form
     args = config_to_nested(args)

--- a/vision/src/autogluon/vision/detector/detector.py
+++ b/vision/src/autogluon/vision/detector/detector.py
@@ -232,6 +232,13 @@ class ObjectDetector(object):
                            'WARNING: Windows OS detected, but ObjectDetector is not supported on Windows!\n'
                            'You may run into many errors. Consider running on Linux instead.\n'
                            '=============================================================================\n')
+        logger.log(30, '=============================================================================\n'
+                       'WARNING: ObjectDetector is deprecated as of v0.4.0 and may contain various bugs and issues!\n'
+                       'In a future release ObjectDetector may be entirely reworked to use Torch as a backend.\n'
+                       'This future change will likely be API breaking.'
+                       'Users should ensure they update their code that depends on ObjectDetector when upgrading to future AutoGluon releases.\n'
+                       'For more information, refer to ObjectDetector refactor GitHub issue: https://github.com/awslabs/autogluon/issues/1559\n'
+                       '=============================================================================\n')
         if presets:
             if not isinstance(presets, list):
                 presets = [presets]

--- a/vision/tests/unittests/test_gluoncv_image_classification.py
+++ b/vision/tests/unittests/test_gluoncv_image_classification.py
@@ -1,3 +1,5 @@
+import pytest
+
 from autogluon.vision._gluoncv import ImageClassification
 
 
@@ -6,6 +8,7 @@ def get_dataset(path):
     return train_data, test_data
 
 
+@pytest.mark.skip(reason="ImagePredictor training with MXNet is not stable and may occasionally error. Skipping as MXNet backend is deprecated as of v0.4.0.")
 def test_image_classification():
     train_data, test_data = get_dataset('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
     task = ImageClassification({'model': 'resnet18_v1', 'num_trials': 1, 'epochs': 1, 'batch_size': 8})
@@ -14,6 +17,7 @@ def test_image_classification():
     test_result = classifier.predict(test_data)
 
 
+@pytest.mark.skip(reason="ImagePredictor training with MXNet is not stable and may occasionally error. Skipping as MXNet backend is deprecated as of v0.4.0.")
 def test_image_classification_custom_net():
     train_data, test_data = get_dataset('https://autogluon.s3.amazonaws.com/datasets/shopee-iet.zip')
     from gluoncv.model_zoo import get_model

--- a/vision/tests/unittests/test_gluoncv_object_detection.py
+++ b/vision/tests/unittests/test_gluoncv_object_detection.py
@@ -1,3 +1,5 @@
+import pytest
+
 from autogluon.core.space import Categorical
 from autogluon.vision._gluoncv import ObjectDetection
 
@@ -6,6 +8,7 @@ def get_dataset(path):
     return ObjectDetection.Dataset.from_voc(path)
 
 
+@pytest.mark.skip(reason="ObjectDetector is not stable to test, and fails due to transient errors occasionally.")
 def test_object_detection_estimator():
     dataset = get_dataset('https://autogluon.s3.amazonaws.com/datasets/tiny_motorbike.zip')
     train_data, val_data, test_data = dataset.random_split(val_size=0.3, test_size=0.2, random_state=0)
@@ -15,6 +18,7 @@ def test_object_detection_estimator():
     test_result = detector.predict(test_data)
 
 
+@pytest.mark.skip(reason="ObjectDetector is not stable to test, and fails due to transient errors occasionally.")
 def test_object_detection_estimator_transfer():
     dataset = get_dataset('https://autogluon.s3.amazonaws.com/datasets/tiny_motorbike.zip')
     train_data, val_data, test_data = dataset.random_split(val_size=0.3, test_size=0.2, random_state=0)

--- a/vision/tests/unittests/test_object_detection.py
+++ b/vision/tests/unittests/test_object_detection.py
@@ -1,5 +1,9 @@
+import pytest
+
 from autogluon.vision import ObjectDetector as Task
 
+
+@pytest.mark.skip(reason="ObjectDetector is not stable to test, and fails due to transient errors occasionally.")
 def test_task():
     dataset = Task.Dataset.from_voc('https://autogluon.s3.amazonaws.com/datasets/tiny_motorbike.zip')
     train_data, _, test_data = dataset.random_split(random_state=0)


### PR DESCRIPTION
Disabled unit tests for MXNet ObjectDetector, ImagePredictor, and TextPredictor, fixed Tabular multi-modal logging

*Issue #, if available:*

*Description of changes:*
- Fixed major bug in Jenkinsfile for Text unittests: Wrong conda environment was being deleted, meaning that stale conda environment artifacts were being sometimes incorporated into testing. Fixing should make CI much more stable for text unittests.
- Disabled unit tests for MXNet ObjectDetector, ImagePredictor, and TextPredictor, fixed Tabular multi-modal logging
- Added deprecation warnings for ImagePredictor MXNet models and ObjectDetector.
- Removed installation of MXNet for Vision, Text, and Tabular unit tests in Jenkinsfile.
- Fixed logging verbosity level in multi-modal TabularPredictor mode (previously would incorrectly silence logs after fitting Text / Image)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
