### PR TITLE
Add deprecation warnings for MXNet NN

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/mxnet/tabular_nn_mxnet.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/mxnet/tabular_nn_mxnet.py
@@ -31,6 +31,7 @@ from ..utils.nn_architecture_utils import infer_y_range, get_default_layers, def
 warnings.filterwarnings("ignore", module='sklearn.preprocessing')  # sklearn processing n_quantiles warning
 logger = logging.getLogger(__name__)
 EPS = 1e-10  # small number
+_has_warned_mxnet_deprecation = False
 
 
 # TODO: Gets stuck after infering feature types near infinitely in nyc-jiashenliu-515k-hotel-reviews-data-in-europe dataset, 70 GB of memory, c5.9xlarge
@@ -134,6 +135,13 @@ class TabularNeuralNetMxnetModel(AbstractNeuralNetworkModel):
         try_import_mxnet()
         import mxnet as mx
         self.verbosity = kwargs.get('verbosity', 2)
+        global _has_warned_mxnet_deprecation
+        if not _has_warned_mxnet_deprecation:
+            _has_warned_mxnet_deprecation = True
+            logger.log(30, '\tWARNING: TabularNeuralNetMxnetModel (alias "NN" & "NN_MXNET") has been deprecated in v0.4.0.\n'
+                           '\t\tStarting in v0.5.0, calling TabularNeuralNetMxnetModel will raise an exception.\n'
+                           '\t\tConsider instead using TabularNeuralNetTorchModel via "NN_TORCH".')
+
         if sample_weight is not None:  # TODO: support
             logger.log(15, "sample_weight not yet supported for TabularNeuralNetModel, this model will ignore them in training.")
 

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -157,7 +157,9 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters,
     model_cfg_priority_dict = defaultdict(list)
     model_type_list = list(hp_level.keys())
     if 'NN' in model_type_list:
-        raise ValueError("'NN' model has been deprecated. Please specify 'NN_MXNET' or 'NN_TORCH' in its place (Tabular Neural Networks implemented in different backend frameworks).")
+        # TODO: Remove in v0.5.0
+        logger.log(30, '\tWARNING: "NN" model has been deprecated in v0.4.0 and renamed to "NN_MXNET". '
+                       'Starting in v0.5.0, specifying "NN" or "NN_MXNET" will raise an exception. Consider instead specifying "NN_TORCH".')
     for model_type in model_type_list:
         if problem_type == QUANTILE:
             if model_type not in DEFAULT_QUANTILE_MODEL:
@@ -171,6 +173,9 @@ def get_preset_models(path, problem_type, eval_metric, hyperparameters,
         if not isinstance(models_of_type, list):
             models_of_type = [models_of_type]
         model_cfgs_to_process = []
+        if model_type == 'NN':
+            # TODO: Remove in v0.5.0
+            model_type = 'NN_MXNET'
         for model_cfg in models_of_type:
             if model_type in invalid_type_set:
                 logger.log(20, f"\tFound '{model_type}' model in hyperparameters, but '{model_type}' is present in `excluded_model_types` and will be removed.")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add deprecation warnings for MXNet NN
- Instead of raising exception when user specifies 'NN' in hyperparameters, instead warn and treat as 'NN_MXNET'. This avoids breaking scripts which specify 'NN' in custom hyperparameters dictionaries when upgrading to v0.4.0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
