### PR TITLE
Doc fix to use correct predictor when calling leaderboard

### DIFF
--- a/docs/tutorials/tabular_prediction/tabular-indepth.md
+++ b/docs/tutorials/tabular_prediction/tabular-indepth.md
@@ -319,7 +319,7 @@ predictor_infer_limit.persist_models()
 # Below is an optimized version that only persists the minimum required models for prediction.
 # predictor_infer_limit.persist_models('best')
 
-predictor.leaderboard(silent=True)
+predictor_infer_limit.leaderboard(silent=True)
 ```
 
 Now we can test the inference speed of the final model and check if it satisfies the inference constraints.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix doc so that the correct predictor is called for leaderboard.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
