### PR TITLE
Support saving with standalone in TextPredictor

### DIFF
--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -639,9 +639,16 @@ def save_pretrained_configs(
     path
         The saving path to the pretained weights i.e. config.json for "clip" and "hf_text"
     '''
-    for idx, model_name in enumerate(config.model.names):
+    if len(config.model.names) > 1:
+        for idx, model_name in enumerate(config.model.names):
+            if model_name.lower().startswith((CLIP, HF_TEXT)):
+                model[idx].model.save_pretrained(os.path.join(path, model_name))
+                model_config = getattr(config.model, model_name)
+                model_config.checkpoint_name = os.path.join('local://', model_name)
+    else:
+        model_name = config.model.names[0]
         if model_name.lower().startswith((CLIP, HF_TEXT)):
-            model[idx].model.save_pretrained(os.path.join(path, model_name))
+            model.save_pretrained(os.path.join(path, model_name))
             model_config = getattr(config.model, model_name)
             model_config.checkpoint_name = os.path.join('local://', model_name)
     return config

--- a/text/src/autogluon/text/text_prediction/mx_predictor.py
+++ b/text/src/autogluon/text/text_prediction/mx_predictor.py
@@ -518,7 +518,7 @@ class MXTextPredictor:
             output = pd.DataFrame(output, index=index)
         return output
 
-    def save(self, path):
+    def save(self, path, standalone = False):
         """
         Save this Predictor to file in directory specified by `path`.
         The relevant files will be saved in two parts:

--- a/text/src/autogluon/text/text_prediction/mx_predictor.py
+++ b/text/src/autogluon/text/text_prediction/mx_predictor.py
@@ -537,6 +537,7 @@ class MXTextPredictor:
         """
         assert self._model is not None, 'Model does not seem to have been constructed.' \
                                         ' Have you called fit(), or load()?'
+        if standalone: logger.info('Standalone=True only works for backen=pytorch, and does nothing with backen=mxnet.')
         os.makedirs(path, exist_ok=True)
         with open(os.path.join(path, 'text_predictor_assets.json'), 'w') as of:
             json.dump({'backend': self._backend,

--- a/text/src/autogluon/text/text_prediction/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor.py
@@ -376,8 +376,8 @@ class TextPredictor:
             The path to directory in which to save this Predictor.
         standalone: bool, default = False
             Whether to save the downloaded model for offline deployment. 
-            When `standalone = True`, save the transformers.CLIPModel and transformers.AutoModel to os.path.join(path,model_name).
-            See `AutoMMPredictor.save()` for more detials. 
+            If `standalone = True`, save the transformers.CLIPModel and transformers.AutoModel to os.path.join(path,model_name).
+            Also, see `AutoMMPredictor.save()` for more detials. 
             Note that `standalone = True` only works for `backen = pytorch` and does noting in `backen = mxnet`.
         """
 

--- a/text/src/autogluon/text/text_prediction/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor.py
@@ -372,13 +372,13 @@ class TextPredictor:
 
         Parameters
         ----------
-        path, str
+        path: str
             The path to directory in which to save this Predictor.
-        standalone, bool
+        standalone: bool, default = False
             Whether to save the downloaded model for offline deployment. 
             When `standalone = True`, save the transformers.CLIPModel and transformers.AutoModel to os.path.join(path,model_name).
             See `AutoMMPredictor.save()` for more detials. 
-            Note that this only works for `backen = pytorch`.
+            Note that `standalone = True` only works for `backen = pytorch` and does noting in `backen = mxnet`.
         """
 
         self._predictor.save(path=path,standalone=standalone)

--- a/text/src/autogluon/text/text_prediction/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor.py
@@ -358,7 +358,7 @@ class TextPredictor:
             as_pandas=as_pandas,
         )
 
-    def save(self, path, standalone = False):
+    def save(self, path, standalone=False):
         """
         Save this Predictor to file in directory specified by `path`.
         The relevant files will be saved in two parts:
@@ -374,6 +374,11 @@ class TextPredictor:
         ----------
         path, str
             The path to directory in which to save this Predictor.
+        standalone, bool
+            Whether to save the downloaded model for offline deployment. 
+            When `standalone = True`, save the transformers.CLIPModel and transformers.AutoModel to os.path.join(path,model_name).
+            See `AutoMMPredictor.save()` for more detials. 
+            Note that this only works for `backen = pytorch`.
         """
 
         self._predictor.save(path=path,standalone=standalone)

--- a/text/src/autogluon/text/text_prediction/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor.py
@@ -358,7 +358,7 @@ class TextPredictor:
             as_pandas=as_pandas,
         )
 
-    def save(self, path):
+    def save(self, path, standalone = False):
         """
         Save this Predictor to file in directory specified by `path`.
         The relevant files will be saved in two parts:
@@ -376,7 +376,7 @@ class TextPredictor:
             The path to directory in which to save this Predictor.
         """
 
-        self._predictor.save(path=path)
+        self._predictor.save(path=path,standalone=standalone)
 
     @classmethod
     def load(

--- a/text/tests/unittests/text_prediction/test_predictor_pytorch.py
+++ b/text/tests/unittests/text_prediction/test_predictor_pytorch.py
@@ -236,7 +236,7 @@ def test_standalone_with_emoji():
     predictions1 = predictor.predict(df,as_pandas=False)
     with tempfile.TemporaryDirectory() as root:
         predictor.save(root,standalone=True)
-        with requests_gag:
+        with requests_gag: # no internet connections
             offline_predictor=TextPredictor.load(root)
             predictions2 = offline_predictor.predict(df,as_pandas=False)
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/autogluon/issues/1115#issuecomment-1090598217

*Description of changes:* 
1. Support `standalone` feature in `TextPredictor`. This is an extension of previous PR in https://github.com/awslabs/autogluon/pull/1575.
2. Fix bug of calling `save_pretrained_configs` in `AutoMMPrediction.save(standalone=True)` when no fusion model exists ([here](https://github.com/awslabs/autogluon/blob/5a323641072431091d2be5e6dbef5a87b646a408/text/src/autogluon/text/automm/utils.py#L644 )). 
3. Add test case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
