### PR TITLE
Improved refit_full support, refactored refit_full logic

### DIFF
--- a/core/src/autogluon/core/models/abstract/_tags.py
+++ b/core/src/autogluon/core/models/abstract/_tags.py
@@ -2,4 +2,23 @@
 _DEFAULT_TAGS = {
     # Whether the model can produce out-of-fold (or similar) predictions of the training data without being significantly overfit.
     'valid_oof': False,
+    # Whether the model can be refit using the combined train and val data as training and no validation data without issue.
+    #  TL;DR: Keep value as False unless you know what you are doing. This is advanced functionality.
+    #  If False, when calling predictor.refit_full(), this model will simply be duplicated (if non-bag) or will have the first fold model duplicated (if bag).
+    #  This will result in a slightly worse refit model than an optimally implemented refit_full, but is a simple fallback that is still effective.
+    #  If True (Advanced), when calling predictor.refit_full(), this model will be fit again on 100% of the data as training data (no validation data)
+    #  using hyperparameters defined by this model's implementation.
+    #  If a model does not use validation data in any way during training, then it is safe to set `can_infer_full` to True without additional work.
+    #  Some models use early stopping or more advanced techniques during training that require validation data.
+    #  For these models, they should implement logic that communicates in the hyperparameters to the refit_full model
+    #  the knowledge gained during the original fit.
+    #  For example, if epochs=100 but the model early stopped on epoch=20 with epoch=10 having the best validation score,
+    #  we want the refit_full model to stop training on epoch 10 (trusting that its performance will mimic the original model).
+    #  This can be implemented via passing epoch=10 (best epoch) at end of `_fit` by setting (example): `self.params_trained['epochs'] = self.model.best_epoch`
+    #  If the model has even more complex functionality associated with the `epochs` value itself (such as cyclic learning rate),
+    #  a solution is to pass epochs=100 and
+    #  implement a new parameter `final_epoch=10` that forces the model to stop at `final_epoch` (while maintaining the same LR schedule).
+    #  This can get very complex to implement correctly for refit_full.
+    #  It is recommended in these scenarios to set `can_refit_full` to False until a correct implementation is added.
+    'can_refit_full': False,
 }

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -876,7 +876,7 @@ class AbstractModel:
         self.rename(self.name + REFIT_FULL_SUFFIX)
         __path_refit = self.path
         self.save(path=self.path, verbose=False)
-        self.rename(self.name)
+        self.rename(__name)
         return self.load(path=__path_refit, verbose=False)
 
     def get_params(self) -> dict:

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -867,6 +867,18 @@ class AbstractModel:
         trained_params.update(self.params_trained)
         return trained_params
 
+    def convert_to_refit_full_via_copy(self):
+        """
+        Creates a new refit_full variant of the model, but instead of training it simply copies `self`.
+        This method is for compatibility with models that have not implemented refit_full support as a fallback.
+        """
+        __name = self.name
+        self.rename(self.name + REFIT_FULL_SUFFIX)
+        __path_refit = self.path
+        self.save(path=self.path, verbose=False)
+        self.rename(self.name)
+        return self.load(path=__path_refit, verbose=False)
+
     def get_params(self) -> dict:
         """Get params of the model at the time of initialization"""
         name = self.name

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -5,6 +5,7 @@ import platform
 import time
 from collections import Counter
 from statistics import mean
+from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -181,6 +182,18 @@ class BaggedEnsembleModel(AbstractModel):
         if self._oof_pred_proba is None and self.is_fit():
             self._load_oof()
 
+        if (not self._get_tags_child().get('can_refit_full', False) or k_fold == 1) and not self.params.get('save_bag_folds', True):
+            # TODO: This is a hack to avoid a very challenging situation:
+            #  in high_quality preset we don't save fold models, but for models that don't support refit_full,
+            #  they must copy the first fold model instead of fitting again.
+            #  Therefore we must override save_bag_folds for these unsupported models so that the refit versions have a fold model to copy.
+            #  This could be implemented better by only keeping the first fold model artifact and avoid saving the other fold model artifacts (lower disk usage)
+            #  However, this is complex to code accounting for the fitting strategies and would be prone to difficult to diagnose bugs.
+            self.params['save_bag_folds'] = True
+            if k_fold != 1:
+                # Only log in the situation where functionality is currently suboptimal
+                logger.log(20, '\tForcing `save_bag_folds=True` because child model does not support `refit_full`.')
+
         save_bag_folds = self.params.get('save_bag_folds', True)
         if k_fold == 1:
             self._fit_single(X=X, y=y, model_base=model_base, use_child_oof=use_child_oof, **kwargs)
