### PR TITLE
Fix useless features

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -381,6 +381,7 @@ class AbstractModel:
         else:
             features_to_drop_internal = None
         if features_to_drop_internal is not None:
+            logger.log(10, f'\tDropped {len(features_to_drop_internal)} of {len(self.features)} internal features: {features_to_drop_internal}')
             self._features_internal = [feature for feature in self.features if feature not in features_to_drop_internal]
             self._feature_metadata = self.feature_metadata.keep_features(self._features_internal)
             self._is_features_in_same_as_ex = False

--- a/features/tests/features/generators/test_identity.py
+++ b/features/tests/features/generators/test_identity.py
@@ -1,5 +1,6 @@
 
 from autogluon.features.generators import IdentityFeatureGenerator
+from autogluon.common.features.feature_metadata import FeatureMetadata
 from autogluon.common.features.types import R_INT, R_FLOAT
 
 
@@ -48,6 +49,44 @@ def test_identity_feature_generator_int_float(generator_helper, data_helper):
     # When
     output_data = generator_helper.fit_transform_assert(
         input_data=input_data,
+        generator=generator,
+        expected_feature_metadata_in_full=expected_feature_metadata_in_full,
+        expected_feature_metadata_full=expected_feature_metadata_full,
+    )
+
+    assert input_data[output_data.columns].equals(output_data)
+
+
+def test_identity_feature_generator_int_float_with_banned_features(generator_helper, data_helper):
+    # Given
+    input_data = data_helper.generate_multi_feature_full()
+
+    generator = IdentityFeatureGenerator(
+        infer_features_in_args=dict(valid_raw_types=[R_INT, R_FLOAT]),
+        banned_feature_special_types=['my_banned_feature_type'],
+    )
+
+    expected_feature_metadata_in_full = {
+        ('int', ('my_valid_feature_type',)): ['int'],
+    }
+
+    expected_feature_metadata_full = {
+        ('int', ('my_valid_feature_type',)): ['int']
+    }
+
+    feature_metadata_in = FeatureMetadata.from_df(input_data)
+
+    feature_metadata_in = feature_metadata_in.add_special_types(
+        {
+            'float': ['my_banned_feature_type'],
+            'int': ['my_valid_feature_type'],
+        }
+    )
+
+    # When
+    output_data = generator_helper.fit_transform_assert(
+        input_data=input_data,
+        feature_metadata_in=feature_metadata_in,
         generator=generator,
         expected_feature_metadata_in_full=expected_feature_metadata_in_full,
         expected_feature_metadata_full=expected_feature_metadata_full,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix scenario where feature is both excluded due to type incompatibility and contains only 1 unique value causing a crash in feature generators.
- Add `banned_feature_special_types` to make it easier for users to exclude features from feature generators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
