### PR TITLE
Update AutoMM presets

### DIFF
--- a/docs/tutorials/text_prediction/automm.md
+++ b/docs/tutorials/text_prediction/automm.md
@@ -204,30 +204,31 @@ scores
 ## Configuration Customization
 The above examples have shown the flexibility of `AutoMMPredictor`. You may want to know how to customize configurations for your tasks. Fortunately, `AutoMMPredictor` has a user-friendly configuration design.
 
-First, let's see the available model presets.
+First, let's see the available presets.
 
 
 ```{.python .input}
-from autogluon.multimodal.presets import list_model_presets, get_preset
-model_presets = list_model_presets()
-model_presets
+from autogluon.multimodal.presets import list_automm_presets, automm_preset_to_config
+presets = list_automm_presets()
+presets
 ```
 
-Currently, `AutoMMPredictor` has only one model preset, from which we can construct the predictor's preset.
+Each preset consists of one basic configuration dictionary and some preset-related hyperparameters. For example, let's take a look at preset `default`.
 
 
 ```{.python .input}
-preset = get_preset(model_presets[0])
-preset
+basic_config, overrides = automm_preset_to_config("default")
+print(basic_config)
+print(overrides)
 ```
 
-`AutoMMPredictor` configurations consist of four parts: `model`, `data`, `optimization`, and `environment`. You can convert the preset to configurations to see the details.
+`AutoMMPredictor` configurations consist of four parts: `model`, `data`, `optimization`, and `environment`. You can convert the preset to full configurations.
 
 
 ```{.python .input}
 from omegaconf import OmegaConf
 from autogluon.multimodal.utils import get_config
-config = get_config(preset)
+config = get_config(preset="default")
 print(OmegaConf.to_yaml(config))
 ```
 

--- a/docs/tutorials/text_prediction/automm.md
+++ b/docs/tutorials/text_prediction/automm.md
@@ -208,7 +208,7 @@ First, let's see the available presets.
 
 
 ```{.python .input}
-from autogluon.multimodal.presets import list_automm_presets, automm_preset_to_config
+from autogluon.multimodal.presets import list_automm_presets, get_automm_preset
 presets = list_automm_presets()
 presets
 ```
@@ -217,9 +217,9 @@ Each preset consists of one basic configuration dictionary and some preset-relat
 
 
 ```{.python .input}
-basic_config, overrides = automm_preset_to_config("default")
+basic_config, preset_overrides = get_automm_preset("default")
 print(basic_config)
-print(overrides)
+print(preset_overrides)
 ```
 
 `AutoMMPredictor` configurations consist of four parts: `model`, `data`, `optimization`, and `environment`. You can convert the preset to full configurations.

--- a/multimodal/src/autogluon/multimodal/configs/optimization/adamw.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/optimization/adamw.yaml
@@ -3,7 +3,7 @@ optimization:
   learning_rate: 1.0e-4
   weight_decay: 0.001
   lr_choice: "layerwise_decay"
