### PR TITLE
[PR #1537 Patch 9] Clean AutoMM logs in tutorials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -347,7 +347,7 @@ stage("Build Tutorials") {
         ${setup_torch_gpu}
         export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
         export AG_DOCS=1
-        export AUTOMM_DISABLE_PROGRESS_BAR=1 # Disable progress bar in AutoMMPredictor
+        export AUTOMM_TUTORIAL_MODE=1 # Disable progress bar in AutoMMPredictor
 
         git clean -fx
         bash docs/build_pip_install.sh
@@ -375,7 +375,7 @@ stage("Build Tutorials") {
         ${setup_mxnet_gpu}
         export CUDA_VISIBLE_DEVICES=${VISIBLE_GPU}
         export AG_DOCS=1
-        export AUTOMM_DISABLE_PROGRESS_BAR=1 # Disable progress bar in AutoMMPredictor
+        export AUTOMM_TUTORIAL_MODE=1 # Disable progress bar in AutoMMPredictor
 
         git clean -fx
         bash docs/build_pip_install.sh
@@ -401,7 +401,7 @@ stage("Build Tutorials") {
         conda activate autogluon-tutorial-cloud_fit_deploy-v3
         conda list
         export AG_DOCS=1
-        export AUTOMM_DISABLE_PROGRESS_BAR=1 # Disable progress bar in AutoMMPredictor
+        export AUTOMM_TUTORIAL_MODE=1 # Disable progress bar in AutoMMPredictor
 
         git clean -fx
         bash docs/build_pip_install.sh

--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -64,3 +64,6 @@ CLIP_IMAGE_STD = (0.26862954, 0.26130258, 0.27577711)
 
 # Logger name
 AUTOMM = "automm"
+
+# environment variables
+AUTOMM_TUTORIAL_MODE = "AUTOMM_TUTORIAL_MODE"

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -112,7 +112,7 @@ class AutoMMPredictor:
             problem_type = REGRESSION
 
         if os.environ.get(AUTOMM_TUTORIAL_MODE):
-            verbosity = 3
+            verbosity = 1  # don't use 3, which doesn't suppress logger.info() in .load().
             enable_progress_bar = False
 
         if verbosity is not None:

--- a/text/src/autogluon/text/text_prediction/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor.py
@@ -25,6 +25,7 @@ class TextPredictor:
             backend=PYTORCH,
             verbosity=3,
             warn_if_exist=True,
+            enable_progress_bar: bool = None,
     ):
         """
         Parameters

--- a/text/src/autogluon/text/text_prediction/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor.py
@@ -25,7 +25,6 @@ class TextPredictor:
             backend=PYTORCH,
             verbosity=3,
             warn_if_exist=True,
-            enable_progress_bar: bool = None
     ):
         """
         Parameters
@@ -65,10 +64,6 @@ class TextPredictor:
             where `L` ranges from 0 to 50 (Note: higher values of `L` correspond to fewer print statements, opposite of verbosity levels)
         warn_if_exist : bool, default = True
             Whether to raise warning if the specified path already exists.
-        enable_progress_bar
-            Whether to show progress bar. It will be True by default and will also be disabled
-            if the environment variable os.environ["AUTOMM_DISABLE_PROGRESS_BAR"] is set.
-
         """
         self.verbosity = verbosity
         if backend == PYTORCH:
@@ -88,14 +83,6 @@ class TextPredictor:
             warn_if_exist=warn_if_exist,
         )
         self._backend = backend
-
-        if enable_progress_bar is None:
-            if os.environ.get('AUTOMM_DISABLE_PROGRESS_BAR'):
-                self._enable_progress_bar = False
-            else:
-                self._enable_progress_bar = True
-        else:
-            self._enable_progress_bar = enable_progress_bar
 
     @property
     def results(self):


### PR DESCRIPTION
1. Turned off logging in prediction by default. Users can turn on logging by increasing the verbosity.
2. Used a tutorial mode for whether to disable the progress bar and filter logging info in .load().
3. Removed a redundant progress bar setup in the text predictor.
