### PR TITLE
[WIP][security] Updated pillow to 9.0.1+

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -23,7 +23,7 @@ DEPENDENT_PACKAGES = {
     'psutil': '>=5.7.3,<5.9',  # TODO: Consider capping to <6.0 instead, capping to 5.9 to avoid possible issues.
     'gluoncv': '>=0.10.5,<0.10.6',
     'tqdm': '>=4.38.0',
-    'Pillow': '>=9.0.0,<9.1.0',
+    'Pillow': '>=9.0.1,<9.1.0',
     'timm': '>=0.5.4,<0.6.0',
 }
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}


### PR DESCRIPTION
*Description of changes:*
Pillow security patching.

```
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| pillow                     | 9.0.0     | <9.0.1                   | 44487    |
+==============================================================================+
| Pillow 9.0.1 includes a fix for CVE-2022-22817: PIL.ImageMath.eval in Pillow |
| before 9.0.0 allows evaluation of arbitrary expressions, such as ones that   |
| use the Python exec method. A first patch was issued for version 9.0.0 but   |
| it did not prevent builtins available to lambda expressions.                 |
| https://pillow.readthedocs.io/en/stable/releasenotes/9.0.1.html#security     |
+==============================================================================+
| pillow                     | 9.0.0     | <9.0.1                   | 45356    |
+==============================================================================+
| Pillow 9.0.1 includes a fix for CVE-2022-24303: If the path to the temporary |
| directory on Linux or macOS contained a space, this would break removal of   |
| the temporary image file after im.show() (and related actions), and          |
| potentially remove an unrelated file. This been present since PIL.           |
+==============================================================================+
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