-  lr_decay: 0.8
+  lr_decay: 0.9
   lr_schedule: "cosine_decay"
   max_epochs: 10
   max_steps: -1

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -84,7 +84,6 @@ from .utils import (
     try_to_infer_pos_label,
     get_mixup,
     CustomUnpickler,
-    parse_dotlist_conf,
 )
 from .optimization.utils import (
     get_metric,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -84,6 +84,7 @@ from .utils import (
     try_to_infer_pos_label,
     get_mixup,
     CustomUnpickler,
+    parse_dotlist_conf,
 )
 from .optimization.utils import (
     get_metric,
@@ -228,6 +229,7 @@ class AutoMMPredictor:
     def fit(
         self,
         train_data: pd.DataFrame,
+        preset: str = None,
         config: Optional[dict] = None,
         tuning_data: Optional[pd.DataFrame] = None,
         time_limit: Optional[int] = None,
@@ -247,6 +249,8 @@ class AutoMMPredictor:
         ----------
         train_data
             A dataframe containing training data.
+        preset
+            Name of a preset. See the available presets in `presets.py`.
         config
             A dictionary with four keys "model", "data", "optimization", and "environment".
             Each key's value can be a string, yaml file path, or OmegaConf's DictConfig.
@@ -453,6 +457,7 @@ class AutoMMPredictor:
             ckpt_path=None if hyperparameter_tune_kwargs is not None else self._ckpt_path,
             resume=False if hyperparameter_tune_kwargs is not None else self._resume,
             enable_progress_bar=False if hyperparameter_tune_kwargs is not None else self._enable_progress_bar,
+            preset=preset,
             config=config,
             hyperparameters=hyperparameters,
             teacher_predictor=teacher_predictor,
@@ -694,6 +699,7 @@ class AutoMMPredictor:
         ckpt_path: str,
         resume: bool,
         enable_progress_bar: bool,
+        preset: Optional[str] = None,
         config: Optional[dict] = None,
         hyperparameters: Optional[Union[str, Dict, List[str]]] = None,
         teacher_predictor: Union[str, AutoMMPredictor] = None,
@@ -704,6 +710,7 @@ class AutoMMPredictor:
             config = self._config
 
         config = get_config(
+            preset=preset,
             config=config,
             overrides=hyperparameters,
         )

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -15,7 +15,6 @@ def default():
     return {
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
-        "optimization.lr_decay": 0.9,
     }
 
 
@@ -25,7 +24,6 @@ def medium_quality_faster_train():
         "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
         "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
         "optimization.learning_rate": 4e-4,
-        "optimization.lr_decay": 0.9,
     }
 
 
@@ -34,7 +32,6 @@ def high_quality():
     return {
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
-        "optimization.lr_decay": 0.9,
     }
 
 
@@ -43,7 +40,6 @@ def best_quality():
     return {
         "model.hf_text.checkpoint_name": "microsoft/deberta-v3-base",
         "model.timm_image.checkpoint_name": "swin_large_patch4_window7_224",
-        "optimization.lr_decay": 0.9,
         "env.per_gpu_batch_size": 1,
     }
 
@@ -53,7 +49,6 @@ def multilingual():
     return {
         "model.hf_text.checkpoint_name": "microsoft/mdeberta-v3-base",
         "optimization.top_k": 1,
-        "optimization.lr_decay": 0.9,
         "env.precision": "bf16",
         "env.per_gpu_batch_size": 4,
     }

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -5,25 +5,96 @@ from .constants import (
     OPTIMIZATION,
     ENVIRONMENT,
 )
+from .registry import Registry
+
+automm_presets = Registry("automm_presets")
 
 
-def list_model_presets():
+@automm_presets.register()
+def default():
+    return {
+        "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
+        "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
+        "optimization.lr_decay": 0.9,
+    }
+
+
+@automm_presets.register()
+def medium_quality_faster_train():
+    return {
+        "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
+        "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
+        "optimization.learning_rate": 4e-4,
+        "optimization.lr_decay": 0.9,
+    }
+
+
+@automm_presets.register()
+def high_quality():
+    return {
+        "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
+        "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
+        "optimization.lr_decay": 0.9,
+    }
+
+
+@automm_presets.register()
+def best_quality():
+    return {
+        "model.hf_text.checkpoint_name": "microsoft/deberta-v3-base",
+        "model.timm_image.checkpoint_name": "swin_large_patch4_window7_224",
+        "optimization.lr_decay": 0.9,
+        "env.per_gpu_batch_size": 1,
+    }
+
+
+@automm_presets.register()
+def multilingual():
+    return {
+        "model.hf_text.checkpoint_name": "microsoft/mdeberta-v3-base",
+        "optimization.top_k": 1,
+        "optimization.lr_decay": 0.9,
+        "env.precision": 'bf16',
+        "env.per_gpu_batch_size": 4,
+    }
+
+
+def list_automm_presets(verbose: bool = False):
     """
-    List all available model types.
-    Image/text backbones can be customized for one model type.
+    List all available presets.
 
     Returns
     -------
-    A list of model types.
+    A list of presets.
     """
-    cur_path = os.path.dirname(os.path.abspath(__file__))
-    model_config_dir = os.path.join(cur_path, "configs", "model")
-    model_config_files = [f for f in os.listdir(model_config_dir) if f.endswith((".yaml", ".yml"))]
-    model_presets = [f.split(".")[0] for f in model_config_files]
-    return model_presets
+    preset_keys = automm_presets.list_keys()
+    if not verbose:
+        return preset_keys
+
+    preset_details = {}
+    for k in preset_keys:
+        preset_details[k] = automm_presets.create(k)
+
+    return preset_details
 
 
-def get_preset(model_preset: str):
+def get_basic_config():
+    """
+    Get the basic config of AutoMM.
+
+    Returns
+    -------
+    A dict config with keys: MODEL, DATA, OPTIMIZATION, ENVIRONMENT, and their default values.
+    """
+    return {
+        MODEL: "fusion_mlp_image_text_tabular",
+        DATA: "default",
+        OPTIMIZATION: "adamw",
+        ENVIRONMENT: "default",
+    }
+
+
+def get_automm_preset(name: str):
     """
     Get the preset of one predictor in AutoMM.
     Currently, we only use model presets to differentiate different predictors.
@@ -32,27 +103,21 @@ def get_preset(model_preset: str):
 
     Parameters
     ----------
-    model_preset
-        A model preset supported by AutoMM.
+    name
+        Name of a preset.
 
     Returns
     -------
     AutoMM predictor's presets of MODEL, DATA, OPTIMIZATION, and ENVIRONMENT.
     """
-    model_preset = model_preset.lower()
-    preset = {
-        MODEL: model_preset,
-        DATA: "default",
-        OPTIMIZATION: "adamw",
-        ENVIRONMENT: "default",
-    }
-
-    cur_path = os.path.dirname(os.path.abspath(__file__))
-    model_config_dir = os.path.join(cur_path, "configs", "model")
-    model_config_path = os.path.join(model_config_dir, f"{model_preset}.yaml")
-    if not os.path.isfile(model_config_path):
+    basic_config = get_basic_config()
+    name = name.lower()
+    if name in automm_presets.list_keys():
+        overrides = automm_presets.create(name)
+    else:
         raise ValueError(
-            f"Model preset '{model_preset}' is not supported yet. Consider one of these: {list_model_presets()}"
+            f"Provided preset '{name}' is not supported. "
+            f"Consider one of these: {automm_presets.list_keys()}"
         )
 
-    return preset
+    return basic_config, overrides

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -54,7 +54,7 @@ def multilingual():
         "model.hf_text.checkpoint_name": "microsoft/mdeberta-v3-base",
         "optimization.top_k": 1,
         "optimization.lr_decay": 0.9,
-        "env.precision": 'bf16',
+        "env.precision": "bf16",
         "env.per_gpu_batch_size": 4,
     }
 
@@ -116,8 +116,7 @@ def get_automm_preset(name: str):
         overrides = automm_presets.create(name)
     else:
         raise ValueError(
-            f"Provided preset '{name}' is not supported. "
-            f"Consider one of these: {automm_presets.list_keys()}"
+            f"Provided preset '{name}' is not supported. " f"Consider one of these: {automm_presets.list_keys()}"
         )
 
     return basic_config, overrides

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -94,29 +94,29 @@ def get_basic_automm_config():
     }
 
 
