### PR TITLE
[Tabular] Optimize NN Inference Speed

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -35,6 +35,8 @@ extras_require = {
     'catboost': [
         'catboost>=1.0,<1.1',
     ],
+    # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4
+    #  It is possibly only present on MacOS, haven't tested linux.
     'xgboost': [
         'xgboost>=1.4,<1.5',
     ],

--- a/tabular/src/autogluon/tabular/models/_utils/torch_utils.py
+++ b/tabular/src/autogluon/tabular/models/_utils/torch_utils.py
@@ -1,0 +1,17 @@
+import torch
+
+
+class TorchThreadManager:
+    """
+    Temporary updates torch num_threads to the specified value within the context, then reverts to the original num_threads upon exit.
+    """
+    def __init__(self, num_threads):
+        self.num_threads = num_threads
+        self.num_threads_og = None
+
+    def __enter__(self):
+        self.num_threads_og = torch.get_num_threads()
+        torch.set_num_threads(self.num_threads)
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        torch.set_num_threads(self.num_threads_og)

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -383,11 +383,9 @@ class NNFastAiTabularModel(AbstractModel):
     #  If this isn't here, inference speed is slowed down massively.
     #  Remove once upgraded to XGBoost>=1.6
     def _predict_proba(self, X, **kwargs):
-        import torch
-        num_threads = torch.get_num_threads()
-        torch.set_num_threads(self._num_cpus_infer)
-        pred_proba = self._predict_proba_internal(X=X, **kwargs)
-        torch.set_num_threads(num_threads)
+        from .._utils.torch_utils import TorchThreadManager
+        with TorchThreadManager(num_threads=self._num_cpus_infer):
+            pred_proba = self._predict_proba_internal(X=X, **kwargs)
         return pred_proba
 
     def _predict_proba_internal(self, X, **kwargs):

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -79,6 +79,7 @@ class NNFastAiTabularModel(AbstractModel):
         self.y_scaler = None
         self._cont_normalization = None
         self._load_model = None  # Whether to load inner model when loading.
+        self._num_cpus_infer = None
 
     def _preprocess_train(self, X, y, X_val, y_val):
         from fastai.tabular.core import TabularPandas
@@ -181,6 +182,7 @@ class NNFastAiTabularModel(AbstractModel):
             logger.log(15, "sample_weight not yet supported for NNFastAiTabularModel, this model will ignore them in training.")
 
         params = self._get_model_params()
+        self._num_cpus_infer = params.pop('_num_cpus_infer', 1)
 
         self.y_scaler = params.get('y_scaler', None)
         if self.y_scaler is None:
@@ -377,7 +379,18 @@ class NNFastAiTabularModel(AbstractModel):
             objective_func_name_to_monitor = monitor_obj_func[objective_func_name]
         return objective_func_name_to_monitor
 
+    # FIXME: torch.set_num_threads(self._num_cpus_infer) is required because XGBoost<=1.5 mutates global OpenMP thread limit
+    #  If this isn't here, inference speed is slowed down massively.
+    #  Remove once upgraded to XGBoost>=1.6
     def _predict_proba(self, X, **kwargs):
+        import torch
+        num_threads = torch.get_num_threads()
+        torch.set_num_threads(self._num_cpus_infer)
+        pred_proba = self._predict_proba_internal(X=X, **kwargs)
+        torch.set_num_threads(num_threads)
+        return pred_proba
+
+    def _predict_proba_internal(self, X, **kwargs):
         X = self.preprocess(X, **kwargs)
 
         single_row = len(X) == 1

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -396,11 +396,9 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
     #  If this isn't here, inference speed is slowed down massively.
     #  Remove once upgraded to XGBoost>=1.6
     def _predict_proba(self, X, **kwargs):
-        import torch
-        num_threads = torch.get_num_threads()
-        torch.set_num_threads(self._num_cpus_infer)
-        pred_proba = self._predict_proba_internal(X=X, **kwargs)
-        torch.set_num_threads(num_threads)
+        from ..._utils.torch_utils import TorchThreadManager
+        with TorchThreadManager(num_threads=self._num_cpus_infer):
+            pred_proba = self._predict_proba_internal(X=X, **kwargs)
         return pred_proba
 
     def _predict_proba_internal(self, X, **kwargs):

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -44,7 +44,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         self.optimizer = None
         self.device = None
         self.max_batch_size = None
-        self._infer_cpus = None
+        self._num_cpus_infer = None
 
     def _set_default_params(self):
         """ Specifies hyperparameter values to use by default """
@@ -151,7 +151,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
 
         seed_value = params.pop('seed_value', 0)
 
-        self._infer_cpus = params.pop('_cpu_infer', 1)
+        self._num_cpus_infer = params.pop('_num_cpus_infer', 1)
         if seed_value is not None:  # Set seeds
             random.seed(seed_value)
             np.random.seed(seed_value)
@@ -392,7 +392,18 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         self.params_trained['batch_size'] = batch_size
         self.params_trained['num_epochs'] = best_epoch
 
+    # FIXME: torch.set_num_threads(self._num_cpus_infer) is required because XGBoost<=1.5 mutates global OpenMP thread limit
+    #  If this isn't here, inference speed is slowed down massively.
+    #  Remove once upgraded to XGBoost>=1.6
     def _predict_proba(self, X, **kwargs):
+        import torch
+        num_threads = torch.get_num_threads()
+        torch.set_num_threads(self._num_cpus_infer)
+        pred_proba = self._predict_proba_internal(X=X, **kwargs)
+        torch.set_num_threads(num_threads)
+        return pred_proba
+
+    def _predict_proba_internal(self, X, **kwargs):
         """ To align predict with abstract_model API.
             Preprocess here only refers to feature processing steps done by all AbstractModel objects,
             not tabularNN-specific preprocessing steps.
@@ -409,10 +420,6 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             raise ValueError("X must be of type pd.DataFrame or TabularTorchDataset, not type: %s" % type(X))
 
     def _predict_tabular_data(self, new_data, process=True):
-        import torch
-        num_threads = torch.get_num_threads()
-        torch.set_num_threads(self._infer_cpus)
-
         from .tabular_torch_dataset import TabularTorchDataset
         if process:
             new_data = self._process_test_data(new_data)
@@ -424,7 +431,6 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             preds_batch = self.model.predict(data_batch)
             preds_dataset.append(preds_batch)
         preds_dataset = np.concatenate(preds_dataset, 0)
-        torch.set_num_threads(num_threads)
         return preds_dataset
 
     def _generate_datasets(self, X, y, params, X_val=None, y_val=None):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Optimize NN Inference Speed by altering torch threads during predict calls.
  - A bug was causing inference to get slower with more CPU cores in a machine due to a bug in XGBoost altering the global OpenMP thread limit.
  - Affected both `FASTAI` and `NN_TORCH`
- NN speedup is based on number of CPUs. ~2x speedup with 8 vCPUs, ~6x speedup with 64 vCPUs.

Special thanks to @willsmithorg for highlighting this issue in his performance benchmarking!

Benchmark is AutoMLBenchmark filtered to datasets with >=10,000 rows.

**Benchmark Results Summary:**

Given 4h64c (4 hour training time, m5.16xlarge), this PR matches mainline in model quality and training speed with the following benefits:
- 6x faster inference speed for `FASTAI` and `NN_TORCH` models
- 3x faster inference speed for AutoGluon Medium Quality.
- 2.5x faster inference speed for AutoGluon Best Quality.

Benchmark (2022_06_21 == mainline, 2022_06_25_nn == this PR):

```
AutoGluon_mq_4h64c_2022_06_21_NeuralNetFastAI VS all
                                          framework   winrate    >    <    =  % Less Avg. Errors  Avg Inf Speed Diff  time_train_s  time_infer_s  loss_rescaled  time_train_s_rescaled  time_infer_s_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0     AutoGluon_mq_4h64c_2022_06_21_NeuralNetFastAI  0.500000    0    0  449            0.000000                 NaN    200.856299      0.000240       0.407522               1.042033               7.856643  2.314988             6           269             0           174            1
1  AutoGluon_mq_4h64c_2022_06_25_nn_NeuralNetFastAI  0.500000    5    5  437           -0.000742            5.866623    198.339571      0.000117       0.407699               1.035986               1.181064  2.314988             5           269             0           174            2
2      AutoGluon_mq_4h64c_2022_06_21_NeuralNetTorch  0.407925  175  254    0            5.716822           -0.212590    431.721623      0.000288       0.592449               2.411062               9.839662  2.683841             1           175             1           252           21
3   AutoGluon_mq_4h64c_2022_06_25_nn_NeuralNetTorch  0.407494  174  253    0            5.692464            5.056267    434.674309      0.000158       0.592506               2.466652               1.472643  2.686183             1           174             0           253           22

```

Benchmark Overall System (Medium Quality):

```
AutoGluon_mq_4h64c_2022_06_21 VS all
                          framework   winrate   >   <    =  % Less Avg. Errors  Avg Inf Speed Diff  time_train_s  time_infer_s  loss_rescaled  time_train_s_rescaled  time_infer_s_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0     AutoGluon_mq_4h64c_2022_06_21  0.500000   0   0  449            0.000000                 NaN   2196.584116      0.000341       0.044743               1.018063               3.173796  1.496644            22           427             0             0            1
1  AutoGluon_mq_4h64c_2022_06_25_nn  0.496644  17  20  410            0.017924            2.161868   2175.861745      0.000201       0.051454               1.012460               1.011928  1.503356            18           430             0             0            2
```

Benchmark Overall System (Best Quality):

```
AutoGluon_bq_4h64c_2022_06_21 VS all
                          framework   winrate    >    <    =  % Less Avg. Errors  Avg Inf Speed Diff  time_train_s  time_infer_s  loss_rescaled  time_train_s_rescaled  time_infer_s_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0     AutoGluon_bq_4h64c_2022_06_21  0.500000    0    0  434            0.000000                 NaN  12256.839070      0.035006       0.330233               1.034826               2.870283  1.498837           129           305             0             0            4
1  AutoGluon_bq_4h64c_2022_06_25_nn  0.498837  124  125  181           -0.135974            1.654371  11912.773488      0.016253       0.358140               1.005858               1.215912  1.501163           128           306             0             0            4

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
