### PR TITLE
Make CLIP support multiple images per sample

### DIFF
--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -1,6 +1,6 @@
 data:
   image:
-    use_zero_img: False  # Whether to use a zero image if an image is missing.
+    use_zero_img: True  # Whether to use a zero image if an image is missing.
   text:
   categorical:
     minimum_cat_count: 100  # The minimum number of occurrences a category must have in the training data to avoid being considered a rare category.

--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -1,6 +1,6 @@
 data:
   image:
-    use_zero_img: True  # Whether to use a zero image if an image is missing.
+    use_zero_img: False  # Whether to use a zero image if an image is missing.
   text:
   categorical:
     minimum_cat_count: 100  # The minimum number of occurrences a category must have in the training data to avoid being considered a rare category.

--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -1,6 +1,6 @@
 data:
   image:
-    use_zero_img: False  # Whether to use a zero image if an image is missing.
+    missing_value_strategy: "skip"  # How to deal with missing images. By default, we skip a sample with missing images.
   text:
   categorical:
     minimum_cat_count: 100  # The minimum number of occurrences a category must have in the training data to avoid being considered a rare category.

--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -1,5 +1,6 @@
 data:
   image:
+    use_zero_img: False  # Whether to use a zero image if an image is missing.
   text:
   categorical:
     minimum_cat_count: 100  # The minimum number of occurrences a category must have in the training data to avoid being considered a rare category.

--- a/text/src/autogluon/text/automm/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/text/src/autogluon/text/automm/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -45,7 +45,7 @@ model:
       - "center_crop"
     image_norm: "imagenet"
     image_size: 224
-    max_img_num_per_col: 3
+    max_img_num_per_col: 2
   clip:
     checkpoint_name: "openai/clip-vit-base-patch32"
     data_types:
@@ -59,7 +59,7 @@ model:
       - "center_crop"
     image_norm: "clip"
     image_size: 224
-    max_img_num_per_col: 0
+    max_img_num_per_col: 2
     tokenizer_name: "clip"
     max_text_len: 77  # The maximum possible length.
     insert_sep: False

--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -67,3 +67,6 @@ AUTOMM = "automm"
 
 # environment variables
 AUTOMM_TUTORIAL_MODE = "AUTOMM_TUTORIAL_MODE"
+
+# error try
+GET_ITEM_ERROR_RETRY = 50

--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -67,6 +67,3 @@ AUTOMM = "automm"
 
 # environment variables
 AUTOMM_TUTORIAL_MODE = "AUTOMM_TUTORIAL_MODE"
-
-# error try
-GET_ITEM_ERROR_RETRY = 50

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -1,11 +1,6 @@
-import logging
 import torch
 import pandas as pd
 from .preprocess_dataframe import MultiModalFeaturePreprocessor
-from ..constants import (
-    GET_ITEM_ERROR_RETRY, AUTOMM
-)
-logger = logging.getLogger(AUTOMM)
 
 
 class BaseDataset(torch.utils.data.Dataset):
@@ -40,7 +35,6 @@ class BaseDataset(torch.utils.data.Dataset):
         super().__init__()
         self.processors = processors
         self.is_training = is_training
-        self._consecutive_errors = 0
 
         self.lengths = []
         for per_modality, per_modality_processors in processors.items():
