### PR TITLE
[PR #1537 Patch 4] Separate users' evaluation metric and the internal validation metric

### DIFF
--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -25,16 +25,13 @@ OUTPUT = "output"
 WEIGHT = "weight"
 FEATURES = "features"
 
-# Log keys
-VAL_LOSS = "val_loss"
-VAL_ACC = "val_acc"
-TEST_ACC = "test_acc"
-MODE = "mode"
+# Metric
 MAX = "max"
 MIN = "min"
 ACCURACY = "accuracy"
 ACC = "acc"
 RMSE = "rmse"
+R2 = "r2"
 QUADRATIC_KAPPA = "quadratic_kappa"
 
 # Training status

--- a/text/src/autogluon/text/automm/optimization/lit_module.py
+++ b/text/src/autogluon/text/automm/optimization/lit_module.py
@@ -39,8 +39,8 @@ class LitModule(pl.LightningModule):
             weight_decay: Optional[float] = None,
             warmup_steps: Optional[int] = None,
             loss_func: Optional[_Loss] = None,
-            val_metric: Optional[torchmetrics.Metric] = None,
-            val_metric_name: Optional[str] = None,
+            validation_metric: Optional[torchmetrics.Metric] = None,
+            validation_metric_name: Optional[str] = None,
             custom_metric_func: Callable = None,
             test_metric: Optional[torchmetrics.Metric] = None,
     ):
@@ -85,10 +85,10 @@ class LitModule(pl.LightningModule):
             "int(warmup_steps * max_steps)". If an integer, it would be the exact step number.
         loss_func
             A Pytorch loss module, e.g., nn.CrossEntropyLoss().
-        val_metric
+        validation_metric
             A torchmetrics module used in the validation stage, e.g., torchmetrics.Accuracy().
-        val_metric_name
-            Name of validation metric in case that val_metric is a aggregation metric,
+        validation_metric_name
+            Name of validation metric in case that validation_metric is a aggregation metric,
             e.g., torchmetrics.MeanMetric, whose name can't reflect the real metric name.
         custom_metric_func
             A customized metric function in case that torchmetrics doesn't have the metric.
@@ -98,14 +98,14 @@ class LitModule(pl.LightningModule):
             A torchmetrics module used in the test stage, e.g., torchmetrics.Accuracy().
         """
         super().__init__()
-        self.save_hyperparameters(ignore=["model", "val_metric", "test_metric", "loss_func"])
+        self.save_hyperparameters(ignore=["model", "validation_metric", "test_metric", "loss_func"])
         self.model = model
-        self.val_metric = val_metric
-        self.val_metric_name = f"val_{val_metric_name}"
+        self.validation_metric = validation_metric
+        self.validation_metric_name = f"val_{validation_metric_name}"
         self.loss_func = loss_func
-        if isinstance(val_metric, BaseAggregator) and custom_metric_func is None:
+        if isinstance(validation_metric, BaseAggregator) and custom_metric_func is None:
             raise ValueError(
-                f"val_metric {val_metric} is an aggregation metric,"
+                f"validation_metric {validation_metric} is an aggregation metric,"
                 f"which must be used with a customized metric function."
             )
         self.custom_metric_func = custom_metric_func
@@ -135,13 +135,13 @@ class LitModule(pl.LightningModule):
             # use only the last logits, which is the fusion logits
             logits = output[-1][LOGITS]
 
-        if isinstance(self.val_metric, torchmetrics.AUROC):
+        if isinstance(self.validation_metric, torchmetrics.AUROC):
             prob = F.softmax(logits.float(), dim=1)
-            return self.val_metric(preds=prob[:, 1], target=label)  # only for binary classification
-        elif isinstance(self.val_metric, BaseAggregator):
-            return self.val_metric(self.custom_metric_func(logits, label))
+            return self.validation_metric(preds=prob[:, 1], target=label)  # only for binary classification
+        elif isinstance(self.validation_metric, BaseAggregator):
+            return self.validation_metric(self.custom_metric_func(logits, label))
         else:
-            return self.val_metric(logits.squeeze(dim=1), label)
+            return self.validation_metric(logits.squeeze(dim=1), label)
 
     def _shared_step(
             self,
@@ -195,7 +195,7 @@ class LitModule(pl.LightningModule):
         # By default, on_step=False and on_epoch=True
         self.log("val_loss", loss)
         self.log(
-            self.val_metric_name,
+            self.validation_metric_name,
             self._compute_metric(output=output, label=batch[self.model.label_key]),
         )
 

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -42,6 +42,7 @@ def get_metric(
 ):
     """
     Obtain a torchmerics.Metric from its name.
