### PR TITLE
Updated feature importance defaults

### DIFF
--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -677,7 +677,7 @@ class AbstractLearner:
     # model: model (str) to get feature importances for, if None will choose best model.
     # features: list of feature names that feature importances are calculated for and returned, specify None to get all feature importances.
     # feature_stage: Whether to compute feature importance on raw original features ('original'), transformed features ('transformed') or on the features used by the particular model ('transformed_model').
-    def get_feature_importance(self, model=None, X=None, y=None, features: list = None, feature_stage='original', subsample_size=1000, silent=False, **kwargs) -> DataFrame:
+    def get_feature_importance(self, model=None, X=None, y=None, features: list = None, feature_stage='original', subsample_size=5000, silent=False, **kwargs) -> DataFrame:
         valid_feature_stages = ['original', 'transformed', 'transformed_model']
         if feature_stage not in valid_feature_stages:
             raise ValueError(f'feature_stage must be one of: {valid_feature_stages}, but was {feature_stage}.')

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1826,7 +1826,7 @@ class TabularPredictor:
                 labels_transformed = self._learner.label_cleaner.transform(y=labels)
         return labels_transformed
 
-    def feature_importance(self, data=None, model=None, features=None, feature_stage='original', subsample_size=1000,
+    def feature_importance(self, data=None, model=None, features=None, feature_stage='original', subsample_size=5000,
                            time_limit=None, num_shuffle_sets=None, include_confidence_band=True, confidence_level=0.99,
                            silent=False):
         """
@@ -1838,7 +1838,7 @@ class TabularPredictor:
         Note that calculating feature importance can be a very computationally expensive process, particularly if the model uses hundreds or thousands of features. In many cases, this can take longer than the original model training.
         To estimate how long `feature_importance(model, data, features)` will take, it is roughly the time taken by `predict_proba(data, model)` multiplied by the number of features.
 
-        Note: For highly accurate importance and p_value estimates, it is recommend to set `subsample_size` to at least 5,000 if possible and `num_shuffle_sets` to at least 10.
+        Note: For highly accurate importance and p_value estimates, it is recommended to set `subsample_size` to at least 5000 if possible and `num_shuffle_sets` to at least 10.
 
         Parameters
         ----------
@@ -1879,7 +1879,7 @@ class TabularPredictor:
                 'transformed_model':
                     Compute importances of the post-model-transformation features. These features are the internal features used by the requested model. They may differ greatly from the original features.
                     If the model is a stack ensemble, this will include stack ensemble features such as the prediction probability features of the stack ensemble's base (ancestor) models.
-        subsample_size : int, default = 1000
+        subsample_size : int, default = 5000
             The number of rows to sample from `data` when computing feature importance.
             If `subsample_size=None` or `data` contains fewer than `subsample_size` rows, all rows will be used during computation.
             Larger values increase the accuracy of the feature importance scores.
@@ -1892,7 +1892,7 @@ class TabularPredictor:
             The number of different permutation shuffles of the data that are evaluated.
             Larger values will increase the quality of the importance evaluation.
             It is generally recommended to increase `subsample_size` before increasing `num_shuffle_sets`.
-            Defaults to 3 if `time_limit` is None or 10 if `time_limit` is specified.
+            Defaults to 5 if `time_limit` is None or 10 if `time_limit` is specified.
             Runtime linearly scales with `num_shuffle_sets`.
         include_confidence_band: bool, default = True
             If True, returned DataFrame will include two additional columns specifying confidence interval for the true underlying importance value of each feature.
@@ -1927,7 +1927,7 @@ class TabularPredictor:
             self._validate_unique_indices(data, 'data')
 
         if num_shuffle_sets is None:
-            num_shuffle_sets = 10 if time_limit else 3
+            num_shuffle_sets = 10 if time_limit else 5
 
         fi_df = self._learner.get_feature_importance(model=model, X=data, features=features,
                                                      feature_stage=feature_stage,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated subsample_size 1000 -> 5000, num_shuffle_sets 3 -> 5

This will greatly improve the quality of the feature importance values by default, especially the 99% confidence bounds.
This will increase the time taken by ~8x, but this is acceptable because of the numerous inference speed optimizations done since these defaults were first introduced.

Comparison on Adult dataset:

Notice the dramatically more powerful p values and tighter stddev and p99_high p99_low.

Further, when compared to an extreme setting that is highly accurate, the new defaults are very close to the results of the extreme setting, whereas the old setting was quite far off on several importance scores.

Old (subsample 1000, sets 3):

```
Computing feature importance via permutation shuffling for 14 features using 1000 rows with 3 shuffle sets...
	1.46s	= Expected runtime (0.49s per shuffle set)
	0.56s	= Actual runtime (Completed 3 of 3 shuffle sets)
                importance    stddev   p_value  n  p99_high   p99_low
marital-status    0.104972  0.012861  0.002483  3  0.178669  0.031276
capital-gain      0.037817  0.014752  0.023581  3  0.122347 -0.046712
education-num     0.029400  0.005606  0.005951  3  0.061522 -0.002721
age               0.025160  0.006811  0.011784  3  0.064189 -0.013869
hours-per-week    0.012465  0.002748  0.007910  3  0.028213 -0.003283
occupation        0.011738  0.001173  0.001656  3  0.018460  0.005017
capital-loss      0.003961  0.002416  0.052435  3  0.017805 -0.009883
workclass         0.003853  0.003557  0.100735  3  0.024237 -0.016531
sex               0.001129  0.001049  0.101759  3  0.007141 -0.004884
race              0.001096  0.003322  0.312737  3  0.020133 -0.017941
native-country    0.001015  0.001526  0.184139  3  0.009757 -0.007727
relationship      0.000226  0.002460  0.444170  3  0.014324 -0.013872
education        -0.000841  0.001920  0.736305  3  0.010162 -0.011843
fnlwgt           -0.004837  0.005281  0.873236  3  0.025425 -0.035100
```

New (subsample 5000, sets 5):

```
Computing feature importance via permutation shuffling for 14 features using 5000 rows with 5 shuffle sets...
	4.02s	= Expected runtime (0.8s per shuffle set)
	3.19s	= Actual runtime (Completed 5 of 5 shuffle sets)
                importance    stddev       p_value  n  p99_high   p99_low
marital-status    0.097758  0.003892  3.007752e-07  5  0.105772  0.089745
capital-gain      0.042754  0.002505  1.407613e-06  5  0.047912  0.037596
age               0.034425  0.005618  8.219423e-05  5  0.045993  0.022857
education-num     0.027695  0.003542  3.142198e-05  5  0.034988  0.020402
hours-per-week    0.017153  0.002625  6.378668e-05  5  0.022557  0.011748
occupation        0.011279  0.001017  7.850518e-06  5  0.013374  0.009185
capital-loss      0.004799  0.000894  1.379196e-04  5  0.006639  0.002959
workclass         0.001851  0.000745  2.563675e-03  5  0.003385  0.000318
sex               0.001151  0.000322  6.631790e-04  5  0.001813  0.000488
race              0.001025  0.001440  9.340475e-02  5  0.003991 -0.001941
relationship      0.000671  0.000402  1.010832e-02  5  0.001499 -0.000156
native-country    0.000489  0.000459  3.774134e-02  5  0.001434 -0.000455
fnlwgt            0.000355  0.001474  3.094974e-01  5  0.003390 -0.002680
education        -0.000437  0.000465  9.482157e-01  5  0.000520 -0.001394
```

Extreme Setting (subsample 9769 (None), sets 100)(For comparison):

```
Computing feature importance via permutation shuffling for 14 features using 9769 rows with 100 shuffle sets...
	132.95s	= Expected runtime (1.33s per shuffle set)
	93.87s	= Actual runtime (Completed 100 of 100 shuffle sets)
                importance    stddev        p_value    n  p99_high   p99_low
marital-status    0.098090  0.003349  1.443115e-147  100  0.098970  0.097211
capital-gain      0.042547  0.001754  1.736297e-139  100  0.043007  0.042086
age               0.034418  0.002070  2.880566e-123  100  0.034961  0.033874
education-num     0.030565  0.001550  1.378641e-130  100  0.030973  0.030158
hours-per-week    0.017362  0.001554  2.767672e-106  100  0.017770  0.016954
occupation        0.011504  0.001064  7.119737e-105  100  0.011784  0.011225
capital-loss      0.005157  0.000372  1.934084e-115  100  0.005255  0.005059
workclass         0.001451  0.000508   6.969131e-50  100  0.001585  0.001318
race              0.001038  0.000479   1.163684e-39  100  0.001163  0.000912
sex               0.000996  0.000224   1.569891e-67  100  0.001054  0.000937
native-country    0.000596  0.000159   1.472196e-60  100  0.000638  0.000555
relationship      0.000593  0.000268   1.954633e-40  100  0.000663  0.000522
fnlwgt            0.000211  0.000636   6.492037e-04  100  0.000378  0.000044
education        -0.000116  0.000278   9.999657e-01  100 -0.000043 -0.000188
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
