### PR TITLE
integrate forecasting models and trainer to time series dataframe format

### DIFF
--- a/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
+++ b/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
@@ -57,6 +57,8 @@ class TimeSeriesDataFrame(pd.DataFrame):
                 This example can be found using example() function.
     """
 
+    index: pd.MultiIndex
+
     def __init__(self, data: Any, *args, **kwargs):
         if isinstance(data, pd.DataFrame):
             if isinstance(data.index, pd.MultiIndex):

--- a/forecasting/src/autogluon/forecasting/models/abstract/abstract_forecasting_model.py
+++ b/forecasting/src/autogluon/forecasting/models/abstract/abstract_forecasting_model.py
@@ -3,15 +3,11 @@ import logging
 import time
 from typing import Any, Dict, Union, Tuple, Optional
 
-import pandas as pd
-from gluonts.dataset.common import (
-    Dataset,
-)  # TODO: this interface should not depend on GluonTS datasets
-
 import autogluon.core as ag
 from autogluon.core.models import AbstractModel
 from autogluon.common.savers import save_pkl
 
+from ...dataset import TimeSeriesDataFrame
 from ...utils.metadata import get_prototype_metadata_dict
 from ...utils.metric_utils import check_get_evaluation_metric
 from .model_trial import skip_hpo, model_trial
@@ -104,7 +100,7 @@ class AbstractForecastingModel(AbstractModel):
         self._init_params_aux()
         self._init_params()
 
-    def _compute_fit_metadata(self, val_data: Dataset = None, **kwargs):
+    def _compute_fit_metadata(self, val_data: TimeSeriesDataFrame = None, **kwargs):
         fit_metadata = dict(
             val_in_fit=val_data is not None,
         )
@@ -146,14 +142,10 @@ class AbstractForecastingModel(AbstractModel):
 
         Other Parameters
         ----------------
-        train_data : gluonts.dataset.common.Dataset
-            The training data. Forecasting models expect data to be in GluonTS format, i.e., an
-            iterator of dictionaries with `start` and `target` keys. `start` is a timestamp object
-            for the first data point in a time series while `target` is the time series which the
-            model will be fit to predict. The data set can optionally have other features which may
-            be used by the model. See individual model documentation and GluonTS dataset documentation
-            for details.
-        val_data : gluonts.dataset.common.Dataset
+        train_data : TimeSeriesDataFrame
+            The training data provided in the library's `autogluon.forecasting.dataset.TimeSeriesDataFrame`
+            format.
+        val_data : TimeSeriesDataFrame
             The validation data set in the same format as training data.
         time_limit : float, default = None
             Time limit in seconds to adhere to when fitting model.
@@ -199,21 +191,17 @@ class AbstractForecastingModel(AbstractModel):
         """
         raise NotImplementedError
 
-    def predict(self, data: Dataset, **kwargs) -> Dict[Any, pd.DataFrame]:
-        """Given a dataset, predict the next `self.prediction_length` time steps. The data
-        set is a GluonTS data set, an iterator over time series represented as python dictionaries.
+    def predict(self, data: TimeSeriesDataFrame, **kwargs) -> TimeSeriesDataFrame:
+        """Given a dataset, predict the next `self.prediction_length` time steps.
         This method produces predictions for the forecast horizon *after* the individual time series.
 
         For example, if the data set includes 24 hour time series, of hourly data, starting from
         00:00 on day 1, and forecast horizon is set to 5. The forecasts are five time steps 00:00-04:00
         on day 2.
 
-        # TODO: The function currently returns a pandas.DataFrame instead of a GluonTS dataset, however
-        # TODO: this API will be aligned with the rest of the library.
-
         Parameters
         ----------
-        data: gluonts.dataset.common.Dataset
+        data: TimeSeriesDataFrame
             The dataset where each time series is the "context" for predictions.
 
         Other Parameters
@@ -225,14 +213,14 @@ class AbstractForecastingModel(AbstractModel):
 
         Returns
         -------
