### PR TITLE
Fix time series dataframe freq inference

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -96,7 +96,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
     def freq(self):
         ts_index = self.index.levels[1]  # noqa
         freq = (
-            ts_index.freq or ts_index.inferred_freq or self.loc[0].index.inferred_freq
+            ts_index.freq
+            or ts_index.inferred_freq
+            or self.loc[0].index.freq  # fall back to freq of first item
+            or self.loc[0].index.inferred_freq
         )
         if freq is None:
             raise ValueError("Frequency not provided and cannot be inferred")

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -272,15 +272,18 @@ def test_when_dataset_constructed_from_dataframe_without_freq_then_freq_is_infer
     assert ts_df.freq == expected_freq
 
 
-@pytest.mark.parametrize(
-    "start_time, freq",
-    [
-        ("2020-01-01 00:00:00", "D"),
-        ("2020-01-01 00:00:00", "2D"),
-        ("2020-01-01 00:00:00", "T"),
-        ("2020-01-01 00:00:00", "H"),
-    ],
-)
+FREQ_TEST_CASES = [
+    ("2020-01-01 00:00:00", "D"),
+    ("2020-01-01", "D"),
+    ("2020-01-01 00:00:00", "2D"),
+    ("2020-01-01 00:00:00", "T"),
+    ("2020-01-01 00:00:00", "H"),
+    ("2020-01-31 00:00:00", "M"),
+    ("2020-01-31", "M"),
+]
+
+
+@pytest.mark.parametrize("start_time, freq", FREQ_TEST_CASES)
 def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(
     start_time, freq
 ):
@@ -294,6 +297,21 @@ def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(
     assert ts_df.freq == freq
 
 
+@pytest.mark.parametrize("start_time, freq", FREQ_TEST_CASES)
+def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferred(
+    start_time, freq
+):
+    item_list = ListDataset(
+        [{"target": [1, 2, 3], "start": pd.Timestamp(start_time, freq=freq)} for _ in range(3)],  # type: ignore
+        freq=freq
+    )
+
+    ts_df = TimeSeriesDataFrame(item_list)
+
+    assert ts_df.freq == freq
+
+
+@pytest.mark.skip("Skipped until re-enabling regularity check.")
 @pytest.mark.parametrize("list_of_timestamps", [
     [
         ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds the option of inferring data frame frequency from the first element's index. This handles edge cases where pandas cannot tell the inferred frequency of multiple concatenated date time indices -- an edge case we discovered during benchmarking.
- Temporarily disables "uniform time series index" check, since pandas appears to sometimes get confused by timedeltas of e.g., months (some months have 30 days and others 31, so not uniform). This led the benchmarks to spuriously fail.
- Moves inner logic of `from_***` constructors out of the constructor methods. This is because we used the constructor methods also in `__init__`, which led to an (inadvertent) recursion.

cc: @huibinshen 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
