### PR TITLE
Fix sktime prediction discrepancy in timeseries

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
@@ -85,10 +85,12 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
         """
         return pd.DataFrame(
             data=data.values,
-            index=pd.MultiIndex.from_arrays([
-                data.index.get_level_values(0),
-                data.index.get_level_values(1).to_period(freq=data.freq),  # noqa
-            ]),
+            index=pd.MultiIndex.from_arrays(
+                [
+                    data.index.get_level_values(0),
+                    data.index.get_level_values(1).to_period(freq=data.freq),  # noqa
+                ]
+            ),
         )
 
     def _to_time_series_data_frame(self, data: pd.DataFrame) -> TimeSeriesDataFrame:
@@ -137,7 +139,12 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
             raise ValueError("No sktime forecaster found. Please fit the model first.")
 
         new_index = list(data.iter_items())
-        if not all(x == y for x, y in zip(self._fit_index, new_index)):
+
+        # TODO: reconsider when to refit the model. currently we refit whenever train and
+        #  test indices are not identical
+        if len(self._fit_index) != len(new_index) or not all(
+            x == y for x, y in zip(self._fit_index, new_index)
+        ):
             logger.warning(
                 f"\tDifferent set of items than those provided during training were provided for "
                 f"prediction. The model {self.name} will be re-trained on newly provided data"

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -222,8 +222,16 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_corr
         get_data_frame_with_item_index(["A", "B", "C"]),
     ),
     (
-        get_data_frame_with_item_index(["A", "B", "C", "D"]),
-        get_data_frame_with_item_index(["A", "E", "F"]),
+        get_data_frame_with_item_index(["A", "B", "C"]),
+        get_data_frame_with_item_index(["A", "B", "D"]),
+    ),
+    (
+        get_data_frame_with_item_index(["A", "B", "C"]),
+        get_data_frame_with_item_index(["A", "B"]),
+    ),
+    (
+        get_data_frame_with_item_index(["A", "B"]),
+        get_data_frame_with_item_index(["A", "B", "C"]),
     ),
 ])
 def test_when_predict_called_with_test_data_then_predictor_inference_correct(
@@ -241,6 +249,7 @@ def test_when_predict_called_with_test_data_then_predictor_inference_correct(
     predictions = model.predict(test_data)
 
     assert isinstance(predictions, TimeSeriesDataFrame)
+    assert len(predictions) == test_data.num_items * prediction_length
 
     predicted_item_index = predictions.index.levels[0]
     assert all(predicted_item_index == test_data.index.levels[0])  # noqa

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -149,8 +149,16 @@ def test_when_skt_models_saved_then_forecasters_can_be_loaded(
         get_data_frame_with_item_index([2, 3, 4, 5])
     ),
     (
-        get_data_frame_with_item_index(["A", "B", "C", "D"]),
-        get_data_frame_with_item_index(["A", "E", "F"]),
+        get_data_frame_with_item_index(["A", "B", "C"]),
+        get_data_frame_with_item_index(["A", "B", "D"]),
+    ),
+    (
+        get_data_frame_with_item_index(["A", "B"]),
+        get_data_frame_with_item_index(["A", "B", "C"]),
+    ),
+    (
+        get_data_frame_with_item_index(["A", "B", "C"]),
+        get_data_frame_with_item_index(["A", "B"]),
     ),
 ])
 def test_when_predict_called_with_test_data_then_predictor_inference_correct(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes sktime discrepancy when partially matching indices when unmatched lengths are passed as training and test data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
