### PR TITLE
Add frequency field to time series dataframes

### DIFF
--- a/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
+++ b/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
@@ -117,6 +117,14 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 f"for {TIMESTAMP}, the only pandas dtype allowed is ‘datetime64[ns]’."
             )
 
+        # check if timeseries are irregularly sampled
+        timedeltas = set()
+        for item_id in df[ITEMID].unique():
+            timedeltas = timedeltas.union(df[df[ITEMID] == item_id][TIMESTAMP].diff()[1:])
+            if len(timedeltas) > 1:
+                raise ValueError(f"Only a single uniformly sampled period is allowed for time series"
+                                 f" data sets. Found {len(timedeltas)}")
+
     @classmethod
     def _validate_multi_index_data_frame(cls, data: pd.DataFrame):
         """Validate a multi-index pd.DataFrame can be converted to TimeSeriesDataFrame

--- a/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
+++ b/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
@@ -67,6 +67,14 @@ class TimeSeriesDataFrame(pd.DataFrame):
             data = self.from_iterable_dataset(data)
         super().__init__(data=data, *args, **kwargs)
 
+    @property
+    def freq(self):
+        ts_index = self.index.levels[1]  # noqa
+        freq = ts_index.freq or ts_index.inferred_freq
+        if freq is None:
+            raise ValueError("Frequency not provided and cannot be inferred")
+        return freq
+
     @classmethod
     def _validate_iterable(cls, data: Iterable):
         if not isinstance(data, Iterable):

--- a/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
+++ b/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
@@ -5,7 +5,6 @@ from typing import Any, Tuple
 from collections.abc import Iterable
 
 import pandas as pd
-import numpy as np
 
 
 ITEMID = "item_id"
@@ -67,40 +66,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
         else:
             data = self.from_iterable_dataset(data)
         super().__init__(data=data, *args, **kwargs)
-
-    # TODO: move out of production code to dedicated example in examples
-    @classmethod
-    def example(cls):
-        """An example TimeSeriesDataFrame.
-
-        Returns
-        -------
-        ts_df : TimeSeriesDataFrame
-            It returns an example TimeSeriesDataFrame as:
-                                    target
-            item_id timestamp
-            0       2019-01-01       0
-                    2019-01-02       1
-                    2019-01-03       2
-            1       2019-01-01       3
-                    2019-01-02       4
-                    2019-01-03       5
-            2       2019-01-01       6
-                    2019-01-02       7
-                    2019-01-03       8
-        """
-
-        target = np.arange(9)
-        datetime_index = tuple(
-            pd.date_range(pd.Timestamp("01-01-2019"), periods=3, freq="D")  # noqa
-        )
-        item_ids = (0, 1, 2)
-        multi_index = pd.MultiIndex.from_product(
-            [item_ids, datetime_index], names=[ITEMID, TIMESTAMP]
-        )
-        return TimeSeriesDataFrame(
-            pd.Series(target, name="target", index=multi_index).to_frame()
-        )
 
     @classmethod
     def _validate_iterable(cls, data: Iterable):

--- a/forecasting/tests/unittests/common.py
+++ b/forecasting/tests/unittests/common.py
@@ -4,6 +4,9 @@ import random
 import pandas as pd
 from gluonts.dataset.common import ListDataset
 
+from autogluon.forecasting.dataset import TimeSeriesDataFrame
+
+
 # TODO: add larger unit test data sets to S3
 DUMMY_DATASET = ListDataset(
     [
@@ -20,6 +23,8 @@ DUMMY_DATASET = ListDataset(
     ],
     freq="H",
 )
+
+DUMMY_TS_DATAFRAME = TimeSeriesDataFrame.from_iterable_dataset(DUMMY_DATASET)
 
 
 def dict_equal_primitive(this, that):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a frequency property to time series data frames. The field is inferred directly via pandas from the multiindex. + minor fixes and additions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
