### PR TITLE
Support using BCELoss for training regression models in AutoMM + Support MinMaxScaler

### DIFF
--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -12,14 +12,15 @@ data:
     scaler_with_std: True  # Whether to normalize with std.
   label:
     numerical_label_preprocessing:  # The mode of label preprocessing for . Support "standardscaler" or "minmaxscaler" or null.
+    predict_heads:  # The projecting head for prediction. It is used for loss functions like BCEWithLogitsLoss which contain projection.
   pos_label:  # The name of binary classification's positive class. It's used in computing some metrics, e.g., roc_auc. If not provided, then use label_encoder.classes_[1],
   mixup:
-    turn_on: False # The total control of mixup.
+    turn_on: False  # The total control of mixup.
     mixup_alpha: 0.8  # Mixup alpha.
     cutmix_alpha: 1.0  # Cutmix alpha.
     cutmix_minmax:  #Cutmix min/max ratio, it will override cutmix alpha if set, a list/tuple with size two.
     mixup_prob: 1.0  # The probability of conducting mixup/cutmix if enable.
     mixup_switch_prob: 0.5  # The probability of switching mixup to cutmix if both enable.
     mixup_mode: "batch"  # Perform mixup/cutmix on "batch" or "pair" or "elem".
-    mixup_off_epoch: 5 # The epoch when the mixup will be turned off.
+    mixup_off_epoch: 5  # The epoch when the mixup will be turned off.
     label_smoothing: 0.1  # Label smoothing.

--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -10,6 +10,8 @@ data:
     convert_to_text: False  # Whether to convert the feature to text.
     scaler_with_mean: True  # Whether to normalize with mean.
     scaler_with_std: True  # Whether to normalize with std.
+  label:
+    numerical_label_preprocessing:  #The mode of label preprocessing for . Support "standardscaler" or "minmaxscaler" or null.
   pos_label:  # The name of binary classification's positive class. It's used in computing some metrics, e.g., roc_auc. If not provided, then use label_encoder.classes_[1],
   mixup:
     turn_on: False # The total control of mixup.
@@ -21,4 +23,3 @@ data:
     mixup_mode: "batch"  # Perform mixup/cutmix on "batch" or "pair" or "elem".
     mixup_off_epoch: 5 # The epoch when the mixup will be turned off.
     label_smoothing: 0.1  # Label smoothing.
-

--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -11,7 +11,7 @@ data:
     scaler_with_mean: True  # Whether to normalize with mean.
     scaler_with_std: True  # Whether to normalize with std.
   label:
-    numerical_label_preprocessing:  #The mode of label preprocessing for . Support "standardscaler" or "minmaxscaler" or null.
+    numerical_label_preprocessing:  # The mode of label preprocessing for . Support "standardscaler" or "minmaxscaler" or null.
   pos_label:  # The name of binary classification's positive class. It's used in computing some metrics, e.g., roc_auc. If not provided, then use label_encoder.classes_[1],
   mixup:
     turn_on: False # The total control of mixup.

--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -12,7 +12,6 @@ data:
     scaler_with_std: True  # Whether to normalize with std.
   label:
     numerical_label_preprocessing:  # The mode of label preprocessing for . Support "standardscaler" or "minmaxscaler" or null.
-    predict_heads:  # The projecting head for prediction. It is used for loss functions like BCEWithLogitsLoss which contain projection.
   pos_label:  # The name of binary classification's positive class. It's used in computing some metrics, e.g., roc_auc. If not provided, then use label_encoder.classes_[1],
   mixup:
     turn_on: False  # The total control of mixup.

--- a/text/src/autogluon/text/automm/configs/data/default.yaml
+++ b/text/src/autogluon/text/automm/configs/data/default.yaml
@@ -17,7 +17,7 @@ data:
     turn_on: False  # The total control of mixup.
     mixup_alpha: 0.8  # Mixup alpha.
     cutmix_alpha: 1.0  # Cutmix alpha.
-    cutmix_minmax:  #Cutmix min/max ratio, it will override cutmix alpha if set, a list/tuple with size two.
+    cutmix_minmax:  # Cutmix min/max ratio, it will override cutmix alpha if set, a list/tuple with size two.
     mixup_prob: 1.0  # The probability of conducting mixup/cutmix if enable.
     mixup_switch_prob: 0.5  # The probability of switching mixup to cutmix if both enable.
     mixup_mode: "batch"  # Perform mixup/cutmix on "batch" or "pair" or "elem".

--- a/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
+++ b/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
@@ -16,3 +16,4 @@ optimization:
   top_k_average_method: "greedy_soup"  # We support averaging method described in https://arxiv.org/pdf/2203.05482.pdf.
                                        # Currently support "uniform_soup", "greedy_soup", and "best".
   efficient_finetune: null  # Can be 'bit_fit' (only finetune bias), 'norm_fit' (finetune the normalization terms + bias terms), or null
+  loss_func_for_regression: "nn.BCEWithLogitsLoss" # The replaced loss for regresssion. Can only support loss function in torch.nn.

--- a/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
+++ b/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
@@ -16,6 +16,6 @@ optimization:
   top_k_average_method: "greedy_soup"  # We support averaging method described in https://arxiv.org/pdf/2203.05482.pdf.
                                        # Currently support "uniform_soup", "greedy_soup", and "best".
   efficient_finetune: null  # Can be 'bit_fit' (only finetune bias), 'norm_fit' (finetune the normalization terms + bias terms), or null
