### PR TITLE
Fix HPO tests in AutoMM

### DIFF
--- a/multimodal/tests/unittests/datasets.py
+++ b/multimodal/tests/unittests/datasets.py
@@ -47,13 +47,13 @@ class PetFinderDataset:
 
         _, self._train_df = train_test_split(
             self._train_df,
-            test_size=0.5,
+            test_size=0.1,
             random_state=np.random.RandomState(123),
             stratify=self._train_df[self.label_columns[0]],
         )
         _, self._test_df = train_test_split(
             self._test_df,
-            test_size=0.2,
+            test_size=0.1,
             random_state=np.random.RandomState(123),
             stratify=self._test_df[self.label_columns[0]],
         )

--- a/multimodal/tests/unittests/test_hpo.py
+++ b/multimodal/tests/unittests/test_hpo.py
@@ -1,0 +1,129 @@
+import os
+import shutil
+import pytest
+from ray import tune
+
+from autogluon.core.hpo.constants import SEARCHER_PRESETS, SCHEDULER_PRESETS
+from autogluon.multimodal import AutoMMPredictor
+
+from datasets import PetFinderDataset
+from utils import get_home_dir
+from test_predictor import verify_predictor_save_load
+
+
+@pytest.mark.parametrize("searcher", list(SEARCHER_PRESETS.keys()))
+@pytest.mark.parametrize("scheduler", list(SCHEDULER_PRESETS.keys()))
+def test_hpo(searcher, scheduler):
+    dataset = PetFinderDataset()
+
+    hyperparameters = {
+        "optimization.learning_rate": tune.uniform(0.0001, 0.01),
+        "optimization.max_epochs": 1,
+        "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
+        "data.categorical.convert_to_text": False,
+        "data.convert_to_text.convert_to_text": False,
+        "env.num_workers": 0,
+        "env.num_workers_evaluation": 0,
+    }
+
+    hyperparameter_tune_kwargs = {
+        "searcher": searcher,
+        "scheduler": scheduler,
+        "num_trials": 2,
+    }
+
+    predictor = AutoMMPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=dataset.metric,
+    )
+
+    save_path = os.path.join(get_home_dir(), "hpo", f"_{searcher}", f"_{scheduler}")
+    if os.path.exists(save_path):
+        shutil.rmtree(save_path)
+
+    predictor = predictor.fit(
+        train_data=dataset.train_df,
+        hyperparameters=hyperparameters,
+        time_limit=60,
+        save_path=save_path,
+        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+    )
+
+    score = predictor.evaluate(dataset.test_df)
+    verify_predictor_save_load(predictor, dataset.test_df)
+
+    # test for continuous training
+    predictor = predictor.fit(
+        train_data=dataset.train_df,
+        hyperparameters=hyperparameters,
+        time_limit=60,
+        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+    )
+
+
+@pytest.mark.parametrize("searcher", list(SEARCHER_PRESETS.keys()))
+@pytest.mark.parametrize("scheduler", list(SCHEDULER_PRESETS.keys()))
+def test_hpo_distillation(searcher, scheduler):
+    dataset = PetFinderDataset()
+
+    hyperparameters = {
+        "optimization.max_epochs": 1,
+        "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
+        "data.categorical.convert_to_text": False,
+        "data.convert_to_text.convert_to_text": False,
+        "env.num_workers": 0,
+        "env.num_workers_evaluation": 0,
+    }
+
+    hyperparameter_tune_kwargs = {
+        "searcher": searcher,
+        "scheduler": scheduler,
+        "num_trials": 2,
+    }
+
+    teacher_predictor = AutoMMPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=dataset.metric,
+    )
+
+    teacher_save_path = os.path.join(get_home_dir(), "hpo_distillation_teacher", f"_{searcher}", f"_{scheduler}")
+    if os.path.exists(teacher_save_path):
+        shutil.rmtree(teacher_save_path)
+
+    teacher_predictor = teacher_predictor.fit(
+        train_data=dataset.train_df,
+        hyperparameters=hyperparameters,
+        time_limit=60,
+        save_path=teacher_save_path,
+    )
+
+    hyperparameters = {
+        "optimization.learning_rate": tune.uniform(0.0001, 0.01),
+        "optimization.max_epochs": 1,
+        "model.names": ["numerical_mlp"],
+        "data.convert_to_text.convert_to_text": False,
+        "env.num_workers": 0,
+        "env.num_workers_evaluation": 0,
+    }
+
+    # test for distillation
+    predictor = AutoMMPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=dataset.metric,
+    )
+
+    student_save_path = os.path.join(get_home_dir(), "hpo_distillation_student", f"_{searcher}", f"_{scheduler}")
+    if os.path.exists(student_save_path):
+        shutil.rmtree(student_save_path)
+
+    predictor = predictor.fit(
+        train_data=dataset.train_df,
+        teacher_predictor=teacher_save_path,
+        hyperparameters=hyperparameters,
+        time_limit=60,
+        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+        save_path=student_save_path,
+    )

