### PR TITLE
Make AutoMM dataloader return feature column information

### DIFF
--- a/text/src/autogluon/text/automm/constants.py
+++ b/text/src/autogluon/text/automm/constants.py
@@ -17,6 +17,7 @@ LABEL = "label"
 TEXT_TOKEN_IDS = "text_token_ids"
 TEXT_VALID_LENGTH = "text_valid_length"
 TEXT_SEGMENT_IDS = "text_segment_ids"
+COLUMN = "column"
 
 # Output keys
 LOGITS = "logits"

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -48,7 +48,7 @@ class BaseDataset(torch.utils.data.Dataset):
             for per_modality in per_processors_group:
                 per_modality_features = getattr(per_preprocessor, f"transform_{per_modality}")(data)
                 setattr(self, f"{per_modality}_{i}", per_modality_features)
-                self.lengths.append(len(per_modality_features[0]))
+                self.lengths.append(len(per_modality_features[next(iter(per_modality_features))]))
         assert len(set(self.lengths)) == 1
 
     def __len__(self):

--- a/text/src/autogluon/text/automm/data/process_categorical.py
+++ b/text/src/autogluon/text/automm/data/process_categorical.py
@@ -76,6 +76,7 @@ class CategoricalProcessor:
         A dictionary containing the processed categorical features.
         """
         ret = {}
+        # TODO: consider moving this for loop into __init__() since each sample has the same information.
         for i, col_name in enumerate(categorical_features.keys()):
             ret[f"{self.categorical_column_prefix}_{col_name}"] = i
 

--- a/text/src/autogluon/text/automm/data/process_categorical.py
+++ b/text/src/autogluon/text/automm/data/process_categorical.py
@@ -1,7 +1,7 @@
-from typing import Optional, List, Any
+from typing import Optional, List, Any, Dict
 import numpy as np
 from nptyping import NDArray
-from ..constants import CATEGORICAL
+from ..constants import CATEGORICAL, COLUMN
 from .collator import Stack, Tuple
 
 
@@ -15,20 +15,28 @@ class CategoricalProcessor:
     def __init__(
             self,
             prefix: str,
-            num_categorical_columns: int,
+            categorical_column_names: List[str],
     ):
         """
         Parameters
         ----------
         prefix
             The prefix connecting a processor to its corresponding model.
-        num_categorical_columns
-            Number of categorical columns in a multimodal pd.DataFrame.
+        categorical_column_names
+            Categorical column names in a multimodal pd.DataFrame.
         """
         self.prefix = prefix
-        self.num_categorical_columns = num_categorical_columns
+        self.categorical_column_names = categorical_column_names
 
-    def collate_fn(self) -> dict:
+    @property
+    def categorical_key(self):
+        return f"{self.prefix}_{CATEGORICAL}"
+
+    @property
+    def categorical_column_prefix(self):
+        return f"{self.categorical_key}_{COLUMN}"
+
+    def collate_fn(self) -> Dict:
         """
         Collate individual samples into a batch. It stacks categorical features of
         each column independently. This function will be used when creating Pytorch DataLoader.
@@ -37,13 +45,23 @@ class CategoricalProcessor:
         -------
         A dictionary containing one model's collator function for categorical features.
         """
-        fn = [Stack() for _ in range(self.num_categorical_columns)]
-        return {f"{self.prefix}_{CATEGORICAL}": Tuple(fn)}
+        fn = {}
+
+        for col_name in self.categorical_column_names:
+            fn[f"{self.categorical_column_prefix}_{col_name}"] = Stack()
+
+        fn[self.categorical_key] = Tuple(
+            [
+                Stack() for _ in range(len(self.categorical_column_names))
+            ]
+        )
+
+        return fn
 
     def process_one_sample(
             self,
-            categorical_features: List[int],
-    ) -> dict:
+            categorical_features: Dict[str, int],
+    ) -> Dict:
         """
         Process one sample's categorical features. Assume the categorical features
         are the encoded labels from sklearn' LabelEncoder().
