### PR TITLE
Support customizing class label for torchmetrics.F1Score

### DIFF
--- a/multimodal/src/autogluon/multimodal/optimization/utils.py
+++ b/multimodal/src/autogluon/multimodal/optimization/utils.py
@@ -149,7 +149,7 @@ def get_metric(
     metric_name
         Name of metric.
     num_classes
-        Number of classes, used in the quadratic_kappa metric for binary classification.
+        Number of classes.
     pos_label
         The label (0 or 1) of binary classification's positive class, which is used in some metrics, e.g., AUROC.
 
@@ -185,7 +185,7 @@ def get_metric(
     elif metric_name == SPEARMANR:
         return torchmetrics.SpearmanCorrCoef(), None
     elif metric_name == F1:
-        return CustomF1Score(pos_label=pos_label), None
+        return CustomF1Score(num_classes=num_classes, pos_label=pos_label), None
     else:
         raise ValueError(f"Unknown metric {metric_name}")
 

--- a/multimodal/src/autogluon/multimodal/optimization/utils.py
+++ b/multimodal/src/autogluon/multimodal/optimization/utils.py
@@ -101,16 +101,16 @@ class CustomF1Score(torchmetrics.F1Score):
     """
 
     def __init__(
-            self,
-            num_classes: Optional[int] = None,
-            threshold: float = 0.5,
-            average: str = "micro",
-            mdmc_average: Optional[str] = None,
-            ignore_index: Optional[int] = None,
-            top_k: Optional[int] = None,
-            multiclass: Optional[bool] = None,
-            pos_label: Optional[int] = None,
-            **kwargs: Any,
+        self,
+        num_classes: Optional[int] = None,
+        threshold: float = 0.5,
+        average: str = "micro",
+        mdmc_average: Optional[str] = None,
+        ignore_index: Optional[int] = None,
+        top_k: Optional[int] = None,
+        multiclass: Optional[bool] = None,
+        pos_label: Optional[int] = None,
+        **kwargs: Any,
     ) -> None:
         self.pos_label = pos_label
         if pos_label is not None:

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -754,7 +754,6 @@ class AutoMMPredictor:
         )
         validation_metric, custom_metric_func = get_metric(
             metric_name=validation_metric_name,
-            problem_type=self._problem_type,
             num_classes=self._output_shape,
             pos_label=pos_label,
         )

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1362,12 +1362,6 @@ class AutoMMPredictor:
 
         results = {}
         for per_metric in metrics:
-            if self._problem_type != BINARY and per_metric.lower() in [
-                "roc_auc",
-                "average_precision",
-                "f1",
-            ]:
-                raise ValueError(f"Metric {per_metric} is only supported for binary classification.")
             pos_label = try_to_infer_pos_label(
                 data_config=self._config.data,
                 label_encoder=self._df_preprocessor.label_generator,

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -101,17 +101,19 @@ def infer_metrics(
     eval_metric_name
         Name of evaluation metric.
     """
-    if problem_type != BINARY and eval_metric_name.lower() in [
-        ROC_AUC,
-        AVERAGE_PRECISION,
-        F1,
-    ]:
-        raise ValueError(f"Metric {eval_metric_name} is only supported for binary classification.")
 
     if eval_metric_name is not None:
+        if problem_type != BINARY and eval_metric_name.lower() in [
+            ROC_AUC,
+            AVERAGE_PRECISION,
+            F1,
+        ]:
+            raise ValueError(f"Metric {eval_metric_name} is only supported for binary classification.")
+
         if eval_metric_name in VALID_METRICS:
             validation_metric_name = eval_metric_name
             return validation_metric_name, eval_metric_name
+
         warnings.warn(
             f"Currently, we cannot convert the metric: {eval_metric_name} to a metric supported in torchmetrics. "
             f"Thus, we will fall-back to use accuracy for multi-class classification problems "

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -101,6 +101,13 @@ def infer_metrics(
     eval_metric_name
         Name of evaluation metric.
     """
+    if problem_type != BINARY and eval_metric_name.lower() in [
+        ROC_AUC,
+        AVERAGE_PRECISION,
+        F1,
+    ]:
+        raise ValueError(f"Metric {eval_metric_name} is only supported for binary classification.")
+
     if eval_metric_name is not None:
         if eval_metric_name in VALID_METRICS:
             validation_metric_name = eval_metric_name
@@ -1357,7 +1364,7 @@ def try_to_infer_pos_label(
 
     pos_label = OmegaConf.select(data_config, "pos_label", default=None)
     if pos_label is not None:
-        print(f"pos_label: {pos_label}\n")
+        logger.debug(f"pos_label: {pos_label}\n")
         pos_label = label_encoder.transform([pos_label]).item()
     else:
         pos_label = 1

--- a/multimodal/tests/unittests/test_metrics.py
+++ b/multimodal/tests/unittests/test_metrics.py
@@ -27,7 +27,7 @@ def test_cross_entropy(metric_name, class_num):
         preds.append(torch.randn(bs, class_num))
         targets.append(torch.randint(0, class_num, (bs,)))
 
-    _, custom_metric_func = get_metric(metric_name=metric_name, problem_type=MULTICLASS)
+    _, custom_metric_func = get_metric(metric_name=metric_name)
     mean_metric = MeanMetric()
 
     for per_pred, per_target in zip(preds, targets):

--- a/multimodal/tests/unittests/test_metrics.py
+++ b/multimodal/tests/unittests/test_metrics.py
@@ -14,7 +14,7 @@ from autogluon.multimodal.utils import compute_score
         ("log_loss", 5),
         ("log_loss", 10),
         ("cross_entropy", 100),
-    ]
+    ],
 )
 def test_cross_entropy(metric_name, class_num):
     preds = []
@@ -47,7 +47,7 @@ def test_cross_entropy(metric_name, class_num):
     "problem_type,loss_func_name",
     [
         ("regression", "bcewithlogitsloss"),
-    ]
+    ],
 )
 def test_bce_with_logits_loss(problem_type, loss_func_name):
     preds = []
@@ -80,7 +80,7 @@ def test_bce_with_logits_loss(problem_type, loss_func_name):
     [
         0,
         1,
-    ]
+    ],
 )
 def test_f1(pos_label):
     y_true = torch.tensor([0, 1, 0, 0, 1, 1])


### PR DESCRIPTION
`torchmetrics.F1Score` (https://torchmetrics.readthedocs.io/en/stable/classification/f1_score.html) doesn't provide the `pos_label` to return the f1 score of one specific class. However, sklearn's `f1_score` has this argument (https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html). In this PR, we define CustomF1Score to inherit from `torchmetrics.F1Score` and add the `pos_label` argument.