@@ -201,6 +214,7 @@ class BaggedEnsembleModel(AbstractModel):
             # FIXME: Don't save folds except for refit
             # FIXME: Cleanup self
             # FIXME: Don't add `_FULL` to name
+            # FIXME: Support `can_refit_full=False` models
             if refit_folds:
                 refit_template = self.convert_to_refit_full_template()
                 refit_template.params['use_child_oof'] = False
@@ -331,19 +345,18 @@ class BaggedEnsembleModel(AbstractModel):
         else:
             self._oof_pred_proba = model_base.predict_proba(X=X)  # TODO: Cheater value, will be overfit to valid set
         self._oof_pred_model_repeats = np.ones(shape=len(X), dtype=np.uint8)
+        model_base.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
+        if not self.params.get('save_bag_folds', True):
+            model_base.model = None
+        self.add_child(model=model_base, add_child_times=True)
+        self._set_n_repeat_single()
+
+    def _set_n_repeat_single(self):
+        """Sets variables that track `n_repeats` to values that represent having only 1 child in the bag."""
         self._n_repeats = 1
         self._n_repeats_finished = 1
         self._k_per_n_repeat = [1]
         self._bagged_mode = False
-        model_base.reduce_memory_size(remove_fit=True, remove_info=False, requires_save=True)
-        if not self.params.get('save_bag_folds', True):
-            model_base.model = None
-        if self.low_memory:
-            self.save_child(model_base, verbose=False)
-            self.models = [model_base.name]
-        else:
-            self.models = [model_base]
-        self._add_child_times_to_bag(model=model_base)
 
     def _get_default_fold_fitting_strategy(self):
         # ray not working properly on macos: https://github.com/ray-project/ray/issues/20084
@@ -356,7 +369,7 @@ class BaggedEnsembleModel(AbstractModel):
         current_os = platform.system()
         fold_fitting_strategy = os_fitting_strategy_map.get(current_os, 'sequential_local')
         if fold_fitting_strategy == 'sequential_local':
-            warning_msg = f'Will use sequential fold fitting strategy because {current_os} OS does not yet support parallel folding.'
+            warning_msg = f'\tWill use sequential fold fitting strategy because {current_os} OS does not yet support parallel folding.'
             dup_filter.attach_filter_targets(warning_msg)
             logger.warning(warning_msg)
         else:
@@ -394,7 +407,7 @@ class BaggedEnsembleModel(AbstractModel):
         if fold_fitting_strategy == 'parallel_local':
             if disable_parallel_fitting:
                 fold_fitting_strategy = SequentialLocalFoldFittingStrategy
-                logger.log(20, f'{model_base.__class__.__name__} does not support parallel folding yet. Will use sequential folding instead')
+                logger.log(20, f'\t{model_base.__class__.__name__} does not support parallel folding yet. Will use sequential folding instead')
             else:
                 fold_fitting_strategy = ParallelLocalFoldFittingStrategy
         elif fold_fitting_strategy == 'sequential_local':
@@ -432,9 +445,6 @@ class BaggedEnsembleModel(AbstractModel):
 
         fold_fit_args_list = [dict(fold_ctx=fold_ctx) for fold_ctx in fold_fit_args_list]
 
-        logger.log(20, f'\tFitting {len(fold_fit_args_list)} child models '
-                       f'({fold_fit_args_list[0]["fold_ctx"]["model_name_suffix"]} - {fold_fit_args_list[-1]["fold_ctx"]["model_name_suffix"]})')
-
         oof_pred_proba, oof_pred_model_repeats = self._construct_empty_oof(X=X, y=y)
         models = []
 