-def get_automm_preset(name: str):
+def automm_preset_to_config(preset: str):
     """
-    Get the preset of one predictor in AutoMM.
-    Currently, we only use model presets to differentiate different predictors.
-    In future, we can simultaneously consider model, data, optimization,
-    and environment to construct more diverse presets.
+    Map a AutoMM preset string to its config including a basic config and an overriding dict.
 
     Parameters
     ----------
-    name
+    preset
         Name of a preset.
 
     Returns
     -------
-    AutoMM predictor's presets of MODEL, DATA, OPTIMIZATION, and ENVIRONMENT.
+    basic_config
+        The basic config of AutoMM.
+    overrides
+        The hyperparameter overrides of this preset.
     """
     basic_config = get_basic_automm_config()
-    name = name.lower()
-    if name in automm_presets.list_keys():
-        overrides = automm_presets.create(name)
+    preset = preset.lower()
+    if preset in automm_presets.list_keys():
+        overrides = automm_presets.create(preset)
     else:
         raise ValueError(
-            f"Provided preset '{name}' is not supported. " f"Consider one of these: {automm_presets.list_keys()}"
+            f"Provided preset '{preset}' is not supported. " f"Consider one of these: {automm_presets.list_keys()}"
         )
 
     return basic_config, overrides

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -89,7 +89,7 @@ def get_basic_automm_config():
     }
 
 
-def automm_preset_to_config(preset: str):
+def get_automm_preset(preset: str):
     """
     Map a AutoMM preset string to its config including a basic config and an overriding dict.
 

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -78,7 +78,7 @@ def list_automm_presets(verbose: bool = False):
     return preset_details
 
 
-def get_basic_config():
+def get_basic_automm_config():
     """
     Get the basic config of AutoMM.
 
