### PR TITLE
Fix repeated bagging

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -988,10 +988,10 @@ class BaggedEnsembleModel(AbstractModel):
         return memory_size
 
     def validate_fit_resources(self, **kwargs):
-        self.model_base.validate_fit_resources(**kwargs)
+        self._get_model_base().validate_fit_resources(**kwargs)
 
     def get_minimum_resources(self) -> Dict[str, int]:
-        return self.model_base.get_minimum_resources()
+        return self._get_model_base().get_minimum_resources()
 
     def _validate_fit_memory_usage(self, **kwargs):
         # memory is checked downstream on the child model
@@ -1032,7 +1032,8 @@ class BaggedEnsembleModel(AbstractModel):
 
         kwargs['feature_metadata'] = self.feature_metadata
         kwargs['num_classes'] = self.num_classes  # TODO: maybe don't pass num_classes to children
-        self.model_base.set_contexts(self.path + 'hpo' + os.path.sep)
+        model_base = self._get_model_base()
+        model_base.set_contexts(self.path + 'hpo' + os.path.sep)
 
         # TODO: Preprocess data here instead of repeatedly
         if preprocess_kwargs is None:
@@ -1062,7 +1063,7 @@ class BaggedEnsembleModel(AbstractModel):
         orig_time = scheduler_options[1]['time_out']
         if orig_time:
             scheduler_options[1]['time_out'] = orig_time * 0.8  # TODO: Scheduler doesn't early stop on final model, this is a safety net. Scheduler should be updated to early stop
-        hpo_models, hpo_model_performances, hpo_results = self.model_base.hyperparameter_tune(X=X_fold, y=y_fold, X_val=X_val_fold, y_val=y_val_fold, scheduler_options=scheduler_options, **kwargs)
+        hpo_models, hpo_model_performances, hpo_results = model_base.hyperparameter_tune(X=X_fold, y=y_fold, X_val=X_val_fold, y_val=y_val_fold, scheduler_options=scheduler_options, **kwargs)
         scheduler_options[1]['time_out'] = orig_time
 
         bags = {}

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1744,7 +1744,7 @@ class AbstractTrainer:
         if eval_metric is None:
             eval_metric = self.eval_metric
         if model is None:
-            model = self.model_best
+            model = self._get_best()
         if eval_metric.needs_pred:
             predict_func = self.predict
         else:


### PR DESCRIPTION
*Issue #, if available:*
#1689 (Introduced first bug, but 2nd and 3rd were already present but rare / inactive)

*Description of changes:*
- Fix repeated bagging failing to fit repeats beyond the first when time limit is specified due to `self.model_base` being None in the loaded model (need to use `self._get_model_base()`).
- Fixed HPO not working for bagged models if the bagged model is loaded from disk (same issue as above).
- Fixed Feature importance erroring if `self.model_best` is None (can happen if no Weighted Ensemble is fit). Now it does same logic as `predict` to find best model if `self.model_best` is None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
