### PR TITLE
Enable knowledge distillation for AutoMM

### DIFF
--- a/text/src/autogluon/text/automm/configs/distiller/default.yaml
+++ b/text/src/autogluon/text/automm/configs/distiller/default.yaml
@@ -1,0 +1,6 @@
+distiller:
+  soft_label_loss_type: "cross_entropy"
+  temperature: 5.
+  hard_label_weight: 0.2
+  soft_label_weight: 50.
+  matches:

--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -57,6 +57,7 @@ MODEL = "model"
 DATA = "data"
 OPTIMIZATION = "optimization"
 ENVIRONMENT = "environment"
+DISTILLER = "distiller"
 
 # Image normalization mean and std. This is only to normalize images for the CLIP model.
 CLIP_IMAGE_MEAN = (0.48145466, 0.4578275, 0.40821073)

--- a/text/src/autogluon/text/automm/data/datamodule.py
+++ b/text/src/autogluon/text/automm/data/datamodule.py
@@ -1,7 +1,7 @@
 from pytorch_lightning import LightningDataModule
 from torch.utils.data import DataLoader
 import pandas as pd
-from typing import Optional
+from typing import Optional, Union, List
 from .dataset import BaseDataset
 from .collator import Dict
 from ..constants import TRAIN, VAL, TEST, PREDICT