-  loss_function:  # The replaced loss for regresssion. Can only support loss function in torch.nn.
+  loss_function: "BCEWithLogitsLoss" # The replaced loss for regresssion. Can only support loss function in torch.nn.
     # example
     # "BCEWithLogitsLoss" or "nn.BCEWithLogitsloss"

--- a/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
+++ b/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
@@ -16,4 +16,6 @@ optimization:
   top_k_average_method: "greedy_soup"  # We support averaging method described in https://arxiv.org/pdf/2203.05482.pdf.
                                        # Currently support "uniform_soup", "greedy_soup", and "best".
   efficient_finetune: null  # Can be 'bit_fit' (only finetune bias), 'norm_fit' (finetune the normalization terms + bias terms), or null
-  loss_func_for_regression: "nn.BCEWithLogitsLoss" # The replaced loss for regresssion. Can only support loss function in torch.nn.
+  loss_function: "BCEWithLogitsLoss" # The replaced loss for regresssion. Can only support loss function in torch.nn.
+    # example
+    # "BCEWithLogitsLoss" or "nn.BCEWithLogitsloss"

--- a/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
+++ b/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
@@ -16,6 +16,6 @@ optimization:
   top_k_average_method: "greedy_soup"  # We support averaging method described in https://arxiv.org/pdf/2203.05482.pdf.
                                        # Currently support "uniform_soup", "greedy_soup", and "best".
   efficient_finetune: null  # Can be 'bit_fit' (only finetune bias), 'norm_fit' (finetune the normalization terms + bias terms), or null
-  loss_function: "BCEWithLogitsLoss" # The replaced loss for regresssion. Can only support loss function in torch.nn.
+  loss_function:  # The replaced loss for regresssion. Can only support loss function in torch.nn.
     # example
     # "BCEWithLogitsLoss" or "nn.BCEWithLogitsloss"

--- a/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
+++ b/text/src/autogluon/text/automm/configs/optimization/adamw.yaml
@@ -16,6 +16,6 @@ optimization:
   top_k_average_method: "greedy_soup"  # We support averaging method described in https://arxiv.org/pdf/2203.05482.pdf.
                                        # Currently support "uniform_soup", "greedy_soup", and "best".
   efficient_finetune: null  # Can be 'bit_fit' (only finetune bias), 'norm_fit' (finetune the normalization terms + bias terms), or null
-  loss_function: "BCEWithLogitsLoss" # The replaced loss for regresssion. Can only support loss function in torch.nn.
+  loss_function: "auto" # The replaced loss for regresssion. Can only support loss function in torch.nn.
     # example
     # "BCEWithLogitsLoss" or "nn.BCEWithLogitsloss"

--- a/text/src/autogluon/text/automm/data/preprocess_dataframe.py
+++ b/text/src/autogluon/text/automm/data/preprocess_dataframe.py
@@ -452,7 +452,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             predict_heads = self.config.label.predict_heads
             for per_head in predict_heads:
                 if "sigmoid" in per_head:
-                    y_pred = y_pred.sigmoid()
+                    y_pred = torch.sigmoid(y_pred)
 
         y_pred = y_pred.detach().cpu().float().numpy()
 

--- a/text/src/autogluon/text/automm/data/preprocess_dataframe.py
+++ b/text/src/autogluon/text/automm/data/preprocess_dataframe.py
@@ -60,7 +60,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             self._label_generator = label_generator
 
         # Scaler used for numerical labels
-        numerical_label_preprocessing = OmegaConf.select(config,"label.numerical_label_preprocessing")
+        numerical_label_preprocessing = OmegaConf.select(config, "label.numerical_label_preprocessing")
         if numerical_label_preprocessing == "minmaxscaler":
             self._label_scaler = MinMaxScaler()
         elif numerical_label_preprocessing == "standardscaler":
@@ -68,7 +68,9 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         elif numerical_label_preprocessing is None:
             self._label_scaler = StandardScaler(with_mean=False, with_std=False)
         else:
-            raise ValueError(f'The numerical_label_preprocessing={numerical_label_preprocessing} is currently not supported')
+            raise ValueError(
+                f'The numerical_label_preprocessing={numerical_label_preprocessing} is currently not supported'
+            )
 
         for col_name, col_type in self._column_types.items():
             if col_name == self._label_column:

--- a/text/src/autogluon/text/automm/data/preprocess_dataframe.py
+++ b/text/src/autogluon/text/automm/data/preprocess_dataframe.py
@@ -2,6 +2,7 @@ import logging
 import pandas as pd
 import numpy as np
 import torch
+from torch.nn.modules.loss import _Loss
 import collections
 from typing import Callable, Iterator, Union, Optional, List, Any, Dict
 from nptyping import NDArray
@@ -432,6 +433,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             self,
             y_pred: torch.Tensor,
             inverse_categorical: bool = True,
+            loss_func: Optional[_Loss] = None,
     ) -> NDArray[(Any,), Any]:
         """
         Transform model's output logits into class labels for classification
@@ -443,12 +445,14 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             The model's output logits.
         inverse_categorical
             Whether to transform categorical value back to the original space, e.g., string values.
+        loss_func
+            The loss function of the model.
 
         Returns
         -------
         Predicted labels ready to compute metric scores.
         """
