### PR TITLE
[PR #1537 Patch 3] Fix running examples for text predictor

### DIFF
--- a/examples/text_prediction/run_competition.py
+++ b/examples/text_prediction/run_competition.py
@@ -39,6 +39,12 @@ def get_parser():
                         default='single',
                         help='Whether to use a single model or a stack ensemble. '
                              'If it is "single", If it is turned on, we will use 5-fold, 1-layer for stacking.')
+    parser.add_argument('--preset', type=str,
+                        help='Pre-registered configurations',
+                        choices=['medium_quality_faster_train',
+                                 'high_quality',
+                                 'best_quality'],
+                        default=None)
     return parser
 
 
@@ -136,17 +142,7 @@ def load_mercari_price_prediction(train_path, test_path):
     return train_df, test_df, label_column
 
 
-def set_seed(seed):
-    import mxnet as mx
-    import torch as th
-    th.manual_seed(seed)
-    mx.random.seed(seed)
-    np.random.seed(seed)
-    random.seed(seed)
-
-
 def run(args):
-    set_seed(args.seed)
     if args.task == 'product_sentiment':
         train_df, test_df, label_column = load_machine_hack_product_sentiment(args.train_file,
                                                                               args.test_file)
@@ -180,6 +176,7 @@ def run(args):
                                   eval_metric=args.eval_metric,
                                   path=args.exp_dir)
         predictor.fit(train_data=train_df,
+                      presets=args.preset,
                       seed=args.seed)
     else:
         raise NotImplementedError

--- a/examples/text_prediction/run_competition.py
+++ b/examples/text_prediction/run_competition.py
@@ -6,6 +6,7 @@ import numpy as np
 import random
 from autogluon.tabular import TabularPredictor
 from autogluon.text import TextPredictor
+from autogluon.tabular.configs.hyperparameter_configs import get_hyperparameter_config
 
 
 def get_parser():
@@ -155,12 +156,17 @@ def run(args):
         train_df, test_df, label_column = load_data_scientist_salary(args.train_file, args.test_file)
     else:
         raise NotImplementedError
+
+    hyperparameters = get_hyperparameter_config('multimodal')
+    if args.mode is not None:
+        hyperparameters['AG_TEXT_NN']['presets'] = args.preset
+
     if args.mode == 'stacking':
         predictor = TabularPredictor(label=label_column,
                                      eval_metric=args.eval_metric,
                                      path=args.exp_dir)
         predictor.fit(train_data=train_df,
-                      hyperparameters='multimodal',
+                      hyperparameters=hyperparameters,
                       num_bag_folds=5,
                       num_stack_levels=1)
     elif args.mode == 'weighted':
@@ -168,7 +174,7 @@ def run(args):
                                      eval_metric=args.eval_metric,
                                      path=args.exp_dir)
         predictor.fit(train_data=train_df,
-                      hyperparameters='multimodal')
+                      hyperparameters=hyperparameters)
     elif args.mode == 'single':
         # When no embedding is used,
         # we will just use TextPredictor that will train a single model internally.

--- a/examples/text_prediction/run_text_prediction.py
+++ b/examples/text_prediction/run_text_prediction.py
@@ -5,9 +5,10 @@ import numpy as np
 import random
 import pandas as pd
 import copy
-from autogluon.text import TextPredictor, ag_text_presets
+from autogluon.text import TextPredictor
 from autogluon.tabular import TabularPredictor
 from autogluon.core.utils.loaders import load_pd
+from autogluon.tabular.configs.hyperparameter_configs import get_hyperparameter_config
 
 
 TASKS = \
@@ -59,6 +60,12 @@ def get_parser():
                         default='single',
                         help='Whether to use a single model or a stack ensemble. '
                              'If it is "single", If it is turned on, we will use 5-fold, 1-layer for stacking.')
+    parser.add_argument('--preset', type=str,
+                        help='Pre-registered configurations',
+                        choices=['medium_quality_faster_train',
+                                 'high_quality',
+                                 'best_quality'],
+                        default=None)
     return parser
 
 
