### PR TITLE
fix preset discrepancy between backends of TextPredictor

### DIFF
--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -5,7 +5,7 @@ data:
   categorical:
     minimum_cat_count: 100  # The minimum number of occurrences a category must have in the training data to avoid being considered a rare category.
     maximum_num_cat: 20  # The maximum amount of categories that can be considered non-rare.
-    convert_to_text: True  # Whether to convert the feature to text.
+    convert_to_text: False  # Whether to convert the feature to text.
   numerical:
     convert_to_text: False  # Whether to convert the feature to text.
     scaler_with_mean: True  # Whether to normalize with mean.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change the default `convert_to_text` in TextPredictor pytorch backend to False.
This will resolve the discrepancy between TextPredictor pytorch and mxnet backend default presets: 

- PyTorch backend (no categorical MLP when using the current default convert_to_text = True): https://github.com/awslabs/autogluon/blob/0.4.1/text/src/autogluon/text/automm/configs/data/default.yaml#L8 

- Mxnet backend: 
https://github.com/awslabs/autogluon/blob/0.4.1/text/src/autogluon/text/text_prediction/legacy_presets.py#L104

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