-        if OmegaConf.select(self.config, "label.sigmoid"):
+        if loss_func is not None and isinstance(loss_func, torch.nn.BCEWithLogitsLoss):
             y_pred = torch.sigmoid(y_pred)
 
         y_pred = y_pred.detach().cpu().float().numpy()

--- a/text/src/autogluon/text/automm/data/preprocess_dataframe.py
+++ b/text/src/autogluon/text/automm/data/preprocess_dataframe.py
@@ -448,11 +448,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         -------
         Predicted labels ready to compute metric scores.
         """
-        if OmegaConf.select(self.config, "label.predict_heads") is not None:
-            predict_heads = self.config.label.predict_heads
-            for per_head in predict_heads:
-                if "sigmoid" in per_head:
-                    y_pred = torch.sigmoid(y_pred)
+        if OmegaConf.select(self.config, "label.sigmoid"):
+            y_pred = torch.sigmoid(y_pred)
 
         y_pred = y_pred.detach().cpu().float().numpy()
 

--- a/text/src/autogluon/text/automm/data/preprocess_dataframe.py
+++ b/text/src/autogluon/text/automm/data/preprocess_dataframe.py
@@ -69,7 +69,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             self._label_scaler = StandardScaler(with_mean=False, with_std=False)
         else:
             raise ValueError(
-                f'The numerical_label_preprocessing={numerical_label_preprocessing} is currently not supported'
+                f"The numerical_label_preprocessing={numerical_label_preprocessing} is currently not supported"
             )
 
         for col_name, col_type in self._column_types.items():

--- a/text/src/autogluon/text/automm/data/preprocess_dataframe.py
+++ b/text/src/autogluon/text/automm/data/preprocess_dataframe.py
@@ -448,6 +448,12 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         -------
         Predicted labels ready to compute metric scores.
         """
+        if OmegaConf.select(self.config, "label.predict_heads") is not None:
+            predict_heads = self.config.label.predict_heads
+            for per_head in predict_heads:
+                if "sigmoid" in per_head:
+                    y_pred = y_pred.sigmoid()
+
         y_pred = y_pred.detach().cpu().float().numpy()
 
         if self.label_type == CATEGORICAL:

--- a/text/src/autogluon/text/automm/optimization/lit_module.py
+++ b/text/src/autogluon/text/automm/optimization/lit_module.py
@@ -144,6 +144,8 @@ class LitModule(pl.LightningModule):
             logits: torch.Tensor,
             label: torch.Tensor,
     ):
+        if isinstance(self.loss_func, nn.BCEWithLogitsLoss):
+            logits = torch.sigmoid(logits)
         if isinstance(metric, (torchmetrics.AUROC, torchmetrics.AveragePrecision)):
             prob = F.softmax(logits.float(), dim=1)
             metric.update(preds=prob[:, 1], target=label)  # only for binary classification

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -39,7 +39,7 @@ from .soft_target_crossentropy import SoftTargetCrossEntropy
 def get_loss_func(
     problem_type: str,
     mixup_active: bool,
-    loss_func_replaced: Optional[str] = None,
+    loss_func_name: Optional[str] = None,
 ):
     """
     Choose a suitable Pytorch loss module based on the provided problem type.
@@ -48,6 +48,10 @@ def get_loss_func(
     ----------
     problem_type
         Type of problem.
+    mixup_active
+        The activation determining whether to use mixup.
+    loss_func_name
+        The name of the function the user wants to use.
 
     Returns
     -------
@@ -59,8 +63,8 @@ def get_loss_func(
         else:
             loss_func = nn.CrossEntropyLoss()
     elif problem_type == REGRESSION:
-        if loss_func_replaced is not None:
-            if "bcewithlogitsloss" in loss_func_replaced.lower():
+        if loss_func_name is not None:
+            if "bcewithlogitsloss" in loss_func_name.lower():
                 loss_func = nn.BCEWithLogitsLoss()
             else:
                 loss_func = nn.MSELoss()

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -518,4 +518,12 @@ def update_config_by_rules(
         if "bcewithlogitsloss" in loss_func.lower():
             config.data.label.numerical_label_preprocessing = "minmaxscaler"
 
+    if problem_type in [MULTICLASS, BINARY] and OmegaConf.select(config,"optimization.loss_function") is not None:
+        if "bcewithlogitsloss" in loss_func.lower():
+            warnings.warn(
+                "The BCE loss can only support for regression currently. "
+                "The loss_function will be chosen automatically. ",
+                UserWarning,
+            )
+
     return config

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -23,6 +23,7 @@ from .soft_target_crossentropy import SoftTargetCrossEntropy
 def get_loss_func(
         problem_type: str,
         mixup_active: bool,
+        bce_type: bool,
 ):
     """
     Choose a suitable Pytorch loss module based on the provided problem type.