@@ -57,16 +75,20 @@ class CategoricalProcessor:
         -------
         A dictionary containing the processed categorical features.
         """
-        return {
-            f"{self.prefix}_{CATEGORICAL}": categorical_features
-        }
+        ret = {}
+        for i, col_name in enumerate(categorical_features.keys()):
+            ret[f"{self.categorical_column_prefix}_{col_name}"] = i
+
+        ret[self.categorical_key] = list(categorical_features.values())
+
+        return ret
 
     def __call__(
             self,
-            all_categorical_features: List[NDArray[(Any,), np.int32]],
+            all_categorical_features: Dict[str, NDArray[(Any,), np.int32]],
             idx: int,
             is_training: bool,
-    ) -> dict:
+    ) -> Dict:
         """
         Extract one sample's categorical features and customize it for a specific model.
 
@@ -83,5 +105,8 @@ class CategoricalProcessor:
         -------
         A dictionary containing one sample's processed categorical features.
         """
-        per_sample_features = [per_column_features[idx] for per_column_features in all_categorical_features]
+        per_sample_features = {
+            per_column_name: per_column_features[idx]
+            for per_column_name, per_column_features in all_categorical_features.items()
+        }
         return self.process_one_sample(per_sample_features)

--- a/text/src/autogluon/text/automm/data/process_numerical.py
+++ b/text/src/autogluon/text/automm/data/process_numerical.py
@@ -78,6 +78,7 @@ class NumericalProcessor:
         A dictionary containing the processed numerical features.
         """
         ret = {}
+        # TODO: consider moving this for loop into __init__() since each sample has the same information.
         for i, col_name in enumerate(numerical_features.keys()):
             ret[f"{self.numerical_column_prefix}_{col_name}"] = i
 

--- a/text/src/autogluon/text/automm/data/process_numerical.py
+++ b/text/src/autogluon/text/automm/data/process_numerical.py
@@ -1,7 +1,7 @@
-from typing import Optional, List, Any
+from typing import Optional, List, Any, Dict
 import numpy as np
 from nptyping import NDArray
-from ..constants import NUMERICAL
+from ..constants import NUMERICAL, COLUMN
 from .collator import Stack
 
 
@@ -15,6 +15,7 @@ class NumericalProcessor:
     def __init__(
             self,
             prefix: str,
+            numerical_column_names: List[str],
             merge: Optional[str] = "concat",
     ):
         """
@@ -22,6 +23,8 @@ class NumericalProcessor:
         ----------
         prefix
             The prefix connecting a processor to its corresponding model.
+        numerical_column_names
+            Numerical column names in a multimodal pd.DataFrame.
         merge
             How to merge numerical features from multiple columns in a multimodal pd.DataFrame.
             Currently, it only supports one choice:
@@ -29,9 +32,18 @@ class NumericalProcessor:
                 Concatenate the numerical features.
         """
         self.prefix = prefix
+        self.numerical_column_names = numerical_column_names
         self.merge = merge
 
-    def collate_fn(self) -> dict:
+    @property
+    def numerical_key(self):
+        return f"{self.prefix}_{NUMERICAL}"
+
+    @property
+    def numerical_column_prefix(self):
+        return f"{self.numerical_key}_{COLUMN}"
+
+    def collate_fn(self) -> Dict:
         """
         Collate individual samples into a batch. Here it stacks numerical features.
         This function will be used when creating Pytorch DataLoader.
@@ -40,13 +52,18 @@ class NumericalProcessor:
         -------
         A dictionary containing one model's collator function for numerical features.
         """