@@ -110,7 +110,7 @@ def get_automm_preset(name: str):
     -------
     AutoMM predictor's presets of MODEL, DATA, OPTIMIZATION, and ENVIRONMENT.
     """
-    basic_config = get_basic_config()
+    basic_config = get_basic_automm_config()
     name = name.lower()
     if name in automm_presets.list_keys():
         overrides = automm_presets.create(name)

--- a/multimodal/src/autogluon/multimodal/registry.py
+++ b/multimodal/src/autogluon/multimodal/registry.py
@@ -1,0 +1,114 @@
+from typing import Optional, List
+import json
+from json import JSONDecodeError
+
+
+class Registry:
+    """
+    Create the registry that will map name to object.
+    This facilitates the users to create custom registry.
+    """
+
+    def __init__(self, name: str) -> None:
+        """
+        Parameters
+        ----------
+        name
+            Registry name
+        """
+        self._name: str = name
+        self._obj_map: dict[str, object] = dict()
+
+    def _do_register(self, name: str, obj: object) -> None:
+        assert (
+            name not in self._obj_map
+        ), "An object named '{}' was already registered in '{}' registry!".format(
+            name, self._name
+        )
+        self._obj_map[name] = obj
+
+    def register(self, *args):
+        """
+        Register the given object under either the nickname or `obj.__name__`. It can be used as
+         either a decorator or not. See docstring of this class for usage.
+        """
+        if len(args) == 2:
+            # Register an object with nick name by function call
+            nickname, obj = args
+            self._do_register(nickname, obj)
+        elif len(args) == 1:
+            if isinstance(args[0], str):
+                # Register an object with nick name by decorator
+                nickname = args[0]
+                def deco(func_or_class: object) -> object:
+                    self._do_register(nickname, func_or_class)
+                    return func_or_class
+                return deco
+            else:
+                # Register an object by function call
+                self._do_register(args[0].__name__, args[0])
+        elif len(args) == 0:
+            # Register an object by decorator
+            def deco(func_or_class: object) -> object:
+                self._do_register(func_or_class.__name__, func_or_class)
+                return func_or_class
+            return deco
+        else:
+            raise ValueError('Do not support the usage!')
+
+    def get(self, name: str) -> object:
+        ret = self._obj_map.get(name)
+        if ret is None:
+            raise KeyError(
+                "No object named '{}' found in '{}' registry!".format(
+                    name, self._name
+                )
+            )
+        return ret
+
+    def list_keys(self) -> List:
+        return list(self._obj_map.keys())
+
+    def __repr__(self) -> str:
+        s = '{name}(keys={keys})'.format(name=self._name,
+                                         keys=self.list_keys())
+        return s
+
+    def create(self, name: str, *args, **kwargs) -> object:
+        """
+        Create the class object with the given args and kwargs
+        Parameters
+        ----------
+        name
+            The name in the registry
+        args
+        kwargs
+        Returns
+        -------
+        ret
+            The created object
+        """
+        return self.get(name)(*args, **kwargs)
+
+    def create_with_json(self, name: str, json_str: str):
+        """
+        Parameters
+        ----------
+        name
+        json_str
+        Returns
+        -------
+        """
+        try:
+            args = json.loads(json_str)
+        except JSONDecodeError:
+            raise ValueError('Unable to decode the json string: json_str="{}"'
+                             .format(json_str))
+        if isinstance(args, (list, tuple)):
+            return self.create(name, *args)
+        elif isinstance(args, dict):
+            return self.create(name, **args)
+        else:
+            raise NotImplementedError('The format of json string is not supported! We only support '
+                                      'list/dict. json_str="{}".'
+                                      .format(json_str))

--- a/multimodal/src/autogluon/multimodal/registry.py
+++ b/multimodal/src/autogluon/multimodal/registry.py
@@ -20,9 +20,7 @@ class Registry:
         self._obj_map: dict[str, object] = dict()
 
     def _do_register(self, name: str, obj: object) -> None:
-        assert (
-            name not in self._obj_map
-        ), "An object named '{}' was already registered in '{}' registry!".format(
+        assert name not in self._obj_map, "An object named '{}' was already registered in '{}' registry!".format(
             name, self._name
         )
         self._obj_map[name] = obj
@@ -40,9 +38,11 @@ class Registry:
             if isinstance(args[0], str):
                 # Register an object with nick name by decorator
                 nickname = args[0]
+
                 def deco(func_or_class: object) -> object:
                     self._do_register(nickname, func_or_class)
                     return func_or_class
+
                 return deco
             else:
                 # Register an object by function call
@@ -52,26 +52,22 @@ class Registry:
             def deco(func_or_class: object) -> object:
                 self._do_register(func_or_class.__name__, func_or_class)
                 return func_or_class
+
             return deco
         else:
-            raise ValueError('Do not support the usage!')
+            raise ValueError("Do not support the usage!")
 
     def get(self, name: str) -> object:
         ret = self._obj_map.get(name)
         if ret is None:
-            raise KeyError(
-                "No object named '{}' found in '{}' registry!".format(
-                    name, self._name
-                )
-            )
+            raise KeyError("No object named '{}' found in '{}' registry!".format(name, self._name))
         return ret
 
     def list_keys(self) -> List:
         return list(self._obj_map.keys())
 
     def __repr__(self) -> str:
-        s = '{name}(keys={keys})'.format(name=self._name,
-                                         keys=self.list_keys())
+        s = "{name}(keys={keys})".format(name=self._name, keys=self.list_keys())
         return s
 
     def create(self, name: str, *args, **kwargs) -> object:
@@ -102,13 +98,13 @@ class Registry:
         try:
             args = json.loads(json_str)
         except JSONDecodeError:
-            raise ValueError('Unable to decode the json string: json_str="{}"'
-                             .format(json_str))
+            raise ValueError('Unable to decode the json string: json_str="{}"'.format(json_str))
         if isinstance(args, (list, tuple)):
             return self.create(name, *args)
         elif isinstance(args, dict):
             return self.create(name, **args)
         else:
-            raise NotImplementedError('The format of json string is not supported! We only support '
-                                      'list/dict. json_str="{}".'
-                                      .format(json_str))
+            raise NotImplementedError(
+                "The format of json string is not supported! We only support "
+                'list/dict. json_str="{}".'.format(json_str)
+            )

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -70,10 +70,7 @@ from .constants import (
     VALID_METRICS,
     VALID_CONFIG_KEYS,
 )
-from .presets import (
-    list_model_presets,
-    get_preset,
-)
+from .presets import get_basic_automm_config
 
 logger = logging.getLogger(AUTOMM)
 
@@ -240,7 +237,7 @@ def get_config(
     Configurations as a DictConfig object
     """
     if config is None:
