### PR TITLE
Clean tutorial printing and indexes

### DIFF
--- a/docs/tutorials/multimodal/index.rst
+++ b/docs/tutorials/multimodal/index.rst
@@ -13,19 +13,19 @@ be used as a basic model in the multi-layer stack-ensemble of `TabularPredictor`
 .. container:: cards
 
    .. card::
-      :title: Use AutoGluon Multimodal for Text Prediction: Quick Start
+      :title: AutoMM for Text - Quick Start
       :link: beginner_text.html
 
       How to train high-quality text prediction models with AutoMMPredictor in under 5 minutes.
 
    .. card::
-      :title: Solving Multilingual Problems
+      :title: AutoMM for Text - Multilingual Problems
       :link: multilingual_text.html
 
       How to use AutoMMPredictor to build models on datasets with languages other than English.
 
    .. card::
-      :title: Multimodal Data Tables with Text
+      :title: AutoMM for Text + Tabular - Quick Start
       :link: multimodal_text_tabular.html
 
       How AutoMMPredictor can be applied to multimodal data tables with a mix of text, numerical, and categorical columns.
@@ -34,7 +34,7 @@ be used as a basic model in the multi-layer stack-ensemble of `TabularPredictor`
       :title: AutoMM for Multimodal - Quick Start
       :link: beginner_multimodal.html
 
-      How to train high-quality multimodal models with AutoMMPredictor under 5 minutes.
+      How to train high-quality multimodal models with AutoMMPredictor.
 
    .. card::
       :title: Customize AutoMM

--- a/docs/tutorials/multimodal/multimodal_text_tabular.md
+++ b/docs/tutorials/multimodal/multimodal_text_tabular.md
@@ -1,4 +1,4 @@
-# Multimodal Table with Text and Tabular Features
+# AutoMM for Text + Tabular - Quick Start
 :label:`sec_automm_textprediction_multimodal`
 
 In many applications, text data may be mixed with numeric/categorical data. 

--- a/docs/tutorials/text_prediction/index.rst
+++ b/docs/tutorials/text_prediction/index.rst
@@ -14,13 +14,6 @@ A single call to `predictor.fit()` will train highly accurate neural networks on
       How to train high-quality text prediction models in under 5 minutes.
 
    .. card::
-      :title: Multimodal Data Tables with Text
-      :link: multimodal_text.html
-
-      How TextPredictor can be applied to multimodal data tables with
-      a mix of text, numeric, and categorical columns.
-
-   .. card::
       :title: Customize TextPredictor Configurations
       :link: customization.html
 
@@ -32,18 +25,10 @@ A single call to `predictor.fit()` will train highly accurate neural networks on
 
       Build models on datasets with languages other than English.
 
-   .. card::
-      :title: Getting Started with AutoMM
-      :link: automm.html
-
-      How to use AutoMM to train models on single modal and multimodal data.
-
 .. toctree::
    :maxdepth: 1
    :hidden:
 
    beginner
-   multimodal_text
    customization
    multilingual_text
-   automm

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1285,6 +1285,8 @@ class AutoMMPredictor:
             blacklist_msgs.append("GPU available")
             blacklist_msgs.append("TPU available")
             blacklist_msgs.append("IPU available")
+            blacklist_msgs.append("HPU available")
+            blacklist_msgs.append("select gpus")
             blacklist_msgs.append("LOCAL_RANK")
         log_filter = LogFilter(blacklist_msgs)
         with apply_log_filter(log_filter):


### PR DESCRIPTION
1. Clean the `index.rst` in the `text_prediction` folder since some docs are removed.
2. Filter two messages in prediction/evaluation.
3. Unify tutorial titles with card titles.
