### PR TITLE
Fix pip install of standalone Text module

### DIFF
--- a/docs/whats_new/v0.4.1.md
+++ b/docs/whats_new/v0.4.1.md
@@ -1,0 +1,9 @@
+# Version 0.4.1
+
+TODO: Add description
+
+This version supports Python versions 3.7 to 3.9.
+
+# Changes
+
+- Fix `pip install autogluon.text` not working without also `pip install autogluon.features` in v0.4. @Innixma

--- a/text/setup.py
+++ b/text/setup.py
@@ -36,6 +36,7 @@ install_requires = [
     'omegaconf>=2.1.1,<2.2.0',
     'sentencepiece>=0.1.95,<0.2.0',
     f'autogluon.core=={version}',
+    f'autogluon.features=={version}',
     f'autogluon.common=={version}',
     'autogluon-contrib-nlp==0.0.1b20220208',
 ]


### PR DESCRIPTION
*Issue #, if available:*
#1607 

*Description of changes:*

- Fixes error if user tries the following in v0.4:

```
pip install autogluon.text
```

```
import autogluon.text
```

This is because `autogluon.text` is missing dependency `autogluon.features` in setup.py.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