-        config = get_preset(list_model_presets()[0])
+        config = get_basic_automm_config()
     if not isinstance(config, DictConfig):
         all_configs = []
         for k, default_value in [

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -70,7 +70,7 @@ from .constants import (
     VALID_METRICS,
     VALID_CONFIG_KEYS,
 )
-from .presets import automm_preset_to_config, get_basic_automm_config
+from .presets import get_automm_preset, get_basic_automm_config
 
 logger = logging.getLogger(AUTOMM)
 
@@ -247,7 +247,7 @@ def get_config(
             basic_config = get_basic_automm_config()
             preset_overrides = None
         else:
-            basic_config, preset_overrides = automm_preset_to_config(preset=preset)
+            basic_config, preset_overrides = get_automm_preset(preset=preset)
 
         for k, default_value in basic_config.items():
             if k not in config:

--- a/multimodal/tests/unittests/test_config.py
+++ b/multimodal/tests/unittests/test_config.py
@@ -31,7 +31,7 @@ def test_config():
         OPTIMIZATION: optimization_config_path,
         ENVIRONMENT: environemnt_config_path,
     }
-    config = get_config(config)
+    config = get_config(config=config)
     assert config == config_gt
 
     # test DictConfg
@@ -41,7 +41,7 @@ def test_config():
         OPTIMIZATION: optimization_config,
         ENVIRONMENT: environemnt_config,
     }
-    config = get_config(config)
+    config = get_config(config=config)
     assert config == config_gt
 
     # test dict
@@ -63,7 +63,7 @@ def test_config():
         OPTIMIZATION: optimization_config,
         ENVIRONMENT: environemnt_config,
     }
-    config = get_config(config)
+    config = get_config(config=config)
     assert config == config_gt
 
     # test default string
@@ -73,7 +73,7 @@ def test_config():
         OPTIMIZATION: "adamw",
         ENVIRONMENT: "default",
     }
