### PR TITLE
Support f1 in AutoMM

### DIFF
--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -46,6 +46,7 @@ AVERAGE_PRECISION = "average_precision"
 LOG_LOSS = "log_loss"
 CROSS_ENTROPY = "cross_entropy"
 COSINE_EMBEDDING_LOSS = "cosine_embedding_loss"
+F1 = "f1"
 METRIC_MODE_MAP = {
     ACC: MAX,
     ACCURACY: MAX,
@@ -58,6 +59,7 @@ METRIC_MODE_MAP = {
     CROSS_ENTROPY: MIN,
     PEARSONR: MAX,
     SPEARMANR: MAX,
+    F1: MAX,
 }
 VALID_METRICS = METRIC_MODE_MAP.keys()
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1352,6 +1352,7 @@ class AutoMMPredictor:
             if self._problem_type != BINARY and per_metric.lower() in [
                 "roc_auc",
                 "average_precision",
+                "f1",
             ]:
                 raise ValueError(f"Metric {per_metric} is only supported for binary classification.")
             pos_label = try_to_infer_pos_label(

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -15,6 +15,7 @@ from typing import Optional, List, Any, Dict, Tuple, Union
 from nptyping import NDArray
 from omegaconf import OmegaConf, DictConfig
 from sklearn.preprocessing import LabelEncoder
+from sklearn.metrics import f1_score
 from autogluon.core.metrics import get_metric
 from .models.utils import inject_lora_to_linear_layer
 from .models import (
@@ -64,6 +65,7 @@ from .constants import (
     FUSION_TRANSFORMER,
     ROC_AUC,
     AVERAGE_PRECISION,
+    F1,
     METRIC_MODE_MAP,
     VALID_METRICS,
     VALID_CONFIG_KEYS,
@@ -1021,6 +1023,8 @@ def compute_score(
     metric = get_metric(metric_name)
     if metric.name in [ROC_AUC, AVERAGE_PRECISION]:
         return metric._sign * metric(metric_data[Y_TRUE], metric_data[Y_PRED_PROB][:, pos_label])
+    elif metric.name in [F1]:  # only for binary classification
+        return f1_score(metric_data[Y_TRUE], metric_data[Y_PRED], pos_label=pos_label)
     else:
         return metric._sign * metric(metric_data[Y_TRUE], metric_data[Y_PRED])
 

--- a/multimodal/tests/unittests/test_metrics.py
+++ b/multimodal/tests/unittests/test_metrics.py
@@ -2,9 +2,10 @@ import pytest
 import random
 import torch
 from torchmetrics import MeanMetric
-from sklearn.metrics import log_loss
+from sklearn.metrics import log_loss, f1_score
 from autogluon.multimodal.optimization.utils import get_metric, get_loss_func
-from autogluon.multimodal.constants import MULTICLASS
+from autogluon.multimodal.constants import MULTICLASS, Y_PRED, Y_TRUE
+from autogluon.multimodal.utils import compute_score
 
 
 @pytest.mark.parametrize(
@@ -72,3 +73,27 @@ def test_bce_with_logits_loss(problem_type, loss_func_name):
     bceloss = torch.nn.BCELoss()
     score2 = bceloss(input=preds, target=targets)
     assert pytest.approx(score1, 1e-6) == score2
+
+
+@pytest.mark.parametrize(
+    "pos_label",
+    [
+        0,
+        1,
+    ]
+)
+def test_f1(pos_label):
+    y_true = [0, 0, 1, 0, 1, 0]
+    y_pred = [1, 0, 0, 0, 1, 0]
+    score1 = f1_score(y_true, y_pred, pos_label=pos_label)
+    metric_data = {
+        Y_PRED: y_pred,
+        Y_TRUE: y_true,
+    }
+    score2 = compute_score(
+        metric_data=metric_data,
+        metric_name="f1",
+        pos_label=pos_label,
+    )
+    assert pytest.approx(score1, 1e-6) == score2
+


### PR DESCRIPTION
1. Since `autogluon.core.metrics`'s `f1` metric doesn't support passing the `pos_label` argument, we choose to directly use `sklearn`'s `f1_score`. We use `pos_label` instead of a customized label encoder to be backward compatible because checkpoints saved in 0.4.0 still use `sklearn`'s label encoder.
2. Add a unit test for `f1`.
