### PR TITLE
Fix show_versions on windows

### DIFF
--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -33,9 +33,15 @@ def get_memory_size():
 
 
 def get_available_disk_size():
-    statvfs = os.statvfs(".")
-    available_blocks = statvfs.f_frsize * statvfs.f_bavail
-    return bytes_to_mega_bytes(available_blocks)
+    # FIXME: os.statvfs doesn't work on Windows... 
+    # Need to find another way to calculate disk on Windows.
+    # Return None for now
+    try:
+        statvfs = os.statvfs(".")
+        available_blocks = statvfs.f_frsize * statvfs.f_bavail
+        return bytes_to_mega_bytes(available_blocks)
+    except Exception:
+        return None
 
 
 def get_gpu_count_all():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`os.statvfs` is not available on windows. Return None for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