@@ -456,18 +466,21 @@ class BaggedEnsembleModel(AbstractModel):
             # If memory is not sufficient, fall back to sequential fold strategy
             fold_fitting_strategy_args.pop('num_folds_parallel', None)
             fold_fitting_strategy: AbstractFoldFittingStrategy = SequentialLocalFoldFittingStrategy(**fold_fitting_strategy_args)
-            logger.log(20, f'Memory not enough to fit {model_base.__class__.__name__} folds in parallel. Will do sequential fitting instead')
-            logger.log(20, 'Consider decrease folds trained in parallel by passing num_folds_parallel to ag_args_ensemble when calling tabular.fit')
-        else:
-            logger.log(20, f'{fold_fitting_strategy.__class__.__name__} is used to fit folds')
+            logger.log(30, f'\tMemory not enough to fit {model_base.__class__.__name__} folds in parallel. Will do sequential fitting instead. '
+                           f'\tConsider decreasing folds trained in parallel by passing num_folds_parallel to ag_args_ensemble when calling predictor.fit')
+
+        logger.log(20, f'\tFitting {len(fold_fit_args_list)} child models '
+                       f'({fold_fit_args_list[0]["fold_ctx"]["model_name_suffix"]} - {fold_fit_args_list[-1]["fold_ctx"]["model_name_suffix"]}) | '
+                       f'Fitting with {fold_fitting_strategy.__class__.__name__}')
 
         # noinspection PyCallingNonCallable
         for fold_fit_args in fold_fit_args_list:
             fold_fitting_strategy.schedule_fold_model_fit(**fold_fit_args)
         fold_fitting_strategy.after_all_folds_scheduled()
 
-        self.models += models
-
+        for model in models:
+            # No need to add child times or save child here as this already occurred in the fold_fitting_strategy
+            self.add_child(model=model, add_child_times=False, save_child=False, verbose=False)
         self._bagged_mode = True
 
         if self._oof_pred_proba is None:
@@ -622,14 +635,52 @@ class BaggedEnsembleModel(AbstractModel):
         assert self.is_fit(), "The model must be fit before calling the get_features method."
         return self.load_child(self.models[0]).get_features()
 
-    def load_child(self, model, verbose=False) -> AbstractModel:
+    def load_child(self, model: Union[AbstractModel, str], verbose=False) -> AbstractModel:
         if isinstance(model, str):
             child_path = self.create_contexts(self.path + model + os.path.sep)
             return self._child_type.load(path=child_path, verbose=verbose)
         else:
             return model
 
-    def save_child(self, model, verbose=False):
+    def add_child(self, model: Union[AbstractModel, str], add_child_times=False, save_child=True, verbose=False):
+        """
+        Add a new fit child model to `self.models`
+
+        Parameters
+        ----------
+        model : Union[AbstractModel, str]
+            The child model to add. If str, it is the name of the model.
+        add_child_times : bool, default = False
+            Whether to add child metadata on times to the bag times.
+            This includes fit_time, predict_time, and predict_1_time.
+        save_child : bool, default = True
+            Whether to save the child model to disk.
+        verbose : bool, default = False
+            Whether to log the child saving process.
+        """
+        if self.models is None:
+            self.models = []
+        if isinstance(model, str):
+            model_name = model
+            model = None
+        else:
+            model_name = model.name
+        if self.low_memory:
+            if save_child:
+                if model is None:
+                    model = self.load_child(model=model_name, verbose=False)
+                self.save_child(model, verbose=verbose)
+            self.models.append(model_name)
+        else:
+            if model is None:
+                model = self.load_child(model=model_name, verbose=False)
+            self.models.append(model)
+        if add_child_times:
+            if model is None:
+                model = self.load_child(model=model_name, verbose=False)
+            self._add_child_times_to_bag(model=model)
+
+    def save_child(self, model: Union[AbstractModel, str], verbose=False):
         child = self.load_child(model)
         child.set_contexts(self.path + child.name + os.path.sep)
         child.save(verbose=verbose)
