### PR TITLE
Support distillation for text predictor and add default for distiller

### DIFF
--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -728,16 +728,11 @@ class AutoMMPredictor:
         if self._config is not None:  # continuous training
             config = self._config
 
-        if config is None:
-            config = {}
-
-        if teacher_predictor is not None and "distiller" not in config:
-            config["distiller"] = "default"
-
         config = get_config(
             presets=presets,
             config=config,
             overrides=hyperparameters,
+            is_distill=teacher_predictor is not None,
         )
 
         config = update_config_by_rules(

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -1,9 +1,10 @@
-import os
+from typing import Optional
 from .constants import (
     MODEL,
     DATA,
     OPTIMIZATION,
     ENVIRONMENT,
+    DISTILLER,
 )
 from .registry import Registry
 
@@ -73,20 +74,29 @@ def list_automm_presets(verbose: bool = False):
     return preset_details
 
 
-def get_basic_automm_config():
+def get_basic_automm_config(is_distill: Optional[bool] = False):
     """
     Get the basic config of AutoMM.
+
+    Parameters
+    ----------
+    is_distill
+        Whether in the distillation mode.
 
     Returns
     -------
     A dict config with keys: MODEL, DATA, OPTIMIZATION, ENVIRONMENT, and their default values.
     """
-    return {
+    config = {
         MODEL: "fusion_mlp_image_text_tabular",
         DATA: "default",
         OPTIMIZATION: "adamw",
         ENVIRONMENT: "default",
     }
+    if is_distill:
+        config[DISTILLER] = "default"
+
+    return config
 
 
 def get_automm_presets(presets: str):
@@ -105,7 +115,6 @@ def get_automm_presets(presets: str):
     overrides
         The hyperparameter overrides of this preset.
     """
-    basic_config = get_basic_automm_config()
     presets = presets.lower()
     if presets in automm_presets.list_keys():
         overrides = automm_presets.create(presets)
@@ -114,4 +123,4 @@ def get_automm_presets(presets: str):
             f"Provided preset '{presets}' is not supported. " f"Consider one of these: {automm_presets.list_keys()}"
         )
 
-    return basic_config, overrides
+    return overrides

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -201,6 +201,7 @@ def get_config(
     presets: Optional[str] = None,
     config: Optional[Union[dict, DictConfig]] = None,
     overrides: Optional[Union[str, List[str], Dict]] = None,
+    is_distill: Optional[bool] = False,
 ):
     """
     Construct configurations for model, data, optimization, and environment.
@@ -252,6 +253,8 @@ def get_config(
                             "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
                             "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
                         }
+    is_distill
+        Whether in the distillation mode.
 
     Returns
     -------
@@ -261,11 +264,11 @@ def get_config(
         config = {}
 
     if not isinstance(config, DictConfig):
+        basic_config = get_basic_automm_config(is_distill=is_distill)
         if presets is None:
-            basic_config = get_basic_automm_config()
             preset_overrides = None
         else:
-            basic_config, preset_overrides = get_automm_presets(presets=presets)
+            preset_overrides = get_automm_presets(presets=presets)
 
         for k, default_value in basic_config.items():
             if k not in config:

--- a/multimodal/tests/unittests/test_distiller.py
+++ b/multimodal/tests/unittests/test_distiller.py
@@ -82,3 +82,23 @@ def test_distillation():
         save_path=student_save_path,
     )
     verify_predictor_save_load(predictor, dataset.test_df)
+
+    # test for distillation with teacher predictor path
+    predictor = AutoMMPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=dataset.metric,
+    )
+
+    student_save_path = os.path.join(get_home_dir(), "petfinder", "student")
+    if os.path.exists(student_save_path):
+        shutil.rmtree(student_save_path)
+
+    predictor = predictor.fit(
+        train_data=dataset.train_df,
+        teacher_predictor=teacher_predictor.path,
+        hyperparameters=hyperparameters,
+        time_limit=30,
+        save_path=student_save_path,
+    )
+    verify_predictor_save_load(predictor, dataset.test_df)

--- a/multimodal/tests/unittests/test_distiller.py
+++ b/multimodal/tests/unittests/test_distiller.py
@@ -37,14 +37,6 @@ ALL_DATASETS = {
 def test_distillation():
     dataset = PetFinderDataset()
 
-    config = {
-        MODEL: f"fusion_mlp_image_text_tabular",
-        DATA: "default",
-        OPTIMIZATION: "adamw",
-        ENVIRONMENT: "default",
-        DISTILLER: "default",
-    }
-
     hyperparameters = {
         "optimization.max_epochs": 1,
         "model.names": ["hf_text", "timm_image", "fusion_mlp"],
@@ -66,7 +58,6 @@ def test_distillation():
 
     teacher_predictor = teacher_predictor.fit(
         train_data=dataset.train_df,
-        config=config,
         hyperparameters=hyperparameters,
         time_limit=30,
         save_path=teacher_save_path,
@@ -86,7 +77,6 @@ def test_distillation():
     predictor = predictor.fit(
         train_data=dataset.train_df,
         teacher_predictor=teacher_predictor,
-        config=config,
         hyperparameters=hyperparameters,
         time_limit=30,
         save_path=student_save_path,

--- a/multimodal/tests/unittests/test_presets.py
+++ b/multimodal/tests/unittests/test_presets.py
@@ -42,4 +42,3 @@ def test_basic_config():
 
     basic_config = get_basic_automm_config(is_distill=True)
     assert list(basic_config.keys()).sort() == [MODEL, DATA, OPTIMIZATION, ENVIRONMENT, DISTILLER].sort()
-

--- a/multimodal/tests/unittests/test_presets.py
+++ b/multimodal/tests/unittests/test_presets.py
@@ -3,6 +3,14 @@ from omegaconf import OmegaConf
 from autogluon.multimodal.presets import (
     get_automm_presets,
     list_automm_presets,
+    get_basic_automm_config,
+)
+from autogluon.multimodal.constants import (
+    MODEL,
+    DATA,
+    OPTIMIZATION,
+    ENVIRONMENT,
+    DISTILLER,
 )
 from autogluon.multimodal.utils import get_config
 
@@ -10,19 +18,28 @@ from autogluon.multimodal.utils import get_config
 def test_presets():
     all_presets = list_automm_presets()
     for preset in all_presets:
-        basic_config, overrides = get_automm_presets(preset)
+        overrides = get_automm_presets(preset)
 
     # test non-existing types
     non_exist_types = ["hello", "haha"]
     for per_type in non_exist_types:
         with pytest.raises(ValueError):
-            basic_config, overrides = get_automm_presets(per_type)
+            overrides = get_automm_presets(per_type)
 
 
 def test_preset_to_config():
     all_presets = list_automm_presets()
     for preset in all_presets:
-        basic_config, overrides = get_automm_presets(preset)
+        overrides = get_automm_presets(preset)
         config = get_config(presets=preset)
         for k, v in overrides.items():
             assert OmegaConf.select(config, k) == v
+
+
+def test_basic_config():
+    basic_config = get_basic_automm_config(is_distill=False)
+    assert list(basic_config.keys()).sort() == [MODEL, DATA, OPTIMIZATION, ENVIRONMENT].sort()
+
+    basic_config = get_basic_automm_config(is_distill=True)
+    assert list(basic_config.keys()).sort() == [MODEL, DATA, OPTIMIZATION, ENVIRONMENT, DISTILLER].sort()
+

--- a/text/src/autogluon/text/text_prediction/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor.py
@@ -229,7 +229,6 @@ class TextPredictor:
         :class:`TextPredictor` object. Returns self.
         """
         if self._backend == PYTORCH:
-            basic_config = get_basic_automm_config(is_distill=teacher_predictor is not None)
             if self._predictor._config is None:
                 if presets is None:
                     presets = "default"
@@ -245,12 +244,11 @@ class TextPredictor:
             if num_gpus is not None:
                 overrides.update({"env.num_gpus": int(num_gpus)})
 
-            if teacher_predictor is not None:
+            if isinstance(teacher_predictor, TextPredictor):
                 teacher_predictor = teacher_predictor._predictor
 
             self._predictor.fit(
                 train_data=train_data,
-                config=basic_config,
                 tuning_data=tuning_data,
                 time_limit=time_limit,
                 hyperparameters=overrides,

--- a/text/src/autogluon/text/text_prediction/presets.py
+++ b/text/src/autogluon/text/text_prediction/presets.py
@@ -1,4 +1,3 @@
-from autogluon.multimodal.presets import get_basic_automm_config
 
 
 def list_text_presets(verbose=False):
@@ -54,7 +53,6 @@ def get_text_preset(preset: str):
     overrides
         A dictionary of overriding configs.
     """
-    basic_config = get_basic_automm_config()
     overrides = {"model.names": ["hf_text", "numerical_mlp", "categorical_mlp", "fusion_mlp"]}
     preset = preset.lower()
     available_presets = list_text_presets(verbose=True)
@@ -67,4 +65,4 @@ def get_text_preset(preset: str):
             f"Consider one of these: {list_text_presets()}"
         )
 
-    return basic_config, overrides
+    return overrides

--- a/text/tests/unittests/text_prediction/test_distiller.py
+++ b/text/tests/unittests/text_prediction/test_distiller.py
@@ -50,3 +50,19 @@ def test_distillation():
         save_path=student_save_path,
     )
     verify_predictor_save_load(predictor, test_data)
+
+    # test for distillation with teacher predictor path
+    predictor = TextPredictor(label="label", eval_metric="acc")
+
+    student_save_path = os.path.join("sst", "student")
+    if os.path.exists(student_save_path):
+        shutil.rmtree(student_save_path)
+
+    predictor = predictor.fit(
+        train_data=train_data,
+        teacher_predictor=teacher_predictor.path,
+        hyperparameters=hyperparameters,
+        time_limit=30,
+        save_path=student_save_path,
+    )
+    verify_predictor_save_load(predictor, test_data)

--- a/text/tests/unittests/text_prediction/test_distiller.py
+++ b/text/tests/unittests/text_prediction/test_distiller.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import numpy as np
+
+from autogluon.core.utils.loaders import load_pd
+from autogluon.text import TextPredictor
+from test_predictor_pytorch import verify_predictor_save_load
+
+
+def test_distillation():
+    train_data = load_pd.load("https://autogluon-text.s3-accelerate.amazonaws.com/" "glue/sst/train.parquet")
+    test_data = load_pd.load("https://autogluon-text.s3-accelerate.amazonaws.com/" "glue/sst/dev.parquet")
+    rng_state = np.random.RandomState(123)
+    train_perm = rng_state.permutation(len(train_data))
+    test_perm = rng_state.permutation(len(test_data))
+    train_data = train_data.iloc[train_perm[:100]]
+    test_data = test_data.iloc[test_perm[:10]]
+
+    teacher_predictor = TextPredictor(label="label", eval_metric="acc")
+
+    hyperparameters = {
+        "model.hf_text.checkpoint_name": "prajjwal1/bert-tiny",
+        "env.num_workers": 0,
+        "env.num_workers_evaluation": 0,
+    }
+
+    teacher_save_path = os.path.join("sst", "teacher")
+    if os.path.exists(teacher_save_path):
+        shutil.rmtree(teacher_save_path)
+
+    teacher_predictor = teacher_predictor.fit(
+        train_data=train_data,
+        hyperparameters=hyperparameters,
+        time_limit=30,
+        save_path=teacher_save_path,
+    )
+
+    # test for distillation
+    predictor = TextPredictor(label="label", eval_metric="acc")
+
+    student_save_path = os.path.join("sst", "student")
+    if os.path.exists(student_save_path):
+        shutil.rmtree(student_save_path)
+
+    predictor = predictor.fit(
+        train_data=train_data,
+        teacher_predictor=teacher_predictor,
+        hyperparameters=hyperparameters,
+        time_limit=30,
+        save_path=student_save_path,
+    )
+    verify_predictor_save_load(predictor, test_data)

--- a/text/tests/unittests/text_prediction/test_text_presets.py
+++ b/text/tests/unittests/text_prediction/test_text_presets.py
@@ -17,14 +17,13 @@ def test_presets():
     available_presets = list_text_presets(verbose=True)
 
     for preset, to_be_verified in available_presets.items():
-        automm_preset, overrides = get_text_preset(preset)
+        overrides = get_text_preset(preset)
         config = get_config(
-            config=automm_preset,
             overrides=overrides,
         )
         for k, v in to_be_verified.items():
             assert v == rgetattr(config, k)
-        assert sorted(config.model.names) == sorted(["hf_text", "numerical_mlp", "categorical_mlp", "fusion_mlp"])
+
     # test invalid presets
     presets = ["hello", "haha"]
     for preset in presets:


### PR DESCRIPTION
1. Support distillation for the text predictor.
2. Previous adding default for distill is not optimal. This is to improve the design.
3. Add unit tests for passing a predictor object or a a predictor path.