--- a/multimodal/tests/unittests/test_hpo.py
+++ b/multimodal/tests/unittests/test_hpo.py
@@ -21,7 +21,7 @@ def test_hpo(searcher, scheduler):
         "optimization.max_epochs": 1,
         "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
         "data.categorical.convert_to_text": False,
-        "data.convert_to_text.convert_to_text": False,
+        "data.numerical.convert_to_text": False,
         "env.num_workers": 0,
         "env.num_workers_evaluation": 0,
     }
@@ -71,7 +71,7 @@ def test_hpo_distillation(searcher, scheduler):
         "optimization.max_epochs": 1,
         "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
         "data.categorical.convert_to_text": False,
-        "data.convert_to_text.convert_to_text": False,
+        "data.numerical.convert_to_text": False,
         "env.num_workers": 0,
         "env.num_workers_evaluation": 0,
     }
@@ -103,7 +103,7 @@ def test_hpo_distillation(searcher, scheduler):
         "optimization.learning_rate": tune.uniform(0.0001, 0.01),
         "optimization.max_epochs": 1,
         "model.names": ["numerical_mlp"],
-        "data.convert_to_text.convert_to_text": False,
+        "data.numerical.convert_to_text": False,
         "env.num_workers": 0,
         "env.num_workers_evaluation": 0,
     }

--- a/multimodal/tests/unittests/test_predictor.py
+++ b/multimodal/tests/unittests/test_predictor.py
@@ -327,10 +327,10 @@ def test_standalone(): # test standalong feature in AutoMMPredictor.save()
         },
 
         {
-            "model.names": ["timm_image_haha", "hf_text_hello", "numerical_mlp_456", "categorical_mlp_abc", "fusion_mlp"],
+            "model.names": ["timm_image_haha", "hf_text_hello", "numerical_mlp_456", "fusion_mlp"],
             "model.timm_image_haha.checkpoint_name": "swin_tiny_patch4_window7_224",
             "model.hf_text_hello.checkpoint_name": "prajjwal1/bert-tiny",
-            "data.categorical.convert_to_text": False,
+            "data.numerical.convert_to_text": False,
         },
     ]
 )

--- a/multimodal/tests/unittests/test_predictor.py
+++ b/multimodal/tests/unittests/test_predictor.py
@@ -5,12 +5,9 @@ import numpy.testing as npt
 import tempfile
 import copy
 import pickle
-
 from omegaconf import OmegaConf
-from ray import tune
 from torch import nn
 
-from autogluon.core.hpo.constants import SEARCHER_PRESETS, SCHEDULER_PRESETS
 from autogluon.multimodal import AutoMMPredictor
 from autogluon.multimodal.utils import modify_duplicate_model_names
 from autogluon.multimodal.constants import (
@@ -588,6 +585,7 @@ def test_modifying_duplicate_model_names():
         for per_processor in per_modality_processors:
             assert per_processor.prefix in teacher_predictor._config.model.names
 
+
 def test_mixup():
     dataset = ALL_DATASETS["petfinder"]()
     metric_name = dataset.metric
@@ -624,6 +622,7 @@ def test_mixup():
 
         score = predictor.evaluate(dataset.test_df)
         verify_predictor_save_load(predictor, dataset.test_df)
+
 
 def test_textagumentor_deepcopy():
     dataset = ALL_DATASETS["ae"]()
@@ -685,135 +684,6 @@ def test_textagumentor_deepcopy():
         time_limit=10,
     )
 