@@ -75,17 +69,8 @@ class BaseDataset(torch.utils.data.Dataset):
         Input data formatted as a dictionary.
         """
         ret = dict()
-        try:  # TODO: consider handling image exceptions within the process_image.py.
-            # TODO: If no images are open, then throw an exception to be captured here.
-            for per_modality, per_modality_processors in self.processors.items():
-                for per_model_processor in per_modality_processors:
-                    ret.update(per_model_processor(getattr(self, per_modality), idx, self.is_training))
-        except Exception as e:
-            logger.debug(f"Skipping sample {idx} due to '{e}'")
-            self._consecutive_errors += 1
-            if self._consecutive_errors < GET_ITEM_ERROR_RETRY:
-                return self.__getitem__((idx + 1) % self.__len__())
-            else:
-                raise e
-        self._consecutive_errors = 0
+        for per_modality, per_modality_processors in self.processors.items():
+            for per_model_processor in per_modality_processors:
+                ret.update(per_model_processor(getattr(self, per_modality), idx, self.is_training))
+
         return ret

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -81,7 +81,7 @@ class BaseDataset(torch.utils.data.Dataset):
                 for per_model_processor in per_modality_processors:
                     ret.update(per_model_processor(getattr(self, per_modality), idx, self.is_training))
         except Exception as e:
-            logger.warning(f"Skipping sample {idx} due to '{e}'")
+            logger.debug(f"Skipping sample {idx} due to '{e}'")
             if self._consecutive_errors < GET_ITEM_ERROR_RETRY:
                 return self.__getitem__((idx + 1) % self.__len__())
             else:

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -1,6 +1,11 @@
+import logging
 import torch
 import pandas as pd
 from .preprocess_dataframe import MultiModalFeaturePreprocessor
+from ..constants import (
+    GET_ITEM_ERROR_RETRY, AUTOMM
+)
+logger = logging.getLogger(AUTOMM)
 
 
 class BaseDataset(torch.utils.data.Dataset):
@@ -35,6 +40,7 @@ class BaseDataset(torch.utils.data.Dataset):
         super().__init__()
         self.processors = processors
         self.is_training = is_training
+        self._consecutive_errors = 0
 
         self.lengths = []
         for per_modality, per_modality_processors in processors.items():
@@ -69,8 +75,16 @@ class BaseDataset(torch.utils.data.Dataset):
         Input data formatted as a dictionary.
         """
         ret = dict()
-        for per_modality, per_modality_processors in self.processors.items():
-            for per_model_processor in per_modality_processors:
-                ret.update(per_model_processor(getattr(self, per_modality), idx, self.is_training))
-
+        try:
+            for per_modality, per_modality_processors in self.processors.items():
+                for per_model_processor in per_modality_processors:
+                    ret.update(per_model_processor(getattr(self, per_modality), idx, self.is_training))
+        except Exception as e:  # to capture the image opening exception if use_zero_img=False in process_image.py.
+            logger.debug(f"Skipping sample {idx} due to '{e}'")
+            self._consecutive_errors += 1
+            if self._consecutive_errors < GET_ITEM_ERROR_RETRY:
+                return self.__getitem__((idx + 1) % self.__len__())
+            else:
+                raise e
+        self._consecutive_errors = 0
         return ret

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -82,6 +82,7 @@ class BaseDataset(torch.utils.data.Dataset):
                     ret.update(per_model_processor(getattr(self, per_modality), idx, self.is_training))
         except Exception as e:
             logger.debug(f"Skipping sample {idx} due to '{e}'")
+            self._consecutive_errors += 1
             if self._consecutive_errors < GET_ITEM_ERROR_RETRY:
                 return self.__getitem__((idx + 1) % self.__len__())
             else:

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -44,10 +44,9 @@ class BaseDataset(torch.utils.data.Dataset):
 
         self.lengths = []
         for per_modality, per_modality_processors in processors.items():
-            if len(per_modality_processors) > 0:
-                per_modality_features = getattr(preprocessor, f"transform_{per_modality}")(data)
-                setattr(self, f"{per_modality}", per_modality_features)
-                self.lengths.append(len(per_modality_features[0]))
+            per_modality_features = getattr(preprocessor, f"transform_{per_modality}")(data)
+            setattr(self, f"{per_modality}", per_modality_features)
+            self.lengths.append(len(per_modality_features[0]))
         assert len(set(self.lengths)) == 1
 
     def __len__(self):

--- a/text/src/autogluon/text/automm/data/infer_types.py
+++ b/text/src/autogluon/text/automm/data/infer_types.py
@@ -1,6 +1,5 @@
 import collections
 import pandas as pd
-from pandas.api.types import is_string_dtype
 import warnings
 import PIL
 from typing import Union, Optional, List, Dict, Tuple

--- a/text/src/autogluon/text/automm/data/preprocess_dataframe.py
+++ b/text/src/autogluon/text/automm/data/preprocess_dataframe.py
@@ -16,9 +16,12 @@ from sklearn.base import (
     TransformerMixin,
     BaseEstimator,
 )
-from ..constants import CATEGORICAL, NUMERICAL, TEXT, IMAGE_PATH, NULL
+from ..constants import (
+    CATEGORICAL, NUMERICAL, TEXT,
+    IMAGE_PATH, NULL, AUTOMM
+)
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(AUTOMM)
 
 
 class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):

--- a/text/src/autogluon/text/automm/data/process_image.py
+++ b/text/src/autogluon/text/automm/data/process_image.py
@@ -36,7 +36,7 @@ class ImageProcessor:
             norm_type: Optional[str] = None,
             size: Optional[int] = None,
             max_img_num_per_col: Optional[int] = 1,