@@ -650,6 +701,27 @@ class BaggedEnsembleModel(AbstractModel):
         refit_child_template = self._child_type(**refit_params)
 
         return refit_child_template
+
+    def convert_to_refit_full_via_copy(self) -> AbstractModel:
+        """
+        Creates a new refit_full variant of the model, but instead of training it simply copies `self` while keeping only the first fold model.
+        This method is for compatibility with models that have not implemented refit_full support as a fallback.
+        """
+        if not self.params.get('save_bag_folds', True):
+            raise AssertionError('Cannot perform copy-based refit_full when save_bag_folds is False!')
+        __models = self.models
+        self.models = []
+        model_full = copy.deepcopy(self)
+        self.models = __models
+        child_0 = self.load_child(self.models[0])
+        model_full.fit_time = None
+        model_full.predict_time = None
+        model_full.predict_1_time = None
+        model_full.val_score = None
+        model_full.rename(model_full.name + REFIT_FULL_SUFFIX)
+        model_full.add_child(model=child_0, add_child_times=True, save_child=True)
+        model_full._set_n_repeat_single()
+        return model_full
 
     def get_params(self):
         init_args = dict(
@@ -1025,4 +1097,11 @@ class BaggedEnsembleModel(AbstractModel):
         return bags, bags_performance, hpo_results
 
     def _more_tags(self):
-        return {'valid_oof': True}
+        return {
+            'valid_oof': True,
+            'can_refit_full': True,
+        }
+
+    def _get_tags_child(self):
+        """Gets the tags of the child model."""
+        return self._get_model_base()._get_tags()

--- a/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
+++ b/tabular/src/autogluon/tabular/models/catboost/catboost_model.py
@@ -235,3 +235,7 @@ class CatBoostModel(AbstractModel):
         num_cpus = psutil.cpu_count(logical=False)
         num_gpus = 0
         return num_cpus, num_gpus
+
+    def _more_tags(self):
+        # `can_refit_full=True` because iterations is communicated at end of `_fit`
+        return {'can_refit_full': True}

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -501,3 +501,6 @@ class NNFastAiTabularModel(AbstractModel):
 
     def _estimate_memory_usage(self, X, **kwargs):
         return 10 * get_approximate_df_mem_usage(X).sum()
+
+    def _more_tags(self):
+        return {'can_refit_full': True}

--- a/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
+++ b/tabular/src/autogluon/tabular/models/fasttext/fasttext_model.py
@@ -184,3 +184,7 @@ class FastTextModel(AbstractModel):
 
     def get_memory_size(self) -> int:
         return self._model_size_estimate
+
+    def _more_tags(self):
+        # `can_refit_full=True` because validation data is not used and there is no form of early stopping implemented.
+        return {'can_refit_full': True}

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -230,3 +230,7 @@ class ImagePredictorModel(AbstractModel):
         from autogluon.vision import ImagePredictor
         num_gpus = ImagePredictor._get_num_gpus_available()
         return num_cpus, num_gpus
+
+    def _more_tags(self):
+        # `can_refit_full=False` because ImagePredictor does not communicate how to train until the best epoch in refit_full.
+        return {'can_refit_full': False}

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -255,7 +255,10 @@ class KNNModel(AbstractModel):
         return self.model
 
     def _more_tags(self):
-        return {'valid_oof': True}
+        return {
+            'valid_oof': True,
+            'can_refit_full': True,
+        }
 
 
 class FAISSModel(KNNModel):

--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -340,3 +340,7 @@ class LGBModel(AbstractModel):
 
     def _ag_params(self) -> set:
         return {'ag.early_stop'}
+
+    def _more_tags(self):
+        # `can_refit_full=True` because num_boost_round is communicated at end of `_fit`
+        return {'can_refit_full': True}

--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -330,7 +330,11 @@ class RFModel(AbstractModel):
         return default_ag_args_ensemble
 
     def _more_tags(self):
+        # `can_refit_full=True` because final n_estimators is communicated at end of `_fit`:
+        #  `self.params_trained['n_estimators'] = self.model.n_estimators`
+        tags = {'can_refit_full': True}
         if self.problem_type == QUANTILE:
-            return {'valid_oof': False} # not supported in quantile regression
+            tags['valid_oof'] = False  # not supported in quantile regression
         else:
-            return {'valid_oof': True}
+            tags['valid_oof'] = True
+        return tags

--- a/tabular/src/autogluon/tabular/models/tabular_nn/mxnet/tabular_nn_mxnet.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/mxnet/tabular_nn_mxnet.py
@@ -590,6 +590,10 @@ class TabularNeuralNetMxnetModel(AbstractNeuralNetworkModel):
             model.summary_writer = None
         return model
 
+    def _more_tags(self):
+        # `can_refit_full=True` because num_epochs is communicated at end of `_fit`: `self.params_trained['num_epochs'] = best_val_epoch + 1`
+        return {'can_refit_full': True}
+
 
 
 """ General TODOs:

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -584,3 +584,9 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             model._architecture_desc = None
             model.model = torch.load(model.path + model.params_file_name)
         return model
+
+    def _more_tags(self):
+        # `can_refit_full=True` because batch_size and num_epochs is communicated at end of `_fit`:
+        #  self.params_trained['batch_size'] = batch_size
+        #  self.params_trained['num_epochs'] = best_epoch
+        return {'can_refit_full': True}

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -202,3 +202,7 @@ class TextPredictorModel(AbstractModel):
 
         y_pred_proba = self.model.predict_proba(X, as_pandas=False)
         return self._convert_proba_to_unified_form(y_pred_proba)
+
+    def _more_tags(self):
+        # `can_refit_full=False` because TextPredictor does not communicate how to train until the best epoch in refit_full.
+        return {'can_refit_full': False}

--- a/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
+++ b/tabular/src/autogluon/tabular/models/vowpalwabbit/vowpalwabbit_model.py
@@ -248,3 +248,7 @@ class VowpalWabbitModel(AbstractModel):
         }
         default_ag_args.update(extra_ag_args)
         return default_ag_args
+
+    def _more_tags(self):
+        # `can_refit_full=True` because best epoch is communicated at end of `_fit`: `self.params_trained['passes'] = epoch`
+        return {'can_refit_full': True}

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -222,3 +222,8 @@ class XGBoostModel(AbstractModel):
             model.model.load_model(path + 'xgb.ubj')
             model._xgb_model_type = None
         return model
+
+    def _more_tags(self):
+        # `can_refit_full=True` because n_estimators is communicated at end of `_fit`:
+        #  self.params_trained['n_estimators'] = bst.best_ntree_limit
+        return {'can_refit_full': True}


### PR DESCRIPTION
*Issue #, if available:*
#991 

*Description of changes:*
This PR addresses 4 issues:

1. Previously, for models TextPredictorModel and ImagePredictorModel when used in Tabular, if the user called refit_full, the refit models would ignore the best epoch found in the models and instead train all epochs. This could result in much worse model quality and could take many times longer to train than expected.
2. Additionally, models that already are effectively `_FULL` such as RandomForest in bag mode would be trained again as an identical copy, instead of simply copying the original model (same end result, avoids doubling training time).
3. Finally, new models contributed by users had to address the refit_full functionality of their model, which often was very complex (the most complex part of the entire contribution). This shouldn't be necessary for a basic contribution.
4. I have also included minor updates and improvements to logging clarity.

In this PR, I have implemented a new model tag `can_refit_full` which defaults to False. Models which have this tag as False will not use the previous refit_full logic when refit. Instead, they will use a generic fallback logic that is safe from overfitting / hyperparameter drift issues: Simply copy the original bag, but only keep the first fold model. Similarly for non-bag, it will simply copy the original model in its entirety. This will avoid needing to train the model again during refit as it is just a copy, and doesn't have all the complexities of having to train again with no validation data (requires advanced knowledge from user).

This means new model contributions will no longer need to:

1. Support `_fit` call where X_val and y_val are None.
2. Pass final hyperparameter information to refit_full model training (such as best epoch).
3. Know that refit_full exists.

Advanced contributors can still add support for `can_refit_full=True`, which is a superior solution in terms of model quality, but this is generally not critical for initial contributions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
