### PR TITLE
Fix TimeSeriesDataFrame type inconsistencies

### DIFF
--- a/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
+++ b/forecasting/src/autogluon/forecasting/dataset/ts_dataframe.py
@@ -5,7 +5,6 @@ from typing import Any, Tuple, Type
 from collections.abc import Iterable
 
 import pandas as pd
-from pandas._typing import FilePathOrBuffer  # noqa
 from pandas.core.internals import ArrayManager, BlockManager
 
 ITEMID = "item_id"
@@ -353,7 +352,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         )
 
     @classmethod
-    def from_pickle(cls, filepath_or_buffer: FilePathOrBuffer) -> "TimeSeriesDataFrame":
+    def from_pickle(cls, filepath_or_buffer: Any) -> "TimeSeriesDataFrame":
         """Convenience method to read pickled time series data frames. If the read pickle
         file refers to a plain pandas DataFrame, it will be cast to a TimeSeriesDataFrame.
         """

--- a/forecasting/src/autogluon/forecasting/predictor.py
+++ b/forecasting/src/autogluon/forecasting/predictor.py
@@ -65,6 +65,8 @@ class ForecastingPredictor:
 
     Other Parameters
     ----------------
+    label: str
+        Alias for `target`.
     learner_type : AbstractLearner, default = ForecastingLearner
         A class which inherits from `AbstractLearner`. The learner specifies the inner logic of the ForecastingPredictor
         for training models and preprocessing data.
@@ -72,6 +74,8 @@ class ForecastingPredictor:
         Keyword arguments to send to the learner (for advanced users only). Options include `trainer_type`, a
         class inheriting from `AbstractTrainer` which controls training of multiple models. If `path` and `eval_metric`
         are re-specified within `learner_kwargs`, these are ignored.
+    quantiles: List[float]
+        Alias for `quantile_levels`.
 
     Attributes
     ----------
@@ -84,7 +88,7 @@ class ForecastingPredictor:
 
     def __init__(
         self,
-        target: str = "target",
+        target: Optional[str] = None,
         eval_metric: Optional[str] = None,
         path: Optional[str] = None,
         verbosity: int = 2,
@@ -95,7 +99,7 @@ class ForecastingPredictor:
         self.verbosity = verbosity
         set_logger_verbosity(self.verbosity, logger=logger)
         self.path = setup_outputdir(path)
-        self.target = target
+        self.target = target or kwargs.get("label", "target")
 
         self.prediction_length = prediction_length
         self.eval_metric = eval_metric

--- a/forecasting/src/autogluon/forecasting/predictor.py
+++ b/forecasting/src/autogluon/forecasting/predictor.py
@@ -99,6 +99,12 @@ class ForecastingPredictor:
         self.verbosity = verbosity
         set_logger_verbosity(self.verbosity, logger=logger)
         self.path = setup_outputdir(path)
+
+        if target is not None and kwargs.get("label") is not None:
+            raise ValueError(
+                "Both `label` and `target` are specified. Please specify at most one of these. "
+                "arguments."
+            )
         self.target = target or kwargs.get("label", "target")
 
         self.prediction_length = prediction_length

--- a/forecasting/tests/unittests/test_ts_dataset.py
+++ b/forecasting/tests/unittests/test_ts_dataset.py
@@ -1,3 +1,7 @@
+import copy
+import tempfile
+from pathlib import Path
+
 import pandas as pd
 import numpy as np
 import pytest
@@ -26,7 +30,8 @@ def _build_ts_dataframe(item_ids, datetime_index, target):
 
 
 SAMPLE_TS_DATAFRAME = _build_ts_dataframe(ITEM_IDS, DATETIME_INDEX, TARGETS)
-SAMPLE_DATAFRAME = SAMPLE_TS_DATAFRAME.reset_index()
+SAMPLE_TS_DATAFRAME_EMPTY = _build_ts_dataframe(EMPTY_ITEM_IDS, EMPTY_DATETIME_INDEX, EMPTY_TARGETS)
+SAMPLE_DATAFRAME = pd.DataFrame(SAMPLE_TS_DATAFRAME).reset_index()
 
 
 SAMPLE_ITERABLE = [
@@ -410,3 +415,81 @@ def test_when_dataset_sliced_by_step_then_output_times_and_values_correct(
     assert isinstance(dfv, TimeSeriesDataFrame)
 
     assert all(ixval[1] == pd.Timestamp(expected_times[i]) for i, ixval in enumerate(dfv.index.values))
+
+
+@pytest.mark.parametrize("input_df", [
+    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
+])
+def test_when_dataframe_copy_called_on_instance_then_output_correct(input_df):
+    copied_df = input_df.copy()
+
+    assert isinstance(copied_df, TimeSeriesDataFrame)
+    assert copied_df._data is not input_df._data
+
+
+@pytest.mark.parametrize("input_df", [
+    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
+])
+def test_when_dataframe_stdlib_copy_called_then_output_correct(input_df):
+    copied_df = copy.deepcopy(input_df)
+
+    assert isinstance(copied_df, TimeSeriesDataFrame)
+    assert copied_df._data is not input_df._data
+
+
+@pytest.mark.parametrize("input_df", [
+    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
+])
+def test_when_dataframe_class_copy_called_then_output_correct(input_df):
+    copied_df = TimeSeriesDataFrame.copy(input_df, deep=True)
+
+    assert isinstance(copied_df, TimeSeriesDataFrame)
+    assert copied_df._data is not input_df._data
+
+
+@pytest.mark.parametrize("input_df", [
+    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
+])
+@pytest.mark.parametrize("inplace", [True, False])
+def test_when_dataframe_class_rename_called_then_output_correct(input_df, inplace):
+    renamed_df = TimeSeriesDataFrame.rename(input_df, columns={"target": "mytarget"}, inplace=inplace)
+    if inplace:
+        renamed_df = input_df
+
+    assert isinstance(renamed_df, TimeSeriesDataFrame)
+    assert "mytarget" in renamed_df.columns
+    assert "target" not in renamed_df.columns
+    if inplace:
+        assert renamed_df._data is input_df._data
+
+
+@pytest.mark.parametrize("input_df", [
+    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
+])
+@pytest.mark.parametrize("inplace", [True, False])
+def test_when_dataframe_instance_rename_called_then_output_correct(input_df, inplace):
+    renamed_df = input_df.rename(columns={"target": "mytarget"}, inplace=inplace)
+    if inplace:
+        renamed_df = input_df
+
+    assert isinstance(renamed_df, TimeSeriesDataFrame)
+    assert "mytarget" in renamed_df.columns
+    assert "target" not in renamed_df.columns
+    if inplace:
+        assert renamed_df._data is input_df._data
+
+
+@pytest.mark.parametrize("input_df", [
+    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
+])
+@pytest.mark.parametrize("read_fn", [pd.read_pickle, TimeSeriesDataFrame.from_pickle])
+def test_when_dataframe_instance_rename_called_then_output_correct(input_df, read_fn):
+
+    with tempfile.TemporaryDirectory() as td:
+        pkl_filename = Path(td) / "temp_pickle.pkl"
+        input_df.to_pickle(str(pkl_filename))
+
+        read_df = read_fn(pkl_filename)
+
+    assert isinstance(read_df, TimeSeriesDataFrame)
+    assert np.allclose(read_df, input_df)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add convenience method and override `_constructor` in `TimeSeriesDataFrame`. This prevents type inconsistencies in DataFrame methods that return copies.
- Add `"label"` alias to Predictor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
