### PR TITLE
Fix evaluate when weight_evaluation=True

### DIFF
--- a/tabular/tests/conftest.py
+++ b/tabular/tests/conftest.py
@@ -122,7 +122,10 @@ class FitHelper:
         if sample_size is not None and sample_size < len(test_data):
             test_data = test_data.sample(n=sample_size, random_state=0)
         predictor.predict(test_data)
-        predictor.predict_proba(test_data)
+        pred_proba = predictor.predict_proba(test_data)
+        predictor.evaluate(test_data)
+        predictor.evaluate_predictions(y_true=test_data[label], y_pred=pred_proba)
+
         model_names = predictor.get_model_names()
         model_name = model_names[0]
         assert len(model_names) == 2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix evaluate when weight_evaluation=True
- Previously, AutoGluon would crash if the user specified `predictor.evaluate(...)` or `predictor.evaluate_predictions(...)` when `self.weight_evaluation==True`, this fixes this so it works properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
