### PR TITLE
[WIP]Add cheat sheet to website

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -2,6 +2,7 @@ Cheat Sheet
 -----------
 
 .. image:: https://auto.gluon.ai/stable/autogluon-cheat-sheet.jpg
+   :width: 300
 
 Check out the PDF version `Here`_.
 

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -1,0 +1,8 @@
+Cheat Sheet
+-----------
+
+.. image:: https://auto.gluon.ai/stable/autogluon-cheat-sheet.jpg
+
+Check out the PDF version `Here`_.
+
+.. _Here: https://auto.gluon.ai/stable/autogluon-cheat-sheet.pdf

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,6 +98,7 @@ Tutorials
    tutorials/text_prediction/index
    tutorials/tabular_prediction/tabular-multimodal
    tutorials/cloud_fit_deploy/index
+   cheatsheet.rst
    api/autogluon.predictor
    api/autogluon.features
    api/autogluon.tabular.models


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add cheat sheet to our documentation site.
Inserting html directly results in weird format. Use a combination of image and link to pdf instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
