### PR TITLE
Fix a unit test and improve top k averaging

### DIFF
--- a/text/src/autogluon/text/automm/configs/environment/default.yaml
+++ b/text/src/autogluon/text/automm/configs/environment/default.yaml
@@ -3,7 +3,7 @@ env:
   num_nodes: 1
   batch_size: 128  # this is a desired batch size; pl trainer will accumulate gradients when per step batch is smaller.
   per_gpu_batch_size: 8  # training per gpu batch size
-  per_gpu_batch_size_evaluation: 64  # evaluation per gpu batch size
+  eval_batch_size_ratio: 4  # per_gpu_batch_size_evaluation = per_gpu_batch_size * eval_batch_size_ratio
   precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
   num_workers: 2  # pytorch training dataloader workers
   num_workers_evaluation: 2  # pytorch prediction/test dataloader workers

--- a/text/src/autogluon/text/automm/configs/environment/default.yaml
+++ b/text/src/autogluon/text/automm/configs/environment/default.yaml
@@ -4,6 +4,7 @@ env:
   batch_size: 128  # this is a desired batch size; pl trainer will accumulate gradients when per step batch is smaller.
   per_gpu_batch_size: 8  # training per gpu batch size
   eval_batch_size_ratio: 4  # per_gpu_batch_size_evaluation = per_gpu_batch_size * eval_batch_size_ratio
+  per_gpu_batch_size_evaluation:  # This is deprecated. Use eval_batch_size_ratio instead.
   precision: 16  # training precision. Refer to https://pytorch-lightning.readthedocs.io/en/latest/advanced/mixed_precision.html
   num_workers: 2  # pytorch training dataloader workers
   num_workers_evaluation: 2  # pytorch prediction/test dataloader workers

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -935,10 +935,11 @@ class AutoMMPredictor:
                               'Currently, AutoGluon will downgrade the precision to 32.', UserWarning)
                 precision = 32
 
-        if hasattr(self._config.env, "eval_batch_size_ratio"):
-            batch_size = self._config.env.per_gpu_batch_size * self._config.env.eval_batch_size_ratio
-        else:
+        if self._config.env.per_gpu_batch_size_evaluation:
             batch_size = self._config.env.per_gpu_batch_size_evaluation
+        else:
+            batch_size = self._config.env.per_gpu_batch_size * self._config.env.eval_batch_size_ratio
+            
         if num_gpus > 1:
             strategy = "dp"
             # If using 'dp', the per_gpu_batch_size would be split by all GPUs.

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -860,6 +860,9 @@ class AutoMMPredictor:
             # and use it as the main ingredients
             ingredients = [last_ckpt_path]
             top_k_model_paths = []
+            # no checkpoints available, do nothing
+            if not os.path.isfile(last_ckpt_path):
+                return
 
         # Average all the ingredients
         avg_state_dict = average_checkpoints(

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -860,7 +860,7 @@ class AutoMMPredictor:
             # and use it as the main ingredients
             ingredients = [last_ckpt_path]
             top_k_model_paths = []
-            # no checkpoints available, do nothing
+            # no checkpoints are available, do nothing
             if not os.path.isfile(last_ckpt_path):
                 return
 
@@ -935,10 +935,10 @@ class AutoMMPredictor:
                               'Currently, AutoGluon will downgrade the precision to 32.', UserWarning)
                 precision = 32
 
-        if hasattr(self._config.env, "per_gpu_batch_size_evaluation"):
-            batch_size = self._config.env.per_gpu_batch_size_evaluation
-        else:
+        if hasattr(self._config.env, "eval_batch_size_ratio"):
             batch_size = self._config.env.per_gpu_batch_size * self._config.env.eval_batch_size_ratio
+        else:
+            batch_size = self._config.env.per_gpu_batch_size_evaluation
         if num_gpus > 1:
             strategy = "dp"
             # If using 'dp', the per_gpu_batch_size would be split by all GPUs.

--- a/text/tests/unittests/automm/test_backward_compatibility.py
+++ b/text/tests/unittests/automm/test_backward_compatibility.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from autogluon.text import TextPredictor
 from datasets import AmazonReviewSentimentCrossLingualDataset
 from test_automm_predictor import verify_predictor_save_load
@@ -16,6 +17,8 @@ def test_load_old_checkpoint():
     save_path = os.path.join(get_home_dir(), "checkpoints")
     file_path = os.path.join(save_path, f"{checkpoint_name}.zip")
     checkpoint_path = os.path.join(get_home_dir(), "checkpoints", checkpoint_name)
+    if os.path.exists(save_path):
+        shutil.rmtree(save_path)
     download(
         url=f"s3://automl-mm-bench/unit-tests-0.4/checkpoints/{checkpoint_name}.zip",
         path=file_path,


### PR DESCRIPTION
1. Fix a unit test by cleaning up saving path.
2. Support resuming top k averaging if encountering failures.
3. Replace `per_gpu_batch_size_evaluation` with `eval_batch_size_ratio`. Users only needs to override `per_gpu_batch_size`. `per_gpu_batch_size_evaluation` would be automatically updated. 
