### PR TITLE
fix mxnet warning in timeseries

### DIFF
--- a/docs/tutorials/timeseries/forecasting-quickstart.md
+++ b/docs/tutorials/timeseries/forecasting-quickstart.md
@@ -9,6 +9,20 @@ Via a simple `fit()` call, AutoGluon can train
 
 to produce multi-step ahead _probabilistic_ forecasts for univariate time series data. 
 
+---
+**NOTE**
+
+`autogluon.timeseries` depends on Apache MXNet. Please install MXNet by
+
+```shell
+python -m pip install mxnet>=1.9
+```
+
+or, if you are using a GPU with a matching MXNet package for your CUDA driver. See the 
+MXNet [documentation](https://mxnet.apache.org/versions/1.9.1/get_started?) for more info.
+
+---
+
 This tutorial demonstrates how to quickly start using AutoGluon to produce forecasts of COVID-19 cases in a 
 country given [historical data from each country](https://www.kaggle.com/c/covid19-global-forecasting-week-4). 
 

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -40,9 +40,10 @@ try:
     assert vparse("2.0") > vparse(mxnet_version) >= vparse("1.9")
 except (ImportError, AssertionError):
     warnings.warn(
-        "autogluon.forecasting depends on Apache MxNet v1.9 or greater (below v2.0). "
-        "Please install a suitable version of MxNet in order to use autogluon.forecasting using "
-        "`pip install mxnet==1.9` or `pip install mxnet-cu112==1.9` for GPU support."
+        "autogluon.forecasting depends on Apache MXNet v1.9 or greater (below v2.0). "
+        "Please install a suitable version of MXNet in order to use autogluon.forecasting using "
+        "`pip install mxnet==1.9` or a matching MXNet package for your CUDA driver if you are using "
+        "a GPU. See the MXNet documentation for more info."
     )
 
 extras_require = {

--- a/timeseries/src/autogluon/timeseries/__init__.py
+++ b/timeseries/src/autogluon/timeseries/__init__.py
@@ -12,9 +12,10 @@ try:
     assert parse("2.0") > parse(mxnet_version) >= parse("1.9")
 except (ImportError, AssertionError):
     raise ImportError(
-        "autogluon.forecasting depends on Apache MxNet v1.9 or greater (below v2.0). "
-        "Please install a suitable version of MxNet in order to use autogluon.forecasting using "
-        "`pip install mxnet==1.9` or `pip install mxnet-cu112==1.9` for GPU support."
+        "autogluon.forecasting depends on Apache MXNet v1.9 or greater (below v2.0). "
+        "Please install a suitable version of MXNet in order to use autogluon.forecasting using "
+        "`pip install mxnet==1.9` or a matching MXNet package for your CUDA driver if you are using "
+        "a GPU. See the MXNet documentation for more info."
     )
 
 from .dataset import TimeSeriesDataFrame

--- a/timeseries/src/autogluon/timeseries/__init__.py
+++ b/timeseries/src/autogluon/timeseries/__init__.py
@@ -6,10 +6,6 @@ try:
 except ImportError:
     pass
 
-from .dataset import TimeSeriesDataFrame
-from .evaluator import TimeSeriesEvaluator
-from .predictor import TimeSeriesPredictor
-
 try:
     from mxnet import __version__ as mxnet_version
 
@@ -20,5 +16,9 @@ except (ImportError, AssertionError):
         "Please install a suitable version of MxNet in order to use autogluon.forecasting using "
         "`pip install mxnet==1.9` or `pip install mxnet-cu112==1.9` for GPU support."
     )
+
+from .dataset import TimeSeriesDataFrame
+from .evaluator import TimeSeriesEvaluator
+from .predictor import TimeSeriesPredictor
 
 logging.basicConfig(format="%(message)s")  # just print message in logs


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Right now after install time series errors with `no module found: mxnet`. This fixes it back to fail more gracefully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
