### PR TITLE
Disable image/text in tabular predictor when gpu is not avaialble

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -422,6 +422,7 @@ class BaggedEnsembleModel(AbstractModel):
                    save_folds=True,
                    groups=None,
                    **kwargs):
+        model_base.verify_fit_resources()
         fold_fitting_strategy = self.params.get('fold_fitting_strategy', 'auto')
         if fold_fitting_strategy == 'auto':
             fold_fitting_strategy = self._get_default_fold_fitting_strategy()

--- a/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
+++ b/tabular/src/autogluon/tabular/models/image_prediction/image_predictor.py
@@ -231,6 +231,14 @@ class ImagePredictorModel(AbstractModel):
         num_gpus = ImagePredictor._get_num_gpus_available()
         return num_cpus, num_gpus
 
+    def _verify_fit_resources(self, num_cpus, num_gpus):
+        minimum_cpu_requirement = 1
+        minimum_gpu_requirement = 1
+        if num_cpus < minimum_cpu_requirement:
+            raise ValueError(f"Requires {minimum_cpu_requirement} to train, only {num_cpus} is available")
+        if num_gpus < minimum_gpu_requirement:
+            raise ValueError(f"Requires {minimum_gpu_requirement} to train, only {num_gpus} is available")
+
     def _more_tags(self):
         # `can_refit_full=False` because ImagePredictor does not communicate how to train until the best epoch in refit_full.
         return {'can_refit_full': False}

--- a/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
+++ b/tabular/src/autogluon/tabular/models/text_prediction/text_prediction_v1_model.py
@@ -10,7 +10,7 @@ import pandas as pd
 from autogluon.common.features.types import R_OBJECT, R_INT, R_FLOAT, R_CATEGORY, \
     S_TEXT_NGRAM, S_TEXT_AS_CATEGORY, S_TEXT_SPECIAL, S_IMAGE_PATH
 from autogluon.core.constants import REGRESSION
-from autogluon.core.utils import get_cpu_count, try_import_autogluon_text
+from autogluon.core.utils import get_cpu_count, get_gpu_count_all, try_import_autogluon_text
 from autogluon.core.models import AbstractModel
 
 logger = logging.getLogger(__name__)
@@ -190,9 +190,16 @@ class TextPredictorModel(AbstractModel):
 
     def _get_default_resources(self):
         num_cpus = get_cpu_count()
-        # TODO: use get_gpu_count_torch() or some better way once torch models are available.
-        num_gpus = None
+        num_gpus = get_gpu_count_all()
         return num_cpus, num_gpus
+
+    def _verify_fit_resources(self, num_cpus, num_gpus):
+        minimum_cpu_requirement = 1
+        minimum_gpu_requirement = 1
+        if num_cpus < minimum_cpu_requirement:
+            raise ValueError(f"Requires {minimum_cpu_requirement} to train, only {num_cpus} is available")
+        if num_gpus < minimum_gpu_requirement:
+            raise ValueError(f"Requires {minimum_gpu_requirement} to train, only {num_gpus} is available")
 
     def _predict_proba(self, X, **kwargs):
         X = self.preprocess(X, **kwargs)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/issues/1675

*Description of changes:*
* Added a method to validate resources before bagging is started. Image/text predictor model would require minimum of 1 gpu.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
