### PR TITLE
fix custom target issue in time series HPO, close #1892

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -127,6 +127,7 @@ class AbstractTimeSeriesModel(AbstractModel):
                 prediction_length=self.prediction_length,
                 quantile_levels=self.quantile_levels,
                 metadata=self.metadata,
+                target=self.target,
             )
         )
         return params
@@ -356,10 +357,10 @@ class AbstractTimeSeriesModel(AbstractModel):
             )
             return skip_hpo(self, train_data, val_data, time_limit=time_limit)
         else:
-            logger.debug(f"Hyperparameter search space for {self.name}: ")
+            logger.debug(f"\tHyperparameter search space for {self.name}: ")
             for hyperparameter in search_space:
                 if isinstance(search_space[hyperparameter], ag.Space):
-                    logger.debug(f"{hyperparameter}: {search_space[hyperparameter]}")
+                    logger.debug(f"\t{hyperparameter}: {search_space[hyperparameter]}")
 
         dataset_train_filename = "dataset_train.pkl"
         train_path = self.path + dataset_train_filename

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from gluonts.model.seq2seq import MQRNNEstimator
 
+import autogluon.core as ag
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.models import DeepARModel
 from autogluon.timeseries.models.gluonts.models import GenericGluonTSModelFactory
@@ -13,9 +14,8 @@ from autogluon.timeseries.predictor import TimeSeriesPredictor
 from .common import DUMMY_TS_DATAFRAME
 
 TEST_HYPERPARAMETER_SETTINGS = [
-    "toy",
     {"SimpleFeedForward": {"epochs": 1}},
-    {"DeepAR": {"epochs": 1}, "SimpleFeedForward": {"epochs": 1}},
+    {"AutoETS": {}, "SimpleFeedForward": {"epochs": 1}},
 ]
 
 
@@ -180,6 +180,57 @@ def test_given_hyperparameters_when_predictor_called_and_loaded_back_then_all_mo
 
         predicted_item_index = predictions.index.levels[0]
         assert all(predicted_item_index == DUMMY_TS_DATAFRAME.index.levels[0])  # noqa
+        assert all(len(predictions.loc[i]) == 2 for i in predicted_item_index)
+        assert not np.any(np.isnan(predictions))
+
+
+@pytest.mark.parametrize("target_column", ["target", "custom"])
+@pytest.mark.parametrize(
+    "hyperparameters",
+    [
+        {"AutoETS": {}, "SimpleFeedForward": {"epochs": 1}},
+        {"AutoETS": {}, "SimpleFeedForward": {"epochs": ag.Int(1, 3)}},
+    ],
+)
+def test_given_hp_spaces_and_custom_target_when_predictor_called_predictor_can_predict(
+    temp_model_path, hyperparameters, target_column
+):
+    df = DUMMY_TS_DATAFRAME.rename(columns={"target": target_column})
+
+    fit_kwargs = dict(
+        train_data=df,
+        hyperparameters=hyperparameters,
+        tuning_data=df,
+    )
+    init_kwargs = dict(path=temp_model_path, prediction_length=2)
+    if target_column != "target":
+        init_kwargs.update({"target": target_column})
+
+    for hps in hyperparameters.values():
+        if any(isinstance(v, ag.Space) for v in hps.values()):
+            fit_kwargs.update(
+                {
+                    "hyperparameter_tune_kwargs": {
+                        "scheduler": "local",
+                        "searcher": "random",
+                        "num_trials": 2,
+                    },
+                }
+            )
+            break
+
+    predictor = TimeSeriesPredictor(**init_kwargs)
+    predictor.fit(**fit_kwargs)
+
+    assert predictor.get_model_names()
+
+    for model_name in predictor.get_model_names():
+        predictions = predictor.predict(df, model=model_name)
+
+        assert isinstance(predictions, TimeSeriesDataFrame)
+
+        predicted_item_index = predictions.index.levels[0]
+        assert all(predicted_item_index == df.index.levels[0])  # noqa
         assert all(len(predictions.loc[i]) == 2 for i in predicted_item_index)
         assert not np.any(np.isnan(predictions))
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixes models ignoring custom target field names during HPO.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