-        predictions: Dict[any, pandas.DataFrame]
-            pandas data frames with an timestamp index, where each input item from the input
+        predictions: TimeSeriesDataFrame
+            pandas data frames with a timestamp index, where each input item from the input
             data is given as a separate forecast item in the dictionary, keyed by the `item_id`s
             of input items.
         """
         raise NotImplementedError
 
-    def score(self, data: Dataset, metric: str = None, **kwargs) -> float:
+    def score(self, data: TimeSeriesDataFrame, metric: str = None, **kwargs) -> float:
         """Return the evaluation scores for given metric and dataset. The last
         `self.prediction_length` time steps of each time series in the input data set
         will be held out and used for computing the evaluation score. Forecasting
@@ -240,7 +228,7 @@ class AbstractForecastingModel(AbstractModel):
 
         Parameters
         ----------
-        data: gluonts.dataset.common.Dataset
+        data: TimeSeriesDataFrame
             Dataset used for scoring.
         metric: str
             String identifier of evaluation metric to use, from one of
@@ -262,8 +250,8 @@ class AbstractForecastingModel(AbstractModel):
 
     def _hyperparameter_tune(
         self,
-        train_data: Dataset,
-        val_data: Dataset,
+        train_data: TimeSeriesDataFrame,
+        val_data: TimeSeriesDataFrame,
         scheduler_options: Tuple[Any, Dict],
         **kwargs,
     ):

--- a/forecasting/tests/unittests/models/test_gluonts.py
+++ b/forecasting/tests/unittests/models/test_gluonts.py
@@ -8,6 +8,7 @@ from gluonts.model.transformer import TransformerEstimator
 
 import autogluon.core as ag
 from autogluon.core.scheduler.scheduler_factory import scheduler_factory
+from autogluon.forecasting.dataset import TimeSeriesDataFrame
 from autogluon.forecasting.models.gluonts import (
     DeepARModel,
     # AutoTabularModel,
@@ -18,7 +19,7 @@ from autogluon.forecasting.models.gluonts import (
 )
 from autogluon.forecasting.models.gluonts.models import GenericGluonTSModelFactory
 
-from ..common import DUMMY_DATASET
+from ..common import DUMMY_TS_DATAFRAME
 
 TESTABLE_MODELS = [
     # AutoTabularModel,  # TODO: enable tests when model is stabilized
@@ -49,14 +50,17 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_corr
     )
 
     assert not model.gts_predictor
-    model.fit(train_data=DUMMY_DATASET)
+    model.fit(train_data=DUMMY_TS_DATAFRAME)
     assert isinstance(model.gts_predictor, GluonTSPredictor)
 
-    predictions = model.predict(DUMMY_DATASET)
+    predictions = model.predict(DUMMY_TS_DATAFRAME)
 
-    assert len(predictions) == len(DUMMY_DATASET)
-    assert all(len(df) == prediction_length for _, df in predictions.items())
-    assert all(df.index[0].hour for _, df in predictions.items())
+    assert isinstance(predictions, TimeSeriesDataFrame)
+
+    predicted_item_index = predictions.index.levels[0]
+    assert all(predicted_item_index == DUMMY_TS_DATAFRAME.index.levels[0])  # noqa
+    assert all(len(predictions.loc[i]) == prediction_length for i in predicted_item_index)
+    assert all(predictions.loc[i].index[0].hour for i in predicted_item_index)
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
@@ -72,17 +76,8 @@ def test_given_time_limit_when_fit_called_then_models_train_correctly(
     )
 
     assert not model.gts_predictor
-    model.fit(train_data=DUMMY_DATASET, time_limit=time_limit)
+    model.fit(train_data=DUMMY_TS_DATAFRAME, time_limit=time_limit)
     assert isinstance(model.gts_predictor, GluonTSPredictor)
-
-
-@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_given_no_freq_argument_when_fit_called_then_model_raises_value_error(
-    model_class, temp_model_path
-):
-    model = model_class(path=temp_model_path)
-    with pytest.raises(ValueError):
-        model.fit(train_data=DUMMY_DATASET, time_limit=10)
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
@@ -91,7 +86,7 @@ def test_given_no_freq_argument_when_fit_called_with_freq_then_model_does_not_ra
 ):
     model = model_class(path=temp_model_path)
     try:
