### PR TITLE
Remove setuptools pin

### DIFF
--- a/text/setup.py
+++ b/text/setup.py
@@ -25,7 +25,6 @@ install_requires = [
     'Pillow',
     'tqdm',
     'boto3',
-    'setuptools<=59.5.0',
     'timm<0.6.0',
     'torch>=1.0,<1.11',
     'fairscale>=0.4.5,<0.5.0',


### PR DESCRIPTION
*Issue #, if available:*

ref https://github.com/awslabs/autogluon/commit/3813f2b746c817b891270f594fa2f14b79d4cf5a#r75527615

*Description of changes:*

Remove an unneeded pin (not directly using setuptools), causing incompatibility with [`kserve`](https://kserve.github.io/) package (directly using setuptools)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
