### PR TITLE
Update the names of top-k checkpoint average methods and support customizing model names for terminal input

### DIFF
--- a/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
+++ b/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
@@ -13,5 +13,5 @@ optimization:
   patience: 10
   val_check_interval: 0.5
   top_k: 3
-  top_k_average_method: 'greedy_soup'  # We support averaging method described in https://arxiv.org/pdf/2203.05482.pdf.
-                                       # Currently support "union_soup", "greedy_soup", "best_soup".
+  top_k_average_method: "greedy_soup"  # We support averaging method described in https://arxiv.org/pdf/2203.05482.pdf.
+                                       # Currently support "uniform_soup", "greedy_soup", and "best".

--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -71,10 +71,10 @@ AUTOMM_TUTORIAL_MODE = "AUTOMM_TUTORIAL_MODE"
 # error try
 GET_ITEM_ERROR_RETRY = 50
 
-# mini-ensemble methods
-UNION_SOUP = 'union_soup'
-GREEDY_SOUP = 'greedy_soup'
-BEST_SOUP = 'best_soup'
+# top-k checkpoint average methods
+UNIFORM_SOUP = "uniform_soup"
+GREEDY_SOUP = "greedy_soup"
+BEST = "best"
 
 # registered model keys. TODO: document how to add new models.
 CLIP = "clip"

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -173,14 +173,14 @@ def get_config(
             all_configs.append(per_config)
 
         config = OmegaConf.merge(*all_configs)
-    verify_config_names(config.model)
+    verify_model_names(config.model)
     logger.debug(f"overrides: {overrides}")
     if overrides is not None:
         # avoid manipulating user-provided overrides
         overrides = copy.deepcopy(overrides)
         # apply customized model names
         overrides = parse_dotlist_conf(overrides)  # convert to a dict
-        config.model = customize_config_names(
+        config.model = customize_model_names(
             config=config.model,
             customized_names=overrides.get("model.names", None),
         )
@@ -188,13 +188,13 @@ def get_config(
         overrides.pop("model.names", None)
         # apply all the overrides
         config = apply_omegaconf_overrides(config, overrides=overrides, check_key_exist=True)
-    verify_config_names(config.model)
+    verify_model_names(config.model)
     return config
 
 
-def verify_config_names(config: DictConfig):
+def verify_model_names(config: DictConfig):
     """
-    Verify whether provided names are valid for a config.
+    Verify whether provided model names are valid.
 
     Parameters
     ----------
@@ -252,9 +252,9 @@ def get_name_prefix(
         return search_results[0]
 
 
-def customize_config_names(
+def customize_model_names(
         config: DictConfig,
-        customized_names: List[str],
+        customized_names: Union[str, List[str]],
 ):
     """
     Customize attribute names of `config` with the provided names.
@@ -279,6 +279,9 @@ def customize_config_names(
     """
     if not customized_names:
         return config
+
+    if isinstance(customized_names, str):
+        customized_names = OmegaConf.from_dotlist([f'names={customized_names}']).names
 
     new_config = OmegaConf.create()
     new_config.names = []


### PR DESCRIPTION
1. Following paper: https://arxiv.org/pdf/2203.05482.pdf to update top-k checkpoint average names: `union_soup` -> `uniform_soup` and `best_soup` -> `best`.
2. Support customizing model names for the terminal input.
3. deepcopy data processors in _predict() to avoid potential issues.
4. Update function names (`customize_config_names` -> `customize_model_names` and `verify_config_names` -> `verify_model_names`) to make it easier to understand them.