-        model.fit(train_data=DUMMY_DATASET, time_limit=2, freq="H")
+        model.fit(train_data=DUMMY_TS_DATAFRAME, time_limit=2, freq="H")
     except ValueError:
         pytest.fail("unexpected ValueError raised in fit")
 
@@ -109,7 +104,7 @@ def test_given_low_time_limit_when_fit_called_then_model_training_does_not_excee
     )
 
     assert not model.gts_predictor
-    model.fit(train_data=DUMMY_DATASET, time_limit=2)
+    model.fit(train_data=DUMMY_TS_DATAFRAME, time_limit=2)
     assert isinstance(model.gts_predictor, GluonTSPredictor)
 
 
@@ -127,7 +122,7 @@ def test_given_hyperparameter_spaces_to_init_when_fit_called_then_error_is_raise
     )
     with pytest.raises(ValueError, match=".*hyperparameter_tune.*"):
         model.fit(
-            train_data=DUMMY_DATASET,
+            train_data=DUMMY_TS_DATAFRAME,
         )
 
 
@@ -144,7 +139,7 @@ def test_when_models_saved_then_gluonts_predictors_can_be_loaded(
         },
     )
     model.fit(
-        train_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
     )
     model.save()
 
@@ -175,13 +170,16 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_has_
         },
     )
 
-    model.fit(train_data=DUMMY_DATASET)
+    model.fit(train_data=DUMMY_TS_DATAFRAME)
+    predictions = model.predict(DUMMY_TS_DATAFRAME, quantile_levels=quantile_levels)
 
-    predictions = model.predict(DUMMY_DATASET, quantile_levels=quantile_levels)
+    assert isinstance(predictions, TimeSeriesDataFrame)
 
-    assert len(predictions) == len(DUMMY_DATASET)
-    for k in ["mean"] + [str(q) for q in quantile_levels]:
-        assert all(k in df.columns for _, df in predictions.items())
+    predicted_item_index = predictions.index.levels[0]
+    assert all(predicted_item_index == DUMMY_TS_DATAFRAME.index.levels[0])  # noqa
+    assert all(
+        k in predictions.columns for k in ["mean"] + [str(q) for q in quantile_levels]
+    )
 
 
 @pytest.mark.skipif(
@@ -200,7 +198,7 @@ def test_when_fit_called_on_prophet_then_hyperparameters_are_passed_to_underlyin
         hyperparameters={"growth": growth, "n_changepoints": n_changepoints},
     )
 
-    model.fit(train_data=DUMMY_DATASET)
+    model.fit(train_data=DUMMY_TS_DATAFRAME)
 
     assert model.gts_predictor.prophet_params.get("growth") == growth  # noqa
     assert (
@@ -225,7 +223,7 @@ def test_when_prophet_model_saved_then_prophet_parameters_are_loaded(
         hyperparameters={"growth": growth, "n_changepoints": n_changepoints},
     )
     model.fit(
-        train_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
     )
     model.save()
 
@@ -256,8 +254,8 @@ def test_when_hyperparameter_tune_called_on_prophet_then_hyperparameters_are_pas
     _, _, results = model.hyperparameter_tune(
         scheduler_options=scheduler_options,
         time_limit=100,
-        train_data=DUMMY_DATASET,
-        val_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
+        val_data=DUMMY_TS_DATAFRAME,
     )
 
     assert len(results["config_history"]) == 2

--- a/forecasting/tests/unittests/models/test_models.py
+++ b/forecasting/tests/unittests/models/test_models.py
@@ -6,7 +6,7 @@ from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 from autogluon.forecasting.models.abstract import AbstractForecastingModel
 from autogluon.forecasting.utils.metric_utils import AVAILABLE_METRICS
 
-from ..common import DUMMY_DATASET, dict_equal_primitive
+from ..common import DUMMY_TS_DATAFRAME, dict_equal_primitive
 from .test_gluonts import TESTABLE_MODELS as GLUONTS_TESTABLE_MODELS
 
 
@@ -32,8 +32,8 @@ def test_when_fit_called_then_models_train_and_all_scores_can_be_computed(
         hyperparameters={"epochs": 2},
     )
 
-    model.fit(train_data=DUMMY_DATASET)
-    score = model.score(DUMMY_DATASET)
+    model.fit(train_data=DUMMY_TS_DATAFRAME)
+    score = model.score(DUMMY_TS_DATAFRAME)
 
     assert isinstance(score, float)
 
@@ -49,7 +49,7 @@ def test_when_models_saved_then_they_can_be_loaded(model_class, temp_model_path)
         },
     )
     model.fit(
-        train_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
     )
     model.save()
 
