### PR TITLE
Enabling black for Code Style Check in AutoMM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,7 +191,7 @@ stage("Unit Test") {
           python3 -m pip install --upgrade pytest-xdist
 
           python3 -m pip install 'black~=22.0,>=22.3'
-          export AUTOMM_LINT_DIRS=text/src/autogluon/text/automm:text/tests/unittests/automm
+          AUTOMM_LINT_DIRS=text/src/autogluon/text/automm:text/tests/unittests/automm
           black --check --preview ${AUTOMM_LINT_DIRS}
           cd text/
           python3 -m pytest --junitxml=results.xml --forked --runslow tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,7 +191,7 @@ stage("Unit Test") {
           python3 -m pip install --upgrade pytest-xdist
 
           python3 -m pip install 'black~=22.0,>=22.3'
-          export AUTOMM_LINT_DIRS=text/src/autogluon/text/automm tests/unittests/automm
+          export AUTOMM_LINT_DIRS=text/src/autogluon/text/automm:text/tests/unittests/automm
           black --check --preview ${AUTOMM_LINT_DIRS}
           cd text/
           python3 -m pytest --junitxml=results.xml --forked --runslow tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,6 +190,8 @@ stage("Unit Test") {
           # launch different process for each test to make sure memory is released
           python3 -m pip install --upgrade pytest-xdist
 
+          check_dirs := text/src/autogluon/text/automm tests/unittests/automm
+          black --check --preview $(check_dirs)
           cd text/
           python3 -m pytest --junitxml=results.xml --forked --runslow tests
           """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,7 @@ stage("Unit Test") {
 
           python3 -m pip install 'black~=22.0,>=22.3'
           export AUTOMM_LINT_DIRS=text/src/autogluon/text/automm tests/unittests/automm
-          black --check --preview $(AUTOMM_LINT_DIRS)
+          black --check --preview ${AUTOMM_LINT_DIRS}
           cd text/
           python3 -m pytest --junitxml=results.xml --forked --runslow tests
           """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,8 +190,9 @@ stage("Unit Test") {
           # launch different process for each test to make sure memory is released
           python3 -m pip install --upgrade pytest-xdist
 
-          check_dirs := text/src/autogluon/text/automm tests/unittests/automm
-          black --check --preview $(check_dirs)
+          pip install 'black~=22.0,>=22.3'
+          export AUTOMM_LINT_DIRS=text/src/autogluon/text/automm tests/unittests/automm
+          black --check --preview $(AUTOMM_LINT_DIRS)
           cd text/
           python3 -m pytest --junitxml=results.xml --forked --runslow tests
           """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,8 +191,7 @@ stage("Unit Test") {
           python3 -m pip install --upgrade pytest-xdist
 
           python3 -m pip install 'black~=22.0,>=22.3'
-          AUTOMM_LINT_DIRS=text/src/autogluon/text/automm:text/tests/unittests/automm
-          black --check --preview ${AUTOMM_LINT_DIRS}
+          black --check --preview text/src/autogluon/text/automm
           cd text/
           python3 -m pytest --junitxml=results.xml --forked --runslow tests
           """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,7 +191,7 @@ stage("Unit Test") {
           python3 -m pip install --upgrade pytest-xdist
 
           python3 -m pip install 'black~=22.0,>=22.3'
-          black --check --preview text/src/autogluon/text/automm
+          black --check --preview --diff text/src/autogluon/text/automm
           cd text/
           python3 -m pytest --junitxml=results.xml --forked --runslow tests
           """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ install_tabular_all = """
 """
 
 install_text = """
-    python3 -m pip install --upgrade -e text/
+    python3 -m pip install --upgrade -e text/[tests]
 """
 
 install_vision = """
@@ -190,7 +190,6 @@ stage("Unit Test") {
           # launch different process for each test to make sure memory is released
           python3 -m pip install --upgrade pytest-xdist
 
-          python3 -m pip install 'black~=22.0,>=22.3'
           black --check --preview --diff text/src/autogluon/text/automm
           cd text/
           python3 -m pytest --junitxml=results.xml --forked --runslow tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,7 +190,7 @@ stage("Unit Test") {
           # launch different process for each test to make sure memory is released
           python3 -m pip install --upgrade pytest-xdist
 
-          pip install 'black~=22.0,>=22.3'
+          python3 -m install 'black~=22.0,>=22.3'
           export AUTOMM_LINT_DIRS=text/src/autogluon/text/automm tests/unittests/automm
           black --check --preview $(AUTOMM_LINT_DIRS)
           cd text/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,7 +190,7 @@ stage("Unit Test") {
           # launch different process for each test to make sure memory is released
           python3 -m pip install --upgrade pytest-xdist
 
-          python3 -m install 'black~=22.0,>=22.3'
+          python3 -m pip install 'black~=22.0,>=22.3'
           export AUTOMM_LINT_DIRS=text/src/autogluon/text/automm tests/unittests/automm
           black --check --preview $(AUTOMM_LINT_DIRS)
           cd text/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 119
+target-version = ['py38']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 119
-target-version = ['py38']
+target-version = ['py37', 'py38', 'py39']

--- a/text/setup.py
+++ b/text/setup.py
@@ -47,6 +47,13 @@ install_requires = [
 
 install_requires = ag.get_dependency_version_ranges(install_requires)
 
+extras_require = {
+    'tests': [
+            'black~=22.0,>=22.3',
+        ]
+}
+
+
 if __name__ == '__main__':
     ag.create_version_file(version=version, submodule=submodule)
     setup_args = ag.default_setup_args(version=version, submodule=submodule)
@@ -58,5 +65,6 @@ if __name__ == '__main__':
     ]
     setup(
         install_requires=install_requires,
+        extras_require=extras_require,
         **setup_args,
     )

--- a/text/setup.py
+++ b/text/setup.py
@@ -43,7 +43,6 @@ install_requires = [
     'autogluon-contrib-nlp==0.0.1b20220208',
     'nlpaug>=1.1.10,<2.0.0',
     'nltk>=3.4.5,<4.0.0'
-    'black~=22.0,>=22.3',
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)

--- a/text/setup.py
+++ b/text/setup.py
@@ -43,6 +43,7 @@ install_requires = [
     'autogluon-contrib-nlp==0.0.1b20220208',
     'nlpaug>=1.1.10,<2.0.0',
     'nltk>=3.4.5,<4.0.0'
+    'black~=22.0,>=22.3',
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)

--- a/text/src/autogluon/text/automm/data/collator.py
+++ b/text/src/autogluon/text/automm/data/collator.py
@@ -32,10 +32,8 @@ def _pad_arrs_to_max_length(arrs, pad_axis, pad_val, round_to=None, max_length=N
     elif max_length is not None:
         if max_length < max_arr_len:
             raise ValueError(
-                "If max_length is specified, max_length={} must be larger "
-                "than the maximum length {} of the given arrays at axis={}.".format(
-                    max_length, max_arr_len, pad_axis
-                )
+                f"If max_length is specified, max_length={max_length} must be larger "
+                f"than the maximum length {max_arr_len} of the given arrays at axis={pad_axis}"
             )
         max_arr_len = max_length
 
@@ -116,18 +114,10 @@ class Pad:
     def __init__(self, axis=0, pad_val=0, round_to=None, max_length=None, ret_length=False):
         self._axis = axis
         if not isinstance(axis, int):
-            raise ValueError(
-                "axis must be an integer! Received axis={}, type={}.".format(
-                    str(axis), str(type(axis))
-                )
-            )
+            raise ValueError(f"axis must be an integer! Received axis={axis}, type={type(axis)}.")
 
         if round_to is not None and max_length is not None:
-            raise ValueError(
-                "Only either round_to={} or max_length={} can be specified.".format(
-                    round_to, max_length
-                )
-            )
+            raise ValueError(f"Only either round_to={round_to} or max_length={max_length} can be specified.")
 
         self._pad_val = 0 if pad_val is None else pad_val
         self._round_to = round_to
@@ -203,17 +193,14 @@ class Tuple:
                     "Input pattern not understood. "
                     "The input of Tuple can be Tuple(A, B, C) "
                     "or Tuple([A, B, C]) or Tuple((A, B, C)). "
-                    "Received fn={}, args={}".format(str(fn), str(args))
+                    f"Received fn={str(fn)}, args={str(args)}"
                 )
             self._fn = fn
         else:
             self._fn = (fn,) + args
         for i, ele_fn in enumerate(self._fn):
             if not hasattr(ele_fn, "__call__"):
-                raise ValueError(
-                    "Collate functions must be callable! "
-                    "type(fn[{}])={}".format(i, str(type(ele_fn)))
-                )
+                raise ValueError(f"Collate functions must be callable! type(fn[{i}])={type(ele_fn)}")
 
     def __call__(self, data):
         """
@@ -229,10 +216,7 @@ class Tuple:
                 A tuple of length N. Contains the collated result of each attribute in the input.
         """
         if len(data[0]) != len(self._fn):
-            raise ValueError(
-                "The number of attributes in each data sample "
-                "should contains {} elements".format(len(self._fn))
-            )
+            raise ValueError(f"The number of attributes in each data sample should contains {len(self._fn)} elements")
         ret = []
         for i, ele_fn in enumerate(self._fn):
             ret.append(ele_fn([ele[i] for ele in data]))
@@ -282,7 +266,7 @@ class Dict:
     def __init__(self, fn_dict):
         self._fn_dict = fn_dict
         if not isinstance(fn_dict, dict):
-            raise ValueError("Input must be a dictionary! type of input={}".format(type(fn_dict)))
+            raise ValueError(f"Input must be a dictionary! type of input={type(fn_dict)}")
         for fn in fn_dict.values():
             if not hasattr(fn, "__call__"):
                 raise ValueError("Elements of the dictionary must be callable!")

--- a/text/src/autogluon/text/automm/data/datamodule.py
+++ b/text/src/autogluon/text/automm/data/datamodule.py
@@ -181,9 +181,7 @@ class BaseDataModule(LightningDataModule):
         )
         return loader
 
-    def get_collate_fn(
-        self,
-    ):
+    def get_collate_fn(self):
         """
         Collect collator functions for each modality input of every model.
         These collator functions are wrapped by the "Dict" collator function,

--- a/text/src/autogluon/text/automm/data/datamodule.py
+++ b/text/src/autogluon/text/automm/data/datamodule.py
@@ -18,15 +18,15 @@ class BaseDataModule(LightningDataModule):
     """
 
     def __init__(
-            self,
-            df_preprocessor: Union[MultiModalFeaturePreprocessor, List[MultiModalFeaturePreprocessor]],
-            data_processors: Union[dict, List[dict]],
-            per_gpu_batch_size: int,
-            num_workers: int,
-            train_data: Optional[pd.DataFrame] = None,
-            val_data: Optional[pd.DataFrame] = None,
-            test_data: Optional[pd.DataFrame] = None,
-            predict_data: Optional[pd.DataFrame] = None,
+        self,
+        df_preprocessor: Union[MultiModalFeaturePreprocessor, List[MultiModalFeaturePreprocessor]],
+        data_processors: Union[dict, List[dict]],
+        per_gpu_batch_size: int,
+        num_workers: int,
+        train_data: Optional[pd.DataFrame] = None,
+        val_data: Optional[pd.DataFrame] = None,
+        test_data: Optional[pd.DataFrame] = None,
+        predict_data: Optional[pd.DataFrame] = None,
     ):
         """
         Parameters
@@ -181,7 +181,9 @@ class BaseDataModule(LightningDataModule):
         )
         return loader
 
-    def get_collate_fn(self,):
+    def get_collate_fn(
+        self,
+    ):
         """
         Collect collator functions for each modality input of every model.
         These collator functions are wrapped by the "Dict" collator function,

--- a/text/src/autogluon/text/automm/data/dataset.py
+++ b/text/src/autogluon/text/automm/data/dataset.py
@@ -3,9 +3,8 @@ import torch
 import pandas as pd
 from typing import List
 from .preprocess_dataframe import MultiModalFeaturePreprocessor
-from ..constants import (
-    GET_ITEM_ERROR_RETRY, AUTOMM
-)
+from ..constants import GET_ITEM_ERROR_RETRY, AUTOMM
+
 logger = logging.getLogger(AUTOMM)
 
 

--- a/text/src/autogluon/text/automm/data/infer_types.py
+++ b/text/src/autogluon/text/automm/data/infer_types.py
@@ -4,21 +4,18 @@ import pandas as pd
 import warnings
 import PIL
 from typing import Union, Optional, List, Dict, Tuple
-from ..constants import (
-    NULL, CATEGORICAL, NUMERICAL, TEXT, IMAGE_PATH,
-    MULTICLASS, BINARY, REGRESSION, AUTOMM
-)
+from ..constants import NULL, CATEGORICAL, NUMERICAL, TEXT, IMAGE_PATH, MULTICLASS, BINARY, REGRESSION, AUTOMM
 
 logger = logging.getLogger(AUTOMM)
 
 
 def is_categorical_column(
-        data: pd.Series,
-        valid_data: pd.Series,
-        threshold: int = None,
-        ratio: Optional[float] = None,
-        oov_ratio_threshold: Optional[float] = None,
-        is_label: bool = False,
+    data: pd.Series,
+    valid_data: pd.Series,
+    threshold: int = None,
+    ratio: Optional[float] = None,
+    oov_ratio_threshold: Optional[float] = None,
+    is_label: bool = False,
 ) -> bool:
     """
     Identify whether a column is one categorical column.
@@ -49,7 +46,7 @@ def is_categorical_column(
     -------
     Whether the column is a categorical column.
     """
-    if data.dtype.name == 'category':
+    if data.dtype.name == "category":
         return True
     else:
         if threshold is None:
@@ -80,8 +77,8 @@ def is_categorical_column(
 
 
 def is_numerical_column(
-        data: pd.Series,
-        valid_data: Optional[pd.Series] = None,
+    data: pd.Series,
+    valid_data: Optional[pd.Series] = None,
 ) -> bool:
     """
     Identify if a column is a numerical column.
@@ -129,7 +126,7 @@ def is_imagepath_column(
     """
     sample_num = min(len(data), 500)
     data = data.sample(n=sample_num, random_state=0)
-    data = data.apply(lambda ele: str(ele).split(';')).tolist()
+    data = data.apply(lambda ele: str(ele).split(";")).tolist()
     failure_count = 0
     for image_paths in data:
         success = False
@@ -150,10 +147,10 @@ def is_imagepath_column(
             logger.warning(
                 f"Among {sample_num} sampled images in column '{col_name}', "
                 f"{failure_ratio:.0%} images can't be open. "
-                f"You may need to thoroughly check your data to see the percentage of missing images, "
-                f"and estimate the potential influence. By default, we skip the samples with missing images. "
-                f"You can also set hyperparameter 'data.image.missing_value_strategy' to be 'zero', "
-                f"which uses a zero image to replace any missing image."
+                "You may need to thoroughly check your data to see the percentage of missing images, "
+                "and estimate the potential influence. By default, we skip the samples with missing images. "
+                "You can also set hyperparameter 'data.image.missing_value_strategy' to be 'zero', "
+                "which uses a zero image to replace any missing image."
             )
         return True
     else:
@@ -193,11 +190,11 @@ def check_if_nlp_feature(X: pd.Series) -> bool:
 
 
 def infer_column_problem_types(
-        train_df: pd.DataFrame,
-        valid_df: pd.DataFrame,
-        label_columns: Union[str, List[str]],
-        problem_type: Optional[str] = None,
-        provided_column_types: Optional[Dict] = None,
+    train_df: pd.DataFrame,
+    valid_df: pd.DataFrame,
+    label_columns: Union[str, List[str]],
+    problem_type: Optional[str] = None,
+    provided_column_types: Optional[Dict] = None,
 ) -> Tuple[collections.OrderedDict, str, int]:
     """
     Infer the column types of a multimodal pd.DataFrame and the problem type.
@@ -231,9 +228,9 @@ def infer_column_problem_types(
     elif isinstance(label_columns, (list, tuple)):
         pass
     else:
-        raise NotImplementedError(f'label_columns is not supported. label_columns={label_columns}.')
+        raise NotImplementedError(f"label_columns is not supported. label_columns={label_columns}.")
     label_set = set(label_columns)
-    assert len(label_set) == 1, 'Currently, only a single label column is supported.'
+    assert len(label_set) == 1, "Currently, only a single label column is supported."
     column_types = collections.OrderedDict()
     # Process all feature columns
 
@@ -248,14 +245,14 @@ def infer_column_problem_types(
             if num_train_missing > 0:
                 raise ValueError(
                     f"Label column '{col_name}' contains missing values in the "
-                    f"training data frame. You may want to filter your data because "
-                    f"missing label is currently not supported."
+                    "training data frame. You may want to filter your data because "
+                    "missing label is currently not supported."
                 )
             if num_valid_missing > 0:
                 raise ValueError(
                     f"Label column '{col_name}' contains missing values in the "
-                    f"validation data frame. You may want to filter your data because "
-                    f"missing label is currently not supported."
+                    "validation data frame. You may want to filter your data because "
+                    "missing label is currently not supported."
                 )
             if problem_type == MULTICLASS or problem_type == BINARY:
                 column_types[col_name] = CATEGORICAL
@@ -271,8 +268,7 @@ def infer_column_problem_types(
                 column_types[col_name] = NULL
             else:
                 warnings.warn(
-                    f"Label column '{col_name}' contains only one label. "
-                    f"You may need to check your dataset again."
+                    f"Label column '{col_name}' contains only one label. You may need to check your dataset again."
                 )
         # Use the following way for type inference
         # 1) Infer categorical column
@@ -280,8 +276,7 @@ def infer_column_problem_types(
         # 3) Infer image-path column
         # 4) Infer text column
         # 4) All the other columns are treated as categorical
-        if is_categorical_column(train_df[col_name], valid_df[col_name],
-                                 is_label=is_label):
+        if is_categorical_column(train_df[col_name], valid_df[col_name], is_label=is_label):
             column_types[col_name] = CATEGORICAL
         elif is_numerical_column(train_df[col_name], valid_df[col_name]):
             column_types[col_name] = NUMERICAL
@@ -301,10 +296,10 @@ def infer_column_problem_types(
 
 
 def infer_problem_type_output_shape(
-        column_types: dict,
-        label_column: str,
-        data_df: pd.DataFrame,
-        provided_problem_type=None,
+    column_types: dict,
+    label_column: str,
+    data_df: pd.DataFrame,
+    provided_problem_type=None,
 ) -> Tuple[str, int]:
     """
     Infer the problem type and output shape based on the label column type and training data.
@@ -332,8 +327,10 @@ def infer_problem_type_output_shape(
     if provided_problem_type is not None:
         if provided_problem_type == MULTICLASS or provided_problem_type == BINARY:
             class_num = len(data_df[label_column].unique())
-            err_msg = f"Provided problem type is '{provided_problem_type}' while the number of " \
-                      f"unique values in the label column is {class_num}."
+            err_msg = (
+                f"Provided problem type is '{provided_problem_type}' while the number of "
+                f"unique values in the label column is {class_num}."
+            )
             if provided_problem_type == BINARY and class_num != 2:
                 raise AssertionError(err_msg)
             elif provided_problem_type == MULTICLASS and class_num <= 2:

--- a/text/src/autogluon/text/automm/data/preprocess_dataframe.py
+++ b/text/src/autogluon/text/automm/data/preprocess_dataframe.py
@@ -16,10 +16,7 @@ from sklearn.base import (
     TransformerMixin,
     BaseEstimator,
 )
-from ..constants import (
-    CATEGORICAL, NUMERICAL, TEXT,
-    IMAGE_PATH, NULL, AUTOMM
-)
+from ..constants import CATEGORICAL, NUMERICAL, TEXT, IMAGE_PATH, NULL, AUTOMM
 
 logger = logging.getLogger(AUTOMM)
 
@@ -32,11 +29,11 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
     """
 
     def __init__(
-            self,
-            config: dict,
-            column_types: collections.OrderedDict,
-            label_column: str,
-            label_generator: Optional[LabelEncoder] = None,
+        self,
+        config: dict,
+        column_types: collections.OrderedDict,
+        label_column: str,
+        label_generator: Optional[LabelEncoder] = None,
     ):
         """
         Parameters
@@ -66,16 +63,24 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
                 continue
             elif col_type == CATEGORICAL:
                 generator = CategoryFeatureGenerator(
-                    cat_order='count',
+                    cat_order="count",
                     minimum_cat_count=config["categorical"]["minimum_cat_count"],
                     maximum_num_cat=config["categorical"]["maximum_num_cat"],
-                    verbosity=0)
+                    verbosity=0,
+                )
                 self._feature_generators[col_name] = generator
             elif col_type == NUMERICAL:
                 generator = Pipeline(
-                    [('imputer', SimpleImputer()),
-                     ('scaler', StandardScaler(with_mean=config["numerical"]["scaler_with_mean"],
-                                               with_std=config["numerical"]["scaler_with_std"]))]
+                    [
+                        ("imputer", SimpleImputer()),
+                        (
+                            "scaler",
+                            StandardScaler(
+                                with_mean=config["numerical"]["scaler_with_mean"],
+                                with_std=config["numerical"]["scaler_with_std"],
+                            ),
+                        ),
+                    ]
                 )
                 self._feature_generators[col_name] = generator
 
@@ -135,9 +140,9 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         return self._fit_called
 
     def fit(
-            self,
-            X: pd.DataFrame,
-            y: pd.Series,
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
     ):
         """
         Fit the pd.DataFrame by grouping column names by their modality types. For example, all the
@@ -152,9 +157,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             The label pd.Series.
         """
         if self._fit_called:
-            raise RuntimeError(
-                "Fit has been called. Please create a new preprocessor and call fit again!"
-            )
+            raise RuntimeError("Fit has been called. Please create a new preprocessor and call fit again!")
         self._fit_called = True
         for col_name in sorted(X.columns):
             # Just in case X accidentally contains the label column
@@ -172,17 +175,17 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
                 if self._config["categorical"]["convert_to_text"]:
                     # Convert categorical column as text column
                     col_value = col_value.astype("object")
-                    processed_data = col_value.apply(lambda ele: '' if pd.isnull(ele) else str(ele))
+                    processed_data = col_value.apply(lambda ele: "" if pd.isnull(ele) else str(ele))
                     if len(processed_data.unique()) == 1:
                         self._ignore_columns_set.add(col_name)
                         continue
                     self._text_feature_names.append(col_name)
                 else:
-                    processed_data = col_value.astype('category')
+                    processed_data = col_value.astype("category")
                     generator = self._feature_generators[col_name]
-                    processed_data = generator.fit_transform(
-                        pd.DataFrame({col_name: processed_data}))[col_name] \
-                        .cat.codes.to_numpy(np.int32, copy=True)
+                    processed_data = generator.fit_transform(pd.DataFrame({col_name: processed_data}))[
+                        col_name
+                    ].cat.codes.to_numpy(np.int32, copy=True)
                     if len(np.unique(processed_data)) == 1:
                         self._ignore_columns_set.add(col_name)
                         continue
@@ -205,8 +208,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
                 self._image_path_names.append(col_name)
             else:
                 raise NotImplementedError(
-                    f"Type of the column is not supported currently. "
-                    f"Received {col_name}={col_type}."
+                    f"Type of the column is not supported currently. Received {col_name}={col_type}."
                 )
         if self.label_type == CATEGORICAL:
             self._label_generator.fit(y)
@@ -214,14 +216,11 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             y = pd.to_numeric(y).to_numpy()
             self._label_scaler.fit(np.expand_dims(y, axis=-1))
         else:
-            raise NotImplementedError(
-                f"Type of label column is not supported. "
-                f"Label column type={self._label_column}"
-            )
+            raise NotImplementedError(f"Type of label column is not supported. Label column type={self._label_column}")
 
     def transform_text(
-            self,
-            df: pd.DataFrame,
+        self,
+        df: pd.DataFrame,
     ) -> Dict[str, List[str]]:
         """
         Preprocess text data by collecting them together. May need to format
@@ -237,9 +236,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         -------
         All the text data stored in a dictionary.
         """
-        assert self._fit_called, 'You will need to first call ' \
-                                 'preprocessor.fit before calling ' \
-                                 'preprocessor.transform.'
+        assert self._fit_called, "You will need to first call preprocessor.fit before calling preprocessor.transform."
         text_features = {}
         for col_name in self._text_feature_names:
             col_value = df[col_name]
@@ -247,9 +244,9 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
             if col_type == TEXT or col_type == CATEGORICAL:
                 # TODO: do we need to consider whether categorical values are valid text?
                 col_value = col_value.astype("object")
-                processed_data = col_value.apply(lambda ele: '' if pd.isnull(ele) else str(ele))
+                processed_data = col_value.apply(lambda ele: "" if pd.isnull(ele) else str(ele))
             elif col_type == NUMERICAL:
-                processed_data = pd.to_numeric(col_value).apply('{:.3f}'.format)
+                processed_data = pd.to_numeric(col_value).apply("{:.3f}".format)
             else:
                 raise NotImplementedError
 
@@ -258,8 +255,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         return text_features
 
     def transform_image(
-            self,
-            df: pd.DataFrame,
+        self,
+        df: pd.DataFrame,
     ) -> Dict[str, List[List[str]]]:
         """
         Preprocess image data by collecting their paths together. If one sample has multiple images
@@ -275,18 +272,16 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         -------
         All the image paths stored in a dictionary.
         """
-        assert self._fit_called, 'You will need to first call ' \
-                                 'preprocessor.fit before calling ' \
-                                 'preprocessor.transform.'
+        assert self._fit_called, "You will need to first call preprocessor.fit before calling preprocessor.transform."
         image_paths = {}
         for col_name in self._image_path_names:
-            processed_data = df[col_name].apply(lambda ele: ele.split(';')).tolist()
+            processed_data = df[col_name].apply(lambda ele: ele.split(";")).tolist()
             image_paths[col_name] = processed_data
         return image_paths
 
     def transform_numerical(
-            self,
-            df: pd.DataFrame,
+        self,
+        df: pd.DataFrame,
     ) -> Dict[str, NDArray[(Any,), np.float32]]:
         """
         Preprocess numerical data by using SimpleImputer to fill possible missing values
@@ -302,9 +297,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         -------
         All the numerical features (a dictionary of np.ndarray).
         """
-        assert self._fit_called, 'You will need to first call ' \
-                                 'preprocessor.fit before calling ' \
-                                 'preprocessor.transform.'
+        assert self._fit_called, "You will need to first call preprocessor.fit before calling preprocessor.transform."
         numerical_features = {}
         for col_name in self._numerical_feature_names:
             generator = self._feature_generators[col_name]
@@ -315,8 +308,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         return numerical_features
 
     def transform_categorical(
-            self,
-            df: pd.DataFrame,
+        self,
+        df: pd.DataFrame,
     ) -> Dict[str, NDArray[(Any,), np.int32]]:
         """
         Preprocess categorical data by using CategoryFeatureGenerator to generate
@@ -332,26 +325,23 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         -------
         All the categorical encodings (a dictionary of np.ndarray).
         """
-        assert self._fit_called, 'You will need to first call ' \
-                                 'preprocessor.fit before calling ' \
-                                 'preprocessor.transform.'
+        assert self._fit_called, "You will need to first call preprocessor.fit before calling preprocessor.transform."
         categorical_features = {}
-        for col_name, num_category in zip(self._categorical_feature_names,
-                                          self._categorical_num_categories):
+        for col_name, num_category in zip(self._categorical_feature_names, self._categorical_num_categories):
             col_value = df[col_name]
-            processed_data = col_value.astype('category')
+            processed_data = col_value.astype("category")
             generator = self._feature_generators[col_name]
-            processed_data = generator.transform(
-                pd.DataFrame({col_name: processed_data}))[col_name] \
-                .cat.codes.to_numpy(np.int32, copy=True)
+            processed_data = generator.transform(pd.DataFrame({col_name: processed_data}))[
+                col_name
+            ].cat.codes.to_numpy(np.int32, copy=True)
             processed_data[processed_data < 0] = num_category - 1
             categorical_features[col_name] = processed_data
 
         return categorical_features
 
     def transform_label(
-            self,
-            df: pd.DataFrame,
+        self,
+        df: pd.DataFrame,
     ) -> Dict[str, NDArray[(Any,), Any]]:
         """
         Preprocess ground-truth labels by using LabelEncoder to generate class labels for
@@ -368,9 +358,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         -------
         All the labels (a dictionary of np.ndarray).
         """
-        assert self._fit_called, 'You will need to first call ' \
-                                 'preprocessor.fit before calling ' \
-                                 'preprocessor.transform.'
+        assert self._fit_called, "You will need to first call preprocessor.fit before calling preprocessor.transform."
         y_df = df[self._label_column]
         if self.label_type == CATEGORICAL:
             y = self._label_generator.transform(y_df)
@@ -383,8 +371,8 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         return {self._label_column: y}
 
     def transform_label_for_metric(
-            self,
-            df: pd.DataFrame,
+        self,
+        df: pd.DataFrame,
     ) -> NDArray[(Any,), Any]:
         """
         Prepare ground-truth labels to compute metric scores in evaluation. Note that
@@ -400,9 +388,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         -------
         Ground-truth labels ready to compute metric scores.
         """
-        assert self._fit_called, 'You will need to first call ' \
-                                 'preprocessor.fit before calling ' \
-                                 'preprocessor.transform.'
+        assert self._fit_called, "You will need to first call preprocessor.fit before calling preprocessor.transform."
         y_df = df[self._label_column]
         if self.label_type == CATEGORICAL:
             # need to encode to integer labels
@@ -416,9 +402,9 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         return y
 
     def transform_prediction(
-            self,
-            y_pred: torch.Tensor,
-            inverse_categorical: bool = True,
+        self,
+        y_pred: torch.Tensor,
+        inverse_categorical: bool = True,
     ) -> NDArray[(Any,), Any]:
         """
         Transform model's output logits into class labels for classification

--- a/text/src/autogluon/text/automm/data/process_categorical.py
+++ b/text/src/autogluon/text/automm/data/process_categorical.py
@@ -13,10 +13,10 @@ class CategoricalProcessor:
     """
 
     def __init__(
-            self,
-            prefix: str,
-            categorical_column_names: List[str],
-            requires_column_info: bool = False,
+        self,
+        prefix: str,
+        categorical_column_names: List[str],
+        requires_column_info: bool = False,
     ):
         """
         Parameters
@@ -55,17 +55,13 @@ class CategoricalProcessor:
             for col_name in self.categorical_column_names:
                 fn[f"{self.categorical_column_prefix}_{col_name}"] = Stack()
 
-        fn[self.categorical_key] = Tuple(
-            [
-                Stack() for _ in range(len(self.categorical_column_names))
-            ]
-        )
+        fn[self.categorical_key] = Tuple([Stack() for _ in range(len(self.categorical_column_names))])
 
         return fn
 
     def process_one_sample(
-            self,
-            categorical_features: Dict[str, int],
+        self,
+        categorical_features: Dict[str, int],
     ) -> Dict:
         """
         Process one sample's categorical features. Assume the categorical features
@@ -91,10 +87,10 @@ class CategoricalProcessor:
         return ret
 
     def __call__(
-            self,
-            all_categorical_features: Dict[str, NDArray[(Any,), np.int32]],
-            idx: int,
-            is_training: bool,
+        self,
+        all_categorical_features: Dict[str, NDArray[(Any,), np.int32]],
+        idx: int,
+        is_training: bool,
     ) -> Dict:
         """
         Extract one sample's categorical features and customize it for a specific model.

--- a/text/src/autogluon/text/automm/data/process_image.py
+++ b/text/src/autogluon/text/automm/data/process_image.py
@@ -9,13 +9,19 @@ import ast
 from .randaug import RandAugment
 from timm import create_model
 from timm.data.constants import (
-    IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD,
-    IMAGENET_INCEPTION_MEAN, IMAGENET_INCEPTION_STD,
+    IMAGENET_DEFAULT_MEAN,
+    IMAGENET_DEFAULT_STD,
+    IMAGENET_INCEPTION_MEAN,
+    IMAGENET_INCEPTION_STD,
 )
 from transformers import AutoConfig
 from ..constants import (
-    IMAGE, IMAGE_VALID_NUM, CLIP_IMAGE_MEAN,
-    CLIP_IMAGE_STD, AUTOMM, COLUMN,
+    IMAGE,
+    IMAGE_VALID_NUM,
+    CLIP_IMAGE_MEAN,
+    CLIP_IMAGE_STD,
+    AUTOMM,
+    COLUMN,
 )
 from .collator import Stack, Pad
 from .utils import extract_value_from_config
@@ -30,17 +36,17 @@ class ImageProcessor:
     """
 
     def __init__(
-            self,
-            prefix: str,
-            train_transform_types: List[str],
-            val_transform_types: List[str],
-            image_column_names: List[str],
-            checkpoint_name: Optional[str] = None,
-            norm_type: Optional[str] = None,
-            size: Optional[int] = None,
-            max_img_num_per_col: Optional[int] = 1,
-            missing_value_strategy: Optional[str] = "skip",
-            requires_column_info: bool = False,
+        self,
+        prefix: str,
+        train_transform_types: List[str],
+        val_transform_types: List[str],
+        image_column_names: List[str],
+        checkpoint_name: Optional[str] = None,
+        norm_type: Optional[str] = None,
+        size: Optional[int] = None,
+        max_img_num_per_col: Optional[int] = 1,
+        missing_value_strategy: Optional[str] = "skip",
+        requires_column_info: bool = False,
     ):
         """
         Parameters
@@ -223,9 +229,7 @@ class ImageProcessor:
                     if isinstance(image_size, tuple):
                         image_size = image_size[-1]
                 else:
-                    raise ValueError(
-                        f" more than one image_size values are detected: {extracted}"
-                    )
+                    raise ValueError(f" more than one image_size values are detected: {extracted}")
                 mean = None
                 std = None
             except Exception as exp2:
@@ -234,8 +238,8 @@ class ImageProcessor:
         return image_size, mean, std
 
     def construct_processor(
-            self,
-            transform_types: List[str],
+        self,
+        transform_types: List[str],
     ) -> transforms.Compose:
         """
         Build up an image processor from the provided list of transform types.
@@ -253,12 +257,12 @@ class ImageProcessor:
         for trans_type in transform_types:
             args = None
             kargs = None
-            if '(' in trans_type:
-                trans_mode = trans_type[0:trans_type.find('(')]
-                if '{' in trans_type:
-                    kargs = ast.literal_eval(trans_type[trans_type.find('{'):trans_type.rfind(')')])
+            if "(" in trans_type:
+                trans_mode = trans_type[0 : trans_type.find("(")]
+                if "{" in trans_type:
+                    kargs = ast.literal_eval(trans_type[trans_type.find("{") : trans_type.rfind(")")])
                 else:
-                    args = ast.literal_eval(trans_type[trans_type.find('('):])
+                    args = ast.literal_eval(trans_type[trans_type.find("(") :])
             else:
                 trans_mode = trans_type
 
@@ -301,9 +305,9 @@ class ImageProcessor:
         return transforms.Compose(processor)
 
     def process_one_sample(
-            self,
-            image_paths: Dict[str, List[str]],
-            is_training: bool,
+        self,
+        image_paths: Dict[str, List[str]],
+        is_training: bool,
     ) -> Dict:
         """
         Read images, process them, and stack them. One sample can have multiple images,
@@ -326,13 +330,13 @@ class ImageProcessor:
         ret = {}
         column_start = 0
         for per_col_name, per_col_image_paths in image_paths.items():
-            for img_path in per_col_image_paths[:self.max_img_num_per_col]:
+            for img_path in per_col_image_paths[: self.max_img_num_per_col]:
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
                         "ignore",
-                        message="Palette images with Transparency "
-                                "expressed in bytes should be "
-                                "converted to RGBA images"
+                        message=(
+                            "Palette images with Transparency expressed in bytes should be converted to RGBA images"
+                        ),
                     )
                     is_zero_img = False
                     try:
@@ -357,7 +361,9 @@ class ImageProcessor:
 
             if self.requires_column_info:
                 # only count the valid images since they are put ahead of the zero images in the below returning
-                ret[f"{self.image_column_prefix}_{per_col_name}"] = np.array([column_start, len(images)], dtype=np.int64)
+                ret[f"{self.image_column_prefix}_{per_col_name}"] = np.array(
+                    [column_start, len(images)], dtype=np.int64
+                )
                 column_start = len(images)
 
         ret.update(
@@ -369,10 +375,10 @@ class ImageProcessor:
         return ret
 
     def __call__(
-            self,
-            all_image_paths: Dict[str, List[List[str]]],
-            idx: int,
-            is_training: bool,
+        self,
+        all_image_paths: Dict[str, List[List[str]]],
+        idx: int,
+        is_training: bool,
     ) -> Dict:
         """
         Obtain one sample's images and customized them for a specific model.

--- a/text/src/autogluon/text/automm/data/process_label.py
+++ b/text/src/autogluon/text/automm/data/process_label.py
@@ -12,8 +12,8 @@ class LabelProcessor:
     """
 
     def __init__(
-            self,
-            prefix: str,
+        self,
+        prefix: str,
     ):
         """
         Parameters
@@ -40,8 +40,8 @@ class LabelProcessor:
         return fn
 
     def process_one_sample(
-            self,
-            labels: Dict[str, Union[int, float]],
+        self,
+        labels: Dict[str, Union[int, float]],
     ) -> Dict:
         """
         Process one sample's labels. Here it only picks the first label.
@@ -60,10 +60,10 @@ class LabelProcessor:
         }
 
     def __call__(
-            self,
-            all_labels: Dict[str, NDArray[(Any,), Any]],
-            idx: int,
-            is_training: bool,
+        self,
+        all_labels: Dict[str, NDArray[(Any,), Any]],
+        idx: int,
+        is_training: bool,
     ) -> Dict:
         """
         Extract one sample's labels and customize them for a specific model.

--- a/text/src/autogluon/text/automm/data/process_numerical.py
+++ b/text/src/autogluon/text/automm/data/process_numerical.py
@@ -13,11 +13,11 @@ class NumericalProcessor:
     """
 
     def __init__(
-            self,
-            prefix: str,
-            numerical_column_names: List[str],
-            merge: Optional[str] = "concat",
-            requires_column_info: bool = False,
+        self,
+        prefix: str,
+        numerical_column_names: List[str],
+        merge: Optional[str] = "concat",
+        requires_column_info: bool = False,
     ):
         """
         Parameters
@@ -66,8 +66,8 @@ class NumericalProcessor:
         return fn
 
     def process_one_sample(
-            self,
-            numerical_features: Dict[str, float],
+        self,
+        numerical_features: Dict[str, float],
     ) -> Dict:
         """
         Process one sample's numerical features.
@@ -96,10 +96,10 @@ class NumericalProcessor:
         return ret
 
     def __call__(
-            self,
-            all_numerical_features: Dict[str, NDArray[(Any,), np.float32]],
-            idx: int,
-            is_training: bool,
+        self,
+        all_numerical_features: Dict[str, NDArray[(Any,), np.float32]],
+        idx: int,
+        is_training: bool,
     ) -> Dict:
         """
         Extract one sample's numerical features and customize it for a specific model.

--- a/text/src/autogluon/text/automm/data/process_text.py
+++ b/text/src/autogluon/text/automm/data/process_text.py
@@ -17,7 +17,8 @@ from ..constants import (
     TEXT_TOKEN_IDS,
     TEXT_VALID_LENGTH,
     TEXT_SEGMENT_IDS,
-    AUTOMM, COLUMN,
+    AUTOMM,
+    COLUMN,
 )
 from .collator import Stack, Pad
 from .utils import extract_value_from_config
@@ -37,16 +38,16 @@ ALL_TOKENIZERS = {
     "bert": BertTokenizer,
     "clip": CLIPTokenizer,
     "electra": ElectraTokenizer,
-    'hf_auto': AutoTokenizer,
+    "hf_auto": AutoTokenizer,
 }
 
 
 def construct_text_augmenter(
-        augment_types: List[str],
+    augment_types: List[str],
 ) -> Optional[naf.Sometimes]:
     """
     Build up a text augmentor from the provided list of augmentation types
-    
+
     Parameters
     ----------
     augment_types
@@ -55,43 +56,43 @@ def construct_text_augmenter(
     Returns
     -------
     A nlpaug sequantial flow.
-    
+
     """
     if augment_types is None or len(augment_types) == 0:
         return None
 
     auglist = []
     try:
-        nltk.data.find('tagger/averaged_perceptron_tagger')
+        nltk.data.find("tagger/averaged_perceptron_tagger")
     except LookupError:
-        nltk.download('averaged_perceptron_tagger')
+        nltk.download("averaged_perceptron_tagger")
     for aug_type in augment_types:
-        if '(' in aug_type:
-            trans_mode = aug_type[0:aug_type.find('(')]
-            kwargs = ast.literal_eval(aug_type[aug_type.find('('):])
+        if "(" in aug_type:
+            trans_mode = aug_type[0 : aug_type.find("(")]
+            kwargs = ast.literal_eval(aug_type[aug_type.find("(") :])
         else:
             trans_mode = aug_type
             kwargs = {}
-        if trans_mode == "synonym_replacement": 
-            kwargs['aug_src'] = 'wordnet'
+        if trans_mode == "synonym_replacement":
+            kwargs["aug_src"] = "wordnet"
             try:
-                nltk.data.find('corpora/wordnet')
+                nltk.data.find("corpora/wordnet")
             except LookupError:
-                nltk.download('wordnet')
+                nltk.download("wordnet")
             try:
-                nltk.data.find('corpora/omw-1.4')
+                nltk.data.find("corpora/omw-1.4")
             except LookupError:
-                nltk.download('omw-1.4')
+                nltk.download("omw-1.4")
             auglist.append(naw.SynonymAug(**kwargs))
         elif trans_mode == "random_swap":
-            kwargs['action'] = 'swap'
+            kwargs["action"] = "swap"
             auglist.append(naw.RandomWordAug(**kwargs))
-        elif trans_mode == "random_delete" :
-            kwargs['action'] = 'delete'
+        elif trans_mode == "random_delete":
+            kwargs["action"] = "delete"
             auglist.append(naw.RandomWordAug(**kwargs))
         else:
             raise ValueError(f"unknown transform type: {trans_mode}")
-    return naf.Sometimes(auglist, aug_p = 0.5)
+    return naf.Sometimes(auglist, aug_p=0.5)
 
 
 class TextProcessor:
@@ -101,18 +102,18 @@ class TextProcessor:
     """
 
     def __init__(
-            self,
-            prefix: str,
-            checkpoint_name: str,
-            text_column_names: List[str],
-            tokenizer_name: Optional[str] = "hf_auto",
-            max_len: Optional[int] = None,
-            insert_sep: Optional[bool] = True,
-            text_segment_num: Optional[int] = 1,
-            stochastic_chunk: Optional[bool] = False,
-            requires_column_info: bool = False,
-            text_detection_length: Optional[int] = None,
-            train_augment_types: List[str] = [],
+        self,
+        prefix: str,
+        checkpoint_name: str,
+        text_column_names: List[str],
+        tokenizer_name: Optional[str] = "hf_auto",
+        max_len: Optional[int] = None,
+        insert_sep: Optional[bool] = True,
+        text_segment_num: Optional[int] = 1,
+        stochastic_chunk: Optional[bool] = False,
+        requires_column_info: bool = False,
+        text_detection_length: Optional[int] = None,
+        train_augment_types: List[str] = [],
     ):
         """
         Parameters
@@ -147,7 +148,7 @@ class TextProcessor:
             tokenizer_name=tokenizer_name,
             checkpoint_name=checkpoint_name,
         )
-        if hasattr(self.tokenizer, 'deprecation_warnings'):
+        if hasattr(self.tokenizer, "deprecation_warnings"):
             # Disable the warning "Token indices sequence length is longer than the specified maximum sequence..."
             # See https://github.com/huggingface/transformers/blob/6ac77534bfe97c00e0127bb4fc846ae0faf1c9c5/src/transformers/tokenization_utils_base.py#L3362
             self.tokenizer.deprecation_warnings["sequence-length-is-longer-than-the-specified-maximum"] = True
@@ -167,10 +168,7 @@ class TextProcessor:
         self.insert_sep = insert_sep
 
         config = AutoConfig.from_pretrained(checkpoint_name).to_diff_dict()
-        extracted = extract_value_from_config(
-            config=config,
-            keys=("type_vocab_size",)
-        )
+        extracted = extract_value_from_config(config=config, keys=("type_vocab_size",))
         if len(extracted) == 0:
             default_segment_num = 1
         elif len(extracted) == 1:
@@ -192,11 +190,11 @@ class TextProcessor:
 
         self.stochastic_chunk = stochastic_chunk
 
-        #construct augmentor
+        # construct augmentor
         self.train_augment_types = train_augment_types
         self.text_detection_length = text_detection_length
         self.train_augmenter = construct_text_augmenter(self.train_augment_types)
-       
+
     @property
     def text_token_ids_key(self):
         return f"{self.prefix}_{TEXT_TOKEN_IDS}"
@@ -238,8 +236,8 @@ class TextProcessor:
         return fn
 
     def build_one_token_sequence(
-            self,
-            text_tokens: Dict[str, NDArray[(Any,), np.int32]],
+        self,
+        text_tokens: Dict[str, NDArray[(Any,), np.int32]],
     ) -> Dict:
         """
         Construct one token sequence based on multiple token sequences coming from different
@@ -274,11 +272,11 @@ class TextProcessor:
                 start_ptr = np.random.randint(0, len(txt_token) - trim_length + 1)
             else:
                 start_ptr = 0
-            token_ids.extend(txt_token[start_ptr:(start_ptr + trim_length)].tolist())
+            token_ids.extend(txt_token[start_ptr : (start_ptr + trim_length)].tolist())
             segment_ids.extend([seg] * trim_length)
             if self.requires_column_info:
                 # np.int64 corresponds to torch.LongTensor
-                col_token_idxs = np.array([segment_start, segment_start+trim_length], dtype=np.int64)
+                col_token_idxs = np.array([segment_start, segment_start + trim_length], dtype=np.int64)
                 ret[f"{self.text_column_prefix}_{col_name}"] = col_token_idxs
             if self.insert_sep:
                 token_ids.append(self.sep_token_id)
@@ -305,9 +303,9 @@ class TextProcessor:
         return ret
 
     def build_one_token_sequence_from_text(
-            self,
-            text: Dict[str, str],
-            is_training: bool,
+        self,
+        text: Dict[str, str],
+        is_training: bool,
     ) -> Dict:
         """
         Tokenize a sample's text data and build one token sequence. One sample may have
@@ -317,7 +315,7 @@ class TextProcessor:
         ----------
         text
             The raw text data of one sample.
-        
+
         is_training
             Flag to apply augmentation only to training.
 
@@ -327,16 +325,13 @@ class TextProcessor:
         """
         # tokenize text
         tokens = {}
-        warnings.filterwarnings(
-            "ignore",
-            "Token indices sequence length is longer than.*result in indexing errors"
-        )
+        warnings.filterwarnings("ignore", "Token indices sequence length is longer than.*result in indexing errors")
         for col_name, col_text in text.items():
 
             if is_training:
                 if self.train_augmenter is not None:
                     # naive way to detect categorical/numerical text:
-                    if len(col_text.split(' ')) >= self.text_detection_length:
+                    if len(col_text.split(" ")) >= self.text_detection_length:
                         col_text = self.train_augmenter.augment(col_text)
 
             col_tokens = self.tokenizer.encode(
@@ -345,7 +340,7 @@ class TextProcessor:
                 truncation=False,
             )
             tokens[col_name] = np.array(col_tokens, dtype=np.int32)
-            
+
         # build token sequence
         return self.build_one_token_sequence(tokens)
 
@@ -371,15 +366,13 @@ class TextProcessor:
             # See https://github.com/huggingface/transformers/blob/v4.14.1/src/transformers/models/clip/modeling_clip.py#L657
             cls_id, sep_id, eos_id = tokenizer.bos_token_id, tokenizer.bos_token_id, tokenizer.eos_token_id
         if cls_id is None or sep_id is None or eos_id is None:
-            raise ValueError(
-                f"tokenizer class: {tokenizer.__class__.__name__} has no valid cls, sep, and eos ids."
-            )
+            raise ValueError(f"tokenizer class: {tokenizer.__class__.__name__} has no valid cls, sep, and eos ids.")
         return cls_id, sep_id, eos_id
 
     @staticmethod
     def get_pretrained_tokenizer(
-            tokenizer_name: str,
-            checkpoint_name: str,
+        tokenizer_name: str,
+        checkpoint_name: str,
     ):
         """
         Load the tokenizer for a pre-trained huggingface checkpoint.
@@ -400,9 +393,9 @@ class TextProcessor:
 
     @staticmethod
     def get_trimmed_lengths(
-            lengths: List[int],
-            max_length: int,
-            do_merge: bool = False,
+        lengths: List[int],
+        max_length: int,
+        do_merge: bool = False,
     ) -> np.ndarray:
         """
         Get the trimmed lengths of multiple text token sequences. It will make sure that
@@ -452,10 +445,10 @@ class TextProcessor:
             return np.minimum(lengths, max_length)
 
     def __call__(
-            self,
-            all_text: Dict[str, List[str]],
-            idx: int,
-            is_training: bool,
+        self,
+        all_text: Dict[str, List[str]],
+        idx: int,
+        is_training: bool,
     ) -> Dict:
         """
         Extract one sample's text data, tokenize them, and build one token sequence.
@@ -467,7 +460,7 @@ class TextProcessor:
         idx
             The sample index in a dataset.
         is_training
-            Whether to do processing in the training mode. 
+            Whether to do processing in the training mode.
 
         Returns
         -------
@@ -484,17 +477,17 @@ class TextProcessor:
         memo[id(self)] = result
 
         for k, v in self.__dict__.items():
-            if k!="train_augmenter":
+            if k != "train_augmenter":
                 setattr(result, k, deepcopy(v, memo))
         # manual recontruct augmenter
         result.train_augmenter = construct_text_augmenter(result.train_augment_types)
         return result
-    
+
     def __getstate__(self):
         odict = self.__dict__.copy()  # get attribute dictionary
-        del odict['train_augmenter']  # remove textaugmenter to support pickle
+        del odict["train_augmenter"]  # remove textaugmenter to support pickle
         return odict
-    
+
     def __setstate__(self, state):
         self.__dict__ = state
-        self.train_augmenter = construct_text_augmenter(state['rain_augment_types'])
+        self.train_augmenter = construct_text_augmenter(state["rain_augment_types"])

--- a/text/src/autogluon/text/automm/data/utils.py
+++ b/text/src/autogluon/text/automm/data/utils.py
@@ -2,8 +2,8 @@ from typing import Tuple
 
 
 def extract_value_from_config(
-        config: dict,
-        keys: Tuple[str, ...],
+    config: dict,
+    keys: Tuple[str, ...],
 ):
     """
     Traverse a config dictionary to get some hyper-parameter's value.

--- a/text/src/autogluon/text/automm/models/categorical_mlp.py
+++ b/text/src/autogluon/text/automm/models/categorical_mlp.py
@@ -14,15 +14,15 @@ class CategoricalMLP(nn.Module):
     """
 
     def __init__(
-            self,
-            prefix: str,
-            num_categories: List[int],
-            out_features: Optional[int] = None,
-            num_layers: Optional[int] = 1,
-            activation: Optional[str] = "gelu",
-            dropout_prob: Optional[float] = 0.5,
-            normalization: Optional[str] = "layer_norm",
-            num_classes: Optional[int] = 0,
+        self,
+        prefix: str,
+        num_categories: List[int],
+        out_features: Optional[int] = None,
+        num_layers: Optional[int] = 1,
+        activation: Optional[str] = "gelu",
+        dropout_prob: Optional[float] = 0.5,
+        normalization: Optional[str] = "layer_norm",
+        num_classes: Optional[int] = 0,
     ):
         """
         Parameters
@@ -55,10 +55,7 @@ class CategoricalMLP(nn.Module):
 
         for num_categories_per_col in num_categories:
             embedding_dim_per_col = int(
-                size_factor * max(2, min(
-                    max_embedding_dim,
-                    1.6 * num_categories_per_col ** embed_exponent
-                ))
+                size_factor * max(2, min(max_embedding_dim, 1.6 * num_categories_per_col**embed_exponent))
             )
             self.column_embeddings.append(
                 nn.Embedding(
@@ -107,8 +104,8 @@ class CategoricalMLP(nn.Module):
         return f"{self.prefix}_{LABEL}"
 
     def forward(
-            self,
-            batch: dict,
+        self,
+        batch: dict,
     ):
         """
 
@@ -136,7 +133,9 @@ class CategoricalMLP(nn.Module):
             }
         }
 
-    def get_layer_ids(self,):
+    def get_layer_ids(
+        self,
+    ):
         """
         All layers have the same id 0 since there is no pre-trained models used here.
 

--- a/text/src/autogluon/text/automm/models/categorical_transformer.py
+++ b/text/src/autogluon/text/automm/models/categorical_transformer.py
@@ -8,7 +8,7 @@ from .ft_transformer import _TokenInitialization, CLSToken, FT_Transformer
 
 class CategoricalFeatureTokenizer(nn.Module):
     """
-    Feature tokenizer for categorical features in tabular data. 
+    Feature tokenizer for categorical features in tabular data.
     It transforms the input categorical features to tokens (embeddings).
 
     The categorical features usually refers to discrete features.
@@ -19,34 +19,34 @@ class CategoricalFeatureTokenizer(nn.Module):
         num_categories: List[int],
         d_token: int,
         bias: Optional[bool] = True,
-        initialization: Optional[str] = 'normal',
+        initialization: Optional[str] = "normal",
     ) -> None:
         """
         Parameters
         ----------
-        num_categories: 
+        num_categories:
             A list of integers. Each one is the number of categories in one categorical column.
-        d_token: 
+        d_token:
             The size of one token.
-        bias: 
+        bias:
             If `True`, for each feature, an additional trainable vector will be added to the
             embedding regardless of feature value. Notablly, the bias are not shared between features.
-        initialization: 
-            Initialization policy for parameters. Must be one of `['uniform', 'normal']`. 
+        initialization:
+            Initialization policy for parameters. Must be one of `['uniform', 'normal']`.
 
         References
         ----------
-        1. Yury Gorishniy, Ivan Rubachev, Valentin Khrulkov, Artem Babenko, 
+        1. Yury Gorishniy, Ivan Rubachev, Valentin Khrulkov, Artem Babenko,
         "Revisiting Deep Learning Models for Tabular Data", 2021
         https://arxiv.org/pdf/2106.11959.pdf
         2. Code: https://github.com/Yura52/tabular-dl-revisiting-models
         """
         super().__init__()
-        
+
         self.num_categories = num_categories
         category_offsets = torch.tensor([0] + num_categories[:-1]).cumsum(0)
 
-        self.register_buffer('category_offsets', category_offsets, persistent=False)
+        self.register_buffer("category_offsets", category_offsets, persistent=False)
         self.embeddings = nn.Embedding(sum(num_categories), d_token)
         self.bias = nn.Parameter(Tensor(len(num_categories), d_token)) if bias else None
         initialization_ = _TokenInitialization.from_str(initialization)
@@ -54,7 +54,7 @@ class CategoricalFeatureTokenizer(nn.Module):
         for parameter in [self.embeddings.weight, self.bias]:
             if parameter is not None:
                 initialization_.apply(parameter, d_token)
-    
+
     @property
     def n_tokens(self) -> int:
         """The number of tokens."""
@@ -76,38 +76,38 @@ class CategoricalFeatureTokenizer(nn.Module):
 
 class CategoricalTransformer(nn.Module):
     """
-    FT-Transformer for categorical tabular features. 
+    FT-Transformer for categorical tabular features.
     The input dimension is automatically computed based on
     the number of categories in each categorical column.
     """
 
     def __init__(
-        self, 
-        prefix: str, 
+        self,
+        prefix: str,
         num_categories: List[int],
         d_token: int,
         cls_token: Optional[bool] = False,
         out_features: Optional[int] = None,
         num_classes: Optional[int] = 0,
         token_bias: Optional[bool] = True,
-        token_initialization: Optional[str] = 'normal',
+        token_initialization: Optional[str] = "normal",
         n_blocks: Optional[int] = 0,
         attention_n_heads: Optional[int] = 8,
-        attention_initialization: Optional[str] = 'kaiming',
-        attention_normalization: Optional[str] = 'layer_norm',
-        attention_dropout: Optional[str] = 0.2, 
+        attention_initialization: Optional[str] = "kaiming",
+        attention_normalization: Optional[str] = "layer_norm",
+        attention_dropout: Optional[str] = 0.2,
         residual_dropout: Optional[str] = 0.0,
-        ffn_activation: Optional[str] = 'reglu',
-        ffn_normalization: Optional[str] = 'layer_norm',
+        ffn_activation: Optional[str] = "reglu",
+        ffn_normalization: Optional[str] = "layer_norm",
         ffn_d_hidden: Optional[str] = 6,
         ffn_dropout: Optional[str] = 0.0,
         prenormalization: Optional[bool] = True,
-        first_prenormalization: Optional[bool] =  False,
+        first_prenormalization: Optional[bool] = False,
         kv_compression_ratio: Optional[float] = None,
         kv_compression_sharing: Optional[str] = None,
-        head_activation: Optional[str] = 'relu',
-        head_normalization: Optional[str] = 'layer_norm',
-    ) -> None :
+        head_activation: Optional[str] = "relu",
+        head_normalization: Optional[str] = "layer_norm",
+    ) -> None:
         """
         Parameters
         ----------
@@ -124,11 +124,11 @@ class CategoricalTransformer(nn.Module):
         num_classes
             Number of classes. 1 for a regression task.
         token_bias
-            If `True`, for each feature, an additional trainable vector will be added in `_CategoricalFeatureTokenizer` 
+            If `True`, for each feature, an additional trainable vector will be added in `_CategoricalFeatureTokenizer`
             to the embedding regardless of feature value. Notablly, the bias are not shared between features.
         token_initialization
-            Initialization policy for parameters in `_CategoricalFeatureTokenizer` and `_CLSToke`. 
-            Must be one of `['uniform', 'normal']`. 
+            Initialization policy for parameters in `_CategoricalFeatureTokenizer` and `_CLSToke`.
+            Must be one of `['uniform', 'normal']`.
         n_blocks
             Number of the `FT_Transformer` blocks, which should be non-negative.
         attention_n_heads
@@ -160,7 +160,7 @@ class CategoricalTransformer(nn.Module):
 
         References
         ----------
-        1. Yury Gorishniy, Ivan Rubachev, Valentin Khrulkov, Artem Babenko, 
+        1. Yury Gorishniy, Ivan Rubachev, Valentin Khrulkov, Artem Babenko,
         "Revisiting Deep Learning Models for Tabular Data", 2021
         https://arxiv.org/pdf/2106.11959.pdf
         2. Code: https://github.com/Yura52/tabular-dl-revisiting-models
@@ -168,31 +168,34 @@ class CategoricalTransformer(nn.Module):
 
         super().__init__()
 
-        assert num_categories, 'num_categories must be non-empty'
-        assert d_token > 0, 'd_token must be positive'
-        assert n_blocks >= 0, 'n_blocks must be non-negative' 
-        assert attention_n_heads > 0, 'attention_n_heads must be postive'
-        assert token_initialization in ['uniform', 'normal'], 'initialization must be uniform or normal'
+        assert num_categories, "num_categories must be non-empty"
+        assert d_token > 0, "d_token must be positive"
+        assert n_blocks >= 0, "n_blocks must be non-negative"
+        assert attention_n_heads > 0, "attention_n_heads must be postive"
+        assert token_initialization in ["uniform", "normal"], "initialization must be uniform or normal"
 
         self.num_categories = num_categories
 
         self.prefix = prefix
         self.out_features = out_features
 
-
         self.categorical_feature_tokenizer = CategoricalFeatureTokenizer(
             num_categories=num_categories,
             d_token=d_token,
             bias=token_bias,
             initialization=token_initialization,
-        ) 
+        )
 
-        self.cls_token = CLSToken(
-            d_token=d_token, 
-            initialization=token_initialization,
-        ) if cls_token else nn.Identity()
+        self.cls_token = (
+            CLSToken(
+                d_token=d_token,
+                initialization=token_initialization,
+            )
+            if cls_token
+            else nn.Identity()
+        )
 
-        if kv_compression_ratio is not None: 
+        if kv_compression_ratio is not None:
             n_tokens = self.categorical_feature_tokenizer.n_tokens + 1
         else:
             n_tokens = None
@@ -224,8 +227,8 @@ class CategoricalTransformer(nn.Module):
             d_in=d_token,
             d_out=num_classes,
             bias=True,
-            activation=head_activation, 
-            normalization=head_normalization if prenormalization else 'Identity',
+            activation=head_activation,
+            normalization=head_normalization if prenormalization else "Identity",
         )
 
         self.name_to_id = self.get_layer_ids()
@@ -238,10 +241,7 @@ class CategoricalTransformer(nn.Module):
     def label_key(self):
         return f"{self.prefix}_{LABEL}"
 
-    def forward(
-        self, 
-        batch: dict
-    ):
+    def forward(self, batch: dict):
         """
 
         Parameters
@@ -254,16 +254,16 @@ class CategoricalTransformer(nn.Module):
         -------
             A dictionary with logits and features.
         """
-        
+
         categorical_features = []
         for categorical_feature in batch[self.categorical_key]:
             categorical_features.append(categorical_feature)
-        categorical_features = torch.stack(categorical_features,dim=1)
+        categorical_features = torch.stack(categorical_features, dim=1)
 
         features = self.categorical_feature_tokenizer(categorical_features)
         features = self.cls_token(features)
         features = self.transformer(features)
-        
+
         logits = self.head(features)
 
         return {
@@ -273,7 +273,9 @@ class CategoricalTransformer(nn.Module):
             }
         }
 
-    def get_layer_ids(self,):
+    def get_layer_ids(
+        self,
+    ):
         """
         All layers have the same id 0 since there is no pre-trained models used here.
 

--- a/text/src/autogluon/text/automm/models/clip.py
+++ b/text/src/autogluon/text/automm/models/clip.py
@@ -8,9 +8,15 @@ from .utils import (
     get_column_features,
 )
 from ..constants import (
-    IMAGE, IMAGE_VALID_NUM, TEXT_TOKEN_IDS,
-    TEXT_VALID_LENGTH, LABEL, LOGITS, FEATURES,
-    AUTOMM, COLUMN,
+    IMAGE,
+    IMAGE_VALID_NUM,
+    TEXT_TOKEN_IDS,
+    TEXT_VALID_LENGTH,
+    LABEL,
+    LOGITS,
+    FEATURES,
+    AUTOMM,
+    COLUMN,
 )
 from typing import Optional
 
@@ -24,10 +30,10 @@ class CLIPForImageText(nn.Module):
     """
 
     def __init__(
-            self,
-            prefix: str,
-            checkpoint_name: str,
-            num_classes: Optional[int] = 0,
+        self,
+        prefix: str,
+        checkpoint_name: str,
+        num_classes: Optional[int] = 0,
     ):
         """
         Load the pretrained CLIP from huggingface transformers.
@@ -93,8 +99,8 @@ class CLIPForImageText(nn.Module):
         return self.model.config.vision_config.hidden_size
 
     def forward(
-            self,
-            batch: dict,
+        self,
+        batch: dict,
     ):
         """
         Parameters
@@ -173,7 +179,9 @@ class CLIPForImageText(nn.Module):
 
         return {self.prefix: ret}
 
-    def get_layer_ids(self,):
+    def get_layer_ids(
+        self,
+    ):
         """
         Assign an id to each layer. Layer ids will be used in layer-wise lr decay.
         Basically, id gradually increases when going from the output end to
@@ -186,11 +194,10 @@ class CLIPForImageText(nn.Module):
         model_prefixes = ["model.text_model", "model.vision_model", "model"]
         # later model prefixes can't starts with the early ones
         for i, model_pre in enumerate(model_prefixes):
-            for model_pre2 in model_prefixes[i+1:]:
+            for model_pre2 in model_prefixes[i + 1 :]:
                 if model_pre2.startswith(model_pre):
                     raise ValueError(
-                        f"{model_pre} is a substring of {model_pre2}. "
-                        f"Need to swap them in {model_prefixes}."
+                        f"{model_pre} is a substring of {model_pre2}. Need to swap them in {model_prefixes}."
                     )
 
         pre_encoder_patterns = ("embeddings", "pre")

--- a/text/src/autogluon/text/automm/models/ft_transformer.py
+++ b/text/src/autogluon/text/automm/models/ft_transformer.py
@@ -2,45 +2,39 @@ import torch
 from torch import nn
 from torch import Tensor
 import torch.nn.functional as F
-import math 
+import math
 import enum
 import time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
 import warnings
 
 ModuleType = Union[str, Callable[..., nn.Module]]
-_INTERNAL_ERROR_MESSAGE = 'Internal error. Please, open an issue.'
+_INTERNAL_ERROR_MESSAGE = "Internal error. Please, open an issue."
 
 
 def _is_glu_activation(activation: ModuleType):
-    return (
-        isinstance(activation, str)
-        and activation.endswith('glu')
-        or activation in [ReGLU, GEGLU]
-    )
+    return isinstance(activation, str) and activation.endswith("glu") or activation in [ReGLU, GEGLU]
 
 
 def _make_nn_module(module_type: ModuleType, *args) -> nn.Module:
     if isinstance(module_type, str):
-        if module_type == 'reglu':
+        if module_type == "reglu":
             return ReGLU()
-        elif module_type == 'geglu':
+        elif module_type == "geglu":
             return GEGLU()
-        elif module_type == 'gelu':
+        elif module_type == "gelu":
             return nn.GELU()
-        elif module_type == 'relu':
+        elif module_type == "relu":
             return nn.ReLU()
-        elif module_type == 'leaky_relu':
+        elif module_type == "leaky_relu":
             return nn.LeakyReLU()
-        elif module_type == 'layer_norm':
+        elif module_type == "layer_norm":
             return nn.LayerNorm(*args)
         else:
             try:
                 cls = getattr(nn, module_type)
             except AttributeError as err:
-                raise ValueError(
-                    f'Failed to construct the module {module_type} with the arguments {args}'
-                ) from err
+                raise ValueError(f"Failed to construct the module {module_type} with the arguments {args}") from err
             return cls(*args)
     else:
         return module_type(*args)
@@ -64,7 +58,7 @@ def reglu(x: Tensor) -> Tensor:
 
 def geglu(x: Tensor) -> Tensor:
     """The GEGLU activation function from [1].
-    
+
     References:
     ----------
     [1] Noam Shazeer, "GLU Variants Improve Transformer", 2020
@@ -77,7 +71,7 @@ def geglu(x: Tensor) -> Tensor:
 class ReGLU(nn.Module):
     """
     The ReGLU activation function from [1].
-    
+
     References:
     ----------
     [1] Noam Shazeer, "GLU Variants Improve Transformer", 2020
@@ -90,7 +84,7 @@ class ReGLU(nn.Module):
 class GEGLU(nn.Module):
     """
     The GEGLU activation function from [1].
-    
+
     References:
     ----------
     [1] Noam Shazeer, "GLU Variants Improve Transformer", 2020
@@ -159,16 +153,16 @@ class CLSToken(nn.Module):
 
 
 class _TokenInitialization(enum.Enum):
-    UNIFORM = 'uniform'
-    NORMAL = 'normal'
+    UNIFORM = "uniform"
+    NORMAL = "normal"
 
     @classmethod
-    def from_str(cls, initialization: str) -> '_TokenInitialization':
+    def from_str(cls, initialization: str) -> "_TokenInitialization":
         try:
             return cls(initialization)
         except ValueError:
             valid_values = [x.value for x in _TokenInitialization]
-            raise ValueError(f'initialization must be one of {valid_values}')
+            raise ValueError(f"initialization must be one of {valid_values}")
 
     def apply(self, x: Tensor, d: int) -> None:
         d_sqrt_inv = 1 / math.sqrt(d)
@@ -206,18 +200,18 @@ class MultiheadAttention(nn.Module):
         """
         Parameters
         ----------
-        d_token: 
+        d_token:
             the token size. Must be a multiple of :code:`n_heads`.
-        n_heads: 
+        n_heads:
             the number of heads. If greater than 1, then the module will have
             an addition output layer (so called "mixing" layer).
-        dropout: 
+        dropout:
             dropout rate for the attention map. The dropout is applied to
             *probabilities* and do not affect logits.
-        bias: 
+        bias:
             if `True`, then input (and output, if presented) layers also have bias.
             `True` is a reasonable default choice.
-        initialization: 
+        initialization:
             initialization for input projection layers. Must be one of
             :code:`['kaiming', 'xavier']`. `kaiming` is a reasonable default choice.
 
@@ -227,8 +221,8 @@ class MultiheadAttention(nn.Module):
         """
         super().__init__()
         if n_heads > 1:
-            assert d_token % n_heads == 0, 'd_token must be a multiple of n_heads'
-        assert initialization in ['kaiming', 'xavier']
+            assert d_token % n_heads == 0, "d_token must be a multiple of n_heads"
+        assert initialization in ["kaiming", "xavier"]
 
         self.W_q = nn.Linear(d_token, d_token, bias)
         self.W_k = nn.Linear(d_token, d_token, bias)
@@ -241,9 +235,7 @@ class MultiheadAttention(nn.Module):
             # the "xavier" branch tries to follow torch.nn.MultiheadAttention;
             # the second condition checks if W_v plays the role of W_out; the latter one
             # is initialized with Kaiming in torch
-            if initialization == 'xavier' and (
-                m is not self.W_v or self.W_out is not None
-            ):
+            if initialization == "xavier" and (m is not self.W_v or self.W_out is not None):
                 # gain is needed since W_qkv is represented with 3 separate layers (it
                 # implies different fan_out)
                 nn.init.xavier_uniform_(m.weight, gain=1 / math.sqrt(2))
@@ -272,13 +264,13 @@ class MultiheadAttention(nn.Module):
 
         Parameters
         ----------
-        x_q: 
+        x_q:
             query tokens
-        x_kv: 
+        x_kv:
             key-value tokens
-        key_compression: 
+        key_compression:
             Linformer-style compression for keys
-        value_compression: 
+        value_compression:
             Linformer-style compression for values
 
         Returns:
@@ -287,7 +279,7 @@ class MultiheadAttention(nn.Module):
         """
         assert _all_or_none(
             [key_compression, value_compression]
-        ), 'If key_compression is (not) None, then value_compression must (not) be None'
+        ), "If key_compression is (not) None, then value_compression must (not) be None"
         q, k, v = self.W_q(x_q), self.W_k(x_kv), self.W_v(x_kv)
         for tensor in [q, k, v]:
             assert tensor.shape[-1] % self.n_heads == 0, _INTERNAL_ERROR_MESSAGE
@@ -315,8 +307,8 @@ class MultiheadAttention(nn.Module):
         if self.W_out is not None:
             x = self.W_out(x)
         return x, {
-            'attention_logits': attention_logits,
-            'attention_probs': attention_probs,
+            "attention_logits": attention_logits,
+            "attention_probs": attention_probs,
         }
 
 
@@ -325,7 +317,7 @@ class FT_Transformer(nn.Module):
 
     This module is the backbone of `FTTransformer`."""
 
-    WARNINGS = {'first_prenormalization': True, 'prenormalization': True}
+    WARNINGS = {"first_prenormalization": True, "prenormalization": True}
 
     class FFN(nn.Module):
         """The Feed-Forward Network module used in every `Transformer` block."""
@@ -409,55 +401,47 @@ class FT_Transformer(nn.Module):
         super().__init__()
         if isinstance(last_layer_query_idx, int):
             raise ValueError(
-                'last_layer_query_idx must be None, list[int] or slice. '
-                f'Do you mean last_layer_query_idx=[{last_layer_query_idx}] ?'
+                "last_layer_query_idx must be None, list[int] or slice. "
+                f"Do you mean last_layer_query_idx=[{last_layer_query_idx}] ?"
             )
         if not prenormalization:
             assert (
                 not first_prenormalization
-            ), 'If `prenormalization` is False, then `first_prenormalization` must be False'
+            ), "If `prenormalization` is False, then `first_prenormalization` must be False"
         assert _all_or_none([n_tokens, kv_compression_ratio, kv_compression_sharing]), (
-            'If any of the following arguments is (not) None, then all of them must (not) be None: '
-            'n_tokens, kv_compression_ratio, kv_compression_sharing'
+            "If any of the following arguments is (not) None, then all of them must (not) be None: "
+            "n_tokens, kv_compression_ratio, kv_compression_sharing"
         )
-        assert kv_compression_sharing in [None, 'headwise', 'key-value', 'layerwise']
+        assert kv_compression_sharing in [None, "headwise", "key-value", "layerwise"]
         if not prenormalization:
-            if self.WARNINGS['prenormalization']:
+            if self.WARNINGS["prenormalization"]:
                 warnings.warn(
-                    'prenormalization is set to False. Are you sure about this? '
-                    'The training can become less stable. '
-                    'You can turn off this warning by tweaking the '
-                    'rtdl.Transformer.WARNINGS dictionary.',
+                    "prenormalization is set to False. Are you sure about this? "
+                    "The training can become less stable. "
+                    "You can turn off this warning by tweaking the "
+                    "rtdl.Transformer.WARNINGS dictionary.",
                     UserWarning,
                 )
             assert (
                 not first_prenormalization
-            ), 'If prenormalization is False, then first_prenormalization is ignored and must be set to False'
-        if (
-            prenormalization
-            and first_prenormalization
-            and self.WARNINGS['first_prenormalization']
-        ):
+            ), "If prenormalization is False, then first_prenormalization is ignored and must be set to False"
+        if prenormalization and first_prenormalization and self.WARNINGS["first_prenormalization"]:
             warnings.warn(
-                'first_prenormalization is set to True. Are you sure about this? '
-                'For example, the vanilla FTTransformer with '
-                'first_prenormalization=True performs SIGNIFICANTLY worse. '
-                'You can turn off this warning by tweaking the '
-                'rtdl.Transformer.WARNINGS dictionary.',
+                "first_prenormalization is set to True. Are you sure about this? "
+                "For example, the vanilla FTTransformer with "
+                "first_prenormalization=True performs SIGNIFICANTLY worse. "
+                "You can turn off this warning by tweaking the "
+                "rtdl.Transformer.WARNINGS dictionary.",
                 UserWarning,
             )
 
         def make_kv_compression():
-            assert (
-                n_tokens and kv_compression_ratio
-            ), _INTERNAL_ERROR_MESSAGE  # for mypy
+            assert n_tokens and kv_compression_ratio, _INTERNAL_ERROR_MESSAGE  # for mypy
             # https://github.com/pytorch/fairseq/blob/1bba712622b8ae4efb3eb793a8a40da386fe11d0/examples/linformer/linformer_src/modules/multihead_linear_attention.py#L83
             return nn.Linear(n_tokens, int(n_tokens * kv_compression_ratio), bias=False)
 
         self.shared_kv_compression = (
-            make_kv_compression()
-            if kv_compression_ratio and kv_compression_sharing == 'layerwise'
-            else None
+            make_kv_compression() if kv_compression_ratio and kv_compression_sharing == "layerwise" else None
         )
 
         self.prenormalization = prenormalization
@@ -467,14 +451,14 @@ class FT_Transformer(nn.Module):
         for layer_idx in range(n_blocks):
             layer = nn.ModuleDict(
                 {
-                    'attention': MultiheadAttention(
+                    "attention": MultiheadAttention(
                         d_token=d_token,
                         n_heads=attention_n_heads,
                         dropout=attention_dropout,
                         bias=True,
                         initialization=attention_initialization,
                     ),
-                    'ffn': FT_Transformer.FFN(
+                    "ffn": FT_Transformer.FFN(
                         d_token=d_token,
                         d_hidden=ffn_d_hidden,
                         bias_first=True,
@@ -482,88 +466,83 @@ class FT_Transformer(nn.Module):
                         dropout=ffn_dropout,
                         activation=ffn_activation,
                     ),
-                    'attention_residual_dropout': nn.Dropout(residual_dropout),
-                    'ffn_residual_dropout': nn.Dropout(residual_dropout),
-                    'output': nn.Identity(),  # for hooks-based introspection
+                    "attention_residual_dropout": nn.Dropout(residual_dropout),
+                    "ffn_residual_dropout": nn.Dropout(residual_dropout),
+                    "output": nn.Identity(),  # for hooks-based introspection
                 }
             )
             if layer_idx or not prenormalization or first_prenormalization:
-                layer['attention_normalization'] = _make_nn_module(
-                    attention_normalization, d_token
-                )
-            layer['ffn_normalization'] = _make_nn_module(ffn_normalization, d_token)
+                layer["attention_normalization"] = _make_nn_module(attention_normalization, d_token)
+            layer["ffn_normalization"] = _make_nn_module(ffn_normalization, d_token)
             if kv_compression_ratio and self.shared_kv_compression is None:
-                layer['key_compression'] = make_kv_compression()
-                if kv_compression_sharing == 'headwise':
-                    layer['value_compression'] = make_kv_compression()
+                layer["key_compression"] = make_kv_compression()
+                if kv_compression_sharing == "headwise":
+                    layer["value_compression"] = make_kv_compression()
                 else:
-                    assert (
-                        kv_compression_sharing == 'key-value'
-                    ), _INTERNAL_ERROR_MESSAGE
+                    assert kv_compression_sharing == "key-value", _INTERNAL_ERROR_MESSAGE
             self.blocks.append(layer)
 
-         
-        self.head = FT_Transformer.Head(
-            d_in=d_token,
-            d_out=d_out,
-            bias=True,
-            activation=head_activation,  # type: ignore
-            normalization=head_normalization if prenormalization else 'Identity',
-        ) if projection else nn.Identity()
+        self.head = (
+            FT_Transformer.Head(
+                d_in=d_token,
+                d_out=d_out,
+                bias=True,
+                activation=head_activation,  # type: ignore
+                normalization=head_normalization if prenormalization else "Identity",
+            )
+            if projection
+            else nn.Identity()
+        )
 
     def _get_kv_compressions(self, layer):
         return (
             (self.shared_kv_compression, self.shared_kv_compression)
             if self.shared_kv_compression is not None
-            else (layer['key_compression'], layer['value_compression'])
-            if 'key_compression' in layer and 'value_compression' in layer
-            else (layer['key_compression'], layer['key_compression'])
-            if 'key_compression' in layer
+            else (layer["key_compression"], layer["value_compression"])
+            if "key_compression" in layer and "value_compression" in layer
+            else (layer["key_compression"], layer["key_compression"])
+            if "key_compression" in layer
             else (None, None)
         )
 
     def _start_residual(self, layer, stage, x):
-        assert stage in ['attention', 'ffn'], _INTERNAL_ERROR_MESSAGE
+        assert stage in ["attention", "ffn"], _INTERNAL_ERROR_MESSAGE
         x_residual = x
         if self.prenormalization:
-            norm_key = f'{stage}_normalization'
+            norm_key = f"{stage}_normalization"
             if norm_key in layer:
                 x_residual = layer[norm_key](x_residual)
         return x_residual
 
     def _end_residual(self, layer, stage, x, x_residual):
-        assert stage in ['attention', 'ffn'], _INTERNAL_ERROR_MESSAGE
-        x_residual = layer[f'{stage}_residual_dropout'](x_residual)
+        assert stage in ["attention", "ffn"], _INTERNAL_ERROR_MESSAGE
+        x_residual = layer[f"{stage}_residual_dropout"](x_residual)
         x = x + x_residual
         if not self.prenormalization:
-            x = layer[f'{stage}_normalization'](x)
+            x = layer[f"{stage}_normalization"](x)
         return x
 
     def forward(self, x: Tensor) -> Tensor:
-        assert (
-            x.ndim == 3
-        ), 'The input must have 3 dimensions: (n_objects, n_tokens, d_token)'
+        assert x.ndim == 3, "The input must have 3 dimensions: (n_objects, n_tokens, d_token)"
         for layer_idx, layer in enumerate(self.blocks):
             layer = cast(nn.ModuleDict, layer)
 
-            query_idx = (
-                self.last_layer_query_idx if layer_idx + 1 == len(self.blocks) else None
-            )
-            x_residual = self._start_residual(layer, 'attention', x)
-            x_residual, _ = layer['attention'](
+            query_idx = self.last_layer_query_idx if layer_idx + 1 == len(self.blocks) else None
+            x_residual = self._start_residual(layer, "attention", x)
+            x_residual, _ = layer["attention"](
                 x_residual if query_idx is None else x_residual[:, query_idx],
                 x_residual,
                 *self._get_kv_compressions(layer),
             )
             if query_idx is not None:
                 x = x[:, query_idx]
-            x = self._end_residual(layer, 'attention', x, x_residual)
+            x = self._end_residual(layer, "attention", x, x_residual)
 
-            x_residual = self._start_residual(layer, 'ffn', x)
-            x_residual = layer['ffn'](x_residual)
-            x = self._end_residual(layer, 'ffn', x, x_residual)
-            x = layer['output'](x)
+            x_residual = self._start_residual(layer, "ffn", x)
+            x_residual = layer["ffn"](x_residual)
+            x = self._end_residual(layer, "ffn", x, x_residual)
+            x = layer["output"](x)
 
-        x =  self.head(x)
-        
+        x = self.head(x)
+
         return x

--- a/text/src/autogluon/text/automm/models/fusion.py
+++ b/text/src/autogluon/text/automm/models/fusion.py
@@ -3,10 +3,7 @@ import torch
 from torch import nn
 from typing import List, Optional
 from .utils import init_weights
-from ..constants import (
-    LABEL, LOGITS, FEATURES,
-    WEIGHT, AUTOMM
-)
+from ..constants import LABEL, LOGITS, FEATURES, WEIGHT, AUTOMM
 from .mlp import MLP
 from .ft_transformer import FT_Transformer, CLSToken
 
@@ -21,16 +18,16 @@ class MultimodalFusionMLP(nn.Module):
     """
 
     def __init__(
-            self,
-            prefix: str,
-            models: list,
-            hidden_features: List[int],
-            num_classes: int,
-            adapt_in_features: Optional[str] = None,
-            activation: Optional[str] = "gelu",
-            dropout_prob: Optional[float] = 0.5,
-            normalization: Optional[str] = "layer_norm",
-            loss_weight: Optional[float] = None,
+        self,
+        prefix: str,
+        models: list,
+        hidden_features: List[int],
+        num_classes: int,
+        adapt_in_features: Optional[str] = None,
+        activation: Optional[str] = "gelu",
+        dropout_prob: Optional[float] = 0.5,
+        normalization: Optional[str] = "layer_norm",
+        loss_weight: Optional[float] = None,
     ):
         """
         Parameters
@@ -82,15 +79,11 @@ class MultimodalFusionMLP(nn.Module):
             else:
                 raise ValueError(f"unknown adapt_in_features: {adapt_in_features}")
 
-            self.adapter = nn.ModuleList(
-                [nn.Linear(in_feat, base_in_feat) for in_feat in raw_in_features]
-            )
+            self.adapter = nn.ModuleList([nn.Linear(in_feat, base_in_feat) for in_feat in raw_in_features])
 
             in_features = base_in_feat * len(raw_in_features)
         else:
-            self.adapter = nn.ModuleList(
-                [nn.Identity() for _ in range(len(raw_in_features))]
-            )
+            self.adapter = nn.ModuleList([nn.Identity() for _ in range(len(raw_in_features))])
             in_features = sum(raw_in_features)
 
         assert len(self.adapter) == len(self.model)
@@ -127,8 +120,8 @@ class MultimodalFusionMLP(nn.Module):
         return f"{self.prefix}_{LABEL}"
 
     def forward(
-            self,
-            batch: dict,
+        self,
+        batch: dict,
     ):
         """
 
@@ -169,7 +162,9 @@ class MultimodalFusionMLP(nn.Module):
         else:
             return fusion_output
 
-    def get_layer_ids(self,):
+    def get_layer_ids(
+        self,
+    ):
         """
         Assign an id to each layer. Layer ids will be used in layer-wise lr decay.
         Basically, id gradually increases when going from the output end to
@@ -200,9 +195,7 @@ class MultimodalFusionMLP(nn.Module):
         for i, per_model in enumerate(self.model):
             per_model_prefix = f"{model_prefix}.{i}"
             if not hasattr(per_model, "name_to_id"):
-                raise ValueError(
-                    f"name_to_id attribute is missing in model: {per_model.__class__.__name__}"
-                )
+                raise ValueError(f"name_to_id attribute is missing in model: {per_model.__class__.__name__}")
             for n, layer_id in per_model.name_to_id.items():
                 full_n = f"{per_model_prefix}.{n}"
                 name_to_id[full_n] = layer_id
@@ -222,29 +215,29 @@ class MultimodalFusionTransformer(nn.Module):
     """
 
     def __init__(
-            self,
-            prefix: str,
-            models: list,
-            hidden_features: int,
-            num_classes: int,
-            n_blocks: Optional[int] = 0,
-            attention_n_heads: Optional[int] = 8,
-            attention_initialization: Optional[str] = 'kaiming',
-            attention_normalization: Optional[str] = 'layer_norm',
-            attention_dropout: Optional[str] = 0.2, 
-            residual_dropout: Optional[str] = 0.0,
-            ffn_activation: Optional[str] = 'reglu',
-            ffn_normalization: Optional[str] = 'layer_norm',
-            ffn_d_hidden: Optional[str] = 192,
-            ffn_dropout: Optional[str] = 0.0,
-            prenormalization: Optional[bool] = True,
-            first_prenormalization: Optional[bool] = False,
-            kv_compression_ratio: Optional[float] = None,
-            kv_compression_sharing: Optional[str] = None,
-            head_activation: Optional[str] =  'relu',
-            head_normalization: Optional[str] = 'layer_norm',
-            adapt_in_features: Optional[str] = None,
-            loss_weight: Optional[float] = None,
+        self,
+        prefix: str,
+        models: list,
+        hidden_features: int,
+        num_classes: int,
+        n_blocks: Optional[int] = 0,
+        attention_n_heads: Optional[int] = 8,
+        attention_initialization: Optional[str] = "kaiming",
+        attention_normalization: Optional[str] = "layer_norm",
+        attention_dropout: Optional[str] = 0.2,
+        residual_dropout: Optional[str] = 0.0,
+        ffn_activation: Optional[str] = "reglu",
+        ffn_normalization: Optional[str] = "layer_norm",
+        ffn_d_hidden: Optional[str] = 192,
+        ffn_dropout: Optional[str] = 0.0,
+        prenormalization: Optional[bool] = True,
+        first_prenormalization: Optional[bool] = False,
+        kv_compression_ratio: Optional[float] = None,
+        kv_compression_sharing: Optional[str] = None,
+        head_activation: Optional[str] = "relu",
+        head_normalization: Optional[str] = "layer_norm",
+        adapt_in_features: Optional[str] = None,
+        loss_weight: Optional[float] = None,
     ):
         super().__init__()
         logger.debug("initializing MultimodalFusionTransformer")
@@ -263,9 +256,7 @@ class MultimodalFusionTransformer(nn.Module):
         else:
             raise ValueError(f"unknown adapt_in_features: {adapt_in_features}")
 
-        self.adapter = nn.ModuleList(
-            [nn.Linear(in_feat, base_in_feat) for in_feat in raw_in_features]
-        )
+        self.adapter = nn.ModuleList([nn.Linear(in_feat, base_in_feat) for in_feat in raw_in_features])
 
         in_features = base_in_feat
 
@@ -292,20 +283,20 @@ class MultimodalFusionTransformer(nn.Module):
             head_activation=head_activation,
             head_normalization=head_normalization,
             d_out=hidden_features,
-            projection=False
+            projection=False,
         )
 
         self.head = FT_Transformer.Head(
             d_in=in_features,
             d_out=num_classes,
             bias=True,
-            activation=head_activation, 
+            activation=head_activation,
             normalization=head_normalization,
         )
-        
+
         self.cls_token = CLSToken(
-            d_token=in_features, 
-            initialization='uniform',
+            d_token=in_features,
+            initialization="uniform",
         )
 
         # init weights
@@ -322,8 +313,8 @@ class MultimodalFusionTransformer(nn.Module):
         return f"{self.prefix}_{LABEL}"
 
     def forward(
-            self,
-            batch: dict,
+        self,
+        batch: dict,
     ):
         multimodal_features = []
         output = {}
@@ -331,9 +322,8 @@ class MultimodalFusionTransformer(nn.Module):
             per_output = per_model(batch)
             multimodal_feature = per_adapter(per_output[per_model.prefix][FEATURES])
             if multimodal_feature.ndim == 2:
-                multimodal_feature = torch.unsqueeze(multimodal_feature,dim=1)
+                multimodal_feature = torch.unsqueeze(multimodal_feature, dim=1)
             multimodal_features.append(multimodal_feature)
-
 
             if self.loss_weight is not None:
                 per_output[per_model.prefix].update({WEIGHT: self.loss_weight})
@@ -357,7 +347,9 @@ class MultimodalFusionTransformer(nn.Module):
         else:
             return fusion_output
 
-    def get_layer_ids(self,):
+    def get_layer_ids(
+        self,
+    ):
         """
         Assign an id to each layer. Layer ids will be used in layer-wise lr decay.
         Basically, id gradually increases when going from the output end to
@@ -388,9 +380,7 @@ class MultimodalFusionTransformer(nn.Module):
         for i, per_model in enumerate(self.model):
             per_model_prefix = f"{model_prefix}.{i}"
             if not hasattr(per_model, "name_to_id"):
-                raise ValueError(
-                    f"name_to_id attribute is missing in model: {per_model.__class__.__name__}"
-                )
+                raise ValueError(f"name_to_id attribute is missing in model: {per_model.__class__.__name__}")
             for n, layer_id in per_model.name_to_id.items():
                 full_n = f"{per_model_prefix}.{n}"
                 name_to_id[full_n] = layer_id

--- a/text/src/autogluon/text/automm/models/huggingface_text.py
+++ b/text/src/autogluon/text/automm/models/huggingface_text.py
@@ -5,8 +5,14 @@ import warnings
 from transformers import AutoModel, AutoTokenizer
 from transformers import logging as hf_logging
 from ..constants import (
-    TEXT_TOKEN_IDS, TEXT_VALID_LENGTH, TEXT_SEGMENT_IDS,
-    LABEL, LOGITS, FEATURES, AUTOMM, COLUMN,
+    TEXT_TOKEN_IDS,
+    TEXT_VALID_LENGTH,
+    TEXT_SEGMENT_IDS,
+    LABEL,
+    LOGITS,
+    FEATURES,
+    AUTOMM,
+    COLUMN,
 )
 from typing import Optional, List, Tuple
 from .utils import (
@@ -27,10 +33,10 @@ class HFAutoModelForTextPrediction(nn.Module):
     """
 
     def __init__(
-            self,
-            prefix: str,
-            checkpoint_name: str = 'microsoft/deberta-v3-base',
-            num_classes: Optional[int] = 0,
+        self,
+        prefix: str,
+        checkpoint_name: str = "microsoft/deberta-v3-base",
+        num_classes: Optional[int] = 0,
     ):
         """
         Load a pretrained huggingface text transformer backbone.
@@ -69,7 +75,7 @@ class HFAutoModelForTextPrediction(nn.Module):
         self.name_to_id = self.get_layer_ids()
         self.head_layer_names = [n for n, layer_id in self.name_to_id.items() if layer_id == 0]
 
-        if hasattr(self.model.config, 'type_vocab_size') and self.model.config.type_vocab_size <= 1:
+        if hasattr(self.model.config, "type_vocab_size") and self.model.config.type_vocab_size <= 1:
             # Disable segment ids for models like RoBERTa
             self.disable_seg_ids = True
         else:
@@ -100,8 +106,8 @@ class HFAutoModelForTextPrediction(nn.Module):
         return self.model.config.hidden_size
 
     def forward(
-            self,
-            batch: dict,
+        self,
+        batch: dict,
     ):
         """
         Parameters

--- a/text/src/autogluon/text/automm/models/mlp.py
+++ b/text/src/autogluon/text/automm/models/mlp.py
@@ -14,12 +14,12 @@ class Unit(nn.Module):
     """
 
     def __init__(
-            self,
-            normalization: str,
-            in_features: int,
-            out_features: int,
-            activation: str,
-            dropout_prob: float,
+        self,
+        normalization: str,
+        in_features: int,
+        out_features: int,
+        activation: str,
+        dropout_prob: float,
     ):
         """
         Parameters
@@ -60,14 +60,14 @@ class MLP(nn.Module):
     """
 
     def __init__(
-            self,
-            in_features: int,
-            hidden_features: Optional[int] = None,
-            out_features: Optional[int] = None,
-            num_layers: Optional[int] = 1,
-            activation: Optional[str] = "gelu",
-            dropout_prob: Optional[float] = 0.5,
-            normalization: Optional[str] = "layer_norm",
+        self,
+        in_features: int,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        num_layers: Optional[int] = 1,
+        activation: Optional[str] = "gelu",
+        dropout_prob: Optional[float] = 0.5,
+        normalization: Optional[str] = "layer_norm",
     ):
         """
         Parameters
@@ -98,7 +98,7 @@ class MLP(nn.Module):
                 in_features=in_features,
                 out_features=hidden_features,
                 activation=activation,
-                dropout_prob=dropout_prob
+                dropout_prob=dropout_prob,
             )
             in_features = hidden_features
             layers.append(per_unit)

--- a/text/src/autogluon/text/automm/models/numerical_mlp.py
+++ b/text/src/autogluon/text/automm/models/numerical_mlp.py
@@ -13,16 +13,16 @@ class NumericalMLP(nn.Module):
     """
 
     def __init__(
-            self,
-            prefix: str,
-            in_features: int,
-            hidden_features: Optional[int] = None,
-            out_features: Optional[int] = None,
-            num_layers: Optional[int] = 1,
-            activation: Optional[str] = "leaky_relu",
-            dropout_prob: Optional[float] = 0.5,
-            normalization: Optional[str] = "layer_norm",
-            num_classes: Optional[int] = 0,
+        self,
+        prefix: str,
+        in_features: int,
+        hidden_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        num_layers: Optional[int] = 1,
+        activation: Optional[str] = "leaky_relu",
+        dropout_prob: Optional[float] = 0.5,
+        normalization: Optional[str] = "layer_norm",
+        num_classes: Optional[int] = 0,
     ):
         """
         Parameters
@@ -75,8 +75,8 @@ class NumericalMLP(nn.Module):
         return f"{self.prefix}_{LABEL}"
 
     def forward(
-            self,
-            batch: dict,
+        self,
+        batch: dict,
     ):
         """
 
@@ -100,7 +100,9 @@ class NumericalMLP(nn.Module):
             }
         }
 
-    def get_layer_ids(self,):
+    def get_layer_ids(
+        self,
+    ):
         """
         All layers have the same id 0 since there is no pre-trained models used here.
 

--- a/text/src/autogluon/text/automm/models/timm_image.py
+++ b/text/src/autogluon/text/automm/models/timm_image.py
@@ -9,8 +9,13 @@ from .utils import (
     get_column_features,
 )
 from ..constants import (
-    IMAGE, IMAGE_VALID_NUM, LABEL,
-    LOGITS, FEATURES, AUTOMM, COLUMN,
+    IMAGE,
+    IMAGE_VALID_NUM,
+    LABEL,
+    LOGITS,
+    FEATURES,
+    AUTOMM,
+    COLUMN,
 )
 
 logger = logging.getLogger(AUTOMM)
@@ -23,12 +28,12 @@ class TimmAutoModelForImagePrediction(nn.Module):
     """
 
     def __init__(
-            self,
-            prefix: str,
-            checkpoint_name: str,
-            num_classes: Optional[int] = 0,
-            mix_choice: Optional[str] = "all_logits",
-            pretrained: Optional[bool] = True,
+        self,
+        prefix: str,
+        checkpoint_name: str,
+        num_classes: Optional[int] = 0,
+        mix_choice: Optional[str] = "all_logits",
+        pretrained: Optional[bool] = True,
     ):
         """
         Load a pretrained image backbone from TIMM.
@@ -89,8 +94,8 @@ class TimmAutoModelForImagePrediction(nn.Module):
         return self.model.num_features
 
     def forward(
-            self,
-            batch: dict,
+        self,
+        batch: dict,
     ):
         """
         Parameters
@@ -145,7 +150,9 @@ class TimmAutoModelForImagePrediction(nn.Module):
 
         return {self.prefix: ret}
 
-    def get_layer_ids(self,):
+    def get_layer_ids(
+        self,
+    ):
         """
         Assign an id to each layer. Layer ids will be used in layer-wise lr decay.
         Basically, id gradually increases when going from the output end to

--- a/text/src/autogluon/text/automm/models/utils.py
+++ b/text/src/autogluon/text/automm/models/utils.py
@@ -26,7 +26,7 @@ def init_weights(module: nn.Module):
 
 
 def assign_encoder_layer_ids(
-        encoder_names: List[List[str]],
+    encoder_names: List[List[str]],
 ):
     """
     Assign ids to encoder layers. The encoder may contain several blocks e.g., block1 and block2.
@@ -51,7 +51,7 @@ def assign_encoder_layer_ids(
         last_inferred_id = -1
         for n in group_names:
             detect_id = False
-            n_splits = n.split('.')
+            n_splits = n.split(".")
 
             for split in n_splits:
                 # the first digit encountered is used to infer layer id
@@ -77,8 +77,8 @@ def assign_encoder_layer_ids(
 
 
 def assign_non_encoder_layer_ids(
-        non_encoder_names: List[str],
-        layer_id: int,
+    non_encoder_names: List[str],
+    layer_id: int,
 ):
     """
     Assign the provided id to non-encoder layers.
@@ -135,10 +135,10 @@ def split_encoder_non_encoder(names: List[str]):
 
 
 def group_param_names(
-        names: List[str],
-        pre_encoder_patterns: Tuple[str, ...],
-        post_encoder_patterns: Tuple[str, ...],
-        model_prefix: Optional[str] = None,
+    names: List[str],
+    pre_encoder_patterns: Tuple[str, ...],
+    post_encoder_patterns: Tuple[str, ...],
+    model_prefix: Optional[str] = None,
 ):
     """
     Group layer names into three types: pre-encoder, encoder, and post-encoder.
@@ -187,7 +187,7 @@ def group_param_names(
     # split blocks at the first level
     children_prefix = []
     for n in selected_names:
-        child_name = n[len(model_prefix)+1:].split(".")[0]
+        child_name = n[len(model_prefix) + 1 :].split(".")[0]
         child_prefix = f"{model_prefix}.{child_name}"
         if child_prefix not in children_prefix:
             children_prefix.append(child_prefix)
@@ -215,9 +215,9 @@ def group_param_names(
 
 
 def reverse_layer_ids(
-        encoder_name_to_id: dict,
-        pre_enocder_name_to_id: dict,
-        post_enocder_name_to_id: dict,
+    encoder_name_to_id: dict,
+    pre_enocder_name_to_id: dict,
+    post_enocder_name_to_id: dict,
 ):
     """
     The layer ids need to increase when going from the output end to the input end.
@@ -249,10 +249,10 @@ def reverse_layer_ids(
 
 
 def assign_layer_ids(
-        names: List[str],
-        pre_encoder_patterns: Tuple[str, ...],
-        post_encoder_patterns: Tuple[str, ...],
-        model_pre: Optional[str] = None,
+    names: List[str],
+    pre_encoder_patterns: Tuple[str, ...],
+    post_encoder_patterns: Tuple[str, ...],
+    model_pre: Optional[str] = None,
 ):
     """
     Assign ids to all layers. It splits a model into three parts: pre-encoder, encoder, and post-encoder.
@@ -282,49 +282,39 @@ def assign_layer_ids(
     left_names
         The layer names not starting with the "model_pre".
     """
-    left_names, encoder_names, pre_encoder_names, post_encoder_names = \
-        group_param_names(
-            names=names,
-            pre_encoder_patterns=pre_encoder_patterns,
-            post_encoder_patterns=post_encoder_patterns,
-            model_prefix=model_pre,
-        )
+    left_names, encoder_names, pre_encoder_names, post_encoder_names = group_param_names(
+        names=names,
+        pre_encoder_patterns=pre_encoder_patterns,
+        post_encoder_patterns=post_encoder_patterns,
+        model_prefix=model_pre,
+    )
     # add a constraint
     if len(encoder_names) == 0 and len(pre_encoder_names) != 0:
-        raise ValueError(
-            f"encoder_names is empty, but pre_encoder_names has values: {pre_encoder_names}"
-        )
+        raise ValueError(f"encoder_names is empty, but pre_encoder_names has values: {pre_encoder_names}")
 
-    encoder_name_to_id, encoder_layer_num = \
-        assign_encoder_layer_ids(
-            encoder_names=encoder_names,
-        )
+    encoder_name_to_id, encoder_layer_num = assign_encoder_layer_ids(
+        encoder_names=encoder_names,
+    )
 
-    pre_encoder_name_to_id = \
-        assign_non_encoder_layer_ids(
-            non_encoder_names=pre_encoder_names,
-            layer_id=0
-        )
+    pre_encoder_name_to_id = assign_non_encoder_layer_ids(non_encoder_names=pre_encoder_names, layer_id=0)
 
-    post_encoder_name_to_id = \
-        assign_non_encoder_layer_ids(
-            non_encoder_names=post_encoder_names,
-            layer_id=encoder_layer_num + 1
-        )
+    post_encoder_name_to_id = assign_non_encoder_layer_ids(
+        non_encoder_names=post_encoder_names, layer_id=encoder_layer_num + 1
+    )
 
     name_to_id = reverse_layer_ids(
         encoder_name_to_id=encoder_name_to_id,
         pre_enocder_name_to_id=pre_encoder_name_to_id,
-        post_enocder_name_to_id=post_encoder_name_to_id
+        post_enocder_name_to_id=post_encoder_name_to_id,
     )
     return name_to_id, left_names
 
 
 def get_column_features(
-        batch: Dict[str, torch.Tensor],
-        column_name_prefix: str,
-        features: torch.Tensor,
-        valid_lengths: torch.Tensor,
+    batch: Dict[str, torch.Tensor],
+    column_name_prefix: str,
+    features: torch.Tensor,
+    valid_lengths: torch.Tensor,
 ):
     """
     Index the features of one column defined by `column_name_prefix`.

--- a/text/src/autogluon/text/automm/optimization/lit_module.py
+++ b/text/src/autogluon/text/automm/optimization/lit_module.py
@@ -28,25 +28,25 @@ class LitModule(pl.LightningModule):
     """
 
     def __init__(
-            self,
-            model: nn.Module,
-            optim_type: Optional[str] = None,
-            lr_choice: Optional[str] = None,
-            lr_schedule: Optional[str] = None,
-            lr: Optional[float] = None,
-            lr_decay: Optional[float] = None,
-            end_lr: Optional[Union[float, int]] = None,
-            lr_mult: Optional[Union[float, int]] = None,
-            weight_decay: Optional[float] = None,
-            warmup_steps: Optional[int] = None,
-            loss_func: Optional[_Loss] = None,
-            validation_metric: Optional[torchmetrics.Metric] = None,
-            validation_metric_name: Optional[str] = None,
-            custom_metric_func: Callable = None,
-            test_metric: Optional[torchmetrics.Metric] = None,
-            efficient_finetune: Optional[str] = None,
-            mixup_fn: Optional[MixupModule] = None,
-            mixup_off_epoch: Optional[int] = 0,
+        self,
+        model: nn.Module,
+        optim_type: Optional[str] = None,
+        lr_choice: Optional[str] = None,
+        lr_schedule: Optional[str] = None,
+        lr: Optional[float] = None,
+        lr_decay: Optional[float] = None,
+        end_lr: Optional[Union[float, int]] = None,
+        lr_mult: Optional[Union[float, int]] = None,
+        weight_decay: Optional[float] = None,
+        warmup_steps: Optional[int] = None,
+        loss_func: Optional[_Loss] = None,
+        validation_metric: Optional[torchmetrics.Metric] = None,
+        validation_metric_name: Optional[str] = None,
+        custom_metric_func: Callable = None,
+        test_metric: Optional[torchmetrics.Metric] = None,
+        efficient_finetune: Optional[str] = None,
+        mixup_fn: Optional[MixupModule] = None,
+        mixup_off_epoch: Optional[int] = 0,
     ):
         """
         Parameters
@@ -119,30 +119,33 @@ class LitModule(pl.LightningModule):
         if isinstance(validation_metric, BaseAggregator) and custom_metric_func is None:
             raise ValueError(
                 f"validation_metric {validation_metric} is an aggregation metric,"
-                f"which must be used with a customized metric function."
+                "which must be used with a customized metric function."
             )
         self.custom_metric_func = custom_metric_func
 
     def _compute_loss(
-            self,
-            output: Dict,
-            label: torch.Tensor,
+        self,
+        output: Dict,
+        label: torch.Tensor,
     ):
         loss = 0
         for _, per_output in output.items():
             weight = per_output[WEIGHT] if WEIGHT in per_output else 1
-            loss += self.loss_func(
-                input=per_output[LOGITS].squeeze(dim=1),
-                target=label,
-            ) * weight
+            loss += (
+                self.loss_func(
+                    input=per_output[LOGITS].squeeze(dim=1),
+                    target=label,
+                )
+                * weight
+            )
         return loss
 
     def _compute_metric_score(
-            self,
-            metric: torchmetrics.Metric,
-            custom_metric_func: Callable,
-            logits: torch.Tensor,
-            label: torch.Tensor,
+        self,
+        metric: torchmetrics.Metric,
+        custom_metric_func: Callable,
+        logits: torch.Tensor,
+        label: torch.Tensor,
     ):
         if isinstance(metric, (torchmetrics.AUROC, torchmetrics.AveragePrecision)):
             prob = F.softmax(logits.float(), dim=1)
@@ -153,8 +156,8 @@ class LitModule(pl.LightningModule):
             metric.update(logits.squeeze(dim=1), label)
 
     def _shared_step(
-            self,
-            batch: Dict,
+        self,
+        batch: Dict,
     ):
         label = batch[self.model.label_key]
         if self.mixup_fn is not None:
@@ -288,13 +291,12 @@ class LitModule(pl.LightningModule):
         logger.debug(f"trainer.max_steps: {self.trainer.max_steps}")
         if self.trainer.max_steps is None or -1:
             max_steps = (
-                    len(self.trainer.datamodule.train_dataloader())
-                    * self.trainer.max_epochs
-                    // self.trainer.accumulate_grad_batches
+                len(self.trainer.datamodule.train_dataloader())
+                * self.trainer.max_epochs
+                // self.trainer.accumulate_grad_batches
             )
             logger.debug(
-                f"len(trainer.datamodule.train_dataloader()): "
-                f"{len(self.trainer.datamodule.train_dataloader())}"
+                f"len(trainer.datamodule.train_dataloader()): {len(self.trainer.datamodule.train_dataloader())}"
             )
             logger.debug(f"trainer.max_epochs: {self.trainer.max_epochs}")
             logger.debug(f"trainer.accumulate_grad_batches: {self.trainer.accumulate_grad_batches}")

--- a/text/src/autogluon/text/automm/optimization/lr_scheduler.py
+++ b/text/src/autogluon/text/automm/optimization/lr_scheduler.py
@@ -36,13 +36,18 @@ def get_cosine_schedule_with_warmup(
     Return:
         `torch.optim.lr_scheduler.LambdaLR` with the appropriate schedule.
     """
-    lr_lambda = functools.partial(_cosine_decay_lr_lambda, num_warmup_steps=num_warmup_steps,
-                                  num_training_steps=num_training_steps, num_cycles=num_cycles)
+    lr_lambda = functools.partial(
+        _cosine_decay_lr_lambda,
+        num_warmup_steps=num_warmup_steps,
+        num_training_steps=num_training_steps,
+        num_cycles=num_cycles,
+    )
     return LambdaLR(optimizer, lr_lambda, last_epoch)
 
 
-def _poly_decay_lr_lambda(current_step: int, num_warmup_steps: int, num_training_steps: int,
-                          lr_init: float, lr_end: float, power: float):
+def _poly_decay_lr_lambda(
+    current_step: int, num_warmup_steps: int, num_training_steps: int, lr_init: float, lr_end: float, power: float
+):
     if current_step < num_warmup_steps:
         return float(current_step) / float(max(1, num_warmup_steps))
     elif current_step > num_training_steps:
@@ -51,7 +56,7 @@ def _poly_decay_lr_lambda(current_step: int, num_warmup_steps: int, num_training
         lr_range = lr_init - lr_end
         decay_steps = num_training_steps - num_warmup_steps
         pct_remaining = 1 - (current_step - num_warmup_steps) / decay_steps
-        decay = lr_range * pct_remaining ** power + lr_end
+        decay = lr_range * pct_remaining**power + lr_end
         return decay / lr_init  # as LambdaLR multiplies by lr_init
 
 
@@ -91,21 +96,21 @@ def get_polynomial_decay_schedule_with_warmup(
     lr_init = optimizer.defaults["lr"]
     if not (lr_init >= lr_end):
         raise ValueError(f"lr_end ({lr_end}) must not be larger than initial lr ({lr_init})")
-    lr_lambda = functools.partial(_poly_decay_lr_lambda,
-                                  num_warmup_steps=num_warmup_steps,
-                                  num_training_steps=num_training_steps,
-                                  lr_init=lr_init,
-                                  lr_end=lr_end,
-                                  power=power)
+    lr_lambda = functools.partial(
+        _poly_decay_lr_lambda,
+        num_warmup_steps=num_warmup_steps,
+        num_training_steps=num_training_steps,
+        lr_init=lr_init,
+        lr_end=lr_end,
+        power=power,
+    )
     return LambdaLR(optimizer, lr_lambda, last_epoch)
 
 
 def _linear_warmup_lr_lambda(current_step: int, num_warmup_steps: int, num_training_steps: int):
     if current_step < num_warmup_steps:
         return float(current_step) / float(max(1, num_warmup_steps))
-    return max(
-        0.0, float(num_training_steps - current_step) / float(max(1, num_training_steps - num_warmup_steps))
-    )
+    return max(0.0, float(num_training_steps - current_step) / float(max(1, num_training_steps - num_warmup_steps)))
 
 
 def get_linear_schedule_with_warmup(optimizer, num_warmup_steps, num_training_steps, last_epoch=-1):
@@ -124,7 +129,7 @@ def get_linear_schedule_with_warmup(optimizer, num_warmup_steps, num_training_st
     Return:
         `torch.optim.lr_scheduler.LambdaLR` with the appropriate schedule.
     """
-    lr_lambda = functools.partial(_linear_warmup_lr_lambda,
-                                  num_warmup_steps=num_warmup_steps,
-                                  num_training_steps=num_training_steps)
+    lr_lambda = functools.partial(
+        _linear_warmup_lr_lambda, num_warmup_steps=num_warmup_steps, num_training_steps=num_training_steps
+    )
     return LambdaLR(optimizer, lr_lambda, last_epoch)

--- a/text/src/autogluon/text/automm/optimization/soft_target_crossentropy.py
+++ b/text/src/autogluon/text/automm/optimization/soft_target_crossentropy.py
@@ -10,12 +10,10 @@ class SoftTargetCrossEntropy(nn.Module):
     It works under the mixup.
     It can calculate the crossentropy of input and label with one-hot.
     """
+
     def __init__(self):
         super(SoftTargetCrossEntropy, self).__init__()
 
-    def forward(self,
-                input: torch.Tensor,
-                target: torch.Tensor
-    ) -> torch.Tensor:
+    def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         loss = torch.sum(-target * F.log_softmax(input, dim=-1), dim=-1)
         return loss.mean()

--- a/text/src/autogluon/text/automm/optimization/utils.py
+++ b/text/src/autogluon/text/automm/optimization/utils.py
@@ -11,18 +11,33 @@ from .lr_scheduler import (
     get_linear_schedule_with_warmup,
 )
 from ..constants import (
-    BINARY, MULTICLASS, REGRESSION, MAX, MIN, NORM_FIT, BIT_FIT,
-    ACC, ACCURACY, RMSE, ROOT_MEAN_SQUARED_ERROR, R2, QUADRATIC_KAPPA,
-    ROC_AUC, AVERAGE_PRECISION, LOG_LOSS, CROSS_ENTROPY,
-    PEARSONR, SPEARMANR,
+    BINARY,
+    MULTICLASS,
+    REGRESSION,
+    MAX,
+    MIN,
+    NORM_FIT,
+    BIT_FIT,
+    ACC,
+    ACCURACY,
+    RMSE,
+    ROOT_MEAN_SQUARED_ERROR,
+    R2,
+    QUADRATIC_KAPPA,
+    ROC_AUC,
+    AVERAGE_PRECISION,
+    LOG_LOSS,
+    CROSS_ENTROPY,
+    PEARSONR,
+    SPEARMANR,
 )
 import warnings
 from .soft_target_crossentropy import SoftTargetCrossEntropy
 
 
 def get_loss_func(
-        problem_type: str,
-        mixup_active: bool,
+    problem_type: str,
+    mixup_active: bool,
 ):
     """
     Choose a suitable Pytorch loss module based on the provided problem type.
@@ -50,10 +65,10 @@ def get_loss_func(
 
 
 def get_metric(
-        metric_name: str,
-        problem_type: str,
-        num_classes: Optional[int] = None,
-        pos_label: Optional[int] = None,
+    metric_name: str,
+    problem_type: str,
+    num_classes: Optional[int] = None,
+    pos_label: Optional[int] = None,
 ):
     """
     Obtain a torchmerics.Metric from its name.
@@ -91,23 +106,24 @@ def get_metric(
     elif metric_name == R2:
         return torchmetrics.R2Score(), MAX, None
     elif metric_name == QUADRATIC_KAPPA:
-        return torchmetrics.CohenKappa(num_classes=num_classes,
-                                       weights="quadratic"), MAX, None
+        return torchmetrics.CohenKappa(num_classes=num_classes, weights="quadratic"), MAX, None
     elif metric_name == ROC_AUC:
         return torchmetrics.AUROC(pos_label=pos_label), MAX, None
     elif metric_name == AVERAGE_PRECISION:
         return torchmetrics.AveragePrecision(pos_label=pos_label), MAX, None
     elif metric_name in [LOG_LOSS, CROSS_ENTROPY]:
-        return torchmetrics.MeanMetric(), MIN, \
-               functools.partial(F.cross_entropy, reduction="none")
+        return torchmetrics.MeanMetric(), MIN, functools.partial(F.cross_entropy, reduction="none")
     elif metric_name == PEARSONR:
         return torchmetrics.PearsonCorrCoef(), MAX, None
     elif metric_name == SPEARMANR:
         return torchmetrics.SpearmanCorrCoef(), MAX, None
     else:
-        warnings.warn(f"Currently, we cannot convert the metric: {metric_name} to a metric supported in torchmetrics. "
-                      f"Thus, we will fall-back to use accuracy for multi-class classification problems "
-                      f", ROC-AUC for binary classification problem, and MSE for regression problems.", UserWarning)
+        warnings.warn(
+            f"Currently, we cannot convert the metric: {metric_name} to a metric supported in torchmetrics. "
+            "Thus, we will fall-back to use accuracy for multi-class classification problems "
+            ", ROC-AUC for binary classification problem, and MSE for regression problems.",
+            UserWarning,
+        )
         if problem_type == REGRESSION:
             return torchmetrics.MeanSquaredError(squared=False), MIN, None
         elif problem_type == MULTICLASS:
@@ -115,17 +131,17 @@ def get_metric(
         elif problem_type == BINARY:
             return torchmetrics.AUROC(pos_label=pos_label), MAX, None
         else:
-            raise ValueError(f'The problem_type={problem_type} is currently not supported')
+            raise ValueError(f"The problem_type={problem_type} is currently not supported")
 
 
 def get_optimizer(
-        optim_type: str,
-        optimizer_grouped_parameters,
-        lr: float,
-        weight_decay: float,
-        eps: Optional[float] = 1e-6,
-        betas: Optional[Tuple[float, float]] = (0.9, 0.999),
-        momentum: Optional[float] = 0.9,
+    optim_type: str,
+    optimizer_grouped_parameters,
+    lr: float,
+    weight_decay: float,
+    eps: Optional[float] = 1e-6,
+    betas: Optional[Tuple[float, float]] = (0.9, 0.999),
+    momentum: Optional[float] = 0.9,
 ):
     """
     Choose a Pytorch optimizer based on its name.
@@ -179,11 +195,11 @@ def get_optimizer(
 
 
 def get_lr_scheduler(
-        optimizer: optim.Optimizer,
-        num_max_steps: int,
-        num_warmup_steps: int,
-        lr_schedule: str,
-        end_lr: Union[float, int],
+    optimizer: optim.Optimizer,
+    num_max_steps: int,
+    num_warmup_steps: int,
+    lr_schedule: str,
+    end_lr: Union[float, int],
 ):
     """
     Get the learning rate scheduler from its name. Here we use our defined learning rate
@@ -223,9 +239,7 @@ def get_lr_scheduler(
         )
     elif lr_schedule == "linear_decay":
         scheduler = get_linear_schedule_with_warmup(
-            optimizer=optimizer,
-            num_warmup_steps=num_warmup_steps,
-            num_training_steps=num_max_steps
+            optimizer=optimizer, num_warmup_steps=num_warmup_steps, num_training_steps=num_max_steps
         )
     else:
         raise ValueError(f"unknown lr schedule: {lr_schedule}")
@@ -247,9 +261,9 @@ def get_weight_decay_param_names(model: nn.Module):
     A list of parameter names not using weight decay.
     """
     # By default, we should not apply weight decay for all the norm layers
-    decay_param_names = get_parameter_names(model,
-                                            [nn.LayerNorm, nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d,
-                                             nn.GroupNorm])
+    decay_param_names = get_parameter_names(
+        model, [nn.LayerNorm, nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.GroupNorm]
+    )
     decay_param_names = [name for name in decay_param_names if "bias" not in name]
     return decay_param_names
 
@@ -270,16 +284,17 @@ def get_norm_layer_param_names(model: nn.Module):
     """
     all_param_names = [name for name, _ in model.named_parameters()]
     all_param_names_except_norm_names = get_parameter_names(
-        model, [nn.LayerNorm, nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.GroupNorm])
+        model, [nn.LayerNorm, nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.GroupNorm]
+    )
     norm_param_names = [name for name in all_param_names if name not in all_param_names_except_norm_names]
     return norm_param_names
 
 
 def apply_single_lr(
-        model: nn.Module,
-        lr: float,
-        weight_decay: float,
-        return_params: Optional[bool] = True,
+    model: nn.Module,
+    lr: float,
+    weight_decay: float,
+    return_params: Optional[bool] = True,
 ):
     """
     Set to use a single learning rate for all parameters. Layer normalization parameters and other
@@ -320,11 +335,11 @@ def apply_single_lr(
 
 
 def apply_two_stages_lr(
-        model: nn.Module,
-        lr: float,
-        lr_mult: Union[float, int],
-        weight_decay: float,
-        return_params: Optional[bool] = True,
+    model: nn.Module,
+    lr: float,
+    lr_mult: Union[float, int],
+    weight_decay: float,
+    return_params: Optional[bool] = True,
 ):
     """
     Set up the pretrained backbone to use a smaller learning rate (lr * lr_mult).
@@ -359,8 +374,7 @@ def apply_two_stages_lr(
             "params": [
                 p if return_params else n
                 for n, p in model.named_parameters()
-                if n in decay_param_names
-                   and not any(bb in n for bb in model.head_layer_names)
+                if n in decay_param_names and not any(bb in n for bb in model.head_layer_names)
             ],
             "weight_decay": weight_decay,
             "lr": lr,
@@ -369,8 +383,7 @@ def apply_two_stages_lr(
             "params": [
                 p if return_params else n
                 for n, p in model.named_parameters()
-                if n not in decay_param_names
-                   and not any(bb in n for bb in model.head_layer_names)
+                if n not in decay_param_names and not any(bb in n for bb in model.head_layer_names)
             ],
             "weight_decay": 0.0,
             "lr": lr,
@@ -379,8 +392,7 @@ def apply_two_stages_lr(
             "params": [
                 p if return_params else n
                 for n, p in model.named_parameters()
-                if n in decay_param_names
-                   and any(bb in n for bb in model.head_layer_names)
+                if n in decay_param_names and any(bb in n for bb in model.head_layer_names)
             ],
             "weight_decay": weight_decay,
             "lr": lr * lr_mult,
@@ -389,8 +401,7 @@ def apply_two_stages_lr(
             "params": [
                 p if return_params else n
                 for n, p in model.named_parameters()
-                if n not in decay_param_names
-                   and any(bb in n for bb in model.head_layer_names)
+                if n not in decay_param_names and any(bb in n for bb in model.head_layer_names)
             ],
             "weight_decay": 0.0,
             "lr": lr * lr_mult,
@@ -401,11 +412,11 @@ def apply_two_stages_lr(
 
 
 def apply_layerwise_lr_decay(
-        model: nn.Module,
-        lr: float,
-        lr_decay: float,
-        weight_decay: float,
-        efficient_finetune: Optional[str] = None,
+    model: nn.Module,
+    lr: float,
+    lr_decay: float,
+    weight_decay: float,
+    efficient_finetune: Optional[str] = None,
 ):
     """
     Assign monotonically decreasing learning rates for layers from the output end to the input end.
@@ -439,11 +450,11 @@ def apply_layerwise_lr_decay(
     for name, param in model.named_parameters():
         if efficient_finetune == BIT_FIT:
             # For bit_fit, we disable tuning everything except the bias terms
-            if 'bias' not in name:
+            if "bias" not in name:
                 param.requires_grad = False
         elif efficient_finetune == NORM_FIT:
             # For norm-fit, we finetune all the normalization layers and bias layers
-            if name not in norm_param_names and 'bias' not in name:
+            if name not in norm_param_names and "bias" not in name:
                 param.requires_grad = False
 
         if not param.requires_grad:
@@ -454,24 +465,16 @@ def apply_layerwise_lr_decay(
             this_weight_decay = weight_decay
         else:
             group_name = "no_decay"
-            this_weight_decay = 0.
+            this_weight_decay = 0.0
 
         layer_id = model.name_to_id[name]
         group_name = "layer_%d_%s" % (layer_id, group_name)
 
         if group_name not in parameter_group_names:
-            scale = lr_decay ** layer_id
+            scale = lr_decay**layer_id
 
-            parameter_group_names[group_name] = {
-                "weight_decay": this_weight_decay,
-                "params": [],
-                "lr": scale * lr
-            }
-            parameter_group_vars[group_name] = {
-                "weight_decay": this_weight_decay,
-                "params": [],
-                "lr": scale * lr
-            }
+            parameter_group_names[group_name] = {"weight_decay": this_weight_decay, "params": [], "lr": scale * lr}
+            parameter_group_vars[group_name] = {"weight_decay": this_weight_decay, "params": [], "lr": scale * lr}
 
         parameter_group_vars[group_name]["params"].append(param)
         parameter_group_names[group_name]["params"].append(name)

--- a/text/src/autogluon/text/automm/predictor.py
+++ b/text/src/autogluon/text/automm/predictor.py
@@ -28,10 +28,23 @@ from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.common.utils.utils import setup_outputdir
 
 from .constants import (
-    LABEL, BINARY, MULTICLASS, REGRESSION, Y_PRED,
-    Y_PRED_PROB, Y_TRUE, LOGITS, FEATURES, AUTOMM,
-    AUTOMM_TUTORIAL_MODE, UNIFORM_SOUP, GREEDY_SOUP,
-    BEST, MIN, MAX, TEXT,
+    LABEL,
+    BINARY,
+    MULTICLASS,
+    REGRESSION,
+    Y_PRED,
+    Y_PRED_PROB,
+    Y_TRUE,
+    LOGITS,
+    FEATURES,
+    AUTOMM,
+    AUTOMM_TUTORIAL_MODE,
+    UNIFORM_SOUP,
+    GREEDY_SOUP,
+    BEST,
+    MIN,
+    MAX,
+    TEXT,
 )
 
 from .data.datamodule import BaseDataModule
@@ -85,12 +98,11 @@ class AutoMMModelCheckpoint(pl.callbacks.ModelCheckpoint):
     """
 
     def _update_best_and_save(
-            self, current: torch.Tensor, trainer: "pl.Trainer",
-            monitor_candidates: Dict[str, _METRIC]
+        self, current: torch.Tensor, trainer: "pl.Trainer", monitor_candidates: Dict[str, _METRIC]
     ) -> None:
-        super(AutoMMModelCheckpoint, self)._update_best_and_save(current=current,
-                                                                 trainer=trainer,
-                                                                 monitor_candidates=monitor_candidates)
+        super(AutoMMModelCheckpoint, self)._update_best_and_save(
+            current=current, trainer=trainer, monitor_candidates=monitor_candidates
+        )
         self.to_yaml()
 
 
@@ -102,14 +114,14 @@ class AutoMMPredictor:
     """
 
     def __init__(
-            self,
-            label: str,
-            problem_type: Optional[str] = None,
-            eval_metric: Optional[str] = None,
-            path: Optional[str] = None,
-            verbosity: Optional[int] = 3,
-            warn_if_exist: Optional[bool] = True,
-            enable_progress_bar: Optional[bool] = None,
+        self,
+        label: str,
+        problem_type: Optional[str] = None,
+        eval_metric: Optional[str] = None,
+        path: Optional[str] = None,
+        verbosity: Optional[int] = 3,
+        warn_if_exist: Optional[bool] = True,
+        enable_progress_bar: Optional[bool] = None,
     ):
         """
         Parameters
@@ -191,17 +203,17 @@ class AutoMMPredictor:
         set_logger_verbosity(verbosity, logger=logger)
 
     def fit(
-            self,
-            train_data: pd.DataFrame,
-            config: Optional[dict] = None,
-            tuning_data: Optional[pd.DataFrame] = None,
-            time_limit: Optional[int] = None,
-            save_path: Optional[str] = None,
-            hyperparameters: Optional[Union[str, Dict, List[str]]] = None,
-            column_types: Optional[dict] = None,
-            holdout_frac: Optional[float] = None,
-            teacher_predictor: Union[str, AutoMMPredictor] = None,
-            seed: Optional[int] = 123,
+        self,
+        train_data: pd.DataFrame,
+        config: Optional[dict] = None,
+        tuning_data: Optional[pd.DataFrame] = None,
+        time_limit: Optional[int] = None,
+        save_path: Optional[str] = None,
+        hyperparameters: Optional[Union[str, Dict, List[str]]] = None,
+        column_types: Optional[dict] = None,
+        holdout_frac: Optional[float] = None,
+        teacher_predictor: Union[str, AutoMMPredictor] = None,
+        seed: Optional[int] = 123,
     ):
         """
         Fit AutoMMPredictor predict label column of a dataframe based on the other columns,
@@ -325,14 +337,13 @@ class AutoMMPredictor:
                 random_state=np.random.RandomState(seed),
             )
 
-        column_types, problem_type, output_shape = \
-            infer_column_problem_types(
-                train_df=train_data,
-                valid_df=tuning_data,
-                label_columns=self._label_column,
-                problem_type=self._problem_type,
-                provided_column_types=column_types,
-            )
+        column_types, problem_type, output_shape = infer_column_problem_types(
+            train_df=train_data,
+            valid_df=tuning_data,
+            label_columns=self._label_column,
+            problem_type=self._problem_type,
+            provided_column_types=column_types,
+        )
 
         logger.debug(f"column_types: {column_types}")
         logger.debug(f"image columns: {[k for k, v in column_types.items() if v == 'image_path']}")
@@ -341,20 +352,20 @@ class AutoMMPredictor:
             warnings.warn(
                 f"Inferred column types {column_types} are inconsistent with "
                 f"the previous {self._column_types}. "
-                f"New columns will not be used in the current training."
+                "New columns will not be used in the current training."
             )
             # use previous column types to avoid inconsistency with previous numerical mlp and categorical mlp
             column_types = self._column_types
 
         if self._problem_type is not None:
-            assert self._problem_type == problem_type, \
-                f"Inferred problem type {problem_type} is different from " \
-                f"the previous {self._problem_type}"
+            assert (
+                self._problem_type == problem_type
+            ), f"Inferred problem type {problem_type} is different from the previous {self._problem_type}"
 
         if self._output_shape is not None:
-            assert self._output_shape == output_shape, \
-                f"Inferred output shape {output_shape} is different from " \
-                f"the previous {self._output_shape}"
+            assert (
+                self._output_shape == output_shape
+            ), f"Inferred output shape {output_shape} is different from the previous {self._output_shape}"
 
         if self._df_preprocessor is None:
             df_preprocessor = init_df_preprocessor(
@@ -388,7 +399,7 @@ class AutoMMPredictor:
                 config=config,
                 num_classes=output_shape,
                 num_numerical_columns=len(df_preprocessor.numerical_feature_names),
-                num_categories=df_preprocessor.categorical_num_categories
+                num_categories=df_preprocessor.categorical_num_categories,
             )
         else:  # continuing training
             model = self._model
@@ -414,14 +425,16 @@ class AutoMMPredictor:
             pos_label=pos_label,
         )
 
-        mixup_active, mixup_fn = get_mixup(model_config=OmegaConf.select(config,'model'),
-                                     mixup_config=OmegaConf.select(config,'data.mixup'),
-                                     num_classes=output_shape,
+        mixup_active, mixup_fn = get_mixup(
+            model_config=OmegaConf.select(config, "model"),
+            mixup_config=OmegaConf.select(config, "data.mixup"),
+            num_classes=output_shape,
         )
         if mixup_active and (config.env.per_gpu_batch_size == 1 or config.env.per_gpu_batch_size % 2 == 1):
-            warnings.warn("The mixup is done on the batch."
-                          "The per_gpu_batch_size should be >1 and even for reasonable operation",
-                          UserWarning)
+            warnings.warn(
+                "The mixup is done on the batch.The per_gpu_batch_size should be >1 and even for reasonable operation",
+                UserWarning,
+            )
 
         loss_func = get_loss_func(problem_type, mixup_active)
 
@@ -458,14 +471,25 @@ class AutoMMPredictor:
 
         # need to assign the above attributes before setting up distillation
         if teacher_predictor is not None:
-            teacher_model, critics, baseline_funcs, soft_label_loss_func, \
-                teacher_df_preprocessor, teacher_data_processors = \
-                self._setup_distillation(
-                    teacher_predictor=teacher_predictor,
-                )
+            (
+                teacher_model,
+                critics,
+                baseline_funcs,
+                soft_label_loss_func,
+                teacher_df_preprocessor,
+                teacher_data_processors,
+            ) = self._setup_distillation(
+                teacher_predictor=teacher_predictor,
+            )
         else:
-            teacher_model, critics, baseline_funcs, soft_label_loss_func,\
-                teacher_df_preprocessor, teacher_data_processors = None, None, None, None, None, None
+            (
+                teacher_model,
+                critics,
+                baseline_funcs,
+                soft_label_loss_func,
+                teacher_df_preprocessor,
+                teacher_data_processors,
+            ) = (None, None, None, None, None, None)
 
         self._fit(
             train_df=train_data,
@@ -495,8 +519,8 @@ class AutoMMPredictor:
         return self
 
     def _setup_distillation(
-            self,
-            teacher_predictor: Union[str, AutoMMPredictor],
+        self,
+        teacher_predictor: Union[str, AutoMMPredictor],
     ):
         """
         Prepare for distillation. It verifies whether the student and teacher predictors have consistent
@@ -547,9 +571,7 @@ class AutoMMPredictor:
         elif self._config.distiller.soft_label_loss_type == "cross_entropy":
             soft_label_loss_func = nn.CrossEntropyLoss()
         else:
-            raise ValueError(
-                f"Unknown soft_label_loss_type: {self._config.distiller.soft_label_loss_type}"
-            )
+            raise ValueError(f"Unknown soft_label_loss_type: {self._config.distiller.soft_label_loss_type}")
 
         # turn on returning column information in data processors
         self._data_processors = turn_on_off_feature_column_info(
@@ -564,28 +586,22 @@ class AutoMMPredictor:
         logger.debug(
             f"teacher preprocessor text_feature_names: {teacher_predictor._df_preprocessor._text_feature_names}"
         )
+        logger.debug(f"teacher preprocessor image_path_names: {teacher_predictor._df_preprocessor._image_path_names}")
         logger.debug(
-            f"teacher preprocessor image_path_names: {teacher_predictor._df_preprocessor._image_path_names}"
+            "teacher preprocessor categorical_feature_names:"
+            f" {teacher_predictor._df_preprocessor._categorical_feature_names}"
         )
         logger.debug(
-            f"teacher preprocessor categorical_feature_names: {teacher_predictor._df_preprocessor._categorical_feature_names}"
-        )
-        logger.debug(
-            f"teacher preprocessor numerical_feature_names: {teacher_predictor._df_preprocessor._numerical_feature_names}"
+            "teacher preprocessor numerical_feature_names:"
+            f" {teacher_predictor._df_preprocessor._numerical_feature_names}"
         )
 
-        logger.debug(
-            f"student preprocessor text_feature_names: {self._df_preprocessor._text_feature_names}"
-        )
-        logger.debug(
-            f"student preprocessor image_path_names: {self._df_preprocessor._image_path_names}"
-        )
+        logger.debug(f"student preprocessor text_feature_names: {self._df_preprocessor._text_feature_names}")
+        logger.debug(f"student preprocessor image_path_names: {self._df_preprocessor._image_path_names}")
         logger.debug(
             f"student preprocessor categorical_feature_names: {self._df_preprocessor._categorical_feature_names}"
         )
-        logger.debug(
-            f"student preprocessor numerical_feature_names: {self._df_preprocessor._numerical_feature_names}"
-        )
+        logger.debug(f"student preprocessor numerical_feature_names: {self._df_preprocessor._numerical_feature_names}")
 
         return (
             teacher_predictor._model,
@@ -597,30 +613,30 @@ class AutoMMPredictor:
         )
 
     def _fit(
-            self,
-            train_df: pd.DataFrame,
-            val_df: pd.DataFrame,
-            df_preprocessor: MultiModalFeaturePreprocessor,
-            data_processors: dict,
-            model: nn.Module,
-            config: DictConfig,
-            loss_func: _Loss,
-            validation_metric: torchmetrics.Metric,
-            validation_metric_name: str,
-            custom_metric_func: Callable,
-            minmax_mode: str,
-            teacher_model: nn.Module,
-            critics: nn.ModuleList,
-            baseline_funcs: nn.ModuleList,
-            soft_label_loss_func: _Loss,
-            teacher_df_preprocessor: MultiModalFeaturePreprocessor,
-            teacher_data_processors: dict,
-            max_time: timedelta,
-            save_path: str,
-            ckpt_path: str,
-            resume: bool,
-            enable_progress_bar: bool,
-            mixup_fn: MixupModule,
+        self,
+        train_df: pd.DataFrame,
+        val_df: pd.DataFrame,
+        df_preprocessor: MultiModalFeaturePreprocessor,
+        data_processors: dict,
+        model: nn.Module,
+        config: DictConfig,
+        loss_func: _Loss,
+        validation_metric: torchmetrics.Metric,
+        validation_metric_name: str,
+        custom_metric_func: Callable,
+        minmax_mode: str,
+        teacher_model: nn.Module,
+        critics: nn.ModuleList,
+        baseline_funcs: nn.ModuleList,
+        soft_label_loss_func: _Loss,
+        teacher_df_preprocessor: MultiModalFeaturePreprocessor,
+        teacher_data_processors: dict,
+        max_time: timedelta,
+        save_path: str,
+        ckpt_path: str,
+        resume: bool,
+        enable_progress_bar: bool,
+        mixup_fn: MixupModule,
     ):
         if teacher_df_preprocessor is not None:
             df_preprocessor = [df_preprocessor, teacher_df_preprocessor]
@@ -671,9 +687,9 @@ class AutoMMPredictor:
             task = LitModule(
                 model=model,
                 loss_func=loss_func,
-                efficient_finetune=OmegaConf.select(config, 'optimization.efficient_finetune'),
+                efficient_finetune=OmegaConf.select(config, "optimization.efficient_finetune"),
                 mixup_fn=mixup_fn,
-                mixup_off_epoch=OmegaConf.select(config, 'data.mixup.mixup_off_epoch'),
+                mixup_off_epoch=OmegaConf.select(config, "data.mixup.mixup_off_epoch"),
                 **metrics_kwargs,
                 **optimization_kwargs,
             )
@@ -690,9 +706,7 @@ class AutoMMPredictor:
             save_last=True,
         )
         early_stopping_callback = pl.callbacks.EarlyStopping(
-            monitor=task.validation_metric_name,
-            patience=config.optimization.patience,
-            mode=minmax_mode
+            monitor=task.validation_metric_name, patience=config.optimization.patience, mode=minmax_mode
         )
         lr_callback = pl.callbacks.LearningRateMonitor(logging_interval="step")
         model_summary = pl.callbacks.ModelSummary(max_depth=1)
@@ -704,11 +718,7 @@ class AutoMMPredictor:
             version="",
         )
 
-        num_gpus = (
-            config.env.num_gpus
-            if isinstance(config.env.num_gpus, int)
-            else len(config.env.num_gpus)
-        )
+        num_gpus = config.env.num_gpus if isinstance(config.env.num_gpus, int) else len(config.env.num_gpus)
         if num_gpus < 0:  # In case config.env.num_gpus is -1, meaning using all gpus.
             num_gpus = torch.cuda.device_count()
 
@@ -720,22 +730,23 @@ class AutoMMPredictor:
                 "Consider to switch to an instance with GPU support.",
                 UserWarning,
             )
-            grad_steps = max(config.env.batch_size // (
-                    config.env.per_gpu_batch_size * config.env.num_nodes
-            ), 1)
+            grad_steps = max(config.env.batch_size // (config.env.per_gpu_batch_size * config.env.num_nodes), 1)
             precision = 32  # Force to use fp32 for training since fp16-based AMP is not available in CPU.
-                            # Try to check the status of bf16 training later.
+            # Try to check the status of bf16 training later.
         else:
-            grad_steps = max(config.env.batch_size // (
-                    config.env.per_gpu_batch_size * num_gpus * config.env.num_nodes
-            ), 1)
+            grad_steps = max(
+                config.env.batch_size // (config.env.per_gpu_batch_size * num_gpus * config.env.num_nodes), 1
+            )
             precision = config.env.precision
 
-            if precision == 'bf16' and not torch.cuda.is_bf16_supported():
-                warnings.warn('bf16 is not supported by the GPU device / cuda version. '
-                              'Consider to use GPU devices with version after Amphere (e.g., available as AWS P4 instances) '
-                              'and upgrade cuda to be >=11.0. '
-                              'Currently, AutoGluon will downgrade the precision to 32.', UserWarning)
+            if precision == "bf16" and not torch.cuda.is_bf16_supported():
+                warnings.warn(
+                    "bf16 is not supported by the GPU device / cuda version. "
+                    "Consider to use GPU devices with version after Amphere (e.g., available as AWS P4 instances) "
+                    "and upgrade cuda to be >=11.0. "
+                    "Currently, AutoGluon will downgrade the precision to 32.",
+                    UserWarning,
+                )
                 precision = 32
 
         if num_gpus <= 1:
@@ -773,12 +784,9 @@ class AutoMMPredictor:
                 "ignore",
                 ".*does not have many workers which may be a bottleneck. "
                 "Consider increasing the value of the `num_workers` argument` "
-                ".* in the `DataLoader` init to improve performance.*"
+                ".* in the `DataLoader` init to improve performance.*",
             )
-            warnings.filterwarnings(
-                "ignore",
-                "Checkpoint directory .* exists and is not empty."
-            )
+            warnings.filterwarnings("ignore", "Checkpoint directory .* exists and is not empty.")
             trainer.fit(
                 task,
                 datamodule=train_dm,
@@ -796,19 +804,17 @@ class AutoMMPredictor:
                 validation_metric_name=validation_metric_name,
             )
         else:
-            sys.exit(
-                f"Training finished, exit the process with global_rank={trainer.global_rank}..."
-            )
+            sys.exit(f"Training finished, exit the process with global_rank={trainer.global_rank}...")
 
     def _top_k_average(
-            self,
-            model,
-            save_path,
-            minmax_mode,
-            is_distill,
-            config,
-            val_df,
-            validation_metric_name,
+        self,
+        model,
+        save_path,
+        minmax_mode,
+        is_distill,
+        config,
+        val_df,
+        validation_metric_name,
     ):
         best_k_models_yaml_path = os.path.join(save_path, "best_k_models.yaml")
         if os.path.exists(best_k_models_yaml_path):
@@ -827,13 +833,12 @@ class AutoMMPredictor:
 
         if best_k_models:
             if config.optimization.top_k_average_method == UNIFORM_SOUP:
-                logger.info(
-                    f"Start to fuse {len(best_k_models)} checkpoints via the uniform soup algorithm."
-                )
+                logger.info(f"Start to fuse {len(best_k_models)} checkpoints via the uniform soup algorithm.")
                 ingredients = top_k_model_paths = list(best_k_models.keys())
             else:
                 top_k_model_paths = [
-                    v[0] for v in sorted(
+                    v[0]
+                    for v in sorted(
                         list(best_k_models.items()),
                         key=lambda ele: ele[1],
                         reverse=(minmax_mode == MAX),
@@ -845,9 +850,7 @@ class AutoMMPredictor:
                     #  increasing inference time", https://arxiv.org/pdf/2203.05482.pdf
                     monitor_op = {MIN: operator.le, MAX: operator.ge}[minmax_mode]
 
-                    logger.info(
-                        f"Start to fuse {len(top_k_model_paths)} checkpoints via the greedy soup algorithm."
-                    )
+                    logger.info(f"Start to fuse {len(top_k_model_paths)} checkpoints via the greedy soup algorithm.")
 
                     ingredients = [top_k_model_paths[0]]
                     self._model = self._load_state_dict(
@@ -874,7 +877,7 @@ class AutoMMPredictor:
                     ingredients = [top_k_model_paths[0]]
                 else:
                     raise ValueError(
-                        f"The key for 'optimization.top_k_average_method' is not supported. "
+                        "The key for 'optimization.top_k_average_method' is not supported. "
                         f"We only support '{GREEDY_SOUP}', '{UNIFORM_SOUP}' and '{BEST}'. "
                         f"The provided value is '{config.optimization.top_k_average_method}'."
                     )
@@ -918,10 +921,10 @@ class AutoMMPredictor:
             os.remove(last_ckpt_path)
 
     def _predict(
-            self,
-            data: Union[pd.DataFrame, dict, list],
-            ret_type: str,
-            requires_label: bool,
+        self,
+        data: Union[pd.DataFrame, dict, list],
+        ret_type: str,
+        requires_label: bool,
     ) -> torch.Tensor:
 
         data = self._data_to_df(data)
@@ -934,9 +937,7 @@ class AutoMMPredictor:
             data_processors = self._data_processors
 
         num_gpus = (
-            self._config.env.num_gpus
-            if isinstance(self._config.env.num_gpus, int)
-            else len(self._config.env.num_gpus)
+            self._config.env.num_gpus if isinstance(self._config.env.num_gpus, int) else len(self._config.env.num_gpus)
         )
         if num_gpus < 0:
             num_gpus = torch.cuda.device_count()
@@ -952,17 +953,20 @@ class AutoMMPredictor:
             precision = 32  # Force to use fp32 for training since fp16-based AMP is not available in CPU
         else:
             precision = self._config.env.precision
-            if precision == 'bf16' and not torch.cuda.is_bf16_supported():
-                warnings.warn('bf16 is not supported by the GPU device / cuda version. '
-                              'Consider to use GPU devices with version after Amphere or upgrade cuda to be >=11.0. '
-                              'Currently, AutoGluon will downgrade the precision to 32.', UserWarning)
+            if precision == "bf16" and not torch.cuda.is_bf16_supported():
+                warnings.warn(
+                    "bf16 is not supported by the GPU device / cuda version. "
+                    "Consider to use GPU devices with version after Amphere or upgrade cuda to be >=11.0. "
+                    "Currently, AutoGluon will downgrade the precision to 32.",
+                    UserWarning,
+                )
                 precision = 32
 
         if self._config.env.per_gpu_batch_size_evaluation:
             batch_size = self._config.env.per_gpu_batch_size_evaluation
         else:
             batch_size = self._config.env.per_gpu_batch_size * self._config.env.eval_batch_size_ratio
-            
+
         if num_gpus > 1:
             strategy = "dp"
             # If using 'dp', the per_gpu_batch_size would be split by all GPUs.
@@ -1008,7 +1012,7 @@ class AutoMMPredictor:
                     "ignore",
                     ".*does not have many workers which may be a bottleneck. "
                     "Consider increasing the value of the `num_workers` argument` "
-                    ".* in the `DataLoader` init to improve performance.*"
+                    ".* in the `DataLoader` init to improve performance.*",
                 )
                 outputs = evaluator.predict(
                     task,
@@ -1033,10 +1037,10 @@ class AutoMMPredictor:
         return prob
 
     def evaluate(
-            self,
-            data: Union[pd.DataFrame, dict, list],
-            metrics: Optional[List[str]] = None,
-            return_pred: Optional[bool] = False,
+        self,
+        data: Union[pd.DataFrame, dict, list],
+        metrics: Optional[List[str]] = None,
+        return_pred: Optional[bool] = False,
     ):
         """
         Evaluate model on a test dataset.
@@ -1070,10 +1074,12 @@ class AutoMMPredictor:
         y_pred_transformed = self._df_preprocessor.transform_prediction(y_pred=logits, inverse_categorical=True)
         y_true = self._df_preprocessor.transform_label_for_metric(df=data)
 
-        metric_data.update({
-            Y_PRED: y_pred,
-            Y_TRUE: y_true,
-        })
+        metric_data.update(
+            {
+                Y_PRED: y_pred,
+                Y_TRUE: y_true,
+            }
+        )
 
         if metrics is None:
             metrics = [self._eval_metric_name]
@@ -1081,9 +1087,7 @@ class AutoMMPredictor:
         results = {}
         for per_metric in metrics:
             if self._problem_type != BINARY and per_metric.lower() in ["roc_auc", "average_precision"]:
-                raise ValueError(
-                    f"Metric {per_metric} is only supported for binary classification."
-                )
+                raise ValueError(f"Metric {per_metric} is only supported for binary classification.")
             pos_label = try_to_infer_pos_label(
                 data_config=self._config.data,
                 label_encoder=self._df_preprocessor.label_generator,
@@ -1102,9 +1106,9 @@ class AutoMMPredictor:
             return results
 
     def predict(
-            self,
-            data: Union[pd.DataFrame, dict, list],
-            as_pandas: Optional[bool] = True,
+        self,
+        data: Union[pd.DataFrame, dict, list],
+        as_pandas: Optional[bool] = True,
     ):
         """
         Predict values for the label column of new data.
@@ -1133,10 +1137,10 @@ class AutoMMPredictor:
         return pred
 
     def predict_proba(
-            self,
-            data: Union[pd.DataFrame, dict, list],
-            as_pandas: Optional[bool] = True,
-            as_multiclass: Optional[bool] = True,
+        self,
+        data: Union[pd.DataFrame, dict, list],
+        as_pandas: Optional[bool] = True,
+        as_multiclass: Optional[bool] = True,
     ):
         """
         Predict probabilities class probabilities rather than class labels.
@@ -1159,8 +1163,7 @@ class AutoMMPredictor:
         When as_multiclass is True, the output will always have shape (#samples, #classes).
         Otherwise, the output will have shape (#samples,)
         """
-        assert self._problem_type in [BINARY, MULTICLASS], \
-            f"Problem {self._problem_type} has no probability output."
+        assert self._problem_type in [BINARY, MULTICLASS], f"Problem {self._problem_type} has no probability output."
 
         logits = self._predict(
             data=data,
@@ -1177,9 +1180,9 @@ class AutoMMPredictor:
         return prob
 
     def extract_embedding(
-            self,
-            data: Union[pd.DataFrame, dict, list],
-            as_pandas: Optional[bool] = False,
+        self,
+        data: Union[pd.DataFrame, dict, list],
+        as_pandas: Optional[bool] = False,
     ):
         """
         Extract features for each sample, i.e., one row in the provided dataframe `data`.
@@ -1218,15 +1221,15 @@ class AutoMMPredictor:
             data = load_pd.load(data)
         else:
             raise NotImplementedError(
-                f'The format of data is not understood. '
+                "The format of data is not understood. "
                 f'We have type(data)="{type(data)}", but a pd.DataFrame was required.'
             )
         return data
 
     def as_pandas(
-            self,
-            data: Union[pd.DataFrame, dict, list],
-            to_be_converted: np.ndarray,
+        self,
+        data: Union[pd.DataFrame, dict, list],
+        to_be_converted: np.ndarray,
     ):
         if isinstance(data, pd.DataFrame):
             index = data.index
@@ -1238,12 +1241,7 @@ class AutoMMPredictor:
             return pd.DataFrame(to_be_converted, index=index, columns=self.class_labels)
 
     @staticmethod
-    def _load_state_dict(
-            model: nn.Module,
-            state_dict: dict = None,
-            path: str = None,
-            prefix: str = "model."
-    ):
+    def _load_state_dict(model: nn.Module, state_dict: dict = None, path: str = None, prefix: str = "model."):
         if state_dict is None:
             state_dict = torch.load(path, map_location=torch.device("cpu"))["state_dict"]
         state_dict = {k.partition(prefix)[2]: v for k, v in state_dict.items() if k.startswith(prefix)}
@@ -1252,9 +1250,9 @@ class AutoMMPredictor:
 
     @staticmethod
     def _replace_model_name_prefix(
-            state_dict: dict,
-            old_prefix: str,
-            new_prefix: str,
+        state_dict: dict,
+        old_prefix: str,
+        new_prefix: str,
     ):
         start_idx = len(old_prefix)
         state_dict_processed = {
@@ -1262,11 +1260,7 @@ class AutoMMPredictor:
         }
         return state_dict_processed
 
-    def save(
-            self, 
-            path: str,
-            standalone: Optional[bool] = False
-    ):
+    def save(self, path: str, standalone: Optional[bool] = False):
         """
         Save this predictor to file in directory specified by `path`.
 
@@ -1275,24 +1269,17 @@ class AutoMMPredictor:
         path
             The directory to save this predictor.
         standalone
-            Whether to save the downloaded model for offline deployment. 
+            Whether to save the downloaded model for offline deployment.
             When standalone = True, save the transformers.CLIPModel and transformers.AutoModel to os.path.join(path,model_name),
-            and reset the associate model.model_name.checkpoint_name start with `local://` in config.yaml. 
+            and reset the associate model.model_name.checkpoint_name start with `local://` in config.yaml.
             When standalone = False, does not save the model, and requires online environment to download in load().
         """
 
         if standalone:
-            self._config = save_pretrained_models(
-                model=self._model,
-                config=self._config, 
-                path=path
-            )
+            self._config = save_pretrained_models(model=self._model, config=self._config, path=path)
 
         os.makedirs(path, exist_ok=True)
-        OmegaConf.save(
-            config=self._config,
-            f=os.path.join(path, 'config.yaml')
-        )
+        OmegaConf.save(config=self._config, f=os.path.join(path, "config.yaml"))
 
         with open(os.path.join(path, "df_preprocessor.pkl"), "wb") as fp:
             pickle.dump(self._df_preprocessor, fp)
@@ -1330,9 +1317,9 @@ class AutoMMPredictor:
 
     @staticmethod
     def load(
-            path: str,
-            resume: Optional[bool] = False,
-            verbosity: Optional[int] = 3,
+        path: str,
+        resume: Optional[bool] = False,
+        verbosity: Optional[int] = 3,
     ):
         """
         Load a predictor object from a directory specified by `path`. The to-be-loaded predictor
@@ -1359,7 +1346,9 @@ class AutoMMPredictor:
         assert os.path.isdir(path), f"'{path}' must be an existing directory."
         config = OmegaConf.load(os.path.join(path, "config.yaml"))
 
-        config = convert_checkpoint_name(config=config, path=path) # check the config for loading offline pretrained models
+        config = convert_checkpoint_name(
+            config=config, path=path
+        )  # check the config for loading offline pretrained models
 
         with open(os.path.join(path, "assets.json"), "r") as fp:
             assets = json.load(fp)
@@ -1422,13 +1411,13 @@ class AutoMMPredictor:
                     raise ValueError(
                         f"Resuming checkpoint '{resume_ckpt_path}' doesn't exist, but "
                         f"final checkpoint '{final_ckpt_path}' exists, which means training "
-                        f"is already completed."
+                        "is already completed."
                     )
                 else:
                     raise ValueError(
                         f"Resuming checkpoint '{resume_ckpt_path}' and "
                         f"final checkpoint '{final_ckpt_path}' both don't exist. "
-                        f"Consider starting training from scratch."
+                        "Consider starting training from scratch."
                     )
             load_path = resume_ckpt_path
             logger.info(f"Resume training from checkpoint: '{resume_ckpt_path}'")
@@ -1445,7 +1434,7 @@ class AutoMMPredictor:
                     raise ValueError(
                         f"Resuming checkpoint '{resume_ckpt_path}' and "
                         f"final checkpoint '{final_ckpt_path}' both don't exist. "
-                        f"Consider starting training from scratch."
+                        "Consider starting training from scratch."
                     )
             load_path = final_ckpt_path
             logger.info(f"Load pretrained checkpoint: {os.path.join(path, 'model.ckpt')}")
@@ -1477,7 +1466,7 @@ class AutoMMPredictor:
         if self._problem_type == MULTICLASS or self._problem_type == BINARY:
             return self._df_preprocessor.label_generator.classes_
         else:
-            warnings.warn('Accessing class names for a non-classification problem. Return None.')
+            warnings.warn("Accessing class names for a non-classification problem. Return None.")
             return None
 
     @property
@@ -1498,10 +1487,11 @@ class AutoMMPredictor:
         """
         if self.problem_type != BINARY:
             logger.warning(
-                f"Warning: Attempted to retrieve positive class label in a non-binary problem. "
-                f"Positive class labels only exist in binary classification. "
+                "Warning: Attempted to retrieve positive class label in a non-binary problem. "
+                "Positive class labels only exist in binary classification. "
                 f"Returning None instead. self.problem_type is '{self.problem_type}'"
-                f" but positive_class only exists for '{BINARY}'.")
+                f" but positive_class only exists for '{BINARY}'."
+            )
             return None
         else:
             return self.class_labels[1]

--- a/text/src/autogluon/text/automm/presets.py
+++ b/text/src/autogluon/text/automm/presets.py
@@ -52,8 +52,7 @@ def get_preset(model_preset: str):
     model_config_path = os.path.join(model_config_dir, f"{model_preset}.yaml")
     if not os.path.isfile(model_config_path):
         raise ValueError(
-            f"Model preset '{model_preset}' is not supported yet. "
-            f"Consider one of these: {list_model_presets()}"
+            f"Model preset '{model_preset}' is not supported yet. Consider one of these: {list_model_presets()}"
         )
 
     return preset

--- a/text/src/autogluon/text/automm/utils.py
+++ b/text/src/autogluon/text/automm/utils.py
@@ -38,14 +38,36 @@ from .data import (
     MixupModule,
 )
 from .constants import (
-    ACCURACY, RMSE, R2, PEARSONR, SPEARMANR, ALL_MODALITIES,
-    IMAGE, TEXT, CATEGORICAL, NUMERICAL,
-    LABEL, MULTICLASS, BINARY, REGRESSION,
-    Y_PRED_PROB, Y_PRED, Y_TRUE, AUTOMM,
-    CLIP, TIMM_IMAGE, HF_TEXT, NUMERICAL_MLP,
-    CATEGORICAL_MLP, FUSION_MLP, NUMERICAL_TRANSFORMER,
-    CATEGORICAL_TRANSFORMER, FUSION_TRANSFORMER,
-    ROC_AUC, AVERAGE_PRECISION, LOG_LOSS,
+    ACCURACY,
+    RMSE,
+    R2,
+    PEARSONR,
+    SPEARMANR,
+    ALL_MODALITIES,
+    IMAGE,
+    TEXT,
+    CATEGORICAL,
+    NUMERICAL,
+    LABEL,
+    MULTICLASS,
+    BINARY,
+    REGRESSION,
+    Y_PRED_PROB,
+    Y_PRED,
+    Y_TRUE,
+    AUTOMM,
+    CLIP,
+    TIMM_IMAGE,
+    HF_TEXT,
+    NUMERICAL_MLP,
+    CATEGORICAL_MLP,
+    FUSION_MLP,
+    NUMERICAL_TRANSFORMER,
+    CATEGORICAL_TRANSFORMER,
+    FUSION_TRANSFORMER,
+    ROC_AUC,
+    AVERAGE_PRECISION,
+    LOG_LOSS,
 )
 from .presets import (
     list_model_presets,
@@ -56,8 +78,8 @@ logger = logging.getLogger(AUTOMM)
 
 
 def infer_metrics(
-        problem_type: Optional[str] = None,
-        eval_metric_name: Optional[str] = None,
+    problem_type: Optional[str] = None,
+    eval_metric_name: Optional[str] = None,
 ):
     """
     Infer the validation metric and the evaluation metric if not provided.
@@ -96,9 +118,7 @@ def infer_metrics(
     elif problem_type == REGRESSION:
         eval_metric_name = RMSE
     else:
-        raise NotImplementedError(
-            f"Problem type: {problem_type} is not supported yet!"
-        )
+        raise NotImplementedError(f"Problem type: {problem_type} is not supported yet!")
 
     validation_metric_name = eval_metric_name
 
@@ -106,8 +126,8 @@ def infer_metrics(
 
 
 def get_config(
-        config: Union[dict, DictConfig],
-        overrides: Optional[Union[str, List[str], Dict]] = None,
+    config: Union[dict, DictConfig],
+    overrides: Optional[Union[str, List[str], Dict]] = None,
 ):
     """
     Construct configurations for model, data, optimization, and environment.
@@ -166,10 +186,12 @@ def get_config(
         config = get_preset(list_model_presets()[0])
     if not isinstance(config, DictConfig):
         all_configs = []
-        for k, default_value in [('model', 'fusion_mlp_image_text_tabular'),
-                                 ('data', 'default'),
-                                 ('optimization', 'adamw'),
-                                 ('environment', 'default')]:
+        for k, default_value in [
+            ("model", "fusion_mlp_image_text_tabular"),
+            ("data", "default"),
+            ("optimization", "adamw"),
+            ("environment", "default"),
+        ]:
             if k not in config:
                 config[k] = default_value
         for k, v in config.items():
@@ -227,21 +249,18 @@ def verify_model_names(config: DictConfig):
     # verify that strings in `config.names` match the keys of `config`.
     keys = list(config.keys())
     keys.remove("names")
-    assert set(config.names).issubset(set(keys)), \
-        f"`{config.names}` do not match config keys {keys}"
+    assert set(config.names).issubset(set(keys)), f"`{config.names}` do not match config keys {keys}"
 
     # verify that no name starts with another one
     names = sorted(config.names, key=lambda ele: len(ele), reverse=True)
     for i in range(len(names)):
-        if names[i].startswith(tuple(names[i+1:])):
-            raise ValueError(
-                f"name {names[i]} starts with one of another name: {names[i+1:]}"
-            )
+        if names[i].startswith(tuple(names[i + 1 :])):
+            raise ValueError(f"name {names[i]} starts with one of another name: {names[i+1:]}")
 
 
 def get_name_prefix(
-        name: str,
-        prefixes: List[str],
+    name: str,
+    prefixes: List[str],
 ):
     """
     Get a name's prefix from some available candidates.
@@ -270,8 +289,8 @@ def get_name_prefix(
 
 
 def customize_model_names(
-        config: DictConfig,
-        customized_names: Union[str, List[str]],
+    config: DictConfig,
+    customized_names: Union[str, List[str]],
 ):
     """
     Customize attribute names of `config` with the provided names.
@@ -298,7 +317,7 @@ def customize_model_names(
         return config
 
     if isinstance(customized_names, str):
-        customized_names = OmegaConf.from_dotlist([f'names={customized_names}']).names
+        customized_names = OmegaConf.from_dotlist([f"names={customized_names}"]).names
 
     new_config = OmegaConf.create()
     new_config.names = []
@@ -314,9 +333,7 @@ def customize_model_names(
             setattr(new_config, per_name, copy.deepcopy(per_config))
             new_config.names.append(per_name)
         else:
-            logger.debug(
-                f"Removing {per_name}, which doesn't start with any of these prefixes: {available_prefixes}."
-            )
+            logger.debug(f"Removing {per_name}, which doesn't start with any of these prefixes: {available_prefixes}.")
 
     if len(new_config.names) == 0:
         raise ValueError(
@@ -327,8 +344,8 @@ def customize_model_names(
 
 
 def select_model(
-        config: DictConfig,
-        df_preprocessor: MultiModalFeaturePreprocessor,
+    config: DictConfig,
+    df_preprocessor: MultiModalFeaturePreprocessor,
 ):
     """
     Filter model config through the detected modalities in the training data.
@@ -398,11 +415,11 @@ def select_model(
 
 
 def init_df_preprocessor(
-        config: DictConfig,
-        column_types: collections.OrderedDict,
-        label_column: str,
-        train_df_x: pd.DataFrame,
-        train_df_y: pd.Series,
+    config: DictConfig,
+    column_types: collections.OrderedDict,
+    label_column: str,
+    train_df_x: pd.DataFrame,
+    train_df_y: pd.Series,
 ):
     """
     Initialize the dataframe preprocessor by calling .fit().
@@ -440,8 +457,8 @@ def init_df_preprocessor(
 
 
 def init_data_processors(
-        config: DictConfig,
-        df_preprocessor: MultiModalFeaturePreprocessor,
+    config: DictConfig,
+    df_preprocessor: MultiModalFeaturePreprocessor,
 ):
     """
     Create the data processors according to the model config. This function creates one processor for
@@ -478,9 +495,7 @@ def init_data_processors(
     for model_name in names:
         model_config = getattr(config.model, model_name)
         # each model has its own label processor
-        data_processors[LABEL].append(
-            LabelProcessor(prefix=model_name)
-        )
+        data_processors[LABEL].append(LabelProcessor(prefix=model_name))
         if model_config.data_types is None:
             continue
         for d_type in model_config.data_types:
@@ -509,8 +524,8 @@ def init_data_processors(
                         insert_sep=model_config.insert_sep,
                         text_segment_num=model_config.text_segment_num,
                         stochastic_chunk=model_config.stochastic_chunk,
-                        text_detection_length = OmegaConf.select(model_config, "text_detection_length"),
-                        train_augment_types= OmegaConf.select(model_config, "text_train_augment_types")
+                        text_detection_length=OmegaConf.select(model_config, "text_detection_length"),
+                        train_augment_types=OmegaConf.select(model_config, "text_train_augment_types"),
                     )
                 )
             elif d_type == CATEGORICAL:
@@ -539,11 +554,11 @@ def init_data_processors(
 
 
 def create_model(
-        config: DictConfig,
-        num_classes: int,
-        num_numerical_columns: Optional[int] = None,
-        num_categories: Optional[List[int]] = None,
-        pretrained: Optional[bool] = True,
+    config: DictConfig,
+    num_classes: int,
+    num_numerical_columns: Optional[int] = None,
+    num_categories: Optional[List[int]] = None,
+    pretrained: Optional[bool] = True,
 ):
     """
     Create models. It supports the auto models of huggingface text and timm image.
@@ -706,9 +721,9 @@ def create_model(
 
 
 def save_pretrained_models(
-        model: nn.Module,
-        config: DictConfig,
-        path: str,
+    model: nn.Module,
+    config: DictConfig,
+    path: str,
 ) -> DictConfig:
     """
     Save the pretrained models and configs to local to make future loading not dependent on Internet access.
@@ -724,9 +739,7 @@ def save_pretrained_models(
     path
         The path to save pretrained checkpoints.
     """
-    requires_saving = any([
-        model_name.lower().startswith((CLIP, HF_TEXT)) for model_name in config.model.names
-    ])
+    requires_saving = any([model_name.lower().startswith((CLIP, HF_TEXT)) for model_name in config.model.names])
     if not requires_saving:
         return config
 
@@ -738,19 +751,16 @@ def save_pretrained_models(
         if per_model.prefix.lower().startswith((CLIP, HF_TEXT)):
             per_model.model.save_pretrained(os.path.join(path, per_model.prefix))
             model_config = getattr(config.model, per_model.prefix)
-            model_config.checkpoint_name = os.path.join('local://', per_model.prefix)
+            model_config.checkpoint_name = os.path.join("local://", per_model.prefix)
 
     return config
 
 
-def convert_checkpoint_name(
-        config: DictConfig,
-        path: str
-) -> DictConfig:  
+def convert_checkpoint_name(config: DictConfig, path: str) -> DictConfig:
     """
     Convert the checkpoint name from relative path to absolute path for
     loading the pretrained weights in offline deployment.
-    It is called by setting "standalone=True" in "AutoMMPredictor.load()". 
+    It is called by setting "standalone=True" in "AutoMMPredictor.load()".
 
     Parameters
     ----------
@@ -762,17 +772,19 @@ def convert_checkpoint_name(
     for model_name in config.model.names:
         if model_name.lower().startswith((CLIP, HF_TEXT)):
             model_config = getattr(config.model, model_name)
-            if model_config.checkpoint_name.startswith('local://'):
-                model_config.checkpoint_name = os.path.join(path, model_config.checkpoint_name[len('local://'):])
-                assert os.path.exists(os.path.join(model_config.checkpoint_name, 'config.json')) # guarantee the existence of local configs
-                assert os.path.exists(os.path.join(model_config.checkpoint_name, 'pytorch_model.bin'))
-                
+            if model_config.checkpoint_name.startswith("local://"):
+                model_config.checkpoint_name = os.path.join(path, model_config.checkpoint_name[len("local://") :])
+                assert os.path.exists(
+                    os.path.join(model_config.checkpoint_name, "config.json")
+                )  # guarantee the existence of local configs
+                assert os.path.exists(os.path.join(model_config.checkpoint_name, "pytorch_model.bin"))
+
     return config
 
 
 def save_text_tokenizers(
-        text_processors: List[TextProcessor],
-        path: str,
+    text_processors: List[TextProcessor],
+    path: str,
 ) -> List[TextProcessor]:
     """
     Save all the text tokenizers and record their relative paths, which are
@@ -798,8 +810,8 @@ def save_text_tokenizers(
 
 
 def load_text_tokenizers(
-        text_processors: List[TextProcessor],
-        path: str,
+    text_processors: List[TextProcessor],
+    path: str,
 ) -> List[TextProcessor]:
     """
     Load saved text tokenizers. If text processors already have tokenizers,
@@ -822,14 +834,14 @@ def load_text_tokenizers(
             per_text_processor.tokenizer = per_text_processor.get_pretrained_tokenizer(
                 tokenizer_name=per_text_processor.tokenizer_name,
                 checkpoint_name=per_path,
-                )
+            )
     return text_processors
 
 
 def make_exp_dir(
-        root_path: str,
-        job_name: str,
-        create: Optional[bool] = True,
+    root_path: str,
+    job_name: str,
+    create: Optional[bool] = True,
 ):
     """
     Creates the exp dir of format e.g.,: root_path/2022_01_01/job_name_12_00_00/
@@ -849,7 +861,7 @@ def make_exp_dir(
     -------
     The formatted directory path.
     """
-    tz = pytz.timezone('US/Pacific')
+    tz = pytz.timezone("US/Pacific")
     ct = datetime.datetime.now(tz=tz)
     date_stamp = ct.strftime("%Y_%m_%d")
     time_stamp = ct.strftime("%H_%M_%S")
@@ -867,7 +879,7 @@ def make_exp_dir(
 
 
 def average_checkpoints(
-        checkpoint_paths: List[str],
+    checkpoint_paths: List[str],
 ):
     """
     Average a list of checkpoints' state_dicts.
@@ -902,9 +914,9 @@ def average_checkpoints(
 
 
 def compute_score(
-        metric_data: dict,
-        metric_name: str,
-        pos_label: Optional[int] = 1,
+    metric_data: dict,
+    metric_name: str,
+    pos_label: Optional[int] = 1,
 ) -> float:
     """
     Use sklearn to compute the score of one metric.
@@ -951,22 +963,22 @@ def parse_dotlist_conf(conf):
     elif isinstance(conf, dict):
         need_parse = False
     else:
-        raise ValueError(f'Unsupported format of conf={conf}')
+        raise ValueError(f"Unsupported format of conf={conf}")
     if need_parse:
         new_conf = dict()
         curr_key = None
-        curr_value = ''
+        curr_value = ""
         for ele in conf:
-            if '=' in ele:
-                key, v = ele.split('=')
+            if "=" in ele:
+                key, v = ele.split("=")
                 if curr_key is not None:
                     new_conf[curr_key] = curr_value
                 curr_key = key
                 curr_value = v
             else:
                 if curr_key is None:
-                    raise ValueError(f'Cannot parse the conf={conf}')
-                curr_value = curr_value + ' ' + ele
+                    raise ValueError(f"Cannot parse the conf={conf}")
+                curr_value = curr_value + " " + ele
         if curr_key is not None:
             new_conf[curr_key] = curr_value
         return new_conf
@@ -975,9 +987,9 @@ def parse_dotlist_conf(conf):
 
 
 def apply_omegaconf_overrides(
-        conf: DictConfig,
-        overrides: Union[List, Tuple, str, Dict, DictConfig],
-        check_key_exist=True,
+    conf: DictConfig,
+    overrides: Union[List, Tuple, str, Dict, DictConfig],
+    check_key_exist=True,
 ):
     """
     Apply omegaconf overrides.
@@ -1000,7 +1012,7 @@ def apply_omegaconf_overrides(
 
     def _check_exist_dotlist(C, key_in_dotlist):
         if not isinstance(key_in_dotlist, list):
-            key_in_dotlist = key_in_dotlist.split('.')
+            key_in_dotlist = key_in_dotlist.split(".")
         if key_in_dotlist[0] in C:
             if len(key_in_dotlist) > 1:
                 return _check_exist_dotlist(C[key_in_dotlist[0]], key_in_dotlist[1:])
@@ -1012,9 +1024,11 @@ def apply_omegaconf_overrides(
     if check_key_exist:
         for ele in overrides.items():
             if not _check_exist_dotlist(conf, ele[0]):
-                raise KeyError(f'"{ele[0]}" is not found in the config. You may need to check the overrides. '
-                               f'overrides={overrides}')
-    override_conf = OmegaConf.from_dotlist([f'{ele[0]}={ele[1]}' for ele in overrides.items()])
+                raise KeyError(
+                    f'"{ele[0]}" is not found in the config. You may need to check the overrides. '
+                    f"overrides={overrides}"
+                )
+    override_conf = OmegaConf.from_dotlist([f"{ele[0]}={ele[1]}" for ele in overrides.items()])
     conf = OmegaConf.merge(conf, override_conf)
     return conf
 
@@ -1107,9 +1121,9 @@ def apply_log_filter(log_filter):
 
 
 def modify_duplicate_model_names(
-        predictor,
-        postfix: str,
-        blacklist: List[str],
+    predictor,
+    postfix: str,
+    blacklist: List[str],
 ):
     """
     Modify a predictor's model names if they exist in a blacklist.
@@ -1161,8 +1175,8 @@ def modify_duplicate_model_names(
 
 
 def assign_feature_column_names(
-        data_processors: Dict,
-        df_preprocessor: MultiModalFeaturePreprocessor,
+    data_processors: Dict,
+    df_preprocessor: MultiModalFeaturePreprocessor,
 ):
     """
     Assign feature column names to data processors.
@@ -1200,8 +1214,8 @@ def assign_feature_column_names(
 
 
 def turn_on_off_feature_column_info(
-        data_processors: Dict,
-        flag: bool,
+    data_processors: Dict,
+    flag: bool,
 ):
     """
     Turn on or off returning feature column information in data processors.
@@ -1227,10 +1241,11 @@ def turn_on_off_feature_column_info(
 
     return data_processors
 
+
 def try_to_infer_pos_label(
-        data_config: DictConfig,
-        label_encoder: LabelEncoder,
-        problem_type: str,
+    data_config: DictConfig,
+    label_encoder: LabelEncoder,
+    problem_type: str,
 ):
     """
     Try to infer positive label for binary classification, which is used in computing some metrics, e.g., roc_auc.
@@ -1264,9 +1279,9 @@ def try_to_infer_pos_label(
 
 
 def get_mixup(
-        model_config: DictConfig,
-        mixup_config: DictConfig,
-        num_classes: int,
+    model_config: DictConfig,
+    mixup_config: DictConfig,
+    num_classes: int,
 ):
     """
     Get the mixup state for loss function choice.
@@ -1297,9 +1312,9 @@ def get_mixup(
 
     mixup_active = False
     if mixup_config is not None and mixup_config.turn_on:
-        mixup_active = mixup_config.mixup_alpha > 0 or \
-                       mixup_config.cutmix_alpha > 0. or \
-                       mixup_config.cutmix_minmax is not None
+        mixup_active = (
+            mixup_config.mixup_alpha > 0 or mixup_config.cutmix_alpha > 0.0 or mixup_config.cutmix_minmax is not None
+        )
 
     mixup_state = model_active & mixup_active & (num_classes > 1)
     mixup_fn = None


### PR DESCRIPTION
As contributors increase, we need linters to ensure the code format consistency in AutoMM. Automatic linting is necessary to guarantee code quality and save reviewers' time from checking the code style. In this PR, we turn on linter black (https://github.com/psf/black)