+    Define a customized metric function in case that torchmetrics doesn't support some metric.
 
     Parameters
     ----------
@@ -54,49 +55,32 @@ def get_metric(
     -------
     torchmetrics.Metric
         A torchmetrics.Metric object.
-    Mode
+    mode
         The min/max mode used in selecting model checkpoints.
         - min
              Its means that smaller metric is better.
         - max
             It means that larger metric is better.
+    custom_metric_func
+        A customized metric function.
     """
     metric_name = metric_name.lower()
     if metric_name in ["acc", "accuracy"]:
-        return torchmetrics.Accuracy(), MAX
+        return torchmetrics.Accuracy(), MAX, None
     elif metric_name in ["rmse", "root_mean_squared_error"]:
-        return torchmetrics.MeanSquaredError(squared=False), MIN
+        return torchmetrics.MeanSquaredError(squared=False), MIN, None
     elif metric_name == "r2":
-        return torchmetrics.R2Score(), MAX
+        return torchmetrics.R2Score(), MAX, None
     elif metric_name == "quadratic_kappa":
         return torchmetrics.CohenKappa(num_classes=num_classes,
-                                       weights="quadratic"), MAX
+                                       weights="quadratic"), MAX, None
     elif metric_name == "roc_auc":
-        return torchmetrics.AUROC(), MAX
+        return torchmetrics.AUROC(), MAX, None
     elif metric_name in ["log_loss", "cross_entropy"]:
-        return torchmetrics.MeanMetric(), MIN
+        return torchmetrics.MeanMetric(), MIN, \
+               functools.partial(F.cross_entropy, reduction="none")
     else:
         raise ValueError(f"unknown metric_name: {metric_name}")
-
-
-def get_custom_metric_func(metric_name):
-    """
-    Define customized metric functions in case that torchmetrics doesn't support some metrics.
-
-    Parameters
-    ----------
-    metric_name
-        Name of metric.
-
-    Returns
-    -------
-    A callable metric function.
-    """
-    metric_name = metric_name.lower()
-    if metric_name in ["log_loss", "cross_entropy"]:
-        return functools.partial(F.cross_entropy, reduction="none")
-
-    return None
 
 
 def get_optimizer(

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -39,7 +39,7 @@ from .utils import (
     compute_score,
     gather_top_k_ckpts,
     average_checkpoints,
-    infer_eval_metric,
+    infer_validation_metric,
     get_config,
 )
 from .optimization.utils import (
@@ -112,20 +112,16 @@ class AutoMMPredictor:
             problem_type = REGRESSION
 
         self._problem_type = problem_type.lower() if problem_type is not None else None
-        if eval_metric is None and problem_type is not None:
-            eval_metric = infer_eval_metric(problem_type)
-
-        # Due to torchmetrics, r2 may encounter errors for per gpu batch size 1.
-        if eval_metric is not None and eval_metric.lower() == "r2":
-            eval_metric = "rmse"
 
         self._eval_metric_name = eval_metric
-        self._output_shape = None
+
         if path is not None:
             path = setup_outputdir(
                 path=path,
                 warn_if_exist=warn_if_exist,
             )
+        self._validation_metric_name = None
+        self._output_shape = None
         self._save_path = path
         self._ckpt_path = None
         self._pretrained_path = None
@@ -319,9 +315,6 @@ class AutoMMPredictor:
                 f"Inferred output shape {output_shape} is different from " \
                 f"the previous {self._output_shape}"
 
-        if self._eval_metric_name is None:
-            self._eval_metric_name = infer_eval_metric(problem_type)
-
         if self._df_preprocessor is None:
             df_preprocessor = init_df_preprocessor(
                 config=config.data,
@@ -356,11 +349,19 @@ class AutoMMPredictor:
         else:  # continuing training
             model = self._model
 
-        val_metric, minmax_mode = get_metric(
-            metric_name=self._eval_metric_name,
-            num_classes=output_shape
+        if self._validation_metric_name is None:
+            validation_metric_name = infer_validation_metric(
+                problem_type=problem_type,
+                eval_metric_name=self._eval_metric_name,
+            )
+        else:
+            validation_metric_name = self._validation_metric_name
+
+        validation_metric, minmax_mode = get_metric(
+            metric_name=validation_metric_name,
+            num_classes=output_shape,
         )
-        custom_metric_func = get_custom_metric_func(self._eval_metric_name)
+        custom_metric_func = get_custom_metric_func(validation_metric_name)
         loss_func = get_loss_func(problem_type)
 
         if time_limit is not None:
@@ -372,6 +373,7 @@ class AutoMMPredictor:
         self._config = config
         self._output_shape = output_shape
         self._column_types = column_types
+        self._validation_metric_name = validation_metric_name
         self._df_preprocessor = df_preprocessor
         self._data_processors = data_processors
         self._model = model
@@ -390,8 +392,8 @@ class AutoMMPredictor:
             model=model,
             config=config,
             loss_func=loss_func,
-            val_metric=val_metric,
-            val_metric_name=self._eval_metric_name,
+            validation_metric=validation_metric,
+            validation_metric_name=validation_metric_name,
             custom_metric_func=custom_metric_func,
             minmax_mode=minmax_mode,
             max_time=time_limit,
@@ -408,8 +410,8 @@ class AutoMMPredictor:
             model: nn.Module,
             config: DictConfig,
             loss_func: _Loss,
-            val_metric: torchmetrics.Metric,
-            val_metric_name: str,
+            validation_metric: torchmetrics.Metric,
+            validation_metric_name: str,
             custom_metric_func: Callable,
             minmax_mode: str,
             max_time: timedelta,
@@ -437,24 +439,24 @@ class AutoMMPredictor:
             weight_decay=config.optimization.weight_decay,
             warmup_steps=config.optimization.warmup_steps,
             loss_func=loss_func,
-            val_metric=val_metric,
-            val_metric_name=val_metric_name,
+            validation_metric=validation_metric,
+            validation_metric_name=validation_metric_name,
             custom_metric_func=custom_metric_func,
         )
 
-        logger.debug(f"val_metric_name: {task.val_metric_name}")
+        logger.debug(f"validation_metric_name: {task.validation_metric_name}")
         logger.debug(f"minmax_mode: {minmax_mode}")
 
         checkpoint_callback = pl.callbacks.ModelCheckpoint(
             dirpath=save_path,
             save_top_k=config.optimization.top_k,
             verbose=True,
-            monitor=task.val_metric_name,
+            monitor=task.validation_metric_name,
             mode=minmax_mode,
             save_last=True,
         )
         early_stopping_callback = pl.callbacks.EarlyStopping(
-            monitor=task.val_metric_name,
+            monitor=task.validation_metric_name,
             patience=config.optimization.patience,
             mode=minmax_mode
         )
@@ -852,6 +854,7 @@ class AutoMMPredictor:
                     "label_column": self._label_column,
                     "problem_type": self._problem_type,
                     "eval_metric_name": self._eval_metric_name,
+                    "validation_metric_name": self._validation_metric_name,
                     "output_shape": self._output_shape,
                     "save_path": self._save_path,
                     "pretrained_path": self._pretrained_path,
@@ -914,6 +917,7 @@ class AutoMMPredictor:
         predictor._config = config
         predictor._output_shape = assets["output_shape"]
         predictor._column_types = assets["column_types"]
+        predictor._validation_metric_name = assets["validation_metric_name"]
         predictor._df_preprocessor = df_preprocessor
         predictor._data_processors = data_processors
 

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -44,7 +44,6 @@ from .utils import (
 )
 from .optimization.utils import (
     get_metric,
-    get_custom_metric_func,
     get_loss_func,
 )
 from .optimization.lit_module import LitModule
@@ -366,11 +365,11 @@ class AutoMMPredictor:
             validation_metric_name = self._validation_metric_name
             eval_metric_name = self._eval_metric_name
 
-        validation_metric, minmax_mode = get_metric(
+        validation_metric, minmax_mode, custom_metric_func = get_metric(
             metric_name=validation_metric_name,
             num_classes=output_shape,
         )
-        custom_metric_func = get_custom_metric_func(validation_metric_name)
+
         loss_func = get_loss_func(problem_type)
 
         if time_limit is not None:

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -61,8 +61,10 @@ def infer_metrics(
 
     Returns
     -------
-    validation
-    The validation metric name.
+    validation_metric_name
+        Name of validation metric.
+    eval_metric_name
+        Name of evaluation metric.
     """
     if eval_metric_name is not None:
         if eval_metric_name.lower() == R2:

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -39,42 +39,50 @@ from .constants import (
 logger = logging.getLogger(AUTOMM)
 
 
-def infer_validation_metric(
-        problem_type: str,
-        eval_metric_name: str = None,
+def infer_metrics(
+        problem_type: Optional[str] = None,
+        eval_metric_name: Optional[str] = None,
 ):
     """
-    Infer the validation metric used for select best model checkpoints and early-stopping.
-    It first tries to use the provided evaluation metric. Otherwise, it uses accuracy and rmse as the
-    validation metrics for classification and regression, respectively.
-    Note that we switch r2 to rmse since torchmetrics.R2Score may encounter errors for per gpu batch size 1.
+    Infer the validation metric and the evaluation metric if not provided.
+    Validation metric is for early-stopping and selecting the best model checkpoints.
+    Evaluation metric is to report performance to users.
+    If the evaluation metric is provided, then we use it as the validation metric.
+    But there are some exceptions that validation metric is different from evaluation metric.
+    For example, if the provided evaluation metric is `r2`, we set the validation metric as `rmse`
+    since `torchmetrics.R2Score` may encounter errors for per gpu batch size 1.
 
     Parameters
     ----------
     problem_type
-        The type of problem.
+        Type of problem.
     eval_metric_name
         Name of evaluation metric provided by users.
 
     Returns
     -------
+    validation
     The validation metric name.
     """
     if eval_metric_name is not None:
         if eval_metric_name.lower() == R2:
-            return RMSE
-        return eval_metric_name
+            validation_metric_name = RMSE
+        else:
+            validation_metric_name = eval_metric_name
+        return validation_metric_name, eval_metric_name
 
     if problem_type in [MULTICLASS, BINARY]:
-        eval_metric = ACCURACY
+        eval_metric_name = ACCURACY
     elif problem_type == REGRESSION:
-        eval_metric = RMSE
+        eval_metric_name = RMSE
     else:
         raise NotImplementedError(
             f"Problem type: {problem_type} is not supported yet!"
         )
 
-    return eval_metric
+    validation_metric_name = eval_metric_name
+
+    return validation_metric_name, eval_metric_name
 
 
 def get_config(

--- a/text/tests/unittests/automm/test_metrics.py
+++ b/text/tests/unittests/automm/test_metrics.py
@@ -1,7 +1,7 @@
 import pytest
 import random
 import torch
-from autogluon.text.automm.optimization.utils import get_custom_metric_func
+from autogluon.text.automm.optimization.utils import get_metric
 from torchmetrics import MeanMetric
 from sklearn.metrics import log_loss
 
@@ -22,7 +22,7 @@ def test_cross_entropy(metric_name, class_num):
         preds.append(torch.randn(bs, class_num))
         targets.append(torch.randint(0, class_num, (bs,)))
 
-    custom_metric_func = get_custom_metric_func(metric_name)
+    _, _, custom_metric_func = get_metric(metric_name=metric_name)
     mean_metric = MeanMetric()
 
     for per_pred, per_target in zip(preds, targets):


### PR DESCRIPTION

*This PR is to separate users' provided evaluation metric and the internal validation metric. If a user provides metric `r2`, we will use `rmse` as the internal validation metric since `torchmetrics.R2Score` encounters errors for batch size 1.*

1. Always keep the evaluation metric provided by users. It can be used in `.evaluate()`.
2. Use a separate internal validation metric, which may be different from the provided evaluation metric.
3. Rename the names of evaluation and validation metrics so that their names are both distinguishable and accurate, especially in the context of deep learning.
4. Clean some unused log keys.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