@@ -78,8 +78,8 @@ def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct
     _, _, results = model.hyperparameter_tune(
         scheduler_options=scheduler_options,
         time_limit=100,
-        train_data=DUMMY_DATASET,
-        val_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
+        val_data=DUMMY_TS_DATAFRAME,
     )
 
     assert len(results["config_history"]) == 2

--- a/forecasting/tests/unittests/trainer/test_trainer.py
+++ b/forecasting/tests/unittests/trainer/test_trainer.py
@@ -8,13 +8,14 @@ from gluonts.model.prophet import PROPHET_IS_INSTALLED
 from gluonts.model.seq2seq import MQRNNEstimator
 
 import autogluon.core as ag
+from autogluon.forecasting.dataset import TimeSeriesDataFrame
 from autogluon.forecasting.models import DeepARModel
 from autogluon.forecasting.models.gluonts import GenericGluonTSModel
 from autogluon.forecasting.models.gluonts.models import GenericGluonTSModelFactory
 from autogluon.forecasting.models.presets import get_default_hps
 from autogluon.forecasting.trainer.auto_trainer import AutoForecastingTrainer
 
-from ..common import DUMMY_DATASET
+from ..common import DUMMY_TS_DATAFRAME
 
 DUMMY_TRAINER_HYPERPARAMETERS = {"SimpleFeedForward": {"epochs": 1}}
 TEST_HYPERPARAMETER_SETTINGS = [
@@ -32,7 +33,7 @@ def test_trainer_can_be_initialized(temp_model_path):
 # smoke test for the short 'happy path'
 def test_when_trainer_called_then_training_is_performed(temp_model_path):
     trainer = AutoForecastingTrainer(path=temp_model_path, freq="H")
-    trainer.fit(train_data=DUMMY_DATASET, hyperparameters=DUMMY_TRAINER_HYPERPARAMETERS)
+    trainer.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters=DUMMY_TRAINER_HYPERPARAMETERS)
 
     assert "SimpleFeedForward" in trainer.get_model_names()
 
@@ -42,9 +43,9 @@ def test_given_validation_data_when_trainer_called_then_training_is_performed(
 ):
     trainer = AutoForecastingTrainer(path=temp_model_path, freq="H")
     trainer.fit(
-        train_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=DUMMY_TRAINER_HYPERPARAMETERS,
-        val_data=DUMMY_DATASET,
+        val_data=DUMMY_TS_DATAFRAME,
     )
 
     assert "SimpleFeedForward" in trainer.get_model_names()
@@ -64,9 +65,9 @@ def test_given_hyperparameters_when_trainer_called_then_leaderboard_is_correct(
         path=temp_model_path, freq="H", eval_metric=eval_metric
     )
     trainer.fit(
-        train_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_DATASET,
+        val_data=DUMMY_TS_DATAFRAME,
     )
     leaderboard = trainer.leaderboard()
 