-@pytest.mark.parametrize('searcher', list(SEARCHER_PRESETS.keys()))
-@pytest.mark.parametrize('scheduler', list(SCHEDULER_PRESETS.keys()))
-def test_hpo(searcher, scheduler):
-    dataset = PetFinderDataset()
-
-    config = {
-        MODEL: f"fusion_mlp_image_text_tabular",
-        DATA: "default",
-        OPTIMIZATION: "adamw",
-        ENVIRONMENT: "default",
-    }
-
-    hyperparameters = {
-        "optimization.learning_rate": tune.uniform(0.0001, 0.01),
-        "optimization.max_epochs": 1,
-        "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
-        "env.num_workers": 0,
-        "env.num_workers_evaluation": 0,
-    }
-
-    hyperparameter_tune_kwargs = {
-        'searcher': searcher,
-        'scheduler': scheduler,
-        'num_trials': 2,
-    }
-
-    predictor = AutoMMPredictor(
-        label=dataset.label_columns[0],
-        problem_type=dataset.problem_type,
-        eval_metric=dataset.metric,
-    )
-
-    save_path = os.path.join(get_home_dir(), 'hpo', f'_{searcher}', f'_{scheduler}')
-    if os.path.exists(save_path):
-        shutil.rmtree(save_path)
-
-    predictor = predictor.fit(
-        train_data=dataset.train_df,
-        config=config,
-        hyperparameters=hyperparameters,
-        time_limit=60,
-        save_path=save_path,
-        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
-    )
-
-    score = predictor.evaluate(dataset.test_df)
-    verify_predictor_save_load(predictor, dataset.test_df)
-
-    # test for continuous training
-    predictor = predictor.fit(
-        train_data=dataset.train_df,
-        config=config,
-        hyperparameters=hyperparameters,
-        time_limit=60,
-        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
-    )
-
-
-@pytest.mark.parametrize('searcher', list(SEARCHER_PRESETS.keys()))
-@pytest.mark.parametrize('scheduler', list(SCHEDULER_PRESETS.keys()))
-def test_hpo_distillation(searcher, scheduler):
-    dataset = PetFinderDataset()
-
-    config = {
-        MODEL: f"fusion_mlp_image_text_tabular",
-        DATA: "default",
-        OPTIMIZATION: "adamw",
-        ENVIRONMENT: "default",
-        DISTILLER: "default",
-    }
-
-    hyperparameters = {
-        "optimization.max_epochs": 1,
-        "model.names": ["numerical_mlp", "categorical_mlp", "fusion_mlp"],
-        "env.num_workers": 0,
-        "env.num_workers_evaluation": 0,
-    }
-
-    hyperparameter_tune_kwargs = {
-        'searcher': searcher,
-        'scheduler': scheduler,
-        'num_trials': 2,
-    }
-
-    teacher_predictor = AutoMMPredictor(
-        label=dataset.label_columns[0],
-        problem_type=dataset.problem_type,
-        eval_metric=dataset.metric,
-    )
-
-    teacher_save_path = os.path.join(get_home_dir(), 'hpo_distillation_teacher', f'_{searcher}', f'_{scheduler}')
-    if os.path.exists(teacher_save_path):
-        shutil.rmtree(teacher_save_path)
-
-    teacher_predictor = teacher_predictor.fit(
-        train_data=dataset.train_df,
-        config=config,
-        hyperparameters=hyperparameters,
-        time_limit=60,
-        save_path=teacher_save_path,
-    )
-
-    hyperparameters = {
-        "optimization.learning_rate": tune.uniform(0.0001, 0.01),
-        "optimization.max_epochs": 1,
-        "model.names": ["numerical_mlp"],
-        "env.num_workers": 0,
-        "env.num_workers_evaluation": 0,
-    }
-    # test for distillation
-    predictor = AutoMMPredictor(
-        label=dataset.label_columns[0],
-        problem_type=dataset.problem_type,
-        eval_metric=dataset.metric,
-    )
-
-    student_save_path = os.path.join(get_home_dir(), 'hpo_distillation_student', f'_{searcher}', f'_{scheduler}')
-    if os.path.exists(student_save_path):
-        shutil.rmtree(student_save_path)
-
-    predictor = predictor.fit(
-        train_data=dataset.train_df,
-        teacher_predictor=teacher_save_path,
-        config=config,
-        hyperparameters=hyperparameters,
-        time_limit=60,
-        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
-        save_path=student_save_path,
-    )
 
 def test_trivialaugment():
     dataset = ALL_DATASETS["petfinder"]()


### PR DESCRIPTION
1. HPO tests fail sometimes in AutoMM due to that no best trial is found. This is to fix the issue by reducing the training data size.
2. Separate HPO tests into a new test file.