-            use_zero_img: Optional[bool] = False,
+            missing_value_strategy: Optional[str] = False,
     ):
         """
         Parameters
@@ -63,15 +63,19 @@ class ImageProcessor:
             The width / height of a square image.
         max_img_num_per_col
             The maximum number of images one sample can have.
-        use_zero_img
-            Whether to use a zero image if an image is missing.
+        missing_value_strategy
+            How to deal with a missing image. We now support:
+            - skip
+                Skip this sample
+            -zero
+                Use an image with zero pixels.
         """
         self.prefix = prefix
         self.train_transform_types = train_transform_types
         self.val_transform_types = val_transform_types
         logger.debug(f"image training transform type: {train_transform_types}")
         logger.debug(f"image validation transform type: {val_transform_types}")
-        self.use_zero_img = use_zero_img
+        self.missing_value_strategy = missing_value_strategy
         self.size = None
         self.mean = None
         self.std = None
@@ -267,7 +271,7 @@ class ImageProcessor:
                     try:
                         img = PIL.Image.open(img_path).convert("RGB")
                     except Exception as e:
-                        if self.use_zero_img:
+                        if self.missing_value_strategy.lower() == "zero":
                             logger.debug(f"Using a zero image due to '{e}'")
                             img = PIL.Image.new("RGB", (self.size, self.size), color=0)
                             is_zero_img = True

--- a/text/src/autogluon/text/automm/data/process_text.py
+++ b/text/src/autogluon/text/automm/data/process_text.py
@@ -15,11 +15,12 @@ from ..constants import (
     TEXT_TOKEN_IDS,
     TEXT_VALID_LENGTH,
     TEXT_SEGMENT_IDS,
+    AUTOMM,
 )
 from .collator import Stack, Pad
 from .utils import extract_value_from_config
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(AUTOMM)
 
 # Disable tokenizer parallelism
 os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/text/src/autogluon/text/automm/models/timm_image.py
+++ b/text/src/autogluon/text/automm/models/timm_image.py
@@ -84,7 +84,7 @@ class TimmAutoModelForImagePrediction(nn.Module):
             logits = self.head(features)
 
         elif self.mix_choice == "all_logits":  # mix outputs
-            b, n, c, h, w = images.shape  # n <= max_img_num_per_col
+            b, n, c, h, w = images.shape
             features = self.model(images.reshape((b * n, c, h, w)))  # (b*n, num_features)
             logits = self.head(features)
             steps = torch.arange(0, n).type_as(image_valid_num)

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -746,7 +746,7 @@ class AutoMMPredictor:
                 )
             score = compute_score(
                 metric_data=metric_data,
-                metric_name=per_metric,
+                metric_name=per_metric.lower(),
             )
             results[per_metric] = score
 

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -341,6 +341,9 @@ class AutoMMPredictor:
         else:  # continuing training
             data_processors = self._data_processors
 
+        data_processors_count = {k: len(v) for k, v in data_processors.items()}
+        logger.debug(f"data_processors_count: {data_processors_count}")
+
         if self._model is None:
             model = create_model(
                 config=config,
@@ -596,7 +599,6 @@ class AutoMMPredictor:
         # For prediction data with no labels provided.
         if not requires_label:
             data_processors.pop(LABEL, None)
-        logger.debug(f"data_processors for prediction: {data_processors.keys()}")
 
         num_gpus = (
             self._config.env.num_gpus

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -375,7 +375,7 @@ def init_data_processors(
                         norm_type=model_config.image_norm,
                         size=model_config.image_size,
                         max_img_num_per_col=model_config.max_img_num_per_col,
-                        use_zero_img=config.data.image.use_zero_img,
+                        missing_value_strategy=config.data.image.missing_value_strategy,
                     )
                 )
             elif d_type == TEXT:


### PR DESCRIPTION
1. Added multiple images support for CLIP.
2. Made the data loader more robust by handling exceptions in loading one sample. Previously, failure of opening missing images could crash training.
3. Added the choice of using a zero image if an image is missing.
4. Improved init_data_processors. Modalities with empty data processors are dropped.
5. Set to use the default AutoMM logger in preprocess_dataframe.py, process_image.py, and process_text.py.
6. Converted metric names to lower case before calling the metric function.
