### PR TITLE
Save the download pretrained model in automm.predictor.save() for offline deployment 

### DIFF
--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -832,7 +832,7 @@ class AutoMMPredictor:
             model = create_and_save_model(
                 config=self._config,
                 num_classes=self._output_shape,
-                save_path=save_path,
+                save_path=path,
                 num_numerical_columns=len(self._df_preprocessor.numerical_feature_names),
                 num_categories=self._df_preprocessor.categorical_num_categories
             )


### PR DESCRIPTION
*Issue #, if available:

https://github.com/awslabs/autogluon/issues/1115#issuecomment-1048434359

*Description of changes:

Add a new flag `save(standalone=True)` in TextPredictor and AutoMMPredictor for offline deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