@@ -85,13 +92,18 @@ def train(args):
     else:
         real_train_df = train_df
         real_dev_df = dev_df
+
+    hyperparameters = get_hyperparameter_config('multimodal')
+    if args.mode is not None:
+        hyperparameters['AG_TEXT_NN']['presets'] = args.preset
+
     if args.mode == 'stacking':
         predictor = TabularPredictor(label=label_column,
                                      eval_metric=eval_metric,
                                      path=args.exp_dir)
         predictor.fit(train_data=real_train_df,
                       tuning_data=real_dev_df,
-                      hyperparameters='multimodal',
+                      hyperparameters=hyperparameters,
                       num_bag_folds=5,
                       num_stack_levels=1)
     elif args.mode == 'weighted':
@@ -100,7 +112,7 @@ def train(args):
                                      path=args.exp_dir)
         predictor.fit(train_data=real_train_df,
                       tuning_data=real_dev_df,
-                      hyperparameters='multimodal')
+                      hyperparameters=hyperparameters)
     elif args.mode == 'single':
         # When no embedding is used,
         # we will just use TextPredictor that will train a single model internally.

--- a/examples/text_prediction/run_text_prediction.py
+++ b/examples/text_prediction/run_text_prediction.py
@@ -62,17 +62,7 @@ def get_parser():
     return parser
 
 
-def set_seed(seed):
-    import mxnet as mx
-    import torch as th
-    th.manual_seed(seed)
-    mx.random.seed(seed)
-    np.random.seed(seed)
-    random.seed(seed)
-
-
 def train(args):
-    set_seed(args.seed)
     if args.task is not None:
         feature_columns, label_column, eval_metric, all_metrics = TASKS[args.task]
     else:

--- a/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
+++ b/tabular/src/autogluon/tabular/configs/hyperparameter_configs.py
@@ -81,7 +81,7 @@ hyperparameter_config_dict = dict(
         'CAT': {},
         'XGB': {},
         # 'FASTAI': {},  # FastAI gets killed if the dataset is large (400K rows).
-        'AG_TEXT_NN': ['medium_quality_faster_train'],  # TODO, Support changing the config w.r.t the preset option.
+        'AG_TEXT_NN': {'presets': 'medium_quality_faster_train'},  # TODO, Support changing the config w.r.t the preset option.
         'AG_IMAGE_NN': {},  # TODO, Support changing the config w.r.t the preset option.
         'VW': {},
     },

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -78,8 +78,6 @@ class TextPredictorModel(AbstractModel):
     def _set_default_params(self):
         super()._set_default_params()
         try_import_autogluon_text()
-        self.params = {}
-        self.preset = "medium_quality_faster_train"
 
     def _fit(self,
              X: pd.DataFrame,
@@ -142,14 +140,16 @@ class TextPredictorModel(AbstractModel):
                                    path=self.path,
                                    eval_metric=self.eval_metric,
                                    verbosity=verbosity_text)
+        params = self._get_model_params()
+        presets = params.pop('presets', None)
         self.model.fit(train_data=X_train,
                        tuning_data=X_val,
                        time_limit=time_limit,
                        num_gpus=num_gpus,
                        num_cpus=num_cpus,
-                       presets=self.preset,
-                       hyperparameters=self.params,
-                       seed=self.params.get('seed', 0))
+                       presets=presets,
+                       hyperparameters=params,
+                       seed=params.pop('seed', 0))
         self.model.set_verbosity(verbosity)
         root_logger.setLevel(root_log_level)  # Reset log level
 

--- a/text/src/autogluon/text/automm/optimization/metrics.py
+++ b/text/src/autogluon/text/automm/optimization/metrics.py
@@ -4,14 +4,38 @@ from torchmetrics import Metric
 
 
 class CrossEntropy(Metric):
+    """
+    A torchmetrics.Metric to compute cross entropy, which corresponds to sklearn's log_loss
+    https://scikit-learn.org/stable/modules/generated/sklearn.metrics.log_loss.html
+    """
+
     def __init__(self, dist_sync_on_step=False):
