### PR TITLE
numpy downgrade - py3.7 is required

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -15,7 +15,8 @@ PYTHON_REQUIRES = '>=3.7, <3.10'
 
 # Only put packages here that would otherwise appear multiple times across different module's setup.py files.
 DEPENDENT_PACKAGES = {
-    'numpy': '>=1.22,<1.23',
+    # note: if python 3.7 is used, the open CVEs are present: CVE-2021-41496 | CVE-2021-34141; fixes are available in 1.22.x, but python 3.8 only
+    'numpy': '>=1.21,<1.23',
     'pandas': '>=1.2.5,<1.4',  # Capped version of pandas to 1.4.0 because of issue: https://github.com/pandas-dev/pandas/issues/45603
     'scikit-learn': '>=1.0.0,<1.1',
     'scipy': '>=1.5.4,<1.8.0',


### PR DESCRIPTION
*Description of changes:*

numpy downgrade - py3.7 is required
open CVEs present, but fixes in 1.22.x is python 3.8 only: CVE-2021-41496 | CVE-2021-34141

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
