### PR TITLE
Unify AutoMM's model output format and support customizing model names

### DIFF
--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -76,14 +76,10 @@ UNION_SOUP = 'union_soup'
 GREEDY_SOUP = 'greedy_soup'
 BEST_SOUP = 'best_soup'
 
-# registered model keys
+# registered model keys. TODO: document how to add new models.
 CLIP = "clip"
 TIMM_IMAGE = "timm_image"
 HF_TEXT = "hf_text"
 NUMERICAL_MLP = "numerical_mlp"
 CATEGORICAL_MLP = "categorical_mlp"
 FUSION_MLP = "fusion_mlp"
-AVAILABLE_MODELS = [
-    CLIP, TIMM_IMAGE, HF_TEXT, NUMERICAL_MLP,
-    CATEGORICAL_MLP, FUSION_MLP,
-]

--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -75,3 +75,15 @@ GET_ITEM_ERROR_RETRY = 50
 UNION_SOUP = 'union_soup'
 GREEDY_SOUP = 'greedy_soup'
 BEST_SOUP = 'best_soup'
+
+# registered model keys
+CLIP = "clip"
+TIMM_IMAGE = "timm_image"
+HF_TEXT = "hf_text"
+NUMERICAL_MLP = "numerical_mlp"
+CATEGORICAL_MLP = "categorical_mlp"
+FUSION_MLP = "fusion_mlp"
+AVAILABLE_MODELS = [
+    CLIP, TIMM_IMAGE, HF_TEXT, NUMERICAL_MLP,
+    CATEGORICAL_MLP, FUSION_MLP,
+]

--- a/text/src/autogluon/text/automm/models/categorical_mlp.py
+++ b/text/src/autogluon/text/automm/models/categorical_mlp.py
@@ -93,6 +93,7 @@ class CategoricalMLP(nn.Module):
         # init weights
         self.apply(init_weights)
 
+        self.prefix = prefix
         self.categorical_key = f"{prefix}_{CATEGORICAL}"
         self.label_key = f"{prefix}_{LABEL}"
 
@@ -123,8 +124,10 @@ class CategoricalMLP(nn.Module):
         features = self.aggregator_mlp(cat_features)
         logits = self.head(features)
         return {
-            LOGITS: logits,
-            FEATURES: features,
+            self.prefix: {
+                LOGITS: logits,
+                FEATURES: features,
+            }
         }
 
     def get_layer_ids(self,):

--- a/text/src/autogluon/text/automm/models/clip.py
+++ b/text/src/autogluon/text/automm/models/clip.py
@@ -45,6 +45,7 @@ class CLIPForImageText(nn.Module):
         self.head = nn.Linear(self.out_features, num_classes) if num_classes > 0 else nn.Identity()
         self.head.apply(init_weights)
 
+        self.prefix = prefix
         self.text_token_ids_key = f"{prefix}_{TEXT_TOKEN_IDS}"
         self.text_valid_length_key = f"{prefix}_{TEXT_VALID_LENGTH}"
         self.image_key = f"{prefix}_{IMAGE}"
@@ -97,8 +98,10 @@ class CLIPForImageText(nn.Module):
         logits = self.head(features)
 
         return {
-            LOGITS: logits,
-            FEATURES: features,
+            self.prefix: {
+                LOGITS: logits,
+                FEATURES: features,
+            }
         }
 
     def get_layer_ids(self,):

--- a/text/src/autogluon/text/automm/models/huggingface_text.py
+++ b/text/src/autogluon/text/automm/models/huggingface_text.py
@@ -58,6 +58,7 @@ class HFAutoModelForTextPrediction(nn.Module):
         self.head = nn.Linear(self.out_features, num_classes) if num_classes > 0 else nn.Identity()
         self.head.apply(init_weights)
 
+        self.prefix = prefix
         self.text_token_ids_key = f"{prefix}_{TEXT_TOKEN_IDS}"
         self.text_segment_ids_key = f"{prefix}_{TEXT_SEGMENT_IDS}"
         self.text_valid_length_key = f"{prefix}_{TEXT_VALID_LENGTH}"
@@ -107,8 +108,10 @@ class HFAutoModelForTextPrediction(nn.Module):
         logits = self.head(cls_features)
 
         return {
-            LOGITS: logits,
-            FEATURES: cls_features,
+            self.prefix: {
+                LOGITS: logits,
+                FEATURES: cls_features,
+            }
         }
 
     def get_layer_ids(self):

--- a/text/src/autogluon/text/automm/models/numerical_mlp.py
+++ b/text/src/autogluon/text/automm/models/numerical_mlp.py
@@ -61,6 +61,7 @@ class NumericalMLP(nn.Module):
         # init weights
         self.apply(init_weights)
 
+        self.prefix = prefix
         self.numerical_key = f"{prefix}_{NUMERICAL}"
         self.label_key = f"{prefix}_{LABEL}"
 
