### PR TITLE
Use class property to set keys

### DIFF
--- a/text/src/autogluon/text/automm/models/categorical_mlp.py
+++ b/text/src/autogluon/text/automm/models/categorical_mlp.py
@@ -94,11 +94,17 @@ class CategoricalMLP(nn.Module):
         self.apply(init_weights)
 
         self.prefix = prefix
-        self.categorical_key = f"{prefix}_{CATEGORICAL}"
-        self.label_key = f"{prefix}_{LABEL}"
 
         self.name_to_id = self.get_layer_ids()
         self.head_layer_names = [n for n, layer_id in self.name_to_id.items() if layer_id == 0]
+
+    @property
+    def categorical_key(self):
+        return f"{self.prefix}_{CATEGORICAL}"
+
+    @property
+    def label_key(self):
+        return f"{self.prefix}_{LABEL}"
 
     def forward(
             self,

--- a/text/src/autogluon/text/automm/models/clip.py
+++ b/text/src/autogluon/text/automm/models/clip.py
@@ -48,14 +48,29 @@ class CLIPForImageText(nn.Module):
         self.head.apply(init_weights)
 
         self.prefix = prefix
-        self.text_token_ids_key = f"{prefix}_{TEXT_TOKEN_IDS}"
-        self.text_valid_length_key = f"{prefix}_{TEXT_VALID_LENGTH}"
-        self.image_key = f"{prefix}_{IMAGE}"
-        self.image_valid_num_key = f"{prefix}_{IMAGE_VALID_NUM}"
-        self.label_key = f"{prefix}_{LABEL}"
 
         self.name_to_id = self.get_layer_ids()
         self.head_layer_names = [n for n, layer_id in self.name_to_id.items() if layer_id == 0]
+
+    @property
+    def text_token_ids_key(self):
+        return f"{self.prefix}_{TEXT_TOKEN_IDS}"
+
+    @property
+    def text_valid_length_key(self):
+        return f"{self.prefix}_{TEXT_VALID_LENGTH}"
+
+    @property
+    def image_key(self):
+        return f"{self.prefix}_{IMAGE}"
+
+    @property
+    def image_valid_num_key(self):
+        return f"{self.prefix}_{IMAGE_VALID_NUM}"
+
+    @property
+    def label_key(self):
+        return f"{self.prefix}_{LABEL}"
 
     def forward(
             self,

--- a/text/src/autogluon/text/automm/models/fusion.py
+++ b/text/src/autogluon/text/automm/models/fusion.py
@@ -116,10 +116,13 @@ class MultimodalFusionMLP(nn.Module):
         self.head.apply(init_weights)
 
         self.prefix = prefix
-        self.label_key = f"{prefix}_{LABEL}"
 
         self.name_to_id = self.get_layer_ids()
         self.head_layer_names = [n for n, layer_id in self.name_to_id.items() if layer_id == 0]
+
+    @property
+    def label_key(self):
+        return f"{self.prefix}_{LABEL}"
 
     def forward(
             self,

--- a/text/src/autogluon/text/automm/models/huggingface_text.py
+++ b/text/src/autogluon/text/automm/models/huggingface_text.py
@@ -61,10 +61,6 @@ class HFAutoModelForTextPrediction(nn.Module):
         self.head.apply(init_weights)
 
         self.prefix = prefix
-        self.text_token_ids_key = f"{prefix}_{TEXT_TOKEN_IDS}"
-        self.text_segment_ids_key = f"{prefix}_{TEXT_SEGMENT_IDS}"
-        self.text_valid_length_key = f"{prefix}_{TEXT_VALID_LENGTH}"
-        self.label_key = f"{prefix}_{LABEL}"
 
         self.name_to_id = self.get_layer_ids()
         self.head_layer_names = [n for n, layer_id in self.name_to_id.items() if layer_id == 0]
@@ -74,6 +70,22 @@ class HFAutoModelForTextPrediction(nn.Module):
             self.disable_seg_ids = True
         else:
             self.disable_seg_ids = False
+
+    @property
+    def text_token_ids_key(self):
+        return f"{self.prefix}_{TEXT_TOKEN_IDS}"
+
+    @property
+    def text_segment_ids_key(self):
+        return f"{self.prefix}_{TEXT_SEGMENT_IDS}"
+
+    @property
+    def text_valid_length_key(self):
+        return f"{self.prefix}_{TEXT_VALID_LENGTH}"
+
+    @property
+    def label_key(self):
+        return f"{self.prefix}_{LABEL}"
 
     def forward(
             self,

--- a/text/src/autogluon/text/automm/models/numerical_mlp.py
+++ b/text/src/autogluon/text/automm/models/numerical_mlp.py
@@ -62,11 +62,17 @@ class NumericalMLP(nn.Module):
         self.apply(init_weights)
 
         self.prefix = prefix
-        self.numerical_key = f"{prefix}_{NUMERICAL}"
-        self.label_key = f"{prefix}_{LABEL}"
 
         self.name_to_id = self.get_layer_ids()
         self.head_layer_names = [n for n, layer_id in self.name_to_id.items() if layer_id == 0]
+
+    @property
+    def numerical_key(self):
+        return f"{self.prefix}_{NUMERICAL}"
+
+    @property
+    def label_key(self):
+        return f"{self.prefix}_{LABEL}"
 
     def forward(
             self,

--- a/text/src/autogluon/text/automm/models/timm_image.py
+++ b/text/src/autogluon/text/automm/models/timm_image.py
@@ -60,12 +60,21 @@ class TimmAutoModelForImagePrediction(nn.Module):
         logger.debug(f"mix_choice: {mix_choice}")
 
         self.prefix = prefix
-        self.image_key = f"{prefix}_{IMAGE}"
-        self.image_valid_num_key = f"{prefix}_{IMAGE_VALID_NUM}"
-        self.label_key = f"{prefix}_{LABEL}"
 
         self.name_to_id = self.get_layer_ids()
         self.head_layer_names = [n for n, layer_id in self.name_to_id.items() if layer_id == 0]
+
+    @property
+    def image_key(self):
+        return f"{self.prefix}_{IMAGE}"
+
+    @property
+    def image_valid_num_key(self):
+        return f"{self.prefix}_{IMAGE_VALID_NUM}"
+
+    @property
+    def label_key(self):
+        return f"{self.prefix}_{LABEL}"
 
     def forward(
             self,


### PR DESCRIPTION
Use class property to set keys in model classes. In this way, if we customize the `prefix` key, other keys are automatically updated.