### PR TITLE
Added cascade ensemble PoC

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1921,7 +1921,7 @@ class AbstractTrainer:
     #  This is different from raw, where the predictions of the folds are averaged and then feature importance is computed.
     #  Consider aligning these methods so they produce the same result.
     # The output of this function is identical to non-raw when model is level 1 and non-bagged
-    def _get_feature_importance_raw(self, X, y, model, eval_metric=None, **kwargs) -> pd.DataFrame:
+    def _get_feature_importance_raw(self, X, y, model: str, eval_metric=None, **kwargs) -> pd.DataFrame:
         if eval_metric is None:
             eval_metric = self.eval_metric
         if model is None:
@@ -1930,7 +1930,6 @@ class AbstractTrainer:
             predict_func = self.predict
         else:
             predict_func = self.predict_proba
-        model: AbstractModel = self.load_model(model)
         predict_func_kwargs = dict(model=model)
         return compute_permutation_feature_importance(
             X=X, y=y, predict_func=predict_func, predict_func_kwargs=predict_func_kwargs, eval_metric=eval_metric, **kwargs

--- a/tabular/tests/unittests/models/test_cascade.py
+++ b/tabular/tests/unittests/models/test_cascade.py
@@ -1,0 +1,26 @@
+
+from autogluon.tabular.models import LGBModel, TabularNeuralNetTorchModel
+
+
+def test_cascade_binary(fit_helper):
+    fit_args = dict(
+        hyperparameters={
+            LGBModel: {},
+            TabularNeuralNetTorchModel: {},
+        },
+    )
+    dataset_name = 'adult'
+    cascade = ['LightGBM', 'WeightedEnsemble_L2']
+    fit_helper.fit_and_validate_dataset_with_cascade(dataset_name=dataset_name, fit_args=fit_args, cascade=cascade, model_count=2)
+
+
+def test_cascade_multiclass(fit_helper):
+    fit_args = dict(
+        hyperparameters={
+            LGBModel: {},
+            TabularNeuralNetTorchModel: {},
+        },
+    )
+    dataset_name = 'covertype_small'
+    cascade = ['LightGBM', 'WeightedEnsemble_L2']
+    fit_helper.fit_and_validate_dataset_with_cascade(dataset_name=dataset_name, fit_args=fit_args, cascade=cascade, model_count=2)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added cascade ensemble PoC.

The goal of a cascade ensemble is to expand the Accuracy - Inference Latency Pareto Frontier by finding a middle ground between single models and full ensembles that gets the majority of the accuracy improvement of ensembles combined with the majority of the inference speed of single models.

Currently, usage / existence of cascade ensemble support is not user-facing. It will be documented once it has been further tested and optimized. Currently the cascade threshold is fixed at 0.9 and the cascade must be manually defined. Next steps are to automatically define the cascade and the thresholds.

The below example script shows how to use cascades to get 80% of the log loss improvement (97% of the accuracy improvement) of the ensemble over a single model with only 35% the inference cost, thus expanding the Pareto Frontier, without any tuning.

Example Script:

```
from autogluon.tabular import TabularPredictor, TabularDataset


if __name__ == '__main__':
    path_prefix = 'https://autogluon.s3.amazonaws.com/datasets/CoverTypeMulticlassClassification/'
    path_train = path_prefix + 'train_data.csv'
    path_test = path_prefix + 'test_data.csv'

    label = 'Cover_Type'
    sample = 50000  # Number of rows to use to train
    train_data = TabularDataset(path_train)

    if sample is not None and (sample < len(train_data)):
        train_data = train_data.sample(n=sample, random_state=0).reset_index(drop=True)

    test_data = TabularDataset(path_test)

    fit_kwargs = dict(
        train_data=train_data,
        hyperparameters={
            'NN_TORCH': {},
            'GBM': {},
            'KNN': {},
        },
    )

    predictor = TabularPredictor(
        label=label,
        eval_metric='log_loss',
    )

    predictor.fit(**fit_kwargs)

    predictor.persist_models('all')

    leaderboard = predictor.leaderboard(test_data)

    import time

    ts = time.time()
    pred_proba = predictor.predict_proba(test_data, model='WeightedEnsemble_L2')
    te = time.time()

    print('--------')
    print('Normal: ')
    print(predictor.evaluate_predictions(y_true=test_data[label], y_pred=pred_proba, silent=True))
    print(f'{te - ts}s')
    print('--------')

    ts = time.time()
    pred_proba = predictor.predict_proba(test_data, model=['NeuralNetTorch', 'WeightedEnsemble_L2'])
    te = time.time()

    print('--------')
    print('Cascade:')
    print(predictor.evaluate_predictions(y_true=test_data[label], y_pred=pred_proba, silent=True))
    print(f'{te - ts}s')
    print('--------')

```

Out:

```
                 model  score_test  score_val  pred_time_test  pred_time_val     fit_time  pred_time_test_marginal  pred_time_val_marginal  fit_time_marginal  stack_level  can_infer  fit_order
0  WeightedEnsemble_L2   -0.234278  -0.260248       14.950171       0.715236  1270.274406                 0.048993                0.001165           0.486316            2       True          4
1             LightGBM   -0.295047  -0.324501       13.393521       0.607209    11.692870                13.393521                0.607209          11.692870            1       True          2
2       NeuralNetTorch   -0.297718  -0.327164        0.851722       0.072343  1258.052863                 0.851722                0.072343        1258.052863            1       True          3
3           KNeighbors   -0.496720  -0.456807        0.655935       0.034519     0.042357                 0.655935                0.034519           0.042357            1       True          1


--------
Normal: 
{'log_loss': -0.23427786256734967, 'accuracy': 0.9106477457552731, 'balanced_accuracy': 0.8266616778634864, 'mcc': 0.8558472797101921}
15.58s
--------
--------
Cascade:
{'log_loss': -0.25118394508483005, 'accuracy': 0.9099506897412287, 'balanced_accuracy': 0.8307863237257622, 'mcc': 0.8547748671813279}
6.10s
--------
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
