### PR TITLE
Fix predict_proba bug in image predictor

### DIFF
--- a/multimodal/tests/unittests/test_predictor.py
+++ b/multimodal/tests/unittests/test_predictor.py
@@ -700,7 +700,7 @@ def test_hpo(searcher, scheduler):
     hyperparameters = {
         "optimization.learning_rate": tune.uniform(0.0001, 0.01),
         "optimization.max_epochs": 1,
-        "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
+        "model.names": ["numerical_mlp"],
         "env.num_workers": 0,
         "env.num_workers_evaluation": 0,
     }
@@ -758,7 +758,7 @@ def test_hpo_distillation(searcher, scheduler):
 
     hyperparameters = {
         "optimization.max_epochs": 1,
-        "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
+        "model.names": ["numerical_mlp"],
         "env.num_workers": 0,
         "env.num_workers_evaluation": 0,
     }

--- a/multimodal/tests/unittests/test_predictor.py
+++ b/multimodal/tests/unittests/test_predictor.py
@@ -700,7 +700,7 @@ def test_hpo(searcher, scheduler):
     hyperparameters = {
         "optimization.learning_rate": tune.uniform(0.0001, 0.01),
         "optimization.max_epochs": 1,
-        "model.names": ["numerical_mlp"],
+        "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
         "env.num_workers": 0,
         "env.num_workers_evaluation": 0,
     }
@@ -758,7 +758,7 @@ def test_hpo_distillation(searcher, scheduler):
 
     hyperparameters = {
         "optimization.max_epochs": 1,
-        "model.names": ["numerical_mlp"],
+        "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
         "env.num_workers": 0,
         "env.num_workers_evaluation": 0,
     }

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -536,16 +536,17 @@ class ImagePredictor(object):
         if self._classifier is None:
             raise RuntimeError('Classifier is not initialized, try `fit` first.')
         assert self._label_cleaner is not None
+
         try:
             y_pred_proba = self._classifier.predict(data, with_proba=True) 
         except AssertionError:
             y_pred_proba = self._classifier.predict(data)
         
-        class_ids = list(self._label_cleaner.cat_mappings_dependent_var.values())
         if isinstance(data, pd.DataFrame):
             y_pred_proba.index = data.index
         
         if self._problem_type in [MULTICLASS, BINARY]:
+            class_ids = list(self._label_cleaner.cat_mappings_dependent_var.values())
             if len(y_pred_proba['image_proba'][0]) > len(class_ids):
                 # inference on multiple images and input data type is torch.Tensor
                 flatten_list = y_pred_proba['image_proba'][0]

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -547,8 +547,9 @@ class ImagePredictor(object):
         
         if self._problem_type in [MULTICLASS, BINARY]:
             class_ids = list(self._label_cleaner.cat_mappings_dependent_var.values())
-            if len(y_pred_proba['image_proba'][0]) > len(class_ids):
+            if len(y_pred_proba['image_proba'].iloc[0]) > len(class_ids):
                 # inference on multiple images and input data type is torch.Tensor
+                # y_pred_proba['image_proba'] is a Pandas Series
                 flatten_list = y_pred_proba['image_proba'][0]
                 nested_list = [flatten_list[i:i + len(class_ids)] for i in range(0, len(flatten_list), len(class_ids))]
                 ret = pd.DataFrame(nested_list)

--- a/vision/src/autogluon/vision/predictor/predictor.py
+++ b/vision/src/autogluon/vision/predictor/predictor.py
@@ -550,7 +550,7 @@ class ImagePredictor(object):
             if len(y_pred_proba['image_proba'].iloc[0]) > len(class_ids):
                 # inference on multiple images and input data type is torch.Tensor
                 # y_pred_proba['image_proba'] is a Pandas Series
-                flatten_list = y_pred_proba['image_proba'][0]
+                flatten_list = y_pred_proba['image_proba'].iloc[0]
                 nested_list = [flatten_list[i:i + len(class_ids)] for i in range(0, len(flatten_list), len(class_ids))]
                 ret = pd.DataFrame(nested_list)
             else:


### PR DESCRIPTION
*Issue #, if available:*
#1890. Problem is caused by using GluonCV image classifier [`predict_proba` function](https://github.com/dmlc/gluon-cv/blob/master/gluoncv/auto/estimators/image_classification/image_classification.py#L601). In this function, the [returned predicted probabilities](https://github.com/dmlc/gluon-cv/blob/master/gluoncv/auto/estimators/image_classification/image_classification.py#L631) are flattened into `BC x 1`. However, in most of the cases, the output should be in `B x C` format. B indicates batch size and C indicates number of classes. This error only happens when input data type is torch.Tensor. When input data type is str, list of strs, dataframe, etc, existing code works fine. So I added an `if` statement.

*Description of changes:*
Add an `if` statement: if input data type is torch.Tensor and we want to inference on multiple images, we reshape the predicted probabilities to `B x C` format, instead of a flattened list. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
