### PR TITLE
[Tabular] Fix crash in FastAI

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -128,10 +128,10 @@ class NNFastAiTabularModel(AbstractModel):
             if self.cat_columns:
                 try:
                     X_stats = X[self.cat_columns].describe(include='all').T.reset_index()
-                    cat_cols_to_drop = X_stats[(X_stats['unique'] > self.params.get('max_unique_categorical_values', 10000)) | (X_stats['unique'].isna())]['index'].values
+                    cat_cols_to_drop = list(X_stats[(X_stats['unique'] > self.params.get('max_unique_categorical_values', 10000)) | (X_stats['unique'].isna())]['index'].values)
                 except:
                     cat_cols_to_drop = []
-                if cat_cols_to_drop:
+                if len(cat_cols_to_drop) != 0:
                     cat_cols_to_drop = set(cat_cols_to_drop)
                     self.cat_columns = [col for col in self.cat_columns if (col not in cat_cols_to_drop)]
             num_cat_cols_use = len(self.cat_columns)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes crash in FastAI preprocessing when cat_cols_to_drop is not empty since it would be a numpy array and starting in numpy 1.21 checking `if cat_cols_to_drop` will error.

```
  File "/repo/frameworks/AutoGluon/lib/autogluon/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py", line 134, in _preprocess
    if cat_cols_to_drop:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
