### PR TITLE
Add get_results, add model_base_kwargs

### DIFF
--- a/core/src/autogluon/core/searcher/local_searcher.py
+++ b/core/src/autogluon/core/searcher/local_searcher.py
@@ -124,6 +124,24 @@ class LocalSearcher(object):
         else:
             return dict()
 
+    def get_results(self, sort=True) -> list:
+        """
+        Gets a list of results in the form (config, reward).
+
+        Parameters
+        ----------
+        sort : bool, default = True
+            If True, sorts the configs in order from best to worst reward.
+            If False, config order is undefined.
+        """
+        results = []
+        for config_pkl, reward in self._results.items():
+            config = self._unpickle_config(config_pkl=config_pkl)
+            results.append((config, reward))
+        if sort:
+            results = sorted(results, key=lambda x: x[1], reverse=True)
+        return results
+
     def _get_params_static(self) -> dict:
         """
         Gets a dictionary of static key values, where no search space is used and therefore the values are always the same in all configs.

--- a/core/tests/unittests/searcher/test_local_searcher.py
+++ b/core/tests/unittests/searcher/test_local_searcher.py
@@ -25,14 +25,19 @@ class TestLocalSearcher(unittest.TestCase):
         assert searcher.get_best_reward() == 0.2
         assert searcher.get_best_config() == config1
 
+        assert searcher.get_results() == [({'param1': 'hello', 7: 42}, 0.2)]
+
         searcher.update(config1, reward=0.1)
         assert searcher.get_best_reward() == 0.1
         assert searcher.get_best_config() == config1
+
+        assert searcher.get_results() == [({'param1': 'hello', 7: 42}, 0.1)]
 
         searcher.update(config2, reward=0.7)
         assert searcher.get_best_reward() == 0.7
         assert searcher.get_best_config() == config2
 
+        assert searcher.get_results() == [({'param1': 'world', 7: 42}, 0.7), ({'param1': 'hello', 7: 42}, 0.1)]
         assert len(searcher._results) == 2
         # This config is technically invalid, but for performance reasons is allowed to avoid having to pickle compare static parameters.
         # Since the static parameter should be fixed, this config is treated as being equivalent to config2
@@ -47,6 +52,7 @@ class TestLocalSearcher(unittest.TestCase):
         self.assertRaises(AssertionError, searcher.update, config_invalid_7, reward=0)
         self.assertRaises(AssertionError, searcher.update, config1, reward='invalid_reward')
         assert len(searcher._results) == 2
+        assert searcher.get_results() == [({'param1': 'hello', 7: 42}, 0.1), ({'param1': 'world', 7: 42}, 0)]
 
     def test_local_searcher_pickle(self):
         search_space = {1: Categorical(1, 2), 2: Categorical(1, 2)}

--- a/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
+++ b/tabular/src/autogluon/tabular/trainer/model_presets/presets.py
@@ -320,8 +320,14 @@ def model_factory(
     model_params = copy.deepcopy(model)
     model_params.pop(AG_ARGS, None)
     model_params.pop(AG_ARGS_ENSEMBLE, None)
-    model_init = model_type(path=path, name=name, problem_type=problem_type, eval_metric=eval_metric,
-                            hyperparameters=model_params)
+
+    model_init_kwargs = dict(
+        path=path,
+        name=name,
+        problem_type=problem_type,
+        eval_metric=eval_metric,
+        hyperparameters=model_params,
+    )
 
     if ensemble_kwargs is not None:
         ensemble_kwargs_model = copy.deepcopy(ensemble_kwargs)
@@ -330,8 +336,10 @@ def model_factory(
         if ensemble_kwargs_model['hyperparameters'] is None:
             ensemble_kwargs_model['hyperparameters'] = {}
         ensemble_kwargs_model['hyperparameters'].update(extra_ensemble_hyperparameters)
-        model_init = ensemble_type(path=path, name=name_stacker, model_base=model_init,
+        model_init = ensemble_type(path=path, name=name_stacker, model_base=model_type, model_base_kwargs=model_init_kwargs,
                                    **ensemble_kwargs_model)
+    else:
+        model_init = model_type(**model_init_kwargs)
 
     return model_init
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added get_results to searchers, useful for debugging and for future extensions to HPO functionality.
- Added new way to init a BaggedEnsembleModel that avoids having to init the base model prior to initing the bagged ensemble model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
