### PR TITLE
Update cheatsheet links to GitHub instead of S3

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -2,11 +2,11 @@ Cheat Sheet
 -----------
 
 .. image:: https://raw.githubusercontent.com/Innixma/autogluon-doc-utils/main/docs/cheatsheets/stable/autogluon-cheat-sheet.jpeg
-   :width: 300
+   :width: 900
 
 Download the PDF version with clickable links `here`_.
 
-.. _Here: https://raw.githubusercontent.com/Innixma/autogluon-doc-utils/main/docs/cheatsheets/stable/autogluon-cheat-sheet.pdf
+.. _Here: https://nbviewer.org/github/Innixma/autogluon-doc-utils/blob/main/docs/cheatsheets/stable/autogluon-cheat-sheet.pdf
 
 Looking for a different version? Refer to the `autogluon-doc-utils`_ repo to view all versions of the cheatsheet.
 

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -1,9 +1,13 @@
 Cheat Sheet
 -----------
 
-.. image:: https://auto.gluon.ai/stable/autogluon-cheat-sheet.jpg
+.. image:: https://raw.githubusercontent.com/Innixma/autogluon-doc-utils/main/docs/cheatsheets/stable/autogluon-cheat-sheet.jpeg
    :width: 300
 
-Check out the PDF version `Here`_.
+Download the PDF version with clickable links `here`_.
 
-.. _Here: https://auto.gluon.ai/stable/autogluon-cheat-sheet.pdf
+.. _Here: https://raw.githubusercontent.com/Innixma/autogluon-doc-utils/main/docs/cheatsheets/stable/autogluon-cheat-sheet.pdf
+
+Looking for a different version? Refer to the `autogluon-doc-utils`_ repo to view all versions of the cheatsheet.
+
+.. _autogluon-doc-utils: https://github.com/Innixma/autogluon-doc-utils/tree/main/docs/cheatsheets


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update cheatsheet links to GitHub instead of S3.
- One minor downside to this is that the PDF link immediately downloads on chrome when using the GitHub link instead of previewing like it does with the S3 link. Thoughts on how to enable preview for the GitHub artifact are welcome.
- Note: We should do the same update to branch `0.4.1` and `0.4.0` but instead link the v0.4.0 GitHub artifacts (instead of stable).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