@@ -19,8 +19,8 @@ class BaseDataModule(LightningDataModule):
 
     def __init__(
             self,
-            df_preprocessor: MultiModalFeaturePreprocessor,
-            data_processors: dict,
+            df_preprocessor: Union[MultiModalFeaturePreprocessor, List[MultiModalFeaturePreprocessor]],
+            data_processors: Union[dict, List[dict]],
             per_gpu_batch_size: int,
             num_workers: int,
             train_data: Optional[pd.DataFrame] = None,
@@ -55,6 +55,11 @@ class BaseDataModule(LightningDataModule):
         """
         super().__init__()
         self.prepare_data_per_node = True
+
+        if isinstance(df_preprocessor, MultiModalFeaturePreprocessor):
+            df_preprocessor = [df_preprocessor]
+        if isinstance(data_processors, dict):
+            data_processors = [data_processors]
 
         self.df_preprocessor = df_preprocessor
         self.data_processors = data_processors
@@ -187,7 +192,8 @@ class BaseDataModule(LightningDataModule):
         A "Dict" collator wrapping other collators.
         """
         collate_fn = {}
-        for d_type in self.data_processors:
-            for per_model_processor in self.data_processors[d_type]:
-                collate_fn.update(per_model_processor.collate_fn())
+        for per_data_processors_group in self.data_processors:
+            for per_modality in per_data_processors_group:
+                for per_model_processor in per_data_processors_group[per_modality]:
+                    collate_fn.update(per_model_processor.collate_fn())
         return Dict(collate_fn)

--- a/text/src/autogluon/text/automm/data/datamodule.py
+++ b/text/src/autogluon/text/automm/data/datamodule.py
@@ -32,7 +32,7 @@ class BaseDataModule(LightningDataModule):
         Parameters
         ----------
         df_preprocessor
-            A dataframe preprocessor. The preprocessing of one modality is generic so that
+            One or a list of dataframe preprocessors. The preprocessing of one modality is generic so that
             the preprocessed data can be used by different models requiring the modality.
             For example, formatting input data as strings is a valid preprocessing operation for text.
             However, tokenizing strings into ids is invalid since different models generally

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -30,7 +30,7 @@ class BaseDataset(torch.utils.data.Dataset):
         data
             A pd.DataFrame containing multimodal features.
         preprocessor
-            A multimodal feature preprocessor generating model-agnostic features.
+            A list of multimodal feature preprocessors generating model-agnostic features.
         processors
             Data processors customizing data for each modality per model.
         is_training

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -45,7 +45,7 @@ class BaseDataset(torch.utils.data.Dataset):
 
         self.lengths = []
         for i, (per_preprocessor, per_processors_group) in enumerate(zip(preprocessor, processors)):
-            for per_modality, per_modality_processors in per_processors_group.items():
+            for per_modality in per_processors_group:
                 per_modality_features = getattr(per_preprocessor, f"transform_{per_modality}")(data)
                 setattr(self, f"{per_modality}_{i}", per_modality_features)
                 self.lengths.append(len(per_modality_features[0]))

--- a/text/src/autogluon/text/automm/data/infer_types.py
+++ b/text/src/autogluon/text/automm/data/infer_types.py
@@ -278,7 +278,8 @@ def infer_column_problem_types(
         # 1) Infer categorical column
         # 2) Infer numerical column
         # 3) Infer image-path column
-        # 4) All the other columns are treated as text column
+        # 4) Infer text column
+        # 4) All the other columns are treated as categorical
         if is_categorical_column(train_df[col_name], valid_df[col_name],
                                  is_label=is_label):
             column_types[col_name] = CATEGORICAL

--- a/text/src/autogluon/text/automm/optimization/lit_distiller.py
+++ b/text/src/autogluon/text/automm/optimization/lit_distiller.py
@@ -1,0 +1,407 @@
+import logging
+import torch
+from torch import nn
+import torch.nn.functional as F
+import pytorch_lightning as pl
+from typing import Union, Optional, List, Dict, Callable
+import torchmetrics
+from torchmetrics.aggregation import BaseAggregator
+from torch.nn.modules.loss import _Loss
+from omegaconf import DictConfig
+from .utils import (
+    get_optimizer,
+    get_lr_scheduler,
+    apply_two_stages_lr,
+    apply_layerwise_lr_decay,
+    apply_single_lr,
+)
+from ..constants import (
+    LOGITS, WEIGHT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LitModuleForDistiller(pl.LightningModule):
+    """
+    Knowledge distillation loops for training, evaluation, and prediction. This module is independent of
+    the model definition. This class inherits from the Pytorch Lightning's LightningModule:
+    https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html
+    """
+
+    def __init__(
+            self,
+            student_model: nn.Module,
+            teacher_model: nn.Module,
+            matches: List[DictConfig],
+            critics: nn.ModuleList,
+            baseline_funcs: nn.ModuleList,
+            hard_label_weight: float,
+            soft_label_weight: float,
+            temperature: float,
+            optim_type: Optional[str] = None,
+            lr_choice: Optional[str] = None,
+            lr_schedule: Optional[str] = None,
+            lr: Optional[float] = None,
+            lr_decay: Optional[float] = None,
+            end_lr: Optional[Union[float, int]] = None,
+            lr_mult: Optional[Union[float, int]] = None,
+            weight_decay: Optional[float] = None,
+            warmup_steps: Optional[int] = None,
+            hard_label_loss_func: Optional[_Loss] = None,
+            soft_label_loss_func: Optional[_Loss] = None,
+            validation_metric: Optional[torchmetrics.Metric] = None,
+            validation_metric_name: Optional[str] = None,
+            custom_metric_func: Callable = None,
+            test_metric: Optional[torchmetrics.Metric] = None,
+    ):
+        """
+        Parameters
+        ----------
+        student_model
+            The student model in knowledge distillation.
+        teacher_model
+            The teacher model in knowledge distillation.
+        matches
+            Teacher/stduent layer matches to compute the intermediate loss.
+        critics
+            The critics used in computing mutual information loss.
+        baseline_funcs
+            The baseline functions used in computing mutual information loss.
+        hard_label_weight
+            Weight for hard label loss.
+        soft_label_weight
+            Weight for soft label loss.
+        temperature
+            A scalar to scale teacher and student logits in soft label loss.
+        optim_type
+            Optimizer type. We now support:
+            - adamw
+            - adam
+            - sgd
+        lr_choice
+            How to set each layer's learning rate. If not specified, the default is a single
+            learnng rate for all layers. Otherwise, we now support two choices:
+            - two_stages
+                The layers in the pretrained models have a small learning rate (lr * lr_mult),
+                while the newly added head layers use the provided learning rate.
+            - layerwise_decay
+                The layers have decreasing learning rate from the output end to the input end.
+                The intuition is that later layers are more task-related, hence larger learning rates.
+        lr_schedule
+            Learning rate schedule. We now support:
+            - cosine_decay
+                Linear warmup followed by cosine decay
+            - polynomial_decay
+                Linear warmup followed by polynomial decay
+        lr
+            Learning rate.
+        lr_decay
+            The learning rate decay factor (0, 1). It is used only when lr_choice is "layerwise_decay".
+        end_lr
+            The final learning rate after decay.
+        lr_mult
+            The learning rate multiplier (0, 1). It is used only when lr_choice is "two_stages".
+        weight_decay
+            The weight decay to regularize layer weights' l2 norm.
+        warmup_steps
+            How many steps to warmup learning rate. If a float (0, 1), it would represent the
+            percentage of steps over all the training steps. The actual number is calculated as
+            "int(warmup_steps * max_steps)". If an integer, it would be the exact step number.
+        hard_label_loss_func
+            A Pytorch loss module, e.g., nn.CrossEntropyLoss(), for hard labels.
+        soft_label_loss_func
+            A Pytorch loss module, e.g., nn.CrossEntropyLoss(), for soft labels.
+        validation_metric
+            A torchmetrics module used in the validation stage, e.g., torchmetrics.Accuracy().
+        validation_metric_name
+            Name of validation metric in case that validation_metric is a aggregation metric,
+            e.g., torchmetrics.MeanMetric, whose name can't reflect the real metric name.
+        custom_metric_func
+            A customized metric function in case that torchmetrics doesn't have the metric.
+            It is generally used together with torchmetrics' aggregators, e.g., torchmetrics.MeanMetric.
+            Refer to https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/aggregation.py
+        test_metric
+            A torchmetrics module used in the test stage, e.g., torchmetrics.Accuracy().
+        """
+        super().__init__()
+        self.save_hyperparameters(
+            ignore=[
+                "student_model", "teacher_model", "validation_metric",
+                "hard_label_loss_func", "soft_label_loss_func",
+                "custom_metric_func", "test_metric",
+                "matches", "critics", "baseline_funcs",
+            ]
+        )
+        if matches:
+            assert len(matches) == len(critics)
+            assert len(matches) == len(baseline_funcs)
+        self.student_model = student_model
+        self.teacher_model = teacher_model
+        self.matches = matches
+        self.critics = critics
+        self.baseline_funcs = baseline_funcs
+        self.validation_metric = validation_metric
+        self.validation_metric_name = f"val_{validation_metric_name}"
+        self.temperature = temperature
+        self.hard_label_weight = hard_label_weight
+        self.soft_label_weight = soft_label_weight
+        self.hard_label_loss_func = hard_label_loss_func
+        self.soft_label_loss_func = soft_label_loss_func
+        if isinstance(validation_metric, BaseAggregator) and custom_metric_func is None:
+            raise ValueError(
+                f"validation_metric {validation_metric} is an aggregation metric,"
+                f"which must be used with a customized metric function."
+            )
+        self.custom_metric_func = custom_metric_func
+
+    def _compute_hard_label_loss(
+            self,
+            output: dict,
+            label: torch.Tensor,
+    ):
+        loss = 0
+        for _, per_output in output.items():
+            weight = per_output[WEIGHT] if WEIGHT in per_output else 1
+            loss += self.hard_label_loss_func(
+                input=per_output[LOGITS].squeeze(dim=1),
+                target=label,
+            ) * weight
+        return loss
+
+    def _compute_soft_label_loss(
+            self,
+            student_output: dict,
+            teacher_output: dict,
+    ):
+        student_logits = student_output[self.student_model.prefix][LOGITS].squeeze(dim=1)
+        soft_labels = teacher_output[self.teacher_model.prefix][LOGITS].squeeze(dim=1)
+        student_logits = student_logits / self.temperature
+        soft_labels = soft_labels / self.temperature
+
+        if isinstance(self.soft_label_loss_func, nn.CrossEntropyLoss):
+            soft_labels = F.softmax(soft_labels, dim=-1)
+
+        loss = self.soft_label_loss_func(
+            input=student_logits,
+            target=soft_labels,
+        )
+        return loss
+
+    def _compute_loss(
+            self,
+            student_output: dict,
+            teacher_output: dict,
+            label: torch.Tensor,
+    ):
+        loss = 0
+        hard_label_loss = self._compute_hard_label_loss(
+            output=student_output,
+            label=label,
+        )
+        loss += hard_label_loss * self.hard_label_weight
+
+        soft_label_loss = self._compute_soft_label_loss(
+            student_output=student_output,
+            teacher_output=teacher_output,
+        )
+        loss += soft_label_loss * self.soft_label_weight
+
+        return loss
+
+    def _compute_metric(
+            self,
+            logits: torch.Tensor,
+            label: torch.Tensor,
+    ):
+        if isinstance(self.validation_metric, torchmetrics.AUROC):
+            prob = F.softmax(logits.float(), dim=1)
+            return self.validation_metric(preds=prob[:, 1], target=label)  # only for binary classification
+        elif isinstance(self.validation_metric, BaseAggregator):
+            return self.validation_metric(self.custom_metric_func(logits, label))
+        else:
+            return self.validation_metric(logits.squeeze(dim=1), label)
+
+    def _shared_step(
+            self,
+            batch: dict,
+    ):
+        student_output = self.student_model(batch)
+        self.teacher_model.eval()
+        with torch.no_grad():
+            teacher_output = self.teacher_model(batch)
+        label = batch[self.student_model.label_key]
+        loss = self._compute_loss(
+            student_output=student_output,
+            teacher_output=teacher_output,
+            label=label,
+        )
+        return student_output, loss
+
+    def training_step(self, batch, batch_idx):
+        """
+        Per training step. This function is registered by pl.LightningModule.
+        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#training-loop
+
+        Parameters
+        ----------
+        batch
+            A dictionary containing the mini-batch data, including both input data and
+            ground-truth labels. The mini-batch data are passed to each individual model,
+            which indexes its required input data by keys with its model prefix. The
+            ground-truth labels are used here to compute the training loss.
+        batch_idx
+            Index of mini-batch.
+
+        Returns
+        -------
+        Average loss of the mini-batch data.
+        """
+        _, loss = self._shared_step(batch)
+        self.log("train_loss", loss)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        """
+        Per validation step. This function is registered by pl.LightningModule.
+        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#validation
+
+        Parameters
+        ----------
+        batch
+            A dictionary containing the mini-batch data, including both input data and
+            ground-truth labels. The mini-batch data are passed to each individual model,
+            which indexes its required input data by keys with its model prefix. The
+            ground-truth labels are used here to compute the validation loss and metric.
+            The validation metric is used for top k model selection and early stopping.
+        batch_idx
+            Index of mini-batch.
+        """
+        student_output, loss = self._shared_step(batch)
+        # By default, on_step=False and on_epoch=True
+        self.log("val_loss", loss)
+        self.log(
+            self.validation_metric_name,
+            self._compute_metric(
+                logits=student_output[self.student_model.prefix][LOGITS],
+                label=batch[self.student_model.label_key],
+            ),
+        )
+
+    def predict_step(self, batch, batch_idx, dataloader_idx=0):
+        """
+        Per prediction step. This function is registered by pl.LightningModule.
+        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#prediction-loop
+
+        Parameters
+        ----------
+        batch
+            A dictionary containing the mini-batch data.
+            The mini-batch data are passed to each individual model,
+            which indexes its required input data by keys with its model prefix.
+            Ground-truth labels are not needed for prediction.
+        batch_idx
+            Index of mini-batch.
+        dataloader_idx
+            Index of dataloader.
+        Returns
+        -------
+        A dictionary with the mini-batch's logits and features.
+        """
+        output = self.student_model(batch)
+        return output[self.student_model.prefix]
+
+    def configure_optimizers(self):
+        """
+        Configure optimizer. This function is registered by pl.LightningModule.
+        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#configure-optimizers
+        Returns
+        -------
+        [optimizer]
+            Optimizer.
+        [sched]
+            Learning rate scheduler.
+        """
+        if self.hparams.lr_choice == "two_stages":
+            logger.debug("applying 2-stage learning rate...")
+            grouped_parameters = apply_two_stages_lr(
+                model=self.student_model,
+                lr=self.hparams.lr,
+                lr_mult=self.hparams.lr_mult,
+                weight_decay=self.hparams.weight_decay,
+                return_params=True,
+            )
+        elif self.hparams.lr_choice == "layerwise_decay":
+            logger.debug("applying layerwise learning rate decay...")
+            grouped_parameters = apply_layerwise_lr_decay(
+                model=self.student_model,
+                lr=self.hparams.lr,
+                lr_decay=self.hparams.lr_decay,
+                weight_decay=self.hparams.weight_decay,
+            )
+        else:
+            logger.debug("applying single learning rate...")
+            grouped_parameters = apply_single_lr(
+                model=self.student_model,
+                lr=self.hparams.lr,
+                weight_decay=self.hparams.weight_decay,
+            )
+
+        if self.critics:  # to handle None
+            for per_model_critics in self.critics:
+                for per_critic in per_model_critics:
+                    critics_parameters = apply_single_lr(
+                        model=per_critic,
+                        lr=self.hparams.lr,
+                        weight_decay=self.hparams.weight_decay,
+                    )
+                    grouped_parameters.extend(critics_parameters)
+
+        if self.baseline_funcs:  # to handle None
+            for per_model_baseline_funcs in self.baseline_funcs:
+                for per_baseline_func in per_model_baseline_funcs:
+                    baseline_func_params = apply_single_lr(
+                        model=per_baseline_func,
+                        lr=self.hparams.lr,
+                        weight_decay=self.hparams.weight_decay,
+                    )
+                    grouped_parameters.extend(baseline_func_params)
+
+        optimizer = get_optimizer(
+            optim_type=self.hparams.optim_type,
+            optimizer_grouped_parameters=grouped_parameters,
+            lr=self.hparams.lr,
+            weight_decay=self.hparams.weight_decay,
+        )
+
+        logger.debug(f"trainer.max_steps: {self.trainer.max_steps}")
+        if self.trainer.max_steps is None or -1:
+            max_steps = (
+                    len(self.trainer.datamodule.train_dataloader())
+                    * self.trainer.max_epochs
+                    // self.trainer.accumulate_grad_batches
+            )
+            logger.debug(f"len(trainer.datamodule.train_dataloader()): "
+                         f"{len(self.trainer.datamodule.train_dataloader())}")
+            logger.debug(f"trainer.max_epochs: {self.trainer.max_epochs}")
+            logger.debug(f"trainer.accumulate_grad_batches: {self.trainer.accumulate_grad_batches}")
+        else:
+            max_steps = self.trainer.max_steps
+
+        logger.debug(f"max steps: {max_steps}")
+
+        warmup_steps = self.hparams.warmup_steps
+        if isinstance(warmup_steps, float):
+            warmup_steps = int(max_steps * warmup_steps)
+
+        logger.debug(f"warmup steps: {warmup_steps}")
+        logger.debug(f"lr_schedule: {self.hparams.lr_schedule}")
+        scheduler = get_lr_scheduler(optimizer=optimizer,
+                                     num_max_steps=max_steps,
+                                     num_warmup_steps=warmup_steps,
+                                     lr_schedule=self.hparams.lr_schedule,
+                                     end_lr=self.hparams.end_lr)
+
+        sched = {"scheduler": scheduler, "interval": "step"}
+        logger.debug("done configuring optimizer and scheduler")
+        return [optimizer], [sched]

--- a/text/src/autogluon/text/automm/optimization/lit_distiller.py
+++ b/text/src/autogluon/text/automm/optimization/lit_distiller.py
@@ -288,29 +288,6 @@ class LitModuleForDistiller(pl.LightningModule):
             ),
         )
 
-    def predict_step(self, batch, batch_idx, dataloader_idx=0):
-        """
-        Per prediction step. This function is registered by pl.LightningModule.
-        Refer to https://pytorch-lightning.readthedocs.io/en/latest/common/lightning_module.html#prediction-loop
-
-        Parameters
-        ----------
-        batch
-            A dictionary containing the mini-batch data.
-            The mini-batch data are passed to each individual model,
-            which indexes its required input data by keys with its model prefix.
-            Ground-truth labels are not needed for prediction.
-        batch_idx
-            Index of mini-batch.
-        dataloader_idx
-            Index of dataloader.
-        Returns
-        -------
-        A dictionary with the mini-batch's logits and features.
-        """
-        output = self.student_model(batch)
-        return output[self.student_model.prefix]
-
     def configure_optimizers(self):
         """
         Configure optimizer. This function is registered by pl.LightningModule.

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -42,7 +42,6 @@ from .utils import (
     init_data_processors,
     select_model,
     compute_score,
-    gather_top_k_ckpts,
     average_checkpoints,
     infer_metrics,
     get_config,
@@ -502,7 +501,7 @@ class AutoMMPredictor:
                             per_model.prefix = new_name
                             break
                 # modify data processor prefix
-                for _, per_modality_processors in teacher_predictor._data_processors.items():
+                for per_modality_processors in teacher_predictor._data_processors.values():
                     for per_processor in per_modality_processors:
                         if n == per_processor.prefix:
                             per_processor.prefix = new_name
@@ -1196,7 +1195,7 @@ class AutoMMPredictor:
             prefix: str = "model."
     ):
         if state_dict is None:
-            state_dict = torch.load(path)["state_dict"]
+            state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"]
         state_dict = {k.partition(prefix)[2]: v for k, v in state_dict.items() if k.startswith(prefix)}
 
         model.load_state_dict(state_dict)

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -1026,3 +1026,57 @@ def apply_log_filter(log_filter):
     finally:
         remove_log_filter(logging.getLogger(), log_filter)
         remove_log_filter(logging.getLogger("pytorch_lightning"), log_filter)
+
+
+def modify_duplicate_model_names(
+        predictor,
+        postfix: str,
+        blacklist: List[str],
+):
+    """
+    Modify a predictor's model names if they exist in a blacklist.
+
+    Parameters
+    ----------
+    predictor
+        An AutoMMPredictor object.
+    postfix
+        The postfix used to change the duplicate names.
+    blacklist
+        A list of names. The provided predictor can't use model names in the list.
+
+    Returns
+    -------
+    The predictor guaranteed has no duplicate model names with the backlist names.
+    """
+    model_names = []
+    for n in predictor._config.model.names:
+        if n in blacklist:
+            new_name = f"{n}_{postfix}"
+            assert new_name not in blacklist
+            assert new_name not in predictor._config.model.names
+            # modify model prefix
+            if n == predictor._model.prefix:
+                predictor._model.prefix = new_name
+            else:
+                assert isinstance(predictor._model.model, nn.ModuleList)
+                for per_model in predictor._model.model:
+                    if n == per_model.prefix:
+                        per_model.prefix = new_name
+                        break
+            # modify data processor prefix
+            for per_modality_processors in predictor._data_processors.values():
+                for per_processor in per_modality_processors:
+                    if n == per_processor.prefix:
+                        per_processor.prefix = new_name
+            # modify model config keys
+            setattr(predictor._config.model, new_name, getattr(predictor._config.model, n))
+            delattr(predictor._config.model, n)
+
+            model_names.append(new_name)
+        else:
+            model_names.append(n)
+
+    predictor._config.model.names = model_names
+
+    return predictor

--- a/text/tests/unittests/automm/test_automm_predictor.py
+++ b/text/tests/unittests/automm/test_automm_predictor.py
@@ -4,8 +4,10 @@ import pytest
 import numpy.testing as npt
 import tempfile
 import copy
+from torch import nn
 
 from autogluon.text.automm import AutoMMPredictor
+from autogluon.text.automm.utils import modify_duplicate_model_names
 from autogluon.text.automm.constants import (
     MODEL,
     DATA,
@@ -381,3 +383,57 @@ def test_customizing_model_names(
         assert sorted(predictor._config.model.names) == sorted(hyperparameters_gt["model.names"])
         for per_name in hyperparameters_gt["model.names"]:
             assert hasattr(predictor._config.model, per_name)
+
+
+def test_modifying_duplicate_model_names():
+    dataset = ALL_DATASETS["petfinder"]()
+    metric_name = dataset.metric
+
+    teacher_predictor = AutoMMPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=metric_name,
+    )
+    config = {
+        MODEL: f"fusion_mlp_image_text_tabular",
+        DATA: "default",
+        OPTIMIZATION: "adamw",
+        ENVIRONMENT: "default",
+    }
+    teacher_predictor.fit(
+        train_data=dataset.train_df,
+        config=config,
+        time_limit=1,
+    )
+    student_predictor = AutoMMPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=metric_name,
+    )
+    student_predictor.fit(
+        train_data=dataset.train_df,
+        config=config,
+        time_limit=0,
+    )
+
+    teacher_predictor = modify_duplicate_model_names(
+        predictor=teacher_predictor,
+        postfix="teacher",
+        blacklist=student_predictor._config.model.names,
+    )
+
+    # verify teacher and student have no duplicate model names
+    assert all([n not in teacher_predictor._config.model.names for n in student_predictor._config.model.names]), \
+        f"teacher model names {teacher_predictor._config.model.names} and" \
+        f" student model names {student_predictor._config.model.names} have duplicates."
+
+    # verify each model name prefix is valid
+    assert teacher_predictor._model.prefix in teacher_predictor._config.model.names
+    if isinstance(teacher_predictor._model.model, nn.ModuleList):
+        for per_model in teacher_predictor._model.model:
+            assert per_model.prefix in teacher_predictor._config.model.names
+
+    # verify each data processor's prefix is valid
+    for per_modality_processors in teacher_predictor._data_processors.values():
+        for per_processor in per_modality_processors:
+            assert per_processor.prefix in teacher_predictor._config.model.names


### PR DESCRIPTION
1. Design the distillation API for AutoMMPredictor. Knowledge distillation reuses the .fit() function. Here is an example to use distillation.
```
from autogluon.text.automm import AutoMMPredictor
teacher_predictor = AutoMMPredictor(label="label_column").fit(train_data)
student_predictor = AutoMMPredictor(label="label_column").fit(
    train_data, 
    hyperparameters=student_and_distiller_hparams, 
    teacher_predictor=teacher_predictor,
)
```
2. Add distillation loops for training and validation.
3. Add a setup function in AutoMMPredictor to prepare for distillation.
4. Reduce the memory usage for top k checkpoints averaging.
