### PR TITLE
Fix saving and loading tokenizers and text processors

### DIFF
--- a/text/src/autogluon/text/automm/data/process_text.py
+++ b/text/src/autogluon/text/automm/data/process_text.py
@@ -326,6 +326,14 @@ class TextProcessor:
             self,
             path: str,
     ):
+        """
+        Save the tokenizer and text processor.
+
+        Parameters
+        ----------
+        path
+            Saving path.
+        """
         self.tokenizer.save_pretrained(path)
         self.tokenizer = None
         with open(os.path.join(path, "text_processor.pkl"), "wb") as fp:
@@ -336,6 +344,18 @@ class TextProcessor:
             cls,
             path: str,
     ):
+        """
+        Load the text processor and tokenizer.
+
+        Parameters
+        ----------
+        path
+            Loading path.
+
+        Returns
+        -------
+            The loaded text processor with tokenizer.
+        """
         with open(os.path.join(path, "text_processor.pkl"), "rb") as fp:
             text_processor = pickle.load(fp)
         text_processor.tokenizer = cls.get_pretrained_tokenizer(

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -1008,10 +1008,11 @@ class AutoMMPredictor:
 
         # Save text processors and others separately due to tokenizers.
         data_processors = copy.deepcopy(self._data_processors)
-        data_processors[TEXT] = save_text_processors(
-            text_processors=data_processors[TEXT],
-            path=path,
-        )
+        if TEXT in data_processors:
+            data_processors[TEXT] = save_text_processors(
+                text_processors=data_processors[TEXT],
+                path=path,
+            )
 
         with open(os.path.join(path, "data_processors.pkl"), "wb") as fp:
             pickle.dump(data_processors, fp)
@@ -1074,11 +1075,12 @@ class AutoMMPredictor:
             df_preprocessor = pickle.load(fp)
         with open(os.path.join(path, "data_processors.pkl"), "rb") as fp:
             data_processors = pickle.load(fp)
-        # Load text processors separately due to tokenizers.
-        data_processors[TEXT] = load_text_processors(
-            relative_paths=data_processors[TEXT],
-            path=path,
-        )
+        if TEXT in data_processors:
+            # Load text processors separately due to tokenizers.
+            data_processors[TEXT] = load_text_processors(
+                relative_paths=data_processors[TEXT],
+                path=path,
+            )
         with open(os.path.join(path, "assets.json"), "r") as fp:
             assets = json.load(fp)
 

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -47,7 +47,7 @@ from .utils import (
     get_config,
     LogFilter,
     apply_log_filter,
-    save_pretrained_configs,
+    save_pretrained_models,
     convert_checkpoint_name,
     save_text_processors,
     load_text_processors,
@@ -991,7 +991,7 @@ class AutoMMPredictor:
 
         if standalone:
             # logger.debug(f"Using the standalone=True for saving pretrained models")
-            self._config = save_pretrained_configs(
+            self._config = save_pretrained_models(
                 model=self._model.model,
                 config=self._config, 
                 path=path

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -680,6 +680,32 @@ def convert_checkpoint_name(
     return config    
 
 
+def save_text_processors(
+        text_processors: List[TextProcessor],
+        path: str,
+):
+    relative_paths = []
+    for per_text_processor in text_processors:
+        relative_paths.append(per_text_processor.prefix)
+        per_path = os.path.join(path, per_text_processor.prefix)
+        per_text_processor.save(per_path)
+
+    return relative_paths
+
+
+def load_text_processors(
+        relative_paths: List[str],
+        path: str,
+):
+    text_processors = []
+    for per_relative_path in relative_paths:
+        per_path = os.path.join(path, per_relative_path)
+        per_text_processor = TextProcessor.load(per_path)
+        text_processors.append(per_text_processor)
+
+    return text_processors
+
+
 def make_exp_dir(
         root_path: str,
         job_name: str,


### PR DESCRIPTION
1. Saved pre-trained huggingface tokenizers separately from the text processors.
2. Saved text processors separately from other processors.
3. Also added the corresponding loading methods.
4. Improved implementations and docstrings of `save_pretrained_models` and `convert_checkpoint_name`.