@@ -87,8 +88,10 @@ class NumericalMLP(nn.Module):
         logits = self.head(features)
 
         return {
-            LOGITS: logits,
-            FEATURES: features,
+            self.prefix: {
+                LOGITS: logits,
+                FEATURES: features,
+            }
         }
 
     def get_layer_ids(self,):

--- a/text/src/autogluon/text/automm/models/timm_image.py
+++ b/text/src/autogluon/text/automm/models/timm_image.py
@@ -57,6 +57,7 @@ class TimmAutoModelForImagePrediction(nn.Module):
         self.mix_choice = mix_choice
         logger.debug(f"mix_choice: {mix_choice}")
 
+        self.prefix = prefix
         self.image_key = f"{prefix}_{IMAGE}"
         self.image_valid_num_key = f"{prefix}_{IMAGE_VALID_NUM}"
         self.label_key = f"{prefix}_{LABEL}"
@@ -101,8 +102,10 @@ class TimmAutoModelForImagePrediction(nn.Module):
             raise ValueError(f"unknown mix_choice: {self.mix_choice}")
 
         return {
-            LOGITS: logits,
-            FEATURES: features,
+            self.prefix: {
+                LOGITS: logits,
+                FEATURES: features,
+            }
         }
 
     def get_layer_ids(self,):

--- a/text/src/autogluon/text/automm/optimization/lit_module.py
+++ b/text/src/autogluon/text/automm/optimization/lit_module.py
@@ -112,7 +112,7 @@ class LitModule(pl.LightningModule):
 
     def _compute_loss(
             self,
-            output: dict,
+            output: Dict,
             label: torch.Tensor,
     ):
         loss = 0
