### PR TITLE
Allow generic item indices in time series dataframe

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -105,6 +105,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
         )
         if freq is None:
             raise ValueError("Frequency not provided and cannot be inferred")
+        if isinstance(freq, str):
+            return freq
+        elif isinstance(freq, pd._libs.tslibs.BaseOffset):
+            return freq.freqstr
         return freq
 
     def iter_items(self) -> Iterable[Any]:
@@ -149,8 +153,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
             raise ValueError(f"`{ITEMID}` column can not have nan")
         if df[TIMESTAMP].isnull().any():
             raise ValueError(f"`{TIMESTAMP}` column can not have nan")
-        if not df[ITEMID].dtype == "int64":
-            raise ValueError(f"for {ITEMID}, the only pandas dtype allowed is ‘int64’.")
         if not df[TIMESTAMP].dtype == "datetime64[ns]":
             raise ValueError(
                 f"for {TIMESTAMP}, the only pandas dtype allowed is ‘datetime64[ns]’."
@@ -174,8 +176,6 @@ class TimeSeriesDataFrame(pd.DataFrame):
             raise ValueError(f"data must be a pd.DataFrame, got {type(data)}")
         if not isinstance(data.index, pd.MultiIndex):
             raise ValueError(f"data must have pd.MultiIndex, got {type(data.index)}")
-        if not data.index.dtypes.array[0] == "int64":
-            raise ValueError(f"for {ITEMID}, the only pandas dtype allowed is ‘int64’.")
         if not data.index.dtypes.array[1] == "datetime64[ns]":
             raise ValueError(
                 f"for {TIMESTAMP}, the only pandas dtype allowed is ‘datetime64[ns]’."

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -231,6 +231,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             f"\tProvided data for prediction with {len(data)} rows, {data.num_items} items. "
             f"Average time series length is {len(data) / data.num_items}."
         )
+        input_index_type = type(data.index.levels[0][0])
 
         with warning_filter():
             quantiles = quantile_levels or self.quantile_levels
@@ -247,6 +248,17 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 predicted_targets,
                 quantile_levels=quantile_levels or self.quantile_levels,
             )
+
+            # if index type is different than the input data, cast it back
+            if len(df.index.levels[0]) > 0:
+                prediction_index_type = type(df.index.levels[0][0])
+                if prediction_index_type is not input_index_type:
+                    df.set_index(
+                        df.index.set_levels(
+                            [input_index_type(i) for i in df.index.levels[0]], level=0
+                        ),
+                        inplace=True,
+                    )
 
         return df
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -308,7 +308,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 item_forecast_dict[quantile] = forecasts[i].quantile(str(quantile))
 
             df = pd.DataFrame(item_forecast_dict)
-            df[ITEMID] = int(item_id)
+            df[ITEMID] = item_id
             df[TIMESTAMP] = pd.date_range(
                 start=forecasts[i].start_date,
                 periods=self.prediction_length,

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -1,5 +1,6 @@
 """Common utils and data for all model tests"""
 import random
+from typing import List, Union
 
 import pandas as pd
 from gluonts.dataset.common import ListDataset
@@ -27,19 +28,23 @@ DUMMY_DATASET = ListDataset(
 )
 
 
-DUMMY_TS_DATAFRAME = TimeSeriesDataFrame(
-    pd.DataFrame(
-        index=pd.MultiIndex.from_product(
-            [
-                ["A", "B", "C", "D"],
-                pd.date_range(pd.Timestamp("2022-01-01"), freq="D", periods=20),  # noqa
-            ],
-            names=(ITEMID, TIMESTAMP),
-        ),
-        data=[random.random() for _ in range(4 * 20)],
-        columns=["target"],
+def get_data_frame_with_item_index(item_list: List[Union[str, int]], data_length: int = 20):
+    return TimeSeriesDataFrame(
+        pd.DataFrame(
+            index=pd.MultiIndex.from_product(
+                [
+                    item_list,
+                    pd.date_range(pd.Timestamp("2022-01-01"), freq="H", periods=data_length),  # noqa
+                ],
+                names=(ITEMID, TIMESTAMP),
+            ),
+            data=[random.random() for _ in range(len(item_list) * data_length)],
+            columns=["target"],
+        )
     )
-)
+
+
+DUMMY_TS_DATAFRAME = get_data_frame_with_item_index(["A", "B", "C", "D"])
 
 
 def dict_equal_primitive(this, that):

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -5,9 +5,11 @@ import pandas as pd
 from gluonts.dataset.common import ListDataset
 
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 
 
 # TODO: add larger unit test data sets to S3
+
 DUMMY_DATASET = ListDataset(
     [
         {
@@ -24,7 +26,20 @@ DUMMY_DATASET = ListDataset(
     freq="H",
 )
 
-DUMMY_TS_DATAFRAME = TimeSeriesDataFrame.from_iterable_dataset(DUMMY_DATASET)
+
+DUMMY_TS_DATAFRAME = TimeSeriesDataFrame(
+    pd.DataFrame(
+        index=pd.MultiIndex.from_product(
+            [
+                ["A", "B", "C", "D"],
+                pd.date_range(pd.Timestamp("2022-01-01"), freq="D", periods=20),  # noqa
+            ],
+            names=(ITEMID, TIMESTAMP),
+        ),
+        data=[random.random() for _ in range(4 * 20)],
+        columns=["target"],
+    )
+)
 
 
 def dict_equal_primitive(this, that):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

~~**Depends on:** #1841 #1839~~

Removes the constraint of specifying only integer type item indices in time series panel data frames, improving user experience.

cc: @huibinshen 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
