### PR TITLE
Add sktime to model types, fix sktime model scoring on test data

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -34,15 +34,15 @@ MODEL_TYPES = dict(
 )
 DEFAULT_MODEL_NAMES = {v: k for k, v in MODEL_TYPES.items()}
 DEFAULT_MODEL_PRIORITY = dict(
-    MQCNN=50,
-    MQRNN=50,
-    SimpleFeedForward=30,
-    Transformer=50,
+    MQCNN=40,
+    MQRNN=40,
+    SimpleFeedForward=50,
+    Transformer=40,
     DeepAR=50,
-    Prophet=50,
+    Prophet=10,
     AutoTabular=10,
-    AutoARIMA=50,
-    AutoETS=50
+    AutoARIMA=60,
+    AutoETS=60,
 )
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -15,6 +15,8 @@ from .gluonts import (
     SimpleFeedForwardModel,
     TransformerModel,
 )
+from .sktime import AutoARIMAModel, AutoETSModel
+
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,8 @@ MODEL_TYPES = dict(
     AutoTabular=AutoTabularModel,
     Prophet=ProphetModel,
     Transformer=TransformerModel,
+    AutoARIMA=AutoARIMAModel,
+    AutoETS=AutoETSModel
 )
 DEFAULT_MODEL_NAMES = {v: k for k, v in MODEL_TYPES.items()}
 DEFAULT_MODEL_PRIORITY = dict(
@@ -37,6 +41,8 @@ DEFAULT_MODEL_PRIORITY = dict(
     DeepAR=50,
     Prophet=50,
     AutoTabular=10,
+    AutoARIMA=50,
+    AutoETS=50
 )
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 

--- a/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
@@ -85,10 +85,12 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
         """
         return pd.DataFrame(
             data=data.values,
-            index=pd.MultiIndex.from_arrays([
-                data.index.get_level_values(0),
-                data.index.get_level_values(1).to_period(freq=data.freq),  # noqa
-            ]),
+            index=pd.MultiIndex.from_arrays(
+                [
+                    data.index.get_level_values(0),
+                    data.index.get_level_values(1).to_period(freq=data.freq),  # noqa
+                ]
+            ),
         )
 
     def _to_time_series_data_frame(self, data: pd.DataFrame) -> TimeSeriesDataFrame:
@@ -137,7 +139,12 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
             raise ValueError("No sktime forecaster found. Please fit the model first.")
 
         new_index = list(data.iter_items())
-        if not all(x == y for x, y in zip(self._fit_index, new_index)):
+
+        # TODO: reconsider when to refit the model. currently we refit whenever train and
+        #  test indices are not identical
+        if len(self._fit_index) != len(new_index) or not all(
+            x == y for x, y in zip(self._fit_index, new_index)
+        ):
             logger.warning(
                 f"\tDifferent set of items than those provided during training were provided for "
                 f"prediction. The model {self.name} will be re-trained on newly provided data"

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -439,7 +439,7 @@ class TimeSeriesPredictor:
         """Returns the name of the best model from trainer."""
         return self._trainer.get_model_best()
 
-    def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None) -> pd.DataFrame:
+    def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None, silent=False) -> pd.DataFrame:
         """Return a leaderboard showing the performance of every trained model, the output is a
         pandas data frame containing the columns,
 
@@ -462,6 +462,8 @@ class TimeSeriesPredictor:
         data: TimeSeriesDataFrame
             dataset used for additional evaluation. If None, the validation set used during training will
             be used.
+        silent : bool, default = False
+            Should leaderboard DataFrame be printed?
 
         Returns
         -------
@@ -469,7 +471,11 @@ class TimeSeriesPredictor:
             The leaderboard containing information on all models and in order of best model to worst in terms of
             validation performance.
         """
-        return self._learner.leaderboard(data)
+        leaderboard = self._learner.leaderboard(data)
+        if not silent:
+            with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 1000):
+                print(leaderboard)
+        return leaderboard
 
     def fit_summary(self, verbosity: int = 1) -> Dict[str, Any]:
         """Output summary of information about models produced during

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -641,11 +641,6 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
     ) -> float:
         model = self._get_model_for_prediction(model)
 
-        # FIXME: this method should be able to score on all data sets regardless of
-        # FIXME: whether the implementation is in GluonTS
-        if not isinstance(model, AbstractGluonTSModel):
-            raise ValueError("Model must be a GluonTS model to score")
-
         # FIXME: when ensembling is implemented, score logic will have to be revised
         # FIXME: in order to enable prior model predictions in the ensemble
         eval_metric = self.eval_metric if metric is None else metric

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -612,12 +612,13 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         the validation score."""
 
         if model is None:
-            logger.info(
-                "Model not specified in predict, will default to the model with the best validation score",
-            )
             if self.model_best is None:
                 best_model_name: str = self.get_model_best()
                 self.model_best = best_model_name
+            logger.info(
+                f"Model not specified in predict, will default to the model with the "
+                f"best validation score: {self.model_best}",
+            )
             return self.load_model(self.model_best)
         else:
             if isinstance(model, str):

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -222,8 +222,16 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_corr
         get_data_frame_with_item_index(["A", "B", "C"]),
     ),
     (
-        get_data_frame_with_item_index(["A", "B", "C", "D"]),
-        get_data_frame_with_item_index(["A", "E", "F"]),
+        get_data_frame_with_item_index(["A", "B", "C"]),
+        get_data_frame_with_item_index(["A", "B", "D"]),
+    ),
+    (
+        get_data_frame_with_item_index(["A", "B", "C"]),
+        get_data_frame_with_item_index(["A", "B"]),
+    ),
+    (
+        get_data_frame_with_item_index(["A", "B"]),
+        get_data_frame_with_item_index(["A", "B", "C"]),
     ),
 ])
 def test_when_predict_called_with_test_data_then_predictor_inference_correct(
@@ -241,6 +249,7 @@ def test_when_predict_called_with_test_data_then_predictor_inference_correct(
     predictions = model.predict(test_data)
 
     assert isinstance(predictions, TimeSeriesDataFrame)
+    assert len(predictions) == test_data.num_items * prediction_length
 
     predicted_item_index = predictions.index.levels[0]
     assert all(predicted_item_index == test_data.index.levels[0])  # noqa

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -149,8 +149,16 @@ def test_when_skt_models_saved_then_forecasters_can_be_loaded(
         get_data_frame_with_item_index([2, 3, 4, 5])
     ),
     (
-        get_data_frame_with_item_index(["A", "B", "C", "D"]),
-        get_data_frame_with_item_index(["A", "E", "F"]),
+        get_data_frame_with_item_index(["A", "B", "C"]),
+        get_data_frame_with_item_index(["A", "B", "D"]),
+    ),
+    (
+        get_data_frame_with_item_index(["A", "B"]),
+        get_data_frame_with_item_index(["A", "B", "C"]),
+    ),
+    (
+        get_data_frame_with_item_index(["A", "B", "C"]),
+        get_data_frame_with_item_index(["A", "B"]),
     ),
 ])
 def test_when_predict_called_with_test_data_then_predictor_inference_correct(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Depends on #1859 , subsumes #1857 

- update model names and priority configs
- fix Trainer.score, which ignored non-GluonTS models


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