@@ -139,7 +139,7 @@ class LitModule(pl.LightningModule):
 
     def _shared_step(
             self,
-            batch: dict,
+            batch: Dict,
     ):
         output = self.model(batch)
         label = batch[self.model.label_key]

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -186,7 +186,6 @@ def get_config(
         overrides.pop("model.names", None)
         # apply all the overrides
         config = apply_omegaconf_overrides(config, overrides=overrides, check_key_exist=True)
-        print(f"names at the end of get_config: {config.model.names}")
     return config
 
 
@@ -257,7 +256,6 @@ def customize_config_names(
             name=per_name,
             prefixes=available_prefixes,
         )
-        print(f"per_name: {per_name}, per_prefix: {per_prefix}")
         if per_prefix:
             per_config = getattr(config, per_prefix)
             setattr(new_config, per_name, copy.deepcopy(per_config))
@@ -314,7 +312,6 @@ def select_model(
         names = [names]
     selected_model_names = []
     fusion_model_name = []
-    print(f"names at the beginning of select_model: {config.model.names}")
     for model_name in names:
         model_config = getattr(config.model, model_name)
         if model_config.data_types is None:

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -176,6 +176,8 @@ def get_config(
     verify_config_names(config.model)
     logger.debug(f"overrides: {overrides}")
     if overrides is not None:
+        # avoid manipulating user-provided overrides
+        overrides = copy.deepcopy(overrides)
         # apply customized model names
         overrides = parse_dotlist_conf(overrides)  # convert to a dict
         config.model = customize_config_names(

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -358,16 +358,20 @@ def select_model(
         else:
             delattr(config.model, model_name)
 
+    if len(selected_model_names) == 0:
+        raise ValueError("No model is available for this dataset.")
     # only allow no more than 1 fusion model
     assert len(fusion_model_name) <= 1
     if len(selected_model_names) > 1:
         assert len(fusion_model_name) == 1
         selected_model_names.extend(fusion_model_name)
+    else:  # remove the fusion model's config make `config.model.names` and the keys of `config.model` consistent.
+        if len(fusion_model_name) == 1 and hasattr(config.model, fusion_model_name[0]):
+            delattr(config.model, fusion_model_name[0])
 
     config.model.names = selected_model_names
     logger.debug(f"selected models: {selected_model_names}")
-    if len(selected_model_names) == 0:
-        raise ValueError("No model is available for this dataset.")
+
     return config
 
 

--- a/text/tests/unittests/automm/test_automm_predictor.py
+++ b/text/tests/unittests/automm/test_automm_predictor.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import numpy.testing as npt
 import tempfile
+import copy
 
 from autogluon.text.automm import AutoMMPredictor
 from autogluon.text.automm.constants import (
@@ -318,7 +319,7 @@ def test_customizing_model_names(
         }
     )
     save_path = os.path.join(get_home_dir(), "outputs", "petfinder")
-
+    backup_hyperparameters = copy.deepcopy(hyperparameters)
     predictor.fit(
         train_data=dataset.train_df,
         config=config,
@@ -326,8 +327,8 @@ def test_customizing_model_names(
         time_limit=10,
         save_path=save_path,
     )
-    assert sorted(predictor._config.model.names) == sorted(hyperparameters["model.names"])
-    for per_name in hyperparameters["model.names"]:
+    assert sorted(predictor._config.model.names) == sorted(backup_hyperparameters["model.names"])
+    for per_name in backup_hyperparameters["model.names"]:
         assert hasattr(predictor._config.model, per_name)
 
     score = predictor.evaluate(dataset.test_df)

--- a/text/tests/unittests/automm/test_automm_predictor.py
+++ b/text/tests/unittests/automm/test_automm_predictor.py
@@ -281,8 +281,8 @@ def test_standalone(): # test standalong feature in AutoMMPredictor.save()
         },
 
         {
-            "model.names": ["hf_text_abc", "hf_text", "hf_text_xyz", "fusion_mlp_123"],
-            "model.hf_text.checkpoint_name": "monsoon-nlp/hindi-bert",
+            "model.names": ["hf_text_abc", "hf_text_def", "hf_text_xyz", "fusion_mlp_123"],
+            "model.hf_text_def.checkpoint_name": "monsoon-nlp/hindi-bert",
             "model.hf_text_xyz.checkpoint_name": "prajjwal1/bert-tiny",
             "model.hf_text_abc.checkpoint_name": "roberta-base",
         },
@@ -319,16 +319,15 @@ def test_customizing_model_names(
         }
     )
     save_path = os.path.join(get_home_dir(), "outputs", "petfinder")
-    backup_hyperparameters = copy.deepcopy(hyperparameters)
     predictor.fit(
         train_data=dataset.train_df,
         config=config,
-        hyperparameters=hyperparameters,
+        hyperparameters=copy.deepcopy(hyperparameters),
         time_limit=10,
         save_path=save_path,
     )
-    assert sorted(predictor._config.model.names) == sorted(backup_hyperparameters["model.names"])
-    for per_name in backup_hyperparameters["model.names"]:
+    assert sorted(predictor._config.model.names) == sorted(hyperparameters["model.names"])
+    for per_name in hyperparameters["model.names"]:
         assert hasattr(predictor._config.model, per_name)
 
     score = predictor.evaluate(dataset.test_df)
@@ -338,9 +337,12 @@ def test_customizing_model_names(
     predictor.fit(
         train_data=dataset.train_df,
         config=config,
-        hyperparameters=hyperparameters,
+        hyperparameters=copy.deepcopy(hyperparameters),
         time_limit=10,
     )
+    assert sorted(predictor._config.model.names) == sorted(hyperparameters["model.names"])
+    for per_name in hyperparameters["model.names"]:
+        assert hasattr(predictor._config.model, per_name)
     verify_predictor_save_load(predictor, dataset.test_df)
 
     # Saving to folder, loading the saved model and call fit again (continuous fit)
@@ -350,6 +352,9 @@ def test_customizing_model_names(
         predictor.fit(
             train_data=dataset.train_df,
             config=config,
-            hyperparameters=hyperparameters,
+            hyperparameters=copy.deepcopy(hyperparameters),
             time_limit=10,
         )
+        assert sorted(predictor._config.model.names) == sorted(hyperparameters["model.names"])
+        for per_name in hyperparameters["model.names"]:
+            assert hasattr(predictor._config.model, per_name)

--- a/text/tests/unittests/automm/test_automm_predictor.py
+++ b/text/tests/unittests/automm/test_automm_predictor.py
@@ -322,7 +322,7 @@ def test_customizing_model_names(
     predictor.fit(
         train_data=dataset.train_df,
         config=config,
-        hyperparameters=copy.deepcopy(hyperparameters),
+        hyperparameters=hyperparameters,
         time_limit=10,
         save_path=save_path,
     )
@@ -337,7 +337,7 @@ def test_customizing_model_names(
     predictor.fit(
         train_data=dataset.train_df,
         config=config,
-        hyperparameters=copy.deepcopy(hyperparameters),
+        hyperparameters=hyperparameters,
         time_limit=10,
     )
     assert sorted(predictor._config.model.names) == sorted(hyperparameters["model.names"])
@@ -352,7 +352,7 @@ def test_customizing_model_names(
         predictor.fit(
             train_data=dataset.train_df,
             config=config,
-            hyperparameters=copy.deepcopy(hyperparameters),
+            hyperparameters=hyperparameters,
             time_limit=10,
         )
         assert sorted(predictor._config.model.names) == sorted(hyperparameters["model.names"])


### PR DESCRIPTION
1. Now each model's output is dictionary with the model prefix as the first level key. The format is uniform between single model and fusion model.
2. Now users can customize model names by using the internal registered names (`timm_image`, `hf_text`, `clip`, `numerical_mlp`, `categorical_mlp`, and `fusion_mlp`) as prefixes. This is helpful when users want to simultaneously use two models of the same type, e.g., `hf_text`. They can just use names `hf_text_0` and `hf_text_1`.