-        fn = {f"{self.prefix}_{NUMERICAL}": Stack()}
+        fn = {}
+        for col_name in self.numerical_column_names:
+            fn[f"{self.numerical_column_prefix}_{col_name}"] = Stack()
+
+        fn[self.numerical_key] = Stack()
+
         return fn
 
     def process_one_sample(
             self,
-            numerical_features: List[float],
-    ) -> dict:
+            numerical_features: Dict[str, float],
+    ) -> Dict:
         """
         Process one sample's numerical features.
         Here it converts numerical features to a NumPy array.
@@ -60,19 +77,23 @@ class NumericalProcessor:
         -------
         A dictionary containing the processed numerical features.
         """
+        ret = {}
+        for i, col_name in enumerate(numerical_features.keys()):
+            ret[f"{self.numerical_column_prefix}_{col_name}"] = i
+
         if self.merge == "concat":
-            return {
-                f"{self.prefix}_{NUMERICAL}": np.array(numerical_features, dtype=np.float32)
-            }
+            ret[self.numerical_key] = np.array(list(numerical_features.values()), dtype=np.float32)
         else:
             raise ValueError(f"Unknown merging type: {self.merge}")
 
+        return ret
+
     def __call__(
             self,
-            all_numerical_features: List[NDArray[(Any,), np.float32]],
+            all_numerical_features: Dict[str, NDArray[(Any,), np.float32]],
             idx: int,
             is_training: bool,
-    ) -> dict:
+    ) -> Dict:
         """
         Extract one sample's numerical features and customize it for a specific model.
 
@@ -89,5 +110,8 @@ class NumericalProcessor:
         -------
         A dictionary containing one sample's processed numerical features.
         """
-        per_sample_features = [per_column_features[idx] for per_column_features in all_numerical_features]
+        per_sample_features = {
+            per_column_name: per_column_features[idx]
+            for per_column_name, per_column_features in all_numerical_features.items()
+        }
         return self.process_one_sample(per_sample_features)

--- a/text/src/autogluon/text/automm/data/process_text.py
+++ b/text/src/autogluon/text/automm/data/process_text.py
@@ -1,7 +1,7 @@
 import os
 import logging
 import pickle
-from typing import Optional, List, Any
+from typing import Optional, List, Any, Dict
 import numpy as np
 from nptyping import NDArray
 import warnings
@@ -16,7 +16,7 @@ from ..constants import (
     TEXT_TOKEN_IDS,
     TEXT_VALID_LENGTH,
     TEXT_SEGMENT_IDS,
-    AUTOMM,
+    AUTOMM, COLUMN,
 )
 from .collator import Stack, Pad
 from .utils import extract_value_from_config
@@ -45,6 +45,7 @@ class TextProcessor:
             self,
             prefix: str,
             checkpoint_name: str,
+            text_column_names: List[str],
             tokenizer_name: Optional[str] = "hf_auto",
             max_len: Optional[int] = None,
             insert_sep: Optional[bool] = True,
@@ -58,6 +59,8 @@ class TextProcessor:
             The prefix connecting a processor to its corresponding model.
         checkpoint_name
             Name of the pretrained huggingface checkpoint, e.g., "microsoft/deberta-v3-small"
+        text_column_names
+            Text column names in a multimodal pd.DataFrame.
         tokenizer_name
             Name of the huggingface tokenizer type (default "hf_auto").
         max_len
@@ -72,6 +75,7 @@ class TextProcessor:
         self.prefix = prefix
         self.tokenizer_name = tokenizer_name
         self.checkpoint_name = checkpoint_name
