### PR TITLE
Improve AutoMM's validation metric computation

### DIFF
--- a/text/src/autogluon/text/automm/optimization/lit_module.py
+++ b/text/src/autogluon/text/automm/optimization/lit_module.py
@@ -133,18 +133,20 @@ class LitModule(pl.LightningModule):
             ) * weight
         return loss
 
-    def _compute_metric(
+    def _compute_metric_score(
             self,
+            metric: torchmetrics.Metric,
+            custom_metric_func: Callable,
             logits: torch.Tensor,
             label: torch.Tensor,
     ):
-        if isinstance(self.validation_metric, (torchmetrics.AUROC, torchmetrics.AveragePrecision)):
+        if isinstance(metric, (torchmetrics.AUROC, torchmetrics.AveragePrecision)):
             prob = F.softmax(logits.float(), dim=1)
-            return self.validation_metric(preds=prob[:, 1], target=label)  # only for binary classification
-        elif isinstance(self.validation_metric, BaseAggregator):
-            return self.validation_metric(self.custom_metric_func(logits, label))
+            metric.update(preds=prob[:, 1], target=label)  # only for binary classification
+        elif isinstance(metric, BaseAggregator):
+            metric.update(custom_metric_func(logits, label))
         else:
-            return self.validation_metric(logits.squeeze(dim=1), label)
+            metric.update(logits.squeeze(dim=1), label)
 
     def _shared_step(
             self,
@@ -197,12 +199,17 @@ class LitModule(pl.LightningModule):
         output, loss = self._shared_step(batch)
         # By default, on_step=False and on_epoch=True
         self.log("val_loss", loss)
+        self._compute_metric_score(
+            metric=self.validation_metric,
+            custom_metric_func=self.custom_metric_func,
+            logits=output[self.model.prefix][LOGITS],
+            label=batch[self.model.label_key],
+        ),
         self.log(
             self.validation_metric_name,
-            self._compute_metric(
-                logits=output[self.model.prefix][LOGITS],
-                label=batch[self.model.label_key],
-            ),
+            self.validation_metric,
+            on_step=False,
+            on_epoch=True,
         )
 
     def predict_step(self, batch, batch_idx, dataloader_idx=0):

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -14,6 +14,7 @@ from ..constants import (
     BINARY, MULTICLASS, REGRESSION, MAX, MIN, NORM_FIT, BIT_FIT,
     ACC, ACCURACY, RMSE, ROOT_MEAN_SQUARED_ERROR, R2, QUADRATIC_KAPPA,
     ROC_AUC, AVERAGE_PRECISION, LOG_LOSS, CROSS_ENTROPY,
+    PEARSONR, SPEARMANR,
 )
 import warnings
 
@@ -89,6 +90,10 @@ def get_metric(
     elif metric_name in [LOG_LOSS, CROSS_ENTROPY]:
         return torchmetrics.MeanMetric(), MIN, \
                functools.partial(F.cross_entropy, reduction="none")
+    elif metric_name == PEARSONR:
+        return torchmetrics.PearsonCorrCoef(), MAX, None
+    elif metric_name == SPEARMANR:
+        return torchmetrics.SpearmanCorrCoef(), MAX, None
     else:
         warnings.warn(f"Currently, we cannot convert the metric: {metric_name} to a metric supported in torchmetrics. "
                       f"Thus, we will fall-back to use accuracy for multi-class classification problems "

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -86,19 +86,7 @@ def infer_metrics(
         Name of evaluation metric.
     """
     if eval_metric_name is not None:
-        if eval_metric_name.lower() in [R2, PEARSONR, SPEARMANR]:
-            validation_metric_name = RMSE
-        elif eval_metric_name.lower() in [ROC_AUC, AVERAGE_PRECISION]:
-            logger.info(
-                f"We use {LOG_LOSS} as the validation metric for more stable training. "
-                f"We avoid using {eval_metric_name} as the validation metric because `torchmetrics` "
-                f"requires that both positive and negative examples are available in a mini-batch."
-                f"If the per gpu batch size is too small to cover both, `torchmetrics` would"
-                f"compute {eval_metric_name} scores incorrectly."
-            )
-            validation_metric_name = LOG_LOSS
-        else:
-            validation_metric_name = eval_metric_name
+        validation_metric_name = eval_metric_name
         return validation_metric_name, eval_metric_name
 
     if problem_type in [MULTICLASS, BINARY]:


### PR DESCRIPTION
We avoid computing the metric score at each validation step through the following:
1. logging metric object instead of score at each validation step. 
2. using `metric.update()` instead of `metric()`.

In this way, we can solve the previous issues regarding the `r2` (error with batch size 1) and `roc_auc` (wrong score and warning: No positive/negative samples in targets, false negative/positive value should be meaningless.)

Now, it's safe to use the validation metrics `r2`, `roc_auc`, etc.