-    config = get_config(config)
+    config = get_config(config=config)
     assert config == config_gt
 
 

--- a/multimodal/tests/unittests/test_presets.py
+++ b/multimodal/tests/unittests/test_presets.py
@@ -1,6 +1,6 @@
 import pytest
 from autogluon.multimodal.presets import (
-    automm_preset_to_config,
+    get_automm_preset,
     list_automm_presets,
 )
 
@@ -8,10 +8,10 @@ from autogluon.multimodal.presets import (
 def test_presets():
     all_model_presets = list_automm_presets()
     for preset in all_model_presets:
-        config, overrides = automm_preset_to_config(preset)
+        config, overrides = get_automm_preset(preset)
 
     # test non-existing types
     non_exist_types = ["hello", "haha"]
     for per_type in non_exist_types:
         with pytest.raises(ValueError):
-            config, overrides = automm_preset_to_config(per_type)
+            config, overrides = get_automm_preset(per_type)

--- a/multimodal/tests/unittests/test_presets.py
+++ b/multimodal/tests/unittests/test_presets.py
@@ -1,17 +1,28 @@
 import pytest
+from omegaconf import OmegaConf
 from autogluon.multimodal.presets import (
     get_automm_preset,
     list_automm_presets,
 )
+from autogluon.multimodal.utils import get_config
 
 
 def test_presets():
-    all_model_presets = list_automm_presets()
-    for preset in all_model_presets:
-        config, overrides = get_automm_preset(preset)
+    all_presets = list_automm_presets()
+    for preset in all_presets:
+        basic_config, overrides = get_automm_preset(preset)
 
     # test non-existing types
     non_exist_types = ["hello", "haha"]
     for per_type in non_exist_types:
         with pytest.raises(ValueError):
-            config, overrides = get_automm_preset(per_type)
+            basic_config, overrides = get_automm_preset(per_type)
+
+
+def test_preset_to_config():
+    all_presets = list_automm_presets()
+    for preset in all_presets:
+        basic_config, overrides = get_automm_preset(preset)
+        config = get_config(preset=preset)
+        for k, v in overrides.items():
+            assert OmegaConf.select(config, k) == v

--- a/multimodal/tests/unittests/test_presets.py
+++ b/multimodal/tests/unittests/test_presets.py
@@ -1,17 +1,17 @@
 import pytest
 from autogluon.multimodal.presets import (
-    get_preset,
-    list_model_presets,
+    get_automm_preset,
+    list_automm_presets,
 )
 
 
 def test_presets():
-    all_model_presets = list_model_presets()
+    all_model_presets = list_automm_presets()
     for preset in all_model_presets:
-        config = get_preset(preset)
+        config, overrides = get_automm_preset(preset)
 
     # test non-existing types
     non_exist_types = ["hello", "haha"]
     for per_type in non_exist_types:
         with pytest.raises(ValueError):
-            config = get_preset(per_type)
+            config = get_automm_preset(per_type)

--- a/multimodal/tests/unittests/test_presets.py
+++ b/multimodal/tests/unittests/test_presets.py
@@ -1,6 +1,6 @@
 import pytest
 from autogluon.multimodal.presets import (
-    get_automm_preset,
+    automm_preset_to_config,
     list_automm_presets,
 )
 
@@ -8,10 +8,10 @@ from autogluon.multimodal.presets import (
 def test_presets():
     all_model_presets = list_automm_presets()
     for preset in all_model_presets:
-        config, overrides = get_automm_preset(preset)
+        config, overrides = automm_preset_to_config(preset)
 
     # test non-existing types
     non_exist_types = ["hello", "haha"]
     for per_type in non_exist_types:
         with pytest.raises(ValueError):
-            config = get_automm_preset(per_type)
+            config, overrides = automm_preset_to_config(per_type)

--- a/multimodal/tests/unittests/test_registry.py
+++ b/multimodal/tests/unittests/test_registry.py
@@ -1,0 +1,49 @@
+from autogluon.multimodal.registry import Registry
+
+
+def test_registry():
+    MODEL_REGISTRY = Registry("MODEL")
+
+    @MODEL_REGISTRY.register()
+    class MyModel:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+    @MODEL_REGISTRY.register()
+    def my_model():
+        return
+
+    @MODEL_REGISTRY.register("test_class")
+    class MyModelWithNickName:
+        def __init__(self, a, b, c):
+            self.a = a
+            self.b = b
+            self.c = c
+
+    @MODEL_REGISTRY.register("test_function")
+    def my_model_with_nick_name():
+        return
+
+    class MyModel2:
+        pass
+
+    MODEL_REGISTRY.register(MyModel2)
+    MODEL_REGISTRY.register("my_model2", MyModel2)
+    assert MODEL_REGISTRY.list_keys() == [
+        "MyModel",
+        "my_model",
+        "test_class",
+        "test_function",
+        "MyModel2",
+        "my_model2",
+    ]
+    model = MODEL_REGISTRY.create("MyModel", 1, 2)
+    assert model.a == 1 and model.b == 2
+    model = MODEL_REGISTRY.create("MyModel", a=2, b=3)
+    assert model.a == 2 and model.b == 3
+    model = MODEL_REGISTRY.create_with_json("MyModel", "[4, 5]")
+    assert model.a == 4 and model.b == 5
+    model = MODEL_REGISTRY.create_with_json("test_class", '{"a": 100, "b": 200, "c": 300}')
+    assert model.a == 100 and model.b == 200 and model.c == 300
+    assert MODEL_REGISTRY.get("test_class") == MyModelWithNickName

--- a/text/src/autogluon/text/text_prediction/presets.py
+++ b/text/src/autogluon/text/text_prediction/presets.py
@@ -11,27 +11,22 @@ def list_text_presets(verbose=False):
     simple_presets = {
         "default": {
             "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
-            "optimization.lr_decay": 0.9,
         },
         "medium_quality_faster_train": {
             "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
             "optimization.learning_rate": 4e-4,
-            "optimization.lr_decay": 0.9,
         },
         # TODO(?) Revise to use registry
         "high_quality": {
             "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
-            "optimization.lr_decay": 0.9,
         },
         "best_quality": {
             "model.hf_text.checkpoint_name": "microsoft/deberta-v3-base",
-            "optimization.lr_decay": 0.9,
             "env.per_gpu_batch_size": 2,
         },
         "multilingual": {
             "model.hf_text.checkpoint_name": "microsoft/mdeberta-v3-base",
             "optimization.top_k": 1,
-            "optimization.lr_decay": 0.9,
             "env.precision": 'bf16',
             "env.per_gpu_batch_size": 4,
         },

--- a/text/src/autogluon/text/text_prediction/presets.py
+++ b/text/src/autogluon/text/text_prediction/presets.py
@@ -1,4 +1,4 @@
-from autogluon.multimodal.presets import get_preset
+from autogluon.multimodal.presets import get_basic_config
 
 
 def list_text_presets(verbose=False):
@@ -59,7 +59,7 @@ def get_text_preset(preset: str):
     overrides
         A dictionary of overriding configs.
     """
-    automm_preset = get_preset("fusion_mlp_image_text_tabular")
+    basic_config = get_basic_config()
     overrides = {"model.names": ["hf_text", "numerical_mlp", "categorical_mlp", "fusion_mlp"]}
     preset = preset.lower()
     available_presets = list_text_presets(verbose=True)
@@ -72,4 +72,4 @@ def get_text_preset(preset: str):
             f"Consider one of these: {list_text_presets()}"
         )
 
-    return automm_preset, overrides
+    return basic_config, overrides

--- a/text/src/autogluon/text/text_prediction/presets.py
+++ b/text/src/autogluon/text/text_prediction/presets.py
@@ -1,4 +1,4 @@
-from autogluon.multimodal.presets import get_basic_config
+from autogluon.multimodal.presets import get_basic_automm_config
 
 
 def list_text_presets(verbose=False):
@@ -59,7 +59,7 @@ def get_text_preset(preset: str):
     overrides
         A dictionary of overriding configs.
     """
-    basic_config = get_basic_config()
+    basic_config = get_basic_automm_config()
     overrides = {"model.names": ["hf_text", "numerical_mlp", "categorical_mlp", "fusion_mlp"]}
     preset = preset.lower()
     available_presets = list_text_presets(verbose=True)


### PR DESCRIPTION
1. Add presets: `default`, `medium_quality_faster_train`, `high_quality`, and `best_quality` in AutoMM.
2. add the `preset` argument in `.fit()` and use it in `get_config()`.
3. Use registry for presets.
4. Add a function to return AutoMM's basic config.
5. Update some function names to be specific for AutoMM.
