### PR TITLE
Add time step slicing to forecasting dataset and mark test as flaky

### DIFF
--- a/forecasting/setup.py
+++ b/forecasting/setup.py
@@ -31,7 +31,7 @@ requirements = [
 ]
 
 # TODO: move test_requirements into extra_requirements
-test_requirements = ["pytest", "flake8", "pytest-timeout"]
+test_requirements = ["pytest", "flake8", "flaky", "pytest-timeout"]
 
 install_requires = requirements + test_requirements
 install_requires = ag.get_dependency_version_ranges(install_requires)

--- a/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
+++ b/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
@@ -264,6 +264,42 @@ class TimeSeriesDataFrame(pd.DataFrame):
         data_after = self.loc[(slice(cutoff_item, None), slice(None)), :]
         return TimeSeriesDataFrame(data_before), TimeSeriesDataFrame(data_after)
 
+    def slice_by_timestep(self, time_step_slice: slice):
+        """Return a slice of time steps (with no regards to the actual timestamp) from within
+        each item in a time series data frame. For example, if a data frame is constructed as::
+
+            item_id  timestamp  target
+                  0 2019-01-01       0
+                  0 2019-01-02       1
+                  0 2019-01-03       2
+                  1 2019-01-02       3
+                  1 2019-01-03       4
+                  1 2019-01-04       5
+                  2 2019-01-03       6
+                  2 2019-01-04       7
+                  2 2019-01-05       8
+
+        then `df.slice_by_timestep(time_step_slice=slice(-2, None)` would return the last two
+        time steps from each item::
+
+            item_id  timestamp  target
+                  0 2019-01-02       1
+                  0 2019-01-03       2
+                  1 2019-01-03       4
+                  1 2019-01-04       5
+                  2 2019-01-04       7
+                  2 2019-01-05       8
+
+        Note that this function returns a copy of the original data. This function is useful for
+        constructing holdout sets for validation.
+
+        Parameters
+        ----------
+        time_step_slice: slice
+            A python slice object representing the slices to return from each item
+        """
+        return pd.concat([self.loc[i].iloc[time_step_slice] for i in self.index.levels[0]])
+
     def subsequence(
         self, start: pd.Timestamp, end: pd.Timestamp
     ) -> TimeSeriesDataFrame:

--- a/forecasting/tests/unittests/models/test_gluonts.py
+++ b/forecasting/tests/unittests/models/test_gluonts.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 import pytest
+from flaky import flaky
 from gluonts.model.prophet import PROPHET_IS_INSTALLED
 from gluonts.model.predictor import Predictor as GluonTSPredictor
 from gluonts.model.seq2seq import MQRNNEstimator
@@ -91,6 +92,7 @@ def test_given_no_freq_argument_when_fit_called_with_freq_then_model_does_not_ra
         pytest.fail("unexpected ValueError raised in fit")
 
 
+@flaky(max_runs=3)
 @pytest.mark.timeout(4)
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 def test_given_low_time_limit_when_fit_called_then_model_training_does_not_exceed_time_limit(

--- a/forecasting/tests/unittests/test_ts_dataset.py
+++ b/forecasting/tests/unittests/test_ts_dataset.py
@@ -319,3 +319,92 @@ def test_when_dataset_constructed_with_irregular_timestamps_then_constructor_rai
 
     with pytest.raises(ValueError, match="uniformly sampled"):
         TimeSeriesDataFrame.from_data_frame(df)
+
+
+SAMPLE_ITERABLE_2 = [
+    {"target": [0, 1, 2, 3], "start": pd.Timestamp("2019-01-01", freq="D")},
+    {"target": [3, 4, 5, 4], "start": pd.Timestamp("2019-01-02", freq="D")},
+    {"target": [6, 7, 8, 5], "start": pd.Timestamp("2019-01-03", freq="D")},
+]
+
+
+@pytest.mark.parametrize(
+    "input_iterable, slice, expected_times, expected_values",
+    [
+        (
+            SAMPLE_ITERABLE,
+            slice(None, 2),
+            [
+                "2019-01-01",
+                "2019-01-02",
+                "2019-01-01",
+                "2019-01-02",
+                "2019-01-01",
+                "2019-01-02",
+            ],
+            [0, 1, 3, 4, 6, 7],
+        ),
+        (
+            SAMPLE_ITERABLE,
+            slice(1, 2),
+            ["2019-01-02", "2019-01-02", "2019-01-02"],
+            [1, 4, 7],
+        ),
+        (
+            SAMPLE_ITERABLE_2,
+            slice(None, 2),
+            [
+                "2019-01-01",
+                "2019-01-02",
+                "2019-01-02",
+                "2019-01-03",
+                "2019-01-03",
+                "2019-01-04",
+            ],
+            [0, 1, 3, 4, 6, 7],
+        ),
+        (
+            SAMPLE_ITERABLE_2,
+            slice(-2, None),
+            [
+                "2019-01-03",
+                "2019-01-04",
+                "2019-01-04",
+                "2019-01-05",
+                "2019-01-05",
+                "2019-01-06",
+            ],
+            [2, 3, 5, 4, 8, 5],
+        ),
+        (
+            SAMPLE_ITERABLE_2,
+            slice(-1000, 2),
+            [
+                "2019-01-01",
+                "2019-01-02",
+                "2019-01-02",
+                "2019-01-03",
+                "2019-01-03",
+                "2019-01-04",
+            ],
+            [0, 1, 3, 4, 6, 7],
+        ),
+        (
+            SAMPLE_ITERABLE_2,
+            slice(1000, 1002),
+            [],
+            [],
+        ),
+    ],
+)
+def test_when_dataset_sliced_by_step_then_output_times_and_values_correct(
+    input_iterable, slice, expected_times, expected_values
+):
+    df = TimeSeriesDataFrame.from_iterable_dataset(input_iterable)
+    dfv = df.slice_by_timestep(slice)
+
+    if not expected_times:
+        assert len(dfv) == 0
+
+    assert np.allclose(dfv["target"], expected_values)
+    assert all(ts == pd.Timestamp(expected_times[i]) for i, ts in enumerate(dfv.index))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR brings two small enhancements to forecasting.
- The time_limit test for GluonTS models is marked as flaky as it sometimes can fail spuriously due to system state.
- We add a method to time series dataframes to return copies of the dataframe sliced by time step number (as opposed to timestamp). this is important for time series data sets whose timelines don't match up but need to be sliced consistently from the last XX time steps (e.g., when creating out of sample validation sets with respect to time).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