@@ -87,15 +88,18 @@ def test_given_hyperparameters_when_trainer_called_then_model_can_predict(
         prediction_length=3,
     )
     trainer.fit(
-        train_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_DATASET,
+        val_data=DUMMY_TS_DATAFRAME,
     )
-    predictions = trainer.predict(DUMMY_DATASET)
+    predictions = trainer.predict(DUMMY_TS_DATAFRAME)
 
-    # assert predictions is not None
-    assert all(len(df) == 3 for df in predictions.values())
-    assert all(not np.any(np.isnan(df)) for df in predictions.values())
+    assert isinstance(predictions, TimeSeriesDataFrame)
+
+    predicted_item_index = predictions.index.levels[0]
+    assert all(predicted_item_index == DUMMY_TS_DATAFRAME.index.levels[0])  # noqa
+    assert all(len(predictions.loc[i]) == 3 for i in predicted_item_index)
+    assert not np.any(np.isnan(predictions))
 
 
 @pytest.mark.parametrize(
@@ -131,9 +135,9 @@ def test_given_hyperparameters_with_spaces_when_trainer_called_then_hpo_is_perfo
         default_hps_mock.return_value = defaultdict(dict)
         trainer = AutoForecastingTrainer(path=temp_model_path, freq="H")
         trainer.fit(
-            train_data=DUMMY_DATASET,
+            train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hyperparameters,
-            val_data=DUMMY_DATASET,
+            val_data=DUMMY_TS_DATAFRAME,
             hyperparameter_tune=True,
         )
         leaderboard = trainer.leaderboard()
@@ -158,9 +162,9 @@ def test_given_hyperparameters_to_prophet_when_trainer_called_then_leaderboard_i
         path=temp_model_path, freq="H", eval_metric=eval_metric
     )
     trainer.fit(
-        train_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_DATASET,
+        val_data=DUMMY_TS_DATAFRAME,
     )
     leaderboard = trainer.leaderboard()
 
@@ -202,9 +206,9 @@ def test_given_hyperparameters_with_spaces_to_prophet_when_trainer_called_then_h
         default_hps_mock.return_value = defaultdict(dict)
         trainer = AutoForecastingTrainer(path=temp_model_path, freq="H")
         trainer.fit(
-            train_data=DUMMY_DATASET,
+            train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hyperparameters,
-            val_data=DUMMY_DATASET,
+            val_data=DUMMY_TS_DATAFRAME,
             hyperparameter_tune=True,
         )
         leaderboard = trainer.leaderboard()
@@ -237,9 +241,9 @@ def test_given_hyperparameters_and_custom_models_when_trainer_called_then_leader
         path=temp_model_path, freq="H", eval_metric=eval_metric
     )
     trainer.fit(
-        train_data=DUMMY_DATASET,
+        train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
-        val_data=DUMMY_DATASET,
+        val_data=DUMMY_TS_DATAFRAME,
     )
     leaderboard = trainer.leaderboard()
 
@@ -365,9 +369,9 @@ def test_given_repeating_model_when_trainer_called_incrementally_then_name_colli
     # incrementally train with new hyperparameters
     for hp in hyperparameter_list:
         trainer.fit(
-            train_data=DUMMY_DATASET,
+            train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hp,
-            val_data=DUMMY_DATASET,
+            val_data=DUMMY_TS_DATAFRAME,
         )
 
     model_names = trainer.get_model_names()
@@ -432,9 +436,9 @@ def test_given_hyperparameters_with_spaces_and_custom_model_when_trainer_called_
         default_hps_mock.return_value = defaultdict(dict)
         trainer = AutoForecastingTrainer(path=temp_model_path, freq="H")
         trainer.fit(
-            train_data=DUMMY_DATASET,
+            train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hyperparameters,
-            val_data=DUMMY_DATASET,
+            val_data=DUMMY_TS_DATAFRAME,
             hyperparameter_tune=True,
         )
         leaderboard = trainer.leaderboard()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Integrates `TimeSeriesDataFrame` format with forecasting `Model`s and `Trainer`, making the forecasting library available for testing e2e except for learner and predictor objects. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
