### PR TITLE
Improve AutoMM's binary classification's metrics by supporting customizing positive class

### DIFF
--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -10,4 +10,4 @@ data:
     convert_to_text: False  # Whether to convert the feature to text.
     scaler_with_mean: True  # Whether to normalize with mean.
     scaler_with_std: True  # Whether to normalize with std.
-  positive_class:  # The name of binary classification's positive class. It's used in computing some metrics, e.g., roc_auc. If not provided, then use label_encoder.classes_[1],
+  pos_label:  # The name of binary classification's positive class. It's used in computing some metrics, e.g., roc_auc. If not provided, then use label_encoder.classes_[1],

--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -10,3 +10,4 @@ data:
     convert_to_text: False  # Whether to convert the feature to text.
     scaler_with_mean: True  # Whether to normalize with mean.
     scaler_with_std: True  # Whether to normalize with std.
+  positive_class:  # The name of binary classification's positive class. It's used in computing some metrics, e.g., roc_auc. If not provided, then use label_encoder.classes_[1],

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -46,7 +46,7 @@ def get_metric(
         metric_name: str,
         problem_type: str,
         num_classes: Optional[int] = None,
-        positive_label: Optional[int] = 1,
+        pos_label: Optional[int] = 1,
 ):
     """
     Obtain a torchmerics.Metric from its name.
@@ -60,7 +60,7 @@ def get_metric(
         The type of the problem.
     num_classes
         Number of classes, used in the quadratic_kappa metric for binary classification.
-    positive_label
+    pos_label
         The label (0 or 1) of binary classification's positive class, which is used in some metrics, e.g., AUROC.
 
     Returns
@@ -87,9 +87,9 @@ def get_metric(
         return torchmetrics.CohenKappa(num_classes=num_classes,
                                        weights="quadratic"), MAX, None
     elif metric_name == ROC_AUC:
-        return torchmetrics.AUROC(pos_label=positive_label), MAX, None
+        return torchmetrics.AUROC(pos_label=pos_label), MAX, None
     elif metric_name == AVERAGE_PRECISION:
-        return torchmetrics.AveragePrecision(pos_label=positive_label), MAX, None
+        return torchmetrics.AveragePrecision(pos_label=pos_label), MAX, None
     elif metric_name in [LOG_LOSS, CROSS_ENTROPY]:
         return torchmetrics.MeanMetric(), MIN, \
                functools.partial(F.cross_entropy, reduction="none")
@@ -106,7 +106,7 @@ def get_metric(
         elif problem_type == MULTICLASS:
             return torchmetrics.Accuracy(), MAX, None
         elif problem_type == BINARY:
-            return torchmetrics.AUROC(pos_label=positive_label), MAX, None
+            return torchmetrics.AUROC(pos_label=pos_label), MAX, None
         else:
             raise ValueError(f'The problem_type={problem_type} is currently not supported')
 

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -46,7 +46,7 @@ def get_metric(
         metric_name: str,
         problem_type: str,
         num_classes: Optional[int] = None,
-        pos_label: Optional[int] = 1,
+        pos_label: Optional[int] = None,
 ):
     """
     Obtain a torchmerics.Metric from its name.

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -46,6 +46,7 @@ def get_metric(
         metric_name: str,
         problem_type: str,
         num_classes: Optional[int] = None,
+        positive_label: Optional[int] = 1,
 ):
     """
     Obtain a torchmerics.Metric from its name.
@@ -59,6 +60,8 @@ def get_metric(
         The type of the problem.
     num_classes
         Number of classes, used in the quadratic_kappa metric for binary classification.
+    positive_label
+        The label (0 or 1) of binary classification's positive class, which is used in some metrics, e.g., AUROC.
 
     Returns
     -------
@@ -84,9 +87,9 @@ def get_metric(
         return torchmetrics.CohenKappa(num_classes=num_classes,
                                        weights="quadratic"), MAX, None
     elif metric_name == ROC_AUC:
-        return torchmetrics.AUROC(), MAX, None
+        return torchmetrics.AUROC(pos_label=positive_label), MAX, None
     elif metric_name == AVERAGE_PRECISION:
-        return torchmetrics.AveragePrecision(), MAX, None
+        return torchmetrics.AveragePrecision(pos_label=positive_label), MAX, None
     elif metric_name in [LOG_LOSS, CROSS_ENTROPY]:
         return torchmetrics.MeanMetric(), MIN, \
                functools.partial(F.cross_entropy, reduction="none")
@@ -103,7 +106,7 @@ def get_metric(
         elif problem_type == MULTICLASS:
             return torchmetrics.Accuracy(), MAX, None
         elif problem_type == BINARY:
-            return torchmetrics.AUROC(), MAX, None
+            return torchmetrics.AUROC(pos_label=positive_label), MAX, None
         else:
             raise ValueError(f'The problem_type={problem_type} is currently not supported')
 

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -56,7 +56,7 @@ from .utils import (
     modify_duplicate_model_names,
     assign_feature_column_names,
     turn_on_off_feature_column_info,
-    try_to_infer_positive_label,
+    try_to_infer_pos_label,
 )
 from .optimization.utils import (
     get_metric,
@@ -400,7 +400,7 @@ class AutoMMPredictor:
             validation_metric_name = self._validation_metric_name
             eval_metric_name = self._eval_metric_name
 
-        pos_label = try_to_infer_positive_label(
+        pos_label = try_to_infer_pos_label(
             data_config=config.data,
             label_encoder=df_preprocessor.label_generator,
             problem_type=problem_type,
@@ -1068,7 +1068,7 @@ class AutoMMPredictor:
                 raise ValueError(
                     f"Metric {per_metric} is only supported for binary classification."
                 )
-            pos_label = try_to_infer_positive_label(
+            pos_label = try_to_infer_pos_label(
                 data_config=self._config.data,
                 label_encoder=self._df_preprocessor.label_generator,
                 problem_type=self._problem_type,

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -56,7 +56,7 @@ from .utils import (
     modify_duplicate_model_names,
     assign_feature_column_names,
     turn_on_off_feature_column_info,
-    try_to_set_positive_label,
+    try_to_infer_positive_label,
 )
 from .optimization.utils import (
     get_metric,
@@ -400,16 +400,16 @@ class AutoMMPredictor:
             validation_metric_name = self._validation_metric_name
             eval_metric_name = self._eval_metric_name
 
-        if problem_type == BINARY:
-            try_to_set_positive_label(
-                data_config=config.data,
-                label_encoder=df_preprocessor.label_generator,
-            )
+        pos_label = try_to_infer_positive_label(
+            data_config=config.data,
+            label_encoder=df_preprocessor.label_generator,
+            problem_type=problem_type,
+        )
         validation_metric, minmax_mode, custom_metric_func = get_metric(
             metric_name=validation_metric_name,
             problem_type=problem_type,
             num_classes=output_shape,
-            positive_label=OmegaConf.select(config, "data.positive_label", default=1),
+            pos_label=pos_label,
         )
 
         loss_func = get_loss_func(problem_type)
@@ -1068,10 +1068,15 @@ class AutoMMPredictor:
                 raise ValueError(
                     f"Metric {per_metric} is only supported for binary classification."
                 )
+            pos_label = try_to_infer_positive_label(
+                data_config=self._config.data,
+                label_encoder=self._df_preprocessor.label_generator,
+                problem_type=self._problem_type,
+            )
             score = compute_score(
                 metric_data=metric_data,
                 metric_name=per_metric.lower(),
-                positive_label=OmegaConf.select(self._config, "data.positive_label", default=1)
+                pos_label=pos_label,
             )
             results[per_metric] = score
 

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -1255,6 +1255,7 @@ def try_to_infer_pos_label(
 
     pos_label = OmegaConf.select(data_config, "pos_label", default=None)
     if pos_label is not None:
+        print(f"pos_label: {pos_label}\n")
         pos_label = label_encoder.transform([pos_label]).item()
     else:
         pos_label = 1

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -1254,7 +1254,7 @@ def try_to_infer_pos_label(
         return None
 
     pos_label = OmegaConf.select(data_config, "pos_label", default=None)
-    if pos_label:
+    if pos_label is not None:
         pos_label = label_encoder.transform([pos_label]).item()
     else:
         pos_label = 1

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -1227,7 +1227,7 @@ def turn_on_off_feature_column_info(
     return data_processors
 
 
-def try_to_infer_positive_label(
+def try_to_infer_pos_label(
         data_config: DictConfig,
         label_encoder: LabelEncoder,
         problem_type: str,

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -14,6 +14,7 @@ from contextlib import contextmanager
 from typing import Optional, List, Any, Dict, Tuple, Union
 from nptyping import NDArray
 from omegaconf import OmegaConf, DictConfig
+from sklearn.preprocessing import LabelEncoder
 from autogluon.core.metrics import get_metric
 
 from .models import (
@@ -902,6 +903,7 @@ def average_checkpoints(
 def compute_score(
         metric_data: dict,
         metric_name: str,
+        positive_label: Optional[int] = 1,
 ) -> float:
     """
     Use sklearn to compute the score of one metric.