@@ -42,7 +43,10 @@ def get_loss_func(
         else:
             loss_func = nn.CrossEntropyLoss()
     elif problem_type == REGRESSION:
-        loss_func = nn.MSELoss()
+        if bce_type:
+            loss_func = nn.BCEWithLogitsLoss()
+        else:
+            loss_func = nn.MSELoss()
     else:
         raise NotImplementedError
 

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -24,7 +24,7 @@ from .soft_target_crossentropy import SoftTargetCrossEntropy
 def get_loss_func(
         problem_type: str,
         mixup_active: bool,
-        loss_func_replaced: str,
+        loss_func_replaced: Optional[str] = None,
 ):
     """
     Choose a suitable Pytorch loss module based on the provided problem type.
@@ -485,7 +485,7 @@ def apply_layerwise_lr_decay(
     return list(parameter_group_vars.values())
 
 
-def modify_config_with_loss_func(
+def config_update_loss_func(
         problem_type,
         config,
 ):
@@ -495,8 +495,8 @@ def modify_config_with_loss_func(
 
     Parameters
     ----------
-    loss_func
-        The loss function used in the project.
+    problem_type
+        The type of the problem of the project.
     config
         The config of the project.
 

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -515,7 +515,7 @@ def update_config_by_rules(
     """
     if problem_type == REGRESSION and OmegaConf.select(config, "optimization.loss_function") is not None:
         loss_func = config.optimization.loss_function
-        if "bceloss" in loss_func.lower() or "bcewithlogitsloss" in loss_func.lower():
+        if "bcewithlogitsloss" in loss_func.lower():
             config.data.label.numerical_label_preprocessing = "minmaxscaler"
 
     return config

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -508,9 +508,5 @@ def config_update_loss_func(
         loss_func = config.optimization.loss_function
         if "bceloss" in loss_func.lower() or "bcewithlogitsloss" in loss_func.lower():
             config.data.label.numerical_label_preprocessing = "minmaxscaler"
-        if "bcewithlogitsloss" in loss_func.lower():
-            config.data.label.update(
-                {"sigmoid": True}
-            )
 
     return config

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -5,7 +5,7 @@ from torch import optim
 from torch.nn import functional as F
 from transformers.trainer_pt_utils import get_parameter_names
 import torchmetrics
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, DictConfig
 from .lr_scheduler import (
     get_cosine_schedule_with_warmup,
     get_polynomial_decay_schedule_with_warmup,
@@ -495,8 +495,8 @@ def apply_layerwise_lr_decay(
 
 
 def config_update_loss_func(
-    problem_type,
-    config,
+    problem_type: str,
+    config: DictConfig,
 ):
     """
     Modify configs based on the need of loss func.

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -504,9 +504,16 @@ def modify_config_with_loss_func(
     -------
     The modified config.
     """
-    if problem_type == REGRESSION and OmegaConf.select(config, 'optimization.loss_func_for_regression') is not None:
-        loss_func = config.optimization.loss_func_for_regression
-        if "BCELoss" in loss_func or "BCEWithLogitsLoss" in loss_func:
+    if OmegaConf.select(config, "data.label.predict_heads") is not None and isinstance(config.data.label.predict_heads, str):
+        config.data.label.predict_heads = [config.data.label.predict_heads]
+    if problem_type == REGRESSION and OmegaConf.select(config, 'optimization.loss_function') is not None:
+        loss_func = config.optimization.loss_function
+        if "bceloss" in loss_func.lower() or "bcewithlogitsloss" in loss_func.lower():
             config.data.label.numerical_label_preprocessing = "minmaxscaler"
+        if "bcewithlogitsloss" in loss_func.lower():
+            if config.data.label.predict_heads is None:
+                config.data.label.predict_heads = ["sigmoid"]
+            elif "sigmoid" not in config.data.label.predict_heads:
+                config.data.label.predict_heads.insert(0, "sigmoid")
 
     return config

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -24,7 +24,7 @@ from .soft_target_crossentropy import SoftTargetCrossEntropy
 def get_loss_func(
         problem_type: str,
         mixup_active: bool,
-        loss_func_for_regression: str,
+        loss_func_replaced: str,
 ):
     """
     Choose a suitable Pytorch loss module based on the provided problem type.
@@ -44,8 +44,8 @@ def get_loss_func(
         else:
             loss_func = nn.CrossEntropyLoss()
     elif problem_type == REGRESSION:
-        if loss_func_for_regression is not None:
-            if "BCEWithLogitsLoss" in loss_func_for_regression:
+        if loss_func_replaced is not None:
+            if "bcewithlogitsloss" in loss_func_replaced.lower():
                 loss_func = nn.BCEWithLogitsLoss()
         else:
             loss_func = nn.MSELoss()

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -518,7 +518,7 @@ def update_config_by_rules(
         if "bcewithlogitsloss" in loss_func.lower():
             config.data.label.numerical_label_preprocessing = "minmaxscaler"
 
-    if problem_type in [MULTICLASS, BINARY] and OmegaConf.select(config,"optimization.loss_function") is not None:
+    if problem_type in [MULTICLASS, BINARY] and OmegaConf.select(config, "optimization.loss_function") is not None:
         if "bcewithlogitsloss" in loss_func.lower():
             warnings.warn(
                 "The BCE loss can only support for regression currently. "

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -507,7 +507,7 @@ def config_update_loss_func(
     problem_type
         The type of the problem of the project.
     config
-        The config of the project.
+        The config of the project. It is a Dictconfig object.
 
     Returns
     -------

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -513,17 +513,16 @@ def update_config_by_rules(
     -------
     The modified config.
     """
-    if problem_type == REGRESSION and OmegaConf.select(config, "optimization.loss_function") is not None:
-        loss_func = config.optimization.loss_function
-        if "bcewithlogitsloss" in loss_func.lower():
+    loss_func = OmegaConf.select(config, "optimization.loss_function")
+    if loss_func is not None:
+        if problem_type == REGRESSION and "bce" in loss_func.lower():
+            # We are using BCELoss for regression problems. Need to first scale the labels.
             config.data.label.numerical_label_preprocessing = "minmaxscaler"
-
-    if problem_type in [MULTICLASS, BINARY] and OmegaConf.select(config, "optimization.loss_function") is not None:
-        if "bcewithlogitsloss" in loss_func.lower():
+        elif loss_func != 'auto':
             warnings.warn(
-                "The BCE loss can only support for regression currently. "
-                "The loss_function will be chosen automatically. ",
+                f"Received loss function={loss_func} for problem={problem_type}. "
+                "Currently, we only support using BCE loss for regression problems and choose "
+                "the loss_function automatically otherwise.",
                 UserWarning,
             )
-
     return config

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -494,7 +494,7 @@ def apply_layerwise_lr_decay(
     return list(parameter_group_vars.values())
 
 
-def config_update_loss_func(
+def update_config_loss_func(
     problem_type: str,
     config: DictConfig,
 ):

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -491,8 +491,8 @@ def apply_layerwise_lr_decay(
 
 
 def config_update_loss_func(
-        problem_type,
-        config,
+    problem_type,
+    config,
 ):
     """
     Modify configs based on the need of loss func.
@@ -509,7 +509,7 @@ def config_update_loss_func(
     -------
     The modified config.
     """
-    if problem_type == REGRESSION and OmegaConf.select(config, 'optimization.loss_function') is not None:
+    if problem_type == REGRESSION and OmegaConf.select(config, "optimization.loss_function") is not None:
         loss_func = config.optimization.loss_function
         if "bceloss" in loss_func.lower() or "bcewithlogitsloss" in loss_func.lower():
             config.data.label.numerical_label_preprocessing = "minmaxscaler"

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -45,7 +45,8 @@ def get_loss_func(
             loss_func = nn.CrossEntropyLoss()
     elif problem_type == REGRESSION:
         if loss_func_for_regression is not None:
-            loss_func = eval(loss_func_for_regression)()
+            if "BCEWithLogitsLoss" in loss_func_for_regression:
+                loss_func = nn.BCEWithLogitsLoss()
         else:
             loss_func = nn.MSELoss()
     else:

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -494,7 +494,7 @@ def apply_layerwise_lr_decay(
     return list(parameter_group_vars.values())
 
 
-def update_config_loss_func(
+def update_config_by_rules(
     problem_type: str,
     config: DictConfig,
 ):

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -504,16 +504,13 @@ def modify_config_with_loss_func(
     -------
     The modified config.
     """
-    if OmegaConf.select(config, "data.label.predict_heads") is not None and isinstance(config.data.label.predict_heads, str):
-        config.data.label.predict_heads = [config.data.label.predict_heads]
     if problem_type == REGRESSION and OmegaConf.select(config, 'optimization.loss_function') is not None:
         loss_func = config.optimization.loss_function
         if "bceloss" in loss_func.lower() or "bcewithlogitsloss" in loss_func.lower():
             config.data.label.numerical_label_preprocessing = "minmaxscaler"
         if "bcewithlogitsloss" in loss_func.lower():
-            if config.data.label.predict_heads is None:
-                config.data.label.predict_heads = ["sigmoid"]
-            elif "sigmoid" not in config.data.label.predict_heads:
-                config.data.label.predict_heads.insert(0, "sigmoid")
+            config.data.label.update(
+                {"sigmoid": True}
+            )
 
     return config

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -518,7 +518,7 @@ def update_config_by_rules(
         if problem_type == REGRESSION and "bce" in loss_func.lower():
             # We are using BCELoss for regression problems. Need to first scale the labels.
             config.data.label.numerical_label_preprocessing = "minmaxscaler"
-        elif loss_func != 'auto':
+        elif loss_func != "auto":
             warnings.warn(
                 f"Received loss function={loss_func} for problem={problem_type}. "
                 "Currently, we only support using BCE loss for regression problems and choose "

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -47,6 +47,8 @@ def get_loss_func(
         if loss_func_replaced is not None:
             if "bcewithlogitsloss" in loss_func_replaced.lower():
                 loss_func = nn.BCEWithLogitsLoss()
+            else:
+                loss_func = nn.MSELoss()
         else:
             loss_func = nn.MSELoss()
     else:

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -434,7 +434,7 @@ class AutoMMPredictor:
         loss_func = get_loss_func(
             problem_type,
             mixup_active,
-            OmegaConf.select(config, 'optimization.loss_func_for_regression')
+            OmegaConf.select(config, 'optimization.loss_function')
         )
 
         if time_limit is not None:

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -458,7 +458,6 @@ class AutoMMPredictor:
         self._df_preprocessor = df_preprocessor
         self._data_processors = data_processors
         self._model = model
-        self._mixup_fn = mixup_fn
         self._loss_func = loss_func
 
         # save artifacts for the current running, except for model checkpoint, which will be saved in _fit()
@@ -521,7 +520,7 @@ class AutoMMPredictor:
             ckpt_path=self._ckpt_path,
             resume=self._resume,
             enable_progress_bar=self._enable_progress_bar,
-            mixup_fn=self._mixup_fn,
+            mixup_fn=mixup_fn,
         )
         return self
 

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -418,9 +418,10 @@ class AutoMMPredictor:
             pos_label=pos_label,
         )
 
-        mixup_active, mixup_fn = get_mixup(model_config=OmegaConf.select(config,'model'),
-                                     mixup_config=OmegaConf.select(config,'data.mixup'),
-                                     num_classes=output_shape,
+        mixup_active, mixup_fn = get_mixup(
+            model_config=OmegaConf.select(config,'model'),
+            mixup_config=OmegaConf.select(config,'data.mixup'),
+            num_classes=output_shape,
         )
         if mixup_active and (config.env.per_gpu_batch_size == 1 or config.env.per_gpu_batch_size % 2 == 1):
             warnings.warn("The mixup is done on the batch."

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -174,7 +174,6 @@ class AutoMMPredictor:
         self._verbosity = verbosity
         self._warn_if_exist = warn_if_exist
         self._enable_progress_bar = enable_progress_bar if enable_progress_bar is not None else True
-        self._mixup_fn = None
 
     @property
     def path(self):
@@ -452,6 +451,7 @@ class AutoMMPredictor:
         self._data_processors = data_processors
         self._model = model
         self._mixup_fn = mixup_fn
+        self._loss_func = loss_func
 
         # save artifacts for the current running, except for model checkpoint, which will be saved in _fit()
         self.save(save_path)
@@ -1078,8 +1078,8 @@ class AutoMMPredictor:
             y_pred_prob = self._logits_to_prob(logits)
             metric_data[Y_PRED_PROB] = y_pred_prob
 
-        y_pred = self._df_preprocessor.transform_prediction(y_pred=logits, inverse_categorical=False)
-        y_pred_transformed = self._df_preprocessor.transform_prediction(y_pred=logits, inverse_categorical=True)
+        y_pred = self._df_preprocessor.transform_prediction(y_pred=logits, inverse_categorical=False, loss_func=self._loss_func)
+        y_pred_transformed = self._df_preprocessor.transform_prediction(y_pred=logits, inverse_categorical=True, loss_func=self._loss_func)
         y_true = self._df_preprocessor.transform_label_for_metric(df=data)
 
         metric_data.update({
@@ -1139,7 +1139,7 @@ class AutoMMPredictor:
             ret_type=LOGITS,
             requires_label=False,
         )
-        pred = self._df_preprocessor.transform_prediction(y_pred=logits)
+        pred = self._df_preprocessor.transform_prediction(y_pred=logits, loss_func=self._loss_func)
         if as_pandas:
             pred = self.as_pandas(data=data, to_be_converted=pred)
         return pred

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -76,7 +76,7 @@ from .utils import (
 from .optimization.utils import (
     get_metric,
     get_loss_func,
-    config_update_loss_func,
+    update_config_loss_func,
 )
 from .optimization.lit_module import LitModule
 from .optimization.lit_distiller import DistillerLitModule
@@ -368,7 +368,7 @@ class AutoMMPredictor:
                 self._output_shape == output_shape
             ), f"Inferred output shape {output_shape} is different from the previous {self._output_shape}"
 
-        config = config_update_loss_func(
+        config = update_config_loss_func(
             problem_type=problem_type,
             config=config,
         )

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -76,7 +76,7 @@ from .utils import (
 from .optimization.utils import (
     get_metric,
     get_loss_func,
-    update_config_loss_func,
+    update_config_by_rules,
 )
 from .optimization.lit_module import LitModule
 from .optimization.lit_distiller import DistillerLitModule
@@ -368,7 +368,7 @@ class AutoMMPredictor:
                 self._output_shape == output_shape
             ), f"Inferred output shape {output_shape} is different from the previous {self._output_shape}"
 
-        config = update_config_loss_func(
+        config = update_config_by_rules(
             problem_type=problem_type,
             config=config,
         )

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -1078,8 +1078,16 @@ class AutoMMPredictor:
             y_pred_prob = self._logits_to_prob(logits)
             metric_data[Y_PRED_PROB] = y_pred_prob
 
-        y_pred = self._df_preprocessor.transform_prediction(y_pred=logits, inverse_categorical=False, loss_func=self._loss_func)
-        y_pred_transformed = self._df_preprocessor.transform_prediction(y_pred=logits, inverse_categorical=True, loss_func=self._loss_func)
+        y_pred = self._df_preprocessor.transform_prediction(
+            y_pred=logits,
+            inverse_categorical=False,
+            loss_func=self._loss_func if hasattr(self, "_loss_func") else None,
+        )
+        y_pred_transformed = self._df_preprocessor.transform_prediction(
+            y_pred=logits,
+            inverse_categorical=True,
+            loss_func=self._loss_func if hasattr(self, "_loss_func") else None,
+        )
         y_true = self._df_preprocessor.transform_label_for_metric(df=data)
 
         metric_data.update({
@@ -1139,7 +1147,10 @@ class AutoMMPredictor:
             ret_type=LOGITS,
             requires_label=False,
         )
-        pred = self._df_preprocessor.transform_prediction(y_pred=logits, loss_func=self._loss_func)
+        pred = self._df_preprocessor.transform_prediction(
+            y_pred=logits,
+            loss_func=self._loss_func if hasattr(self, "_loss_func") else None,
+        )
         if as_pandas:
             pred = self.as_pandas(data=data, to_be_converted=pred)
         return pred

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -442,11 +442,7 @@ class AutoMMPredictor:
                 UserWarning,
             )
 
-        loss_func = get_loss_func(
-            problem_type,
-            mixup_active,
-            OmegaConf.select(config, 'optimization.loss_function')
-        )
+        loss_func = get_loss_func(problem_type,mixup_active, OmegaConf.select(config, "optimization.loss_function"))
 
         if time_limit is not None:
             time_limit = timedelta(seconds=time_limit)

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -419,8 +419,8 @@ class AutoMMPredictor:
         )
 
         mixup_active, mixup_fn = get_mixup(
-            model_config=OmegaConf.select(config,'model'),
-            mixup_config=OmegaConf.select(config,'data.mixup'),
+            model_config=OmegaConf.select(config, 'model'),
+            mixup_config=OmegaConf.select(config, 'data.mixup'),
             num_classes=output_shape,
         )
         if mixup_active and (config.env.per_gpu_batch_size == 1 or config.env.per_gpu_batch_size % 2 == 1):

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -442,7 +442,7 @@ class AutoMMPredictor:
                 UserWarning,
             )
 
-        loss_func = get_loss_func(problem_type,mixup_active, OmegaConf.select(config, "optimization.loss_function"))
+        loss_func = get_loss_func(problem_type, mixup_active, OmegaConf.select(config, "optimization.loss_function"))
 
         if time_limit is not None:
             time_limit = timedelta(seconds=time_limit)

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -1044,13 +1044,6 @@ class AutoMMPredictor:
         prob = prob.detach().cpu().float().numpy()
         return prob
 
-    @staticmethod
-    def _logits_to_sigmoid(logits: torch.Tensor):
-        assert logits.ndim == 2
-        prob = torch.sigmoid(logits.float())
-        prob = prob.detach().cpu().float().numpy()
-        return prob
-
     def evaluate(
             self,
             data: Union[pd.DataFrame, dict, list],
@@ -1083,9 +1076,6 @@ class AutoMMPredictor:
         metric_data = {}
         if self._problem_type in [BINARY, MULTICLASS]:
             y_pred_prob = self._logits_to_prob(logits)
-            metric_data[Y_PRED_PROB] = y_pred_prob
-        if self._bce:
-            y_pred_prob = self._logits_to_sigmoid(logits)
             metric_data[Y_PRED_PROB] = y_pred_prob
 
         y_pred = self._df_preprocessor.transform_prediction(y_pred=logits, inverse_categorical=False)

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -63,7 +63,7 @@ from .utils import (
 from .optimization.utils import (
     get_metric,
     get_loss_func,
-    modify_config_with_loss_func,
+    config_update_loss_func,
 )
 from .optimization.lit_module import LitModule
 from .optimization.lit_distiller import DistillerLitModule
@@ -358,7 +358,7 @@ class AutoMMPredictor:
                 f"Inferred output shape {output_shape} is different from " \
                 f"the previous {self._output_shape}"
 
-        config = modify_config_with_loss_func(
+        config = config_update_loss_func(
             problem_type=problem_type,
             config=config,
         )

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -146,6 +146,7 @@ class AutoMMPredictor:
         if eval_metric is not None and not isinstance(eval_metric, str):
             eval_metric = eval_metric.name
 
+        bce_regression_state = False
         if eval_metric is not None and eval_metric.lower() in ["rmse", "r2", "pearsonr", "spearmanr"]:
             if problem_type == BINARY:
                 bce_regression_state = True
@@ -176,7 +177,7 @@ class AutoMMPredictor:
         self._warn_if_exist = warn_if_exist
         self._enable_progress_bar = enable_progress_bar if enable_progress_bar is not None else True
         self._mixup_fn = None
-        self._bce = bce_regression_state if bce_regression_state is not None else False
+        self._bce = bce_regression_state
 
     @property
     def path(self):

--- a/text/tests/unittests/automm/test_metrics.py
+++ b/text/tests/unittests/automm/test_metrics.py
@@ -43,12 +43,12 @@ def test_cross_entropy(metric_name, class_num):
 
 
 @pytest.mark.parametrize(
-    "problem_type,loss_func_replaced",
+    "problem_type,loss_func_name",
     [
         ("regression", "bcewithlogitsloss"),
     ]
 )
-def test_bce_with_logits_loss(problem_type, loss_func_replaced):
+def test_bce_with_logits_loss(problem_type, loss_func_name):
     preds = []
     targets = []
     random.seed(123)
@@ -64,7 +64,7 @@ def test_bce_with_logits_loss(problem_type, loss_func_replaced):
     loss_func = get_loss_func(
         problem_type=problem_type,
         mixup_active=False,
-        loss_func_replaced=loss_func_replaced,
+        loss_func_name=loss_func_name,
     )
 
     score1 = loss_func(input=preds, target=targets)

--- a/text/tests/unittests/automm/test_metrics.py
+++ b/text/tests/unittests/automm/test_metrics.py
@@ -58,6 +58,8 @@ def test_bce_with_logits_loss(problem_type, loss_func_replaced):
         bs = random.randint(1, 16)
         preds.append(torch.randn(bs, 1))
         targets.append(torch.rand(bs, 1))
+    preds = torch.cat(preds)
+    targets = torch.cat(targets)
 
     loss_func = get_loss_func(
         problem_type=problem_type,
@@ -65,12 +67,8 @@ def test_bce_with_logits_loss(problem_type, loss_func_replaced):
         loss_func_replaced=loss_func_replaced,
     )
 
-    score1 = loss_func(targets,preds)
-    preds = torch.cat(preds).sigmoid()
-    targets = torch.cat(targets)
+    score1 = loss_func(input=preds, target=targets)
+    preds = preds.sigmoid()
     bceloss = torch.nn.BCELoss()
-    score2 = bceloss(
-        input=targets,
-        target=preds,
-    )
+    score2 = bceloss(input=preds, target=targets)
     assert pytest.approx(score1, 1e-6) == score2

--- a/text/tests/unittests/automm/test_metrics.py
+++ b/text/tests/unittests/automm/test_metrics.py
@@ -72,7 +72,8 @@ def test_bce_with_logits_loss(problem_type, loss_func_replaced):
     score1 = mean_metric.compute()
     preds = torch.cat(preds).sigmoid()
     targets = torch.cat(targets)
-    score2 = torch.nn.BCELoss(
+    bceloss = torch.nn.BCELoss()
+    score2 = bceloss(
         input=targets,
         target=preds,
     )

--- a/text/tests/unittests/automm/test_metrics.py
+++ b/text/tests/unittests/automm/test_metrics.py
@@ -3,7 +3,7 @@ import random
 import torch
 from torchmetrics import MeanMetric
 from sklearn.metrics import log_loss
-from autogluon.text.automm.optimization.utils import get_metric
+from autogluon.text.automm.optimization.utils import get_metric, get_loss_func
 from autogluon.text.automm.constants import MULTICLASS
 
 
@@ -34,6 +34,43 @@ def test_cross_entropy(metric_name, class_num):
 
     score1 = mean_metric.compute()
     preds = torch.cat(preds).softmax(dim=1)
+    targets = torch.cat(targets)
+    score2 = log_loss(
+        y_true=targets,
+        y_pred=preds,
+    )
+    assert pytest.approx(score1, 1e-6) == score2
+
+
+@pytest.mark.parametrize(
+    "problem_type,loss_func_replaced",
+    [
+        ("regression", "bcewithlogitsloss"),
+    ]
+)
+def test_bce_with_logits_loss(problem_type, loss_func_replaced):
+    preds = []
+    targets = []
+    random.seed(123)
+    torch.manual_seed(123)
+
+    for i in range(100):
+        bs = random.randint(1, 16)
+        preds.append(torch.randn(bs, 1))
+        targets.append(torch.rand(bs, 1))
+
+    loss_func = get_loss_func(
+        problem_type=problem_type,
+        mixup_active=False,
+        loss_func_replaced=loss_func_replaced,
+    )
+    mean_metric = MeanMetric()
+
+    for per_pred, per_target in zip(preds, targets):
+        mean_metric.update(loss_func(per_pred, per_target))
+
+    score1 = mean_metric.compute()
+    preds = torch.cat(preds).sigmoid()
     targets = torch.cat(targets)
     score2 = log_loss(
         y_true=targets,

--- a/text/tests/unittests/automm/test_metrics.py
+++ b/text/tests/unittests/automm/test_metrics.py
@@ -64,12 +64,8 @@ def test_bce_with_logits_loss(problem_type, loss_func_replaced):
         mixup_active=False,
         loss_func_replaced=loss_func_replaced,
     )
-    mean_metric = MeanMetric()
 
-    for per_pred, per_target in zip(preds, targets):
-        mean_metric.update(loss_func(per_pred, per_target))
-
-    score1 = mean_metric.compute()
+    score1 = loss_func(targets,preds)
     preds = torch.cat(preds).sigmoid()
     targets = torch.cat(targets)
     bceloss = torch.nn.BCELoss()

--- a/text/tests/unittests/automm/test_metrics.py
+++ b/text/tests/unittests/automm/test_metrics.py
@@ -72,8 +72,8 @@ def test_bce_with_logits_loss(problem_type, loss_func_replaced):
     score1 = mean_metric.compute()
     preds = torch.cat(preds).sigmoid()
     targets = torch.cat(targets)
-    score2 = log_loss(
-        y_true=targets,
-        y_pred=preds,
+    score2 = torch.nn.BCELoss(
+        input=targets,
+        target=preds,
     )
     assert pytest.approx(score1, 1e-6) == score2


### PR DESCRIPTION
*Issue #, if available:*
Adding BCEloss into automm regression. It is a special method for dealing with regression problems.
*Description of changes:*
Add BCEloss. It will be active if the problem_type = binary and the eval_metrics belong to regression.
This requires the label to be converted to [0,1].
So the default standardization should be modified. Now users can choose "minmaxscaler", "standardscaler" or nothing to do in the data default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
