### PR TITLE
Limit RF max_leaf_nodes to 15000

### DIFF
--- a/tabular/src/autogluon/tabular/models/rf/rf_model.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_model.py
@@ -73,6 +73,14 @@ class RFModel(AbstractModel):
             # TODO: 600 is much better, but increases info leakage in stacking -> therefore 300 is ~equal in stack ensemble final quality.
             #  Consider adding targeted noise to OOF to avoid info leakage, or increase `min_samples_leaf`.
             'n_estimators': 300,
+            # Cap leaf nodes to 15000 to avoid large datasets using unreasonable amounts of memory/disk for RF/XT.
+            #  Ensures that memory and disk usage of RF model with 300 n_estimators is at most ~500 MB for binary/regression, ~200 MB per class for multiclass.
+            #  This has no effect on datasets with <=15000 rows, and minimal to no impact on datasets with <50000 rows.
+            #  For large datasets, will often make the model worse, but will significantly speed up inference speed and massively reduce memory and disk usage.
+            #  For example, when left uncapped, RF can use 5 GB of disk for a regression dataset with 2M rows.
+            #  Multiply by the 8 RF/XT models in config for best quality / high quality and this is 40 GB of tree models, which is unreasonable.
+            #  This size scales linearly with number of rows.
+            'max_leaf_nodes': 15000,
             'n_jobs': -1,
             'random_state': 0,
             'bootstrap': True,  # Required for OOB estimates, setting to False will raise exception if bagging.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Limit RF/XT max_leaf_nodes to 15000 (previously uncapped).
Previously, for very large datasets RF/XT memory and disk usage would quickly become unreasonable. This ensures that at a certain point RF and XT will no longer become larger given more rows of training data.

Benchmark results show that the change is an improvement, particularly for the high quality preset.

Benchmark Results:

Good Quality is mostly unaffected as it already used smaller trees.

High Quality has superior win-rate (56%) while having 43% faster inference speed on datasets with >=50,000 rows of training data due to this change:

```
AutoGluon_hq_1h8c_2022_03_25 VS all
                         framework   winrate    >    <    =  % Less Avg. Errors  Avg Inf Speed Diff  time_train_s  time_infer_s  loss_rescaled  time_train_s_rescaled  time_infer_s_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0  AutoGluon_hq_1h8c_2022_05_09_rf  0.560764  158  123    7            0.635785            0.426549   4095.051389      0.000825       0.440972               1.009426               1.038351  1.439236           158           130             0             0            2
1     AutoGluon_hq_1h8c_2022_03_25  0.500000    0    0  290            0.000000                 NaN   4151.851389      0.001013       0.548611               1.023174               1.464900  1.560764           125           165             0             0            0

```

Best Quality has a 50% win-rate with 14% faster inference:

```
AutoGluon_bq_1h8c_2022_03_25 VS all
                         framework   winrate    >    <    =  % Less Avg. Errors  Avg Inf Speed Diff  time_train_s  time_infer_s  loss_rescaled  time_train_s_rescaled  time_infer_s_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0  AutoGluon_bq_1h8c_2022_05_09_rf  0.501736  136  135   17            0.110907            0.135681   3775.933333      0.002924       0.496528               1.008465               1.068908  1.498264           136           152             0             0            2
1     AutoGluon_bq_1h8c_2022_03_25  0.500000    0    0  290            0.000000                 NaN   3804.341319      0.003040       0.486111               1.015276               1.204589  1.501736           137           153             0             0            0

```

Medium Quality is slightly worse in win-rate but has 29% faster inference speed. Likely the reason it has worse win-rate is because it had enough time to fully train all models, and since the RF is slightly worse, it ever so slightly loses on average (shown by the average error difference of 0.11%).

```
AutoGluon_mq_1h8c_2022_03_25 VS all
                         framework   winrate   >    <    =  % Less Avg. Errors  Avg Inf Speed Diff  time_train_s  time_infer_s  loss_rescaled  time_train_s_rescaled  time_infer_s_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0     AutoGluon_mq_1h8c_2022_03_25  0.500000   0    0  290            0.000000                 NaN   2231.871626      0.000838       0.290657               1.016999               1.361957  1.453287           107           183             0             0            0
1  AutoGluon_mq_1h8c_2022_05_09_rf  0.453287  79  106  104           -0.118644            0.285947   2220.786159      0.000769       0.384083               1.015825               1.076010  1.546713            79           210             0             0            1

```

TODO:

- [x]  Benchmark

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
