### PR TITLE
Improve computing validation metric in AutoMM distiller

### DIFF
--- a/multimodal/src/autogluon/multimodal/optimization/lit_distiller.py
+++ b/multimodal/src/autogluon/multimodal/optimization/lit_distiller.py
@@ -220,18 +220,20 @@ class DistillerLitModule(pl.LightningModule):
 
         return loss
 
-    def _compute_metric(
+    def _compute_metric_score(
         self,
+        metric: torchmetrics.Metric,
+        custom_metric_func: Callable,
         logits: torch.Tensor,
         label: torch.Tensor,
     ):
-        if isinstance(self.validation_metric, torchmetrics.AUROC):
+        if isinstance(metric, (torchmetrics.AUROC, torchmetrics.AveragePrecision)):
             prob = F.softmax(logits.float(), dim=1)
-            return self.validation_metric(preds=prob[:, 1], target=label)  # only for binary classification
-        elif isinstance(self.validation_metric, BaseAggregator):
-            return self.validation_metric(self.custom_metric_func(logits, label))
+            metric.update(preds=prob[:, 1], target=label)  # only for binary classification
+        elif isinstance(metric, BaseAggregator):
+            metric.update(custom_metric_func(logits, label))
         else:
-            return self.validation_metric(logits.squeeze(dim=1), label)
+            metric.update(logits.squeeze(dim=1), label)
 
     def _shared_step(
         self,
@@ -291,12 +293,17 @@ class DistillerLitModule(pl.LightningModule):
         student_output, loss = self._shared_step(batch)
         # By default, on_step=False and on_epoch=True
         self.log("val_loss", loss)
+        self._compute_metric_score(
+            metric=self.validation_metric,
+            custom_metric_func=self.custom_metric_func,
+            logits=student_output[self.student_model.prefix][LOGITS],
+            label=batch[self.student_model.label_key],
+        ),
         self.log(
             self.validation_metric_name,
-            self._compute_metric(
-                logits=student_output[self.student_model.prefix][LOGITS],
-                label=batch[self.student_model.label_key],
-            ),
+            self.validation_metric,
+            on_step=False,
+            on_epoch=True,
         )
 
     def configure_optimizers(self):

--- a/multimodal/tests/unittests/test_distiller.py
+++ b/multimodal/tests/unittests/test_distiller.py
@@ -1,0 +1,94 @@
+import os
+import shutil
+
+from autogluon.multimodal import AutoMMPredictor
+from autogluon.multimodal.constants import (
+    MODEL,
+    DATA,
+    OPTIMIZATION,
+    ENVIRONMENT,
+    DISTILLER,
+    BINARY,
+    MULTICLASS,
+    UNIFORM_SOUP,
+    GREEDY_SOUP,
+    BEST,
+    NORM_FIT,
+    BIT_FIT,
+    LORA,
+    LORA_BIAS,
+    LORA_NORM,
+)
+from datasets import (
+    PetFinderDataset,
+    HatefulMeMesDataset,
+    AEDataset,
+)
+from utils import get_home_dir
+from test_predictor import verify_predictor_save_load
+
+ALL_DATASETS = {
+    "petfinder": PetFinderDataset,
+    "hateful_memes": HatefulMeMesDataset,
+    "ae": AEDataset,
+}
+
+
+def test_distillation():
+    dataset = PetFinderDataset()
+
+    config = {
+        MODEL: f"fusion_mlp_image_text_tabular",
+        DATA: "default",
+        OPTIMIZATION: "adamw",
+        ENVIRONMENT: "default",
+        DISTILLER: "default",
+    }
+
+    hyperparameters = {
+        "optimization.max_epochs": 1,
+        "model.names": ["hf_text", "timm_image", "fusion_mlp"],
+        "model.hf_text.checkpoint_name": "prajjwal1/bert-tiny",
+        "model.timm_image.checkpoint_name": "swin_tiny_patch4_window7_224",
+        "env.num_workers": 0,
+        "env.num_workers_evaluation": 0,
+    }
+
+    teacher_predictor = AutoMMPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=dataset.metric,
+    )
+
+    teacher_save_path = os.path.join(get_home_dir(), "petfinder", "teacher")
+    if os.path.exists(teacher_save_path):
+        shutil.rmtree(teacher_save_path)
+
+    teacher_predictor = teacher_predictor.fit(
+        train_data=dataset.train_df,
+        config=config,
+        hyperparameters=hyperparameters,
+        time_limit=30,
+        save_path=teacher_save_path,
+    )
+
+    # test for distillation
+    predictor = AutoMMPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=dataset.metric,
+    )
+
+    student_save_path = os.path.join(get_home_dir(), "petfinder", "student")
+    if os.path.exists(student_save_path):
+        shutil.rmtree(student_save_path)
+
+    predictor = predictor.fit(
+        train_data=dataset.train_df,
+        teacher_predictor=teacher_predictor,
+        config=config,
+        hyperparameters=hyperparameters,
+        time_limit=30,
+        save_path=student_save_path,
+    )
+    verify_predictor_save_load(predictor, dataset.test_df)


### PR DESCRIPTION
1. Use `.update()` in computing the validation metric to compute `roc_auc` more accurately and avoid errors for `r2`.
2. Add one unit test for distillation.