+        """
+        Each state variable should be called using self.add_state(...).
+
+        Parameters
+        ----------
+        dist_sync_on_step
+            Synchronize metric state across processes at each forward() before returning the value at the step.
+            Refer to https://torchmetrics.readthedocs.io/en/stable/pages/implement.html#torchmetrics.Metric
+        """
         super().__init__(dist_sync_on_step=dist_sync_on_step)
 
         self.add_state("loss", default=torch.tensor(0.0), dist_reduce_fx="sum")
         self.add_state("total", default=torch.tensor(0.0), dist_reduce_fx="sum")
 
     def update(self, preds: torch.Tensor, target: torch.Tensor):
+        """
+        Update the state given inputs of one batch.
+        It needs to accumulate metric scores over multiple batches.
 
+        Parameters
+        ----------
+        preds
+            Logits output of a model.
+        target
+            Ground-truth labels.
+        """
         self.loss += F.cross_entropy(
             input=preds,
             target=target,
@@ -20,4 +44,11 @@ class CrossEntropy(Metric):
         self.total += len(target)
 
     def compute(self):
+        """
+        Computes the average cross entropy loss over all samples.
+
+        Returns
+        -------
+        Average loss.
+        """
         return self.loss.float() / self.total

--- a/text/src/autogluon/text/automm/optimization/metrics.py
+++ b/text/src/autogluon/text/automm/optimization/metrics.py
@@ -1,0 +1,23 @@
+import torch
+from torch.nn import functional as F
+from torchmetrics import Metric
+
+
+class CrossEntropy(Metric):
+    def __init__(self, dist_sync_on_step=False):
+        super().__init__(dist_sync_on_step=dist_sync_on_step)
+
+        self.add_state("loss", default=torch.tensor(0.0), dist_reduce_fx="sum")
+        self.add_state("total", default=torch.tensor(0.0), dist_reduce_fx="sum")
+
+    def update(self, preds: torch.Tensor, target: torch.Tensor):
+
+        self.loss += F.cross_entropy(
+            input=preds,
+            target=target,
+            reduction="sum",
+        )
+        self.total += len(target)
+
+    def compute(self):
+        return self.loss.float() / self.total

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -9,6 +9,7 @@ from .lr_scheduler import (
     get_linear_schedule_with_warmup,
 )
 from ..constants import BINARY, MULTICLASS, REGRESSION, MAX, MIN
+from .metrics import CrossEntropy
 
 
 def get_loss_func(problem_type: str):
@@ -55,6 +56,8 @@ def get_metric(
     metric_name = metric_name.lower()
     if metric_name in ["acc", "accuracy"]:
         return torchmetrics.Accuracy(), MAX
+    elif metric_name in ["log_loss", "cross_entropy"]:
+        return CrossEntropy(), MIN
     elif metric_name in ["rmse", "root_mean_squared_error"]:
         return torchmetrics.MeanSquaredError(squared=False), MIN
     elif metric_name == "r2":

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -114,6 +114,10 @@ class AutoMMPredictor:
         if eval_metric is None and problem_type is not None:
             eval_metric = infer_eval_metric(problem_type)
 
+        # Due to torchmetrics, r2 may encounter errors for per gpu batch size 1.
+        if eval_metric.lower() == "r2":
+            eval_metric = "rmse"
+
         self._eval_metric_name = eval_metric
         self._output_shape = None
         if path is not None:

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -592,8 +592,8 @@ def compute_score(
 
 
 def apply_omegaconf_overrides(
-        conf: Union[List, Tuple, str, Dict],
-        overrides,
+        conf: DictConfig,
+        overrides: Union[List, Tuple, str, Dict, DictConfig],
         check_key_exist=True,
 ):
     """


### PR DESCRIPTION

*This PR is mainly to fix running examples in `autogluon.examples.text_prediction`*:

1. Fixing passing `presets` from tabular predictor to text predictor.
2. Automatically switching from metric `r2` to `rmse` to avoid a potential bug for per gpu batch 1.
3. Added the cross entropy metric using torchmetrics to match the sklearn's `log_loss`.
4. Removed setting seed in examples since it involves MXNet and setting seed is already done inside AutoMM.
5. Fixed one type hint.