@@ -913,6 +915,8 @@ def compute_score(
         The predicted class probabilities are required to compute the roc_auc score.
     metric_name
         The name of metric to compute.
+    positive_label
+        The encoded label (0 or 1) of binary classification's positive class.
 
     Returns
     -------
@@ -920,7 +924,7 @@ def compute_score(
     """
     metric = get_metric(metric_name)
     if metric.name in [ROC_AUC, AVERAGE_PRECISION]:
-        return metric._sign * metric(metric_data[Y_TRUE], metric_data[Y_PRED_PROB][:, 1])
+        return metric._sign * metric(metric_data[Y_TRUE], metric_data[Y_PRED_PROB][:, positive_label])
     else:
         return metric._sign * metric(metric_data[Y_TRUE], metric_data[Y_PRED])
 
@@ -1221,3 +1225,33 @@ def turn_on_off_feature_column_info(
                 per_model_processor.requires_column_info = flag
 
     return data_processors
+
+
+def try_to_set_positive_label(
+        data_config: DictConfig,
+        label_encoder: LabelEncoder,
+):
+    """
+    Try to set positive label for binary classification, which is used in computing some metrics, e.g., roc_auc.
+    If positive_class is not provided, then use positive_label=1 by default.
+
+    Parameters
+    ----------
+    data_config
+        A DictConfig object containing only the data configurations.
+    label_encoder
+        The label encoder of classification tasks.
+
+    Returns
+    -------
+
+    """
+    positive_class = OmegaConf.select(data_config, "positive_class", default=None)
+    if positive_class:
+        positive_label = label_encoder.transform([positive_class]).item()
+    else:
+        positive_label = 1
+
+    data_config.positive_label = positive_label
+
+    return

--- a/text/tests/unittests/automm/test_auto_model.py
+++ b/text/tests/unittests/automm/test_auto_model.py
@@ -1,7 +1,9 @@
 import pytest
-from autogluon.text.automm.models import HFAutoModelForTextPrediction
-from autogluon.text.automm.models import TimmAutoModelForImagePrediction
-from autogluon.text.automm.models import NumericalTransformer
+from autogluon.text.automm.models import (
+    HFAutoModelForTextPrediction,
+    TimmAutoModelForImagePrediction,
+    NumericalTransformer,
+)
 
 
 @pytest.mark.parametrize(

--- a/text/tests/unittests/automm/test_metrics.py
+++ b/text/tests/unittests/automm/test_metrics.py
@@ -1,10 +1,10 @@
 import pytest
 import random
 import torch
-from autogluon.text.automm.optimization.utils import get_metric
-from autogluon.text.automm.constants import MULTICLASS
 from torchmetrics import MeanMetric
 from sklearn.metrics import log_loss
+from autogluon.text.automm.optimization.utils import get_metric
+from autogluon.text.automm.constants import MULTICLASS
 
 
 @pytest.mark.parametrize(

--- a/text/tests/unittests/automm/test_utils.py
+++ b/text/tests/unittests/automm/test_utils.py
@@ -1,6 +1,20 @@
 import pytest
-from autogluon.text.automm.utils import apply_omegaconf_overrides, parse_dotlist_conf
 from omegaconf import OmegaConf
+from sklearn.preprocessing import LabelEncoder
+from autogluon.text.automm.utils import (
+    apply_omegaconf_overrides,
+    parse_dotlist_conf,
+    get_config,
+    try_to_infer_pos_label,
+)
+from autogluon.text.automm.constants import (
+    MODEL,
+    DATA,
+    OPTIMIZATION,
+    ENVIRONMENT,
+    BINARY,
+    MULTICLASS,
+)
 
 
 @pytest.mark.parametrize('data,expected',
@@ -29,3 +43,44 @@ def test_apply_omegaconf_overrides():
 
     with pytest.raises(KeyError):
         new_conf3 = apply_omegaconf_overrides(conf, {'a.aa.aaaaaa': [1, 3, 5, 7], 'a.aa.bbb': 4})
+
+
+@pytest.mark.parametrize(
+    "labels,pos_label,problem_type,true_pos_label",
+    [
+        ([1, 2, 2], 2, BINARY, 1),
+        ([1, 2, 2], 1, BINARY, 0),
+        ([1, 0, 1, 0, 0], 0, BINARY, 0),
+        ([1, 0, 1, 0, 0], None, BINARY, 1),
+        (["a", "e", "e", "a"], "a", BINARY, 0),
+        (["b", "d", "b", "d"], "d", BINARY, 1),
+        (["a", "d", "e", "b"], "d", MULTICLASS, None),
+        ([3, 2, 1, 0], 2, MULTICLASS, None),
+    ]
+)
+def test_inferring_pos_label(labels, pos_label, problem_type, true_pos_label):
+    config = {
+        MODEL: f"fusion_mlp_image_text_tabular",
+        DATA: "default",
+        OPTIMIZATION: "adamw",
+        ENVIRONMENT: "default",
+    }
+    overrides = {}
+    if pos_label is not None:
+        overrides.update(
+            {
+                "data.pos_label": pos_label,
+            }
+        )
+    config = get_config(
+        config=config,
+        overrides=overrides,
+    )
+    label_encoder = LabelEncoder()
+    label_encoder.fit(labels)
+    pos_label = try_to_infer_pos_label(
+        data_config=config.data,
+        label_encoder=label_encoder,
+        problem_type=problem_type,
+    )
+    assert pos_label == true_pos_label


### PR DESCRIPTION
Previously, AutoMM always used label 1 as the positive label in computing the `roc_auc` and `average_precision` metrics in binary classification. However, 1, corresponding to class name label_encoder.classes_[1], may not always be the semantically positive class's label for specific tasks. For example, users provide string class names `a` and `b`, and wants `a` to be the semantically positive class. This PR makes it possible for users to customize their positive classes.

Related discussions:
https://github.com/scikit-learn/scikit-learn/issues/15303
https://github.com/scikit-learn/scikit-learn/pull/15405


1. Add a hyper-parameter `pos_label` (positive class name) in data config. We use `pos_label` to align with sklearn's APIs, e.g., https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_curve.html#sklearn.metrics.roc_curve
2. Add a util to infer the encoded positive label from `pos_label`.
3. Add the `pos_label` choice in functions related to computing binary classification's metrics.
4. Make it backward compatible.