+        self.text_column_names = text_column_names
         self.tokenizer = self.get_pretrained_tokenizer(
             tokenizer_name=tokenizer_name,
             checkpoint_name=checkpoint_name,
@@ -81,7 +85,7 @@ class TextProcessor:
             # See https://github.com/huggingface/transformers/blob/6ac77534bfe97c00e0127bb4fc846ae0faf1c9c5/src/transformers/tokenization_utils_base.py#L3362
             self.tokenizer.deprecation_warnings["sequence-length-is-longer-than-the-specified-maximum"] = True
 
-        self.cls_token_id, self.sep_token_id = self.get_special_tokens(tokenizer=self.tokenizer)
+        self.cls_token_id, self.sep_token_id, self.eos_token_id = self.get_special_tokens(tokenizer=self.tokenizer)
         if max_len is None or max_len <= 0:
             self.max_len = self.tokenizer.model_max_length
         else:
@@ -121,7 +125,23 @@ class TextProcessor:
 
         self.stochastic_chunk = stochastic_chunk
 
-    def collate_fn(self) -> dict:
+    @property
+    def text_token_ids_key(self):
+        return f"{self.prefix}_{TEXT_TOKEN_IDS}"
+
+    @property
+    def text_segment_ids_key(self):
+        return f"{self.prefix}_{TEXT_SEGMENT_IDS}"
+
+    @property
+    def text_valid_length_key(self):
+        return f"{self.prefix}_{TEXT_VALID_LENGTH}"
+
+    @property
+    def text_column_prefix(self):
+        return f"{self.text_token_ids_key}_{COLUMN}"
+
+    def collate_fn(self) -> Dict:
         """
         Collate text features into a batch.
         This function will be used when creating Pytorch DataLoader.
@@ -131,15 +151,23 @@ class TextProcessor:
         A dictionary containing one model's collator function for text data.
         """
         fn = {}
-        fn.update({f"{self.prefix}_{TEXT_TOKEN_IDS}": Pad(pad_val=self.tokenizer.pad_token_id)})
-        fn.update({f"{self.prefix}_{TEXT_VALID_LENGTH}": Stack()})
-        fn.update({f"{self.prefix}_{TEXT_SEGMENT_IDS}": Pad(pad_val=0)})
+        for col_name in self.text_column_names:
+            fn[f"{self.text_column_prefix}_{col_name}"] = Stack()
+
+        fn.update(
+            {
+                self.text_token_ids_key: Pad(pad_val=self.tokenizer.pad_token_id),
+                self.text_valid_length_key: Stack(),
+                self.text_segment_ids_key: Pad(pad_val=0),
+            }
+        )
+
         return fn
 
     def build_one_token_sequence(
             self,
-            text_tokens: List[NDArray[(Any,), np.int32]],
-    ) -> dict:
+            text_tokens: Dict[str, NDArray[(Any,), np.int32]],
+    ) -> Dict:
         """
         Construct one token sequence based on multiple token sequences coming from different
         text columns in a multimodal pd.DataFrame. The token sequence length and the text segment
@@ -159,40 +187,53 @@ class TextProcessor:
         else:
             max_length = self.max_len - 2
         trimmed_lengths = self.get_trimmed_lengths(
-            [len(txt_token) for txt_token in text_tokens],
+            [len(txt_token) for txt_token in text_tokens.values()],
             max_length,
             do_merge=True,
         )
         seg = 0
         token_ids = [self.cls_token_id]
         segment_ids = [seg]
-        for txt_token, trim_length in zip(text_tokens, trimmed_lengths):
-
+        ret = {}
+        for (col_name, txt_token), trim_length in zip(text_tokens.items(), trimmed_lengths):
+            segment_start = len(token_ids)
             if self.stochastic_chunk:
                 start_ptr = np.random.randint(0, len(txt_token) - trim_length + 1)
             else:
                 start_ptr = 0
             token_ids.extend(txt_token[start_ptr:(start_ptr + trim_length)].tolist())
             segment_ids.extend([seg] * trim_length)
+            # np.int64 corresponds to torch.LongTensor
+            col_token_idxs = np.array([segment_start, segment_start+trim_length], dtype=np.int64)
+            ret[f"{self.text_column_prefix}_{col_name}"] = col_token_idxs
             if self.insert_sep:
                 token_ids.append(self.sep_token_id)
                 segment_ids.append(seg)
             seg = (seg + 1) % self.text_segment_num
 
-        if token_ids[-1] != self.sep_token_id:
-            token_ids.append(self.sep_token_id)
-            segment_ids.append(seg)
+        if hasattr(self, "eos_token_id"):
+            if token_ids[-1] != self.eos_token_id:
+                token_ids.append(self.eos_token_id)
+                segment_ids.append(seg)
+        else:  # backward compatibility
+            if token_ids[-1] != self.sep_token_id:
+                token_ids.append(self.sep_token_id)
+                segment_ids.append(seg)
 
-        return {
-            f"{self.prefix}_{TEXT_TOKEN_IDS}": np.array(token_ids, dtype=np.int32),
-            f"{self.prefix}_{TEXT_VALID_LENGTH}": len(token_ids),
-            f"{self.prefix}_{TEXT_SEGMENT_IDS}": np.array(segment_ids, dtype=np.int32)
-        }
+        ret.update(
+            {
+                self.text_token_ids_key: np.array(token_ids, dtype=np.int32),
+                self.text_valid_length_key: len(token_ids),
+                self.text_segment_ids_key: np.array(segment_ids, dtype=np.int32),
+            }
+        )
+
+        return ret
 
     def build_one_token_sequence_from_text(
             self,
-            text: List[str],
-    ) -> dict:
+            text: Dict[str, str],
+    ) -> Dict:
         """
         Tokenize a sample's text data and build one token sequence. One sample may have
         multiple text columns in a multimodal pd.DataFrame.
