### PR TITLE
Skip AutoMM HPO tests temporarily

### DIFF
--- a/multimodal/tests/unittests/test_hpo.py
+++ b/multimodal/tests/unittests/test_hpo.py
@@ -12,7 +12,7 @@ from test_predictor import verify_predictor_save_load
 
 pytest.skip(
     "HPO testing fails due to RuntimeError: CUDA error: out of memory, "
-    "but the GPU memory usage is low. Seems something seems wrong with ray. "
+    "but the GPU memory usage is low. Something seems wrong with ray. "
     "Need to investigate the reasons. Skip the tests for now.",
     allow_module_level=True
 )

--- a/multimodal/tests/unittests/test_hpo.py
+++ b/multimodal/tests/unittests/test_hpo.py
@@ -10,6 +10,13 @@ from datasets import PetFinderDataset
 from utils import get_home_dir
 from test_predictor import verify_predictor_save_load
 
+pytest.skip(
+    "HPO testing fails due to RuntimeError: CUDA error: out of memory, "
+    "but the GPU memory usage is low. Seems something seems wrong with ray. "
+    "Need to investigate the reasons. Skip the tests for now.",
+    allow_module_level=True
+)
+
 
 @pytest.mark.parametrize("searcher", list(SEARCHER_PRESETS.keys()))
 @pytest.mark.parametrize("scheduler", list(SCHEDULER_PRESETS.keys()))


### PR DESCRIPTION
HPO testing sometimes fails due to RuntimeError: CUDA error: out of memory, but the GPU memory usage is low. Seems something is wrong with ray. Need to investigate the reasons. Skip the tests for now. @yinweisu 