### PR TITLE
Optionally turn on returning feature column information

### DIFF
--- a/text/src/autogluon/text/automm/data/process_categorical.py
+++ b/text/src/autogluon/text/automm/data/process_categorical.py
@@ -16,6 +16,7 @@ class CategoricalProcessor:
             self,
             prefix: str,
             categorical_column_names: List[str],
+            requires_column_info: bool = False,
     ):
         """
         Parameters
@@ -24,9 +25,12 @@ class CategoricalProcessor:
             The prefix connecting a processor to its corresponding model.
         categorical_column_names
             Categorical column names in a multimodal pd.DataFrame.
+        requires_column_info
+            Whether to require feature column information in dataloader.
         """
         self.prefix = prefix
         self.categorical_column_names = categorical_column_names
+        self.requires_column_info = requires_column_info
 
     @property
     def categorical_key(self):
@@ -47,8 +51,9 @@ class CategoricalProcessor:
         """
         fn = {}
 
-        for col_name in self.categorical_column_names:
-            fn[f"{self.categorical_column_prefix}_{col_name}"] = Stack()
+        if self.requires_column_info:
+            for col_name in self.categorical_column_names:
+                fn[f"{self.categorical_column_prefix}_{col_name}"] = Stack()
 
         fn[self.categorical_key] = Tuple(
             [
@@ -76,9 +81,10 @@ class CategoricalProcessor:
         A dictionary containing the processed categorical features.
         """
         ret = {}
-        # TODO: consider moving this for loop into __init__() since each sample has the same information.
-        for i, col_name in enumerate(categorical_features.keys()):
-            ret[f"{self.categorical_column_prefix}_{col_name}"] = i
+        if self.requires_column_info:
+            # TODO: consider moving this for loop into __init__() since each sample has the same information.
+            for i, col_name in enumerate(categorical_features.keys()):
+                ret[f"{self.categorical_column_prefix}_{col_name}"] = i
 
         ret[self.categorical_key] = list(categorical_features.values())
 

--- a/text/src/autogluon/text/automm/data/process_numerical.py
+++ b/text/src/autogluon/text/automm/data/process_numerical.py
@@ -17,6 +17,7 @@ class NumericalProcessor:
             prefix: str,
             numerical_column_names: List[str],
             merge: Optional[str] = "concat",
+            requires_column_info: bool = False,
     ):
         """
         Parameters
@@ -30,10 +31,13 @@ class NumericalProcessor:
             Currently, it only supports one choice:
             - concat
                 Concatenate the numerical features.
+        requires_column_info
+            Whether to require feature column information in dataloader.
         """
         self.prefix = prefix
         self.numerical_column_names = numerical_column_names
         self.merge = merge
+        self.requires_column_info = requires_column_info
 
     @property
     def numerical_key(self):
@@ -53,8 +57,9 @@ class NumericalProcessor:
         A dictionary containing one model's collator function for numerical features.
         """
         fn = {}
-        for col_name in self.numerical_column_names:
-            fn[f"{self.numerical_column_prefix}_{col_name}"] = Stack()
+        if self.requires_column_info:
+            for col_name in self.numerical_column_names:
+                fn[f"{self.numerical_column_prefix}_{col_name}"] = Stack()
 
         fn[self.numerical_key] = Stack()
 
@@ -78,9 +83,10 @@ class NumericalProcessor:
         A dictionary containing the processed numerical features.
         """
         ret = {}
-        # TODO: consider moving this for loop into __init__() since each sample has the same information.
-        for i, col_name in enumerate(numerical_features.keys()):
-            ret[f"{self.numerical_column_prefix}_{col_name}"] = i
+        if self.requires_column_info:
+            # TODO: consider moving this for loop into __init__() since each sample has the same information.
+            for i, col_name in enumerate(numerical_features.keys()):
+                ret[f"{self.numerical_column_prefix}_{col_name}"] = i
 
         if self.merge == "concat":
             ret[self.numerical_key] = np.array(list(numerical_features.values()), dtype=np.float32)

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -53,6 +53,7 @@ from .utils import (
     load_text_tokenizers,
     modify_duplicate_model_names,
     assign_feature_column_names,
+    turn_on_off_feature_column_info,
 )
 from .optimization.utils import (
     get_metric,
@@ -501,6 +502,16 @@ class AutoMMPredictor:
             raise ValueError(
                 f"Unknown soft_label_loss_type: {self._config.distiller.soft_label_loss_type}"
             )
+
+        # turn on returning column information in data processors
+        self._data_processors = turn_on_off_feature_column_info(
+            data_processors=self._data_processors,
+            flag=True,
+        )
+        teacher_predictor._data_processors = turn_on_off_feature_column_info(
+            data_processors=teacher_predictor._data_processors,
+            flag=True,
+        )
 
         logger.debug(
             f"teacher preprocessor text_feature_names: {teacher_predictor._df_preprocessor._text_feature_names}"

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -1170,6 +1170,8 @@ def assign_feature_column_names(
         if per_modality == LABEL:
             continue
         for per_model_processor in data_processors[per_modality]:
+            # requires_column_info=True is used for feature column distillation.
+            per_model_processor.requires_column_info = False
             if per_modality == IMAGE:
                 per_model_processor.image_column_names = df_preprocessor.image_path_names
             elif per_modality == TEXT:
@@ -1180,5 +1182,34 @@ def assign_feature_column_names(
                 per_model_processor.categorical_column_names = df_preprocessor.categorical_feature_names
             else:
                 raise ValueError(f"Unknown modality: {per_modality}")
+
+    return data_processors
+
+
+def turn_on_off_feature_column_info(
+        data_processors: Dict,
+        flag: bool,
+):
+    """
+    Turn on or off returning feature column information in data processors.
+    Since feature column information is not always required in training models,
+    we optionally turn this flag on or off.
+
+    Parameters
+    ----------
+    data_processors
+        The data processors.
+    flag
+        True/False
+
+    Returns
+    -------
+    The data processors with the flag on or off.
+    """
+    for per_modality_processors in data_processors.values():
+        for per_model_processor in per_modality_processors:
+            # label processor doesn't have requires_column_info.
+            if hasattr(per_model_processor, "requires_column_info"):
+                per_model_processor.requires_column_info = flag
 
     return data_processors


### PR DESCRIPTION
We optionally turn on returning feature column information for the case of feature column distillation. By default, we turn this functionality off to reduce latency of the dataloader.

1. Add a requires_column_info flag in data processors.
2. Add a util function to turn this flag on or off.