@@ -207,18 +248,18 @@ class TextProcessor:
         A dictionary containing one sample's text tokens, valid length, and segment ids.
         """
         # tokenize text
-        tokens = []
+        tokens = {}
         warnings.filterwarnings(
             "ignore",
             "Token indices sequence length is longer than.*result in indexing errors"
         )
-        for col_text in text:
+        for col_name, col_text in text.items():
             col_tokens = self.tokenizer.encode(
                 col_text,
                 add_special_tokens=False,
                 truncation=False,
             )
-            tokens.append(np.array(col_tokens, dtype=np.int32))
+            tokens[col_name] = np.array(col_tokens, dtype=np.int32)
 
         # build token sequence
         return self.build_one_token_sequence(tokens)
@@ -226,7 +267,7 @@ class TextProcessor:
     @staticmethod
     def get_special_tokens(tokenizer):
         """
-        Extract the cls and sep token ids from a huggingface tokenizer. In most cases,
+        Extract the cls, sep, and eos token ids from a huggingface tokenizer. In most cases,
         we can use the attributes "cls_token_id" and "sep_token_id". But for CLIP, we
         need to use "bos_token_id" and "eos_token_id".
 
@@ -237,16 +278,18 @@ class TextProcessor:
 
         Returns
         -------
-        The cls and sep token ids.
+        The cls, sep, and eos token ids.
         """
-        cls_id, sep_id = tokenizer.cls_token_id, tokenizer.sep_token_id
+        cls_id, sep_id, eos_id = tokenizer.cls_token_id, tokenizer.sep_token_id, tokenizer.sep_token_id
         if cls_id is None or sep_id is None:
-            cls_id, sep_id = tokenizer.bos_token_id, tokenizer.eos_token_id
-        if cls_id is None or sep_id is None:
+            # CLIP uses eos_token's feature as the pooled output.
+            # See https://github.com/huggingface/transformers/blob/v4.14.1/src/transformers/models/clip/modeling_clip.py#L657
+            cls_id, sep_id, eos_id = tokenizer.bos_token_id, tokenizer.bos_token_id, tokenizer.eos_token_id
+        if cls_id is None or sep_id is None or eos_id is None:
             raise ValueError(
-                f"tokenizer class: {tokenizer.__class__.__name__} has no valid cls and sep ids."
+                f"tokenizer class: {tokenizer.__class__.__name__} has no valid cls, sep, and eos ids."
             )
-        return cls_id, sep_id
+        return cls_id, sep_id, eos_id
 
     @staticmethod
     def get_pretrained_tokenizer(
@@ -325,10 +368,10 @@ class TextProcessor:
 
     def __call__(
             self,
-            all_text: List[List[str]],
+            all_text: Dict[str, List[str]],
             idx: int,
             is_training: bool,
-    ) -> dict:
+    ) -> Dict:
         """
         Extract one sample's text data, tokenize them, and build one token sequence.
 
@@ -345,5 +388,7 @@ class TextProcessor:
         -------
         A dictionary containing one sample's text tokens, valid length, and segment ids.
         """
-        per_sample_text = [per_column_text[idx] for per_column_text in all_text]
+        per_sample_text = {
+            per_column_name: per_column_text[idx] for per_column_name, per_column_text in all_text.items()
+        }
         return self.build_one_token_sequence_from_text(per_sample_text)

--- a/text/tests/unittests/automm/test_automm_predictor.py
+++ b/text/tests/unittests/automm/test_automm_predictor.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from omegaconf import OmegaConf
 import pytest
 import numpy.testing as npt
@@ -178,6 +179,8 @@ def test_predictor(
     if image_backbone is not None:
         save_path = os.path.join(save_path, image_backbone)
 
+    if os.path.exists(save_path):
+        shutil.rmtree(save_path)
     predictor.fit(
         train_data=dataset.train_df,
         config=config,
@@ -246,7 +249,8 @@ def test_standalone(): # test standalong feature in AutoMMPredictor.save()
     )
 
     save_path = os.path.join(get_home_dir(), "standalone", "false")
-
+    if os.path.exists(save_path):
+        shutil.rmtree(save_path)
 
     predictor.fit(
         train_data=dataset.train_df,
@@ -259,14 +263,14 @@ def test_standalone(): # test standalong feature in AutoMMPredictor.save()
     save_path_standalone = os.path.join(get_home_dir(), "standalone", "true")
 
     predictor.save(
-        path = save_path_standalone,
-        standalone = True
+        path=save_path_standalone,
+        standalone=True,
     )
 
     del predictor
     torch.cuda.empty_cache()
 
-    loaded_online_predictor = AutoMMPredictor.load(path = save_path)
+    loaded_online_predictor = AutoMMPredictor.load(path=save_path)
     online_predictions = loaded_online_predictor.predict(dataset.test_df, as_pandas=False)
     del loaded_online_predictor
 
@@ -275,7 +279,7 @@ def test_standalone(): # test standalong feature in AutoMMPredictor.save()
         # No internet connection here. If any command require internet connection, a RuntimeError will be raised.
         with tempfile.TemporaryDirectory() as tmpdirname:
             torch.hub.set_dir(tmpdirname) # block reading files in `.cache`
-            loaded_offline_predictor = AutoMMPredictor.load(path = save_path_standalone)
+            loaded_offline_predictor = AutoMMPredictor.load(path=save_path_standalone)
 
 
     offline_predictions = loaded_offline_predictor.predict(dataset.test_df, as_pandas=False)
@@ -343,6 +347,8 @@ def test_customizing_model_names(
         hyperparameters_gt["model.names"] = OmegaConf.from_dotlist([f'names={hyperparameters["model.names"]}']).names
 
     save_path = os.path.join(get_home_dir(), "outputs", "petfinder")
+    if os.path.exists(save_path):
+        shutil.rmtree(save_path)
     predictor.fit(
         train_data=dataset.train_df,
         config=config,


### PR DESCRIPTION
To do feature column level distillation, we need to let AutoMM dataloader return feature column information.

1. Add feature column names in data processors.
2. Dataframe preprocessor outputs dictionary instead of list.
3. Data processors's return contains feature column information.
4. Use property for return keys in data processors.
5. CLIP uses eos token as the cls token. So avoid using eos as the sep token for CLIP.
