### PR TITLE
[TimeSeries] streamline unit tests

### DIFF
--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -2,6 +2,7 @@
 See also, https://ts.gluon.ai/api/gluonts/gluonts.evaluation.html
 """
 import logging
+import warnings
 from typing import Callable, List, Optional, Any
 
 import numpy as np
@@ -227,7 +228,7 @@ class TimeSeriesEvaluator:
         for item_id in data.iter_items():
             y_true_w_hist = data.loc[item_id][self.target_column]
 
-            target = np.array(y_true_w_hist[-self.prediction_length :])
+            target = np.array(y_true_w_hist[-self.prediction_length:])
             target_history = np.array(y_true_w_hist[: -self.prediction_length])
 
             item_metrics = {}
@@ -299,5 +300,8 @@ class TimeSeriesEvaluator:
             data.iter_items()
         ), "Prediction and data indices do not match."
 
-        with evaluator_warning_filter():
+        with evaluator_warning_filter(), warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            warnings.simplefilter("ignore", category=FutureWarning)
             return self.metric_method(data, predictions)

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -11,7 +11,6 @@ from ... import TimeSeriesEvaluator
 from ...dataset import TimeSeriesDataFrame
 from ...utils.metadata import get_prototype_metadata_dict
 from .model_trial import skip_hpo, model_trial
-from ...utils.warning_filters import evaluator_warning_filter
 
 logger = logging.getLogger(__name__)
 
@@ -311,14 +310,13 @@ class AbstractTimeSeriesModel(AbstractModel):
             time steps of each time series.
         """
         metric = self.eval_metric if metric is None else metric
-        with evaluator_warning_filter():
-            evaluator = TimeSeriesEvaluator(
-                eval_metric=metric,
-                prediction_length=self.prediction_length,
-                target_column=self.target,
-            )
-            predictions = self.predict_for_scoring(data)
-            metric_value = evaluator(data, predictions)
+        evaluator = TimeSeriesEvaluator(
+            eval_metric=metric,
+            prediction_length=self.prediction_length,
+            target_column=self.target,
+        )
+        predictions = self.predict_for_scoring(data)
+        metric_value = evaluator(data, predictions)
 
         return metric_value * TimeSeriesEvaluator.METRIC_COEFFICIENTS[metric]
 

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import time
-from typing import List, Dict
+from typing import List
 
 import numpy as np
 
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class TimeSeriesEnsembleSelection(EnsembleSelection):
-    def __init__(
+    def __init__(  # noqa
         self,
         ensemble_size: int,
         problem_type: str,

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -442,7 +442,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             )
             logger.info(
                 f"\t{hpo_results.get('total_time'):<7.2f} s".ljust(15)
-                + f"= Total tuning time"
+                + "= Total tuning time"
             )
             logger.debug(
                 f"\tBest hyperparameter configuration: {hpo_results.get('best_config')}"

--- a/timeseries/src/autogluon/timeseries/utils/warning_filters.py
+++ b/timeseries/src/autogluon/timeseries/utils/warning_filters.py
@@ -2,7 +2,6 @@ import contextlib
 import functools
 import logging
 import os
-import warnings
 
 __all__ = ["evaluator_warning_filter", "disable_root_logger", "disable_tqdm"]
 
@@ -12,16 +11,10 @@ def evaluator_warning_filter():
     env_py_warnings = os.environ.get("PYTHONWARNINGS", "")
     warning_categories = [RuntimeWarning, UserWarning, FutureWarning]  # ignore these
     try:
-        for warning_category in warning_categories:
-            warnings.filterwarnings("ignore", category=warning_category)
-
         # required to suppress gluonts evaluation warnings as the module uses multiprocessing
         os.environ["PYTHONWARNINGS"] = ",".join([f"ignore::{c.__name__}" for c in warning_categories])
-
         yield
     finally:
-        for warning_category in warning_categories:
-            warnings.filterwarnings("default", category=warning_category)
         os.environ["PYTHONWARNINGS"] = env_py_warnings
 
 

--- a/timeseries/tests/conftest.py
+++ b/timeseries/tests/conftest.py
@@ -6,26 +6,18 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption(
-        "--runslow", action="store_true", default=False, help="run slow tests"
-    )
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     # known mxnet warnings
-    config.addinivalue_line(
-        "filterwarnings", "ignore:In accordance with NEP 32:DeprecationWarning"
-    )
+    config.addinivalue_line("filterwarnings", "ignore:In accordance with NEP 32:DeprecationWarning")
     config.addinivalue_line("filterwarnings", "ignore:.np.bool:DeprecationWarning")
 
     # known gluonts warnings
-    config.addinivalue_line(
-        "filterwarnings", "ignore::DeprecationWarning:.*gluonts.mx.distribution.*"
-    )
-    config.addinivalue_line(
-        "filterwarnings", "ignore::DeprecationWarning:.*gluonts.mx.trainer.*"
-    )
+    config.addinivalue_line("filterwarnings", "ignore::DeprecationWarning:.*gluonts.mx.distribution.*")
+    config.addinivalue_line("filterwarnings", "ignore::DeprecationWarning:.*gluonts.mx.trainer.*")
     config.addinivalue_line("filterwarnings", "ignore:Using `json`-module:UserWarning")
 
     # pandas future warnings on timestamp freq being deprecated

--- a/timeseries/tests/test_check_style.py
+++ b/timeseries/tests/test_check_style.py
@@ -15,6 +15,4 @@ def test_check_style():
     count = int(lines[-1].decode())
     if count > 0:
         warnings.warn(f"{count} PEP8 warnings remaining\n" + flake8_out.decode())
-    assert (
-        count < 1000
-    ), "Too many PEP8 warnings found, improve code quality to pass test."
+    assert count < 1000, "Too many PEP8 warnings found, improve code quality to pass test."

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -59,8 +59,6 @@ def dict_equal_primitive(this, that):
         if isinstance(v, dict):
             equal_fields.append(dict_equal_primitive(v, that[k]))
         if isinstance(v, list):
-            equal_fields.append(
-                dict_equal_primitive(dict(enumerate(v)), dict(enumerate(that[k])))
-            )
+            equal_fields.append(dict_equal_primitive(dict(enumerate(v)), dict(enumerate(that[k]))))
 
     return all(equal_fields)

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -29,9 +29,7 @@ TESTABLE_MODELS = [
     # MQRNNModel,
     SimpleFeedForwardModel,
     # TransformerModel,
-    partial(
-        GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator
-    ),  # partial constructor for generic model
+    partial(GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator),  # partial constructor for generic model
     GenericGluonTSModelFactory(TransformerEstimator),
 ]
 
@@ -41,9 +39,7 @@ TESTABLE_MODELS = [
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("time_limit", [10, None])
-def test_given_time_limit_when_fit_called_then_models_train_correctly(
-    model_class, time_limit, temp_model_path
-):
+def test_given_time_limit_when_fit_called_then_models_train_correctly(model_class, time_limit, temp_model_path):
     model = model_class(
         path=temp_model_path,
         freq="H",
@@ -76,9 +72,7 @@ def test_given_low_time_limit_when_fit_called_then_model_training_does_not_excee
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_models_saved_then_gluonts_predictors_can_be_loaded(
-    model_class, temp_model_path
-):
+def test_when_models_saved_then_gluonts_predictors_can_be_loaded(model_class, temp_model_path):
     model = model_class(
         path=temp_model_path,
         freq="H",
@@ -117,10 +111,7 @@ def test_when_fit_called_on_prophet_then_hyperparameters_are_passed_to_underlyin
     model.fit(train_data=DUMMY_TS_DATAFRAME)
 
     assert model.gts_predictor.prophet_params.get("growth") == growth  # noqa
-    assert (
-        model.gts_predictor.prophet_params.get("n_changepoints")  # noqa
-        == n_changepoints  # noqa
-    )  # noqa
+    assert model.gts_predictor.prophet_params.get("n_changepoints") == n_changepoints  # noqa  # noqa  # noqa
 
 
 @pytest.mark.skipif(
@@ -129,9 +120,7 @@ def test_when_fit_called_on_prophet_then_hyperparameters_are_passed_to_underlyin
 )
 @pytest.mark.parametrize("growth", ["linear", "logistic"])
 @pytest.mark.parametrize("n_changepoints", [3, 5])
-def test_when_prophet_model_saved_then_prophet_parameters_are_loaded(
-    growth, n_changepoints, temp_model_path
-):
+def test_when_prophet_model_saved_then_prophet_parameters_are_loaded(growth, n_changepoints, temp_model_path):
     model = ProphetModel(
         path=temp_model_path,
         freq="H",
@@ -146,10 +135,7 @@ def test_when_prophet_model_saved_then_prophet_parameters_are_loaded(
     loaded_model = model.__class__.load(path=model.path)
 
     assert loaded_model.gts_predictor.prophet_params.get("growth") == growth  # noqa
-    assert (
-        loaded_model.gts_predictor.prophet_params.get("n_changepoints")  # noqa
-        == n_changepoints
-    )  # noqa
+    assert loaded_model.gts_predictor.prophet_params.get("n_changepoints") == n_changepoints  # noqa  # noqa
 
 
 @pytest.mark.skipif(

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -36,8 +36,8 @@ TESTABLE_MODELS = [
     GenericGluonTSModelFactory(TransformerEstimator),
 ]
 
-if PROPHET_IS_INSTALLED:
-    TESTABLE_MODELS += [ProphetModel]
+# if PROPHET_IS_INSTALLED:
+#     TESTABLE_MODELS += [ProphetModel]
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 import pytest
-from flaky import flaky
 from gluonts.model.prophet import PROPHET_IS_INSTALLED
 from gluonts.model.predictor import Predictor as GluonTSPredictor
 from gluonts.model.seq2seq import MQRNNEstimator
@@ -14,10 +13,10 @@ from autogluon.timeseries.models.gluonts import (
     # AutoTabularModel,
     GenericGluonTSModel,
     MQCNNModel,
-    MQRNNModel,
+    # MQRNNModel,
     ProphetModel,
     SimpleFeedForwardModel,
-    TransformerModel,
+    # TransformerModel,
 )
 from autogluon.timeseries.models.gluonts.models import GenericGluonTSModelFactory
 
@@ -119,7 +118,7 @@ def test_when_fit_called_on_prophet_then_hyperparameters_are_passed_to_underlyin
 
     assert model.gts_predictor.prophet_params.get("growth") == growth  # noqa
     assert (
-        model.gts_predictor.prophet_params.get("n_changepoints")
+        model.gts_predictor.prophet_params.get("n_changepoints")  # noqa
         == n_changepoints  # noqa
     )  # noqa
 

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -213,7 +213,11 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_corr
     assert all(predictions.loc[i].index[0].hour > 0 for i in predicted_item_index)
 
 
-@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("model_class", [
+    DeepARModel, AutoETSModel, partial(
+        GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator
+    )
+])
 @pytest.mark.parametrize("test_data_index", [["A", "B"], ["C", "D"], ["A"]])
 def test_when_fit_called_then_models_train_and_returned_predictor_inference_aligns_with_time(
     model_class, test_data_index, temp_model_path
@@ -247,10 +251,6 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_alig
     (
         get_data_frame_with_item_index([0, 1, 2, 3]),
         get_data_frame_with_item_index([0, 1, 2, 3])
-    ),
-    (
-        get_data_frame_with_item_index([0, 1, 2, 3]),
-        get_data_frame_with_item_index([2, 3, 4, 5])
     ),
     (
         get_data_frame_with_item_index(["A", "B", "C"]),

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -32,9 +32,7 @@ TESTABLE_PREDICTION_LENGTHS = [1, 5]
 def trained_models():
     models = {}
     model_paths = []
-    for model_class, prediction_length in itertools.product(
-        TESTABLE_MODELS, TESTABLE_PREDICTION_LENGTHS
-    ):
+    for model_class, prediction_length in itertools.product(TESTABLE_MODELS, TESTABLE_PREDICTION_LENGTHS):
         temp_model_path = tempfile.mkdtemp()
         model = model_class(
             path=temp_model_path + os.path.sep,
@@ -81,12 +79,10 @@ def test_when_predict_for_scoring_called_then_model_receives_truncated_data(
     with mock.patch.object(model, "predict") as patch_method:
         _ = model.predict_for_scoring(DUMMY_TS_DATAFRAME)
 
-        call_df, = patch_method.call_args[0]
+        (call_df,) = patch_method.call_args[0]
 
         for j in DUMMY_TS_DATAFRAME.iter_items():
-            assert np.allclose(
-                call_df.loc[j], DUMMY_TS_DATAFRAME.loc[j][:-prediction_length]
-            )
+            assert np.allclose(call_df.loc[j], DUMMY_TS_DATAFRAME.loc[j][:-prediction_length])
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
@@ -105,9 +101,7 @@ def test_when_models_saved_then_they_can_be_loaded(model_class, trained_models, 
 
 @flaky
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct(
-    model_class, temp_model_path
-):
+def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct(model_class, temp_model_path):
     scheduler_options = scheduler_factory(hyperparameter_tune_kwargs="auto")
 
     model = model_class(
@@ -143,9 +137,7 @@ def test_given_no_freq_argument_when_fit_called_with_freq_then_model_does_not_ra
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_given_hyperparameter_spaces_to_init_when_fit_called_then_error_is_raised(
-    model_class, temp_model_path
-):
+def test_given_hyperparameter_spaces_to_init_when_fit_called_then_error_is_raised(model_class, temp_model_path):
     model = model_class(
         path=temp_model_path,
         freq="H",
@@ -188,9 +180,7 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_has_
 
     predicted_item_index = predictions.index.levels[0]
     assert all(predicted_item_index == DUMMY_TS_DATAFRAME.index.levels[0])  # noqa
-    assert all(
-        k in predictions.columns for k in ["mean"] + [str(q) for q in quantile_levels]
-    )
+    assert all(k in predictions.columns for k in ["mean"] + [str(q) for q in quantile_levels])
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
@@ -213,11 +203,9 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_corr
     assert all(predictions.loc[i].index[0].hour > 0 for i in predicted_item_index)
 
 
-@pytest.mark.parametrize("model_class", [
-    DeepARModel, AutoETSModel, partial(
-        GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator
-    )
-])
+@pytest.mark.parametrize(
+    "model_class", [DeepARModel, AutoETSModel, partial(GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator)]
+)
 @pytest.mark.parametrize("test_data_index", [["A", "B"], ["C", "D"], ["A"]])
 def test_when_fit_called_then_models_train_and_returned_predictor_inference_aligns_with_time(
     model_class, test_data_index, temp_model_path
@@ -242,33 +230,31 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_alig
     assert min_hour_in_pred == max_hour_in_test + 1
 
 
-@pytest.mark.parametrize("model_class", [
-    DeepARModel, AutoETSModel, partial(
-        GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator
-    )
-])
-@pytest.mark.parametrize("train_data, test_data", [
-    (
-        get_data_frame_with_item_index([0, 1, 2, 3]),
-        get_data_frame_with_item_index([0, 1, 2, 3])
-    ),
-    (
-        get_data_frame_with_item_index(["A", "B", "C"]),
-        get_data_frame_with_item_index(["A", "B", "C"]),
-    ),
-    (
-        get_data_frame_with_item_index(["A", "B", "C"]),
-        get_data_frame_with_item_index(["A", "B", "D"]),
-    ),
-    (
-        get_data_frame_with_item_index(["A", "B", "C"]),
-        get_data_frame_with_item_index(["A", "B"]),
-    ),
-    (
-        get_data_frame_with_item_index(["A", "B"]),
-        get_data_frame_with_item_index(["A", "B", "C"]),
-    ),
-])
+@pytest.mark.parametrize(
+    "model_class", [DeepARModel, AutoETSModel, partial(GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator)]
+)
+@pytest.mark.parametrize(
+    "train_data, test_data",
+    [
+        (get_data_frame_with_item_index([0, 1, 2, 3]), get_data_frame_with_item_index([0, 1, 2, 3])),
+        (
+            get_data_frame_with_item_index(["A", "B", "C"]),
+            get_data_frame_with_item_index(["A", "B", "C"]),
+        ),
+        (
+            get_data_frame_with_item_index(["A", "B", "C"]),
+            get_data_frame_with_item_index(["A", "B", "D"]),
+        ),
+        (
+            get_data_frame_with_item_index(["A", "B", "C"]),
+            get_data_frame_with_item_index(["A", "B"]),
+        ),
+        (
+            get_data_frame_with_item_index(["A", "B"]),
+            get_data_frame_with_item_index(["A", "B", "C"]),
+        ),
+    ],
+)
 def test_when_predict_called_with_test_data_then_predictor_inference_correct(
     model_class, temp_model_path, train_data, test_data
 ):

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -18,7 +18,8 @@ from autogluon.timeseries.models.sktime import (
     AutoARIMAModel,
     AutoETSModel,
     TBATSModel,
-    ThetaModel, AbstractSktimeModel,
+    ThetaModel,
+    AbstractSktimeModel,
 )
 
 from ..common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
@@ -74,9 +75,7 @@ def test_when_sktime_models_fitted_then_allowed_hyperparameters_are_passed_to_sk
     hyperparameters.update(bad_params)
     model = model_class(hyperparameters=hyperparameters)
 
-    with mock.patch.object(
-        target=sktime_forecaster_class, attribute="__init__"
-    ) as const_mock:
+    with mock.patch.object(target=sktime_forecaster_class, attribute="__init__") as const_mock:
         try:
             model.fit(train_data=DUMMY_TS_DATAFRAME)
         except TypeError:
@@ -129,9 +128,7 @@ def test_when_sktime_converts_from_dataframe_then_data_not_duplicated_and_index_
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_skt_models_saved_then_forecasters_can_be_loaded(
-    model_class, temp_model_path
-):
+def test_when_skt_models_saved_then_forecasters_can_be_loaded(model_class, temp_model_path):
     model = model_class()
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     model.save()
@@ -143,24 +140,24 @@ def test_when_skt_models_saved_then_forecasters_can_be_loaded(
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-@pytest.mark.parametrize("train_data, test_data", [
-    (
-        get_data_frame_with_item_index([0, 1, 2, 3]),
-        get_data_frame_with_item_index([2, 3, 4, 5])
-    ),
-    (
-        get_data_frame_with_item_index(["A", "B", "C"]),
-        get_data_frame_with_item_index(["A", "B", "D"]),
-    ),
-    (
-        get_data_frame_with_item_index(["A", "B"]),
-        get_data_frame_with_item_index(["A", "B", "C"]),
-    ),
-    (
-        get_data_frame_with_item_index(["A", "B", "C"]),
-        get_data_frame_with_item_index(["A", "B"]),
-    ),
-])
+@pytest.mark.parametrize(
+    "train_data, test_data",
+    [
+        (get_data_frame_with_item_index([0, 1, 2, 3]), get_data_frame_with_item_index([2, 3, 4, 5])),
+        (
+            get_data_frame_with_item_index(["A", "B", "C"]),
+            get_data_frame_with_item_index(["A", "B", "D"]),
+        ),
+        (
+            get_data_frame_with_item_index(["A", "B"]),
+            get_data_frame_with_item_index(["A", "B", "C"]),
+        ),
+        (
+            get_data_frame_with_item_index(["A", "B", "C"]),
+            get_data_frame_with_item_index(["A", "B"]),
+        ),
+    ],
+)
 def test_when_predict_called_with_test_data_then_predictor_inference_correct(
     model_class, temp_model_path, train_data, test_data
 ):

--- a/timeseries/tests/unittests/test_evaluator.py
+++ b/timeseries/tests/unittests/test_evaluator.py
@@ -50,9 +50,7 @@ def deepar_trained_zero_data() -> AbstractGluonTSModel:
 
 
 @pytest.mark.parametrize("metric_name", GLUONTS_PARITY_METRICS)
-def test_when_given_learned_model_when_evaluator_called_then_output_equal_to_gluonts(
-    metric_name, deepar_trained
-):
+def test_when_given_learned_model_when_evaluator_called_then_output_equal_to_gluonts(metric_name, deepar_trained):
     model = deepar_trained
 
     forecast_iter, ts_iter = make_evaluation_predictions(
@@ -61,9 +59,7 @@ def test_when_given_learned_model_when_evaluator_called_then_output_equal_to_glu
         num_samples=100,
     )
     fcast_list, ts_list = list(forecast_iter), list(ts_iter)
-    forecast_df = model._gluonts_forecasts_to_data_frame(
-        fcast_list, quantile_levels=model.quantile_levels
-    )
+    forecast_df = model._gluonts_forecasts_to_data_frame(fcast_list, quantile_levels=model.quantile_levels)
 
     ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=2)
     ag_value = ag_evaluator(DUMMY_TS_DATAFRAME, forecast_df)
@@ -90,9 +86,7 @@ def test_when_given_all_zero_data_when_evaluator_called_then_output_equal_to_glu
         num_samples=100,
     )
     fcast_list, ts_list = list(forecast_iter), list(ts_iter)
-    forecast_df = model._gluonts_forecasts_to_data_frame(
-        fcast_list, quantile_levels=model.quantile_levels
-    )
+    forecast_df = model._gluonts_forecasts_to_data_frame(fcast_list, quantile_levels=model.quantile_levels)
 
     ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=2)
     ag_value = ag_evaluator(data, forecast_df)
@@ -104,9 +98,7 @@ def test_when_given_all_zero_data_when_evaluator_called_then_output_equal_to_glu
 
 
 @pytest.mark.parametrize("metric_name", GLUONTS_PARITY_METRICS)
-def test_when_given_zero_forecasts_when_evaluator_called_then_output_equal_to_gluonts(
-    metric_name, deepar_trained
-):
+def test_when_given_zero_forecasts_when_evaluator_called_then_output_equal_to_gluonts(metric_name, deepar_trained):
     model = deepar_trained
     forecast_iter, ts_iter = make_evaluation_predictions(
         dataset=model._to_gluonts_dataset(DUMMY_TS_DATAFRAME),
@@ -125,17 +117,13 @@ def test_when_given_zero_forecasts_when_evaluator_called_then_output_equal_to_gl
                 item_id=s.item_id,
             )
         )
-    forecast_df = model._gluonts_forecasts_to_data_frame(
-        zero_forecast_list, quantile_levels=model.quantile_levels
-    )
+    forecast_df = model._gluonts_forecasts_to_data_frame(zero_forecast_list, quantile_levels=model.quantile_levels)
 
     ag_evaluator = TimeSeriesEvaluator(eval_metric=metric_name, prediction_length=2)
     ag_value = ag_evaluator(DUMMY_TS_DATAFRAME, forecast_df)
 
     gts_evaluator = GluonTSEvaluator()
-    gts_results, _ = gts_evaluator(
-        ts_iterator=ts_list, fcst_iterator=zero_forecast_list
-    )
+    gts_results, _ = gts_evaluator(ts_iterator=ts_list, fcst_iterator=zero_forecast_list)
 
     assert np.isclose(gts_results[metric_name], ag_value, atol=1e-5)
 
@@ -153,9 +141,7 @@ def test_available_metrics_have_coefficients():
     + [(k, k) for k in TimeSeriesEvaluator.AVAILABLE_METRICS],
 )
 @pytest.mark.parametrize("raise_errors", [True, False])
-def test_given_correct_input_check_get_eval_metric_output_correct(
-    check_input, expected_output, raise_errors
-):
+def test_given_correct_input_check_get_eval_metric_output_correct(check_input, expected_output, raise_errors):
     assert expected_output == TimeSeriesEvaluator.check_get_evaluation_metric(
         check_input, raise_if_not_available=raise_errors
     )
@@ -163,25 +149,17 @@ def test_given_correct_input_check_get_eval_metric_output_correct(
 
 @pytest.mark.parametrize("raise_errors", [True, False])
 def test_given_no_input_check_get_eval_metric_output_default(raise_errors):
-    assert (
-        TimeSeriesEvaluator.DEFAULT_METRIC
-        == TimeSeriesEvaluator.check_get_evaluation_metric(
-            raise_if_not_available=raise_errors
-        )
+    assert TimeSeriesEvaluator.DEFAULT_METRIC == TimeSeriesEvaluator.check_get_evaluation_metric(
+        raise_if_not_available=raise_errors
     )
 
 
 def test_given_unavailable_input_and_raise_check_get_eval_metric_raises():
     with pytest.raises(ValueError):
-        TimeSeriesEvaluator.check_get_evaluation_metric(
-            "some_nonsense_eval_metric", raise_if_not_available=True
-        )
+        TimeSeriesEvaluator.check_get_evaluation_metric("some_nonsense_eval_metric", raise_if_not_available=True)
 
 
 def test_given_unavailable_input_and_no_raise_check_get_eval_metric_output_default():
-    assert (
-        TimeSeriesEvaluator.DEFAULT_METRIC
-        == TimeSeriesEvaluator.check_get_evaluation_metric(
-            "some_nonsense_eval_metric", raise_if_not_available=False
-        )
+    assert TimeSeriesEvaluator.DEFAULT_METRIC == TimeSeriesEvaluator.check_get_evaluation_metric(
+        "some_nonsense_eval_metric", raise_if_not_available=False
     )

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -96,15 +96,11 @@ def test_given_hyperparameters_when_learner_called_then_model_can_predict(
 
 
 @pytest.mark.parametrize("model_name", ["DeepAR", "SimpleFeedForward"])
-def test_given_hyperparameters_with_spaces_when_learner_called_then_hpo_is_performed(
-    temp_model_path, model_name
-):
+def test_given_hyperparameters_with_spaces_when_learner_called_then_hpo_is_performed(temp_model_path, model_name):
     hyperparameters = {model_name: {"epochs": ag.Int(1, 3)}}
     # mock the default hps factory to prevent preset hyperparameter configurations from
     # creeping into the test case
-    with mock.patch(
-        "autogluon.timeseries.models.presets.get_default_hps"
-    ) as default_hps_mock:
+    with mock.patch("autogluon.timeseries.models.presets.get_default_hps") as default_hps_mock:
         default_hps_mock.return_value = defaultdict(dict)
         learner = TimeSeriesLearner(path_context=temp_model_path, eval_metric="MAPE")
         learner.fit(
@@ -161,11 +157,7 @@ def test_given_hyperparameters_and_custom_models_when_learner_called_then_leader
 def test_given_hyperparameters_when_learner_called_and_loaded_back_then_all_models_can_predict(
     temp_model_path, hyperparameters, expected_board_length
 ):
-    learner = TimeSeriesLearner(
-        path_context=temp_model_path,
-        eval_metric="MAPE",
-        prediction_length=2
-    )
+    learner = TimeSeriesLearner(path_context=temp_model_path, eval_metric="MAPE", prediction_length=2)
     learner.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
@@ -188,9 +180,7 @@ def test_given_hyperparameters_when_learner_called_and_loaded_back_then_all_mode
 
 
 @pytest.mark.parametrize("random_seed", [None, 1616])
-def test_given_random_seed_when_learner_called_then_random_seed_set_correctly(
-    temp_model_path, random_seed
-):
+def test_given_random_seed_when_learner_called_then_random_seed_set_correctly(temp_model_path, random_seed):
     init_kwargs = dict(path_context=temp_model_path, eval_metric="MAPE")
     if random_seed is not None:
         init_kwargs["random_state"] = random_seed

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -11,15 +11,14 @@ from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.learner import TimeSeriesLearner
 from autogluon.timeseries.models import DeepARModel
 from autogluon.timeseries.models.gluonts.models import GenericGluonTSModelFactory
-from autogluon.timeseries.models.presets import get_default_hps
 
 from .common import DUMMY_TS_DATAFRAME
 
 TEST_HYPERPARAMETER_SETTINGS = [
-    "toy",
     {"SimpleFeedForward": {"epochs": 1}},
-    {"DeepAR": {"epochs": 1}, "SimpleFeedForward": {"epochs": 1}},
+    {"DeepAR": {"epochs": 1}, "AutoETS": {}},
 ]
+TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS = [1, 2]
 
 
 def test_learner_can_be_initialized(temp_model_path):
@@ -38,13 +37,12 @@ def test_when_learner_called_then_training_is_performed(temp_model_path):
     assert "SimpleFeedForward" in learner.load_trainer().get_model_names()
 
 
-@pytest.mark.parametrize("eval_metric", ["MAPE", None])
 @pytest.mark.parametrize(
     "hyperparameters, expected_board_length",
-    zip(TEST_HYPERPARAMETER_SETTINGS, [len(get_default_hps("toy", 1)), 1, 2]),
+    zip(TEST_HYPERPARAMETER_SETTINGS, TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS),
 )
 def test_given_hyperparameters_when_learner_called_then_leaderboard_is_correct(
-    temp_model_path, eval_metric, hyperparameters, expected_board_length
+    temp_model_path, hyperparameters, expected_board_length
 ):
     learner = TimeSeriesLearner(path_context=temp_model_path, eval_metric="MAPE")
     learner.fit(
@@ -62,7 +60,7 @@ def test_given_hyperparameters_when_learner_called_then_leaderboard_is_correct(
 
 @pytest.mark.parametrize(
     "hyperparameters, expected_board_length",
-    zip(TEST_HYPERPARAMETER_SETTINGS, [len(get_default_hps("toy", 1)), 1, 2]),
+    zip(TEST_HYPERPARAMETER_SETTINGS, TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS),
 )
 def test_given_hyperparameters_when_learner_called_then_model_can_predict(
     temp_model_path, hyperparameters, expected_board_length
@@ -144,7 +142,7 @@ def test_given_hyperparameters_and_custom_models_when_learner_called_then_leader
 
 @pytest.mark.parametrize(
     "hyperparameters, expected_board_length",
-    zip(TEST_HYPERPARAMETER_SETTINGS, [len(get_default_hps("toy", 1)), 1, 2]),
+    zip(TEST_HYPERPARAMETER_SETTINGS, TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS),
 )
 def test_given_hyperparameters_when_learner_called_and_loaded_back_then_all_models_can_predict(
     temp_model_path, hyperparameters, expected_board_length
@@ -171,7 +169,7 @@ def test_given_hyperparameters_when_learner_called_and_loaded_back_then_all_mode
         assert not np.any(np.isnan(predictions))
 
 
-@pytest.mark.parametrize("random_seed", [None, 12, 23, 34])
+@pytest.mark.parametrize("random_seed", [None, 1616])
 def test_given_random_seed_when_learner_called_then_random_seed_set_correctly(
     temp_model_path, random_seed
 ):

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -35,7 +35,7 @@ def test_when_predictor_called_then_training_is_performed(temp_model_path):
     assert "SimpleFeedForward" in predictor.get_model_names()
 
 
-@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS)
+@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])
 def test_given_hyperparameters_when_predictor_called_then_model_can_predict(
     temp_model_path, hyperparameters
 ):
@@ -57,7 +57,7 @@ def test_given_hyperparameters_when_predictor_called_then_model_can_predict(
     assert not np.any(np.isnan(predictions))
 
 
-@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS)
+@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])
 def test_given_different_target_name_when_predictor_called_then_model_can_predict(
     temp_model_path, hyperparameters
 ):

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -36,12 +36,8 @@ def test_when_predictor_called_then_training_is_performed(temp_model_path):
 
 
 @pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])  # noqa
-def test_given_hyperparameters_when_predictor_called_then_model_can_predict(
-    temp_model_path, hyperparameters
-):
-    predictor = TimeSeriesPredictor(
-        path=temp_model_path, eval_metric="MAPE", prediction_length=3
-    )
+def test_given_hyperparameters_when_predictor_called_then_model_can_predict(temp_model_path, hyperparameters):
+    predictor = TimeSeriesPredictor(path=temp_model_path, eval_metric="MAPE", prediction_length=3)
     predictor.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
@@ -58,9 +54,7 @@ def test_given_hyperparameters_when_predictor_called_then_model_can_predict(
 
 
 @pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])  # noqa
-def test_given_different_target_name_when_predictor_called_then_model_can_predict(
-    temp_model_path, hyperparameters
-):
+def test_given_different_target_name_when_predictor_called_then_model_can_predict(temp_model_path, hyperparameters):
     df = TimeSeriesDataFrame(copy.copy(DUMMY_TS_DATAFRAME))
     df.rename(columns={"target": "mytarget"}, inplace=True)
 
@@ -85,12 +79,8 @@ def test_given_different_target_name_when_predictor_called_then_model_can_predic
 
 
 @pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS)
-def test_given_no_tuning_data_when_predictor_called_then_model_can_predict(
-    temp_model_path, hyperparameters
-):
-    predictor = TimeSeriesPredictor(
-        path=temp_model_path, eval_metric="MAPE", prediction_length=3
-    )
+def test_given_no_tuning_data_when_predictor_called_then_model_can_predict(temp_model_path, hyperparameters):
+    predictor = TimeSeriesPredictor(path=temp_model_path, eval_metric="MAPE", prediction_length=3)
     predictor.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
@@ -110,9 +100,7 @@ def test_given_no_tuning_data_when_predictor_called_then_model_can_predict(
 def test_given_hyperparameters_and_quantiles_when_predictor_called_then_model_can_predict(
     temp_model_path, hyperparameters, quantile_kwarg_name
 ):
-    predictor_init_kwargs = dict(
-        path=temp_model_path, eval_metric="MAPE", prediction_length=3
-    )
+    predictor_init_kwargs = dict(path=temp_model_path, eval_metric="MAPE", prediction_length=3)
     predictor_init_kwargs[quantile_kwarg_name] = [0.1, 0.4, 0.9]
     predictor = TimeSeriesPredictor(**predictor_init_kwargs)
 

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -35,7 +35,7 @@ def test_when_predictor_called_then_training_is_performed(temp_model_path):
     assert "SimpleFeedForward" in predictor.get_model_names()
 
 
-@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])
+@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])  # noqa
 def test_given_hyperparameters_when_predictor_called_then_model_can_predict(
     temp_model_path, hyperparameters
 ):
@@ -57,7 +57,7 @@ def test_given_hyperparameters_when_predictor_called_then_model_can_predict(
     assert not np.any(np.isnan(predictions))
 
 
-@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])
+@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])  # noqa
 def test_given_different_target_name_when_predictor_called_then_model_can_predict(
     temp_model_path, hyperparameters
 ):

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -155,9 +155,7 @@ def test_given_hyperparameters_when_trainer_model_templates_called_then_hyperpar
         },
     ],
 )
-def test_given_hyperparameters_when_trainer_fit_then_freq_set_correctly(
-    temp_model_path, hyperparameters
-):
+def test_given_hyperparameters_when_trainer_fit_then_freq_set_correctly(temp_model_path, hyperparameters):
     trainer = AutoTimeSeriesTrainer(path=temp_model_path, eval_metric="MAPE")
     trainer.fit(
         train_data=DUMMY_TS_DATAFRAME,
@@ -171,15 +169,11 @@ def test_given_hyperparameters_when_trainer_fit_then_freq_set_correctly(
 
 
 @pytest.mark.parametrize("model_name", ["DeepAR", "SimpleFeedForward"])
-def test_given_hyperparameters_with_spaces_when_trainer_called_then_hpo_is_performed(
-    temp_model_path, model_name
-):
+def test_given_hyperparameters_with_spaces_when_trainer_called_then_hpo_is_performed(temp_model_path, model_name):
     hyperparameters = {model_name: {"epochs": ag.Int(1, 4)}}
     # mock the default hps factory to prevent preset hyperparameter configurations from
     # creeping into the test case
-    with mock.patch(
-        "autogluon.timeseries.models.presets.get_default_hps"
-    ) as default_hps_mock:
+    with mock.patch("autogluon.timeseries.models.presets.get_default_hps") as default_hps_mock:
         default_hps_mock.return_value = defaultdict(dict)
         trainer = AutoTimeSeriesTrainer(path=temp_model_path)
         trainer.fit(
@@ -247,9 +241,7 @@ def test_given_hyperparameters_with_spaces_to_prophet_when_trainer_called_then_h
     hyperparameters = {"Prophet": {"n_changepoints": ag.Int(1, 4)}}
     # mock the default hps factory to prevent preset hyperparameter configurations from
     # creeping into the test case
-    with mock.patch(
-        "autogluon.timeseries.models.presets.get_default_hps"
-    ) as default_hps_mock:
+    with mock.patch("autogluon.timeseries.models.presets.get_default_hps") as default_hps_mock:
         default_hps_mock.return_value = defaultdict(dict)
         trainer = AutoTimeSeriesTrainer(path=temp_model_path)
         trainer.fit(
@@ -371,9 +363,7 @@ def test_given_hyperparameters_and_custom_models_when_trainer_called_then_leader
                 {
                     GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": 1},
                     GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": 1},
-                    GenericGluonTSModelFactory(MQRNNEstimator, name="MQRNN_2"): {
-                        "epochs": 1
-                    },
+                    GenericGluonTSModelFactory(MQRNNEstimator, name="MQRNN_2"): {"epochs": 1},
                 },
             ],
             3,
@@ -388,15 +378,11 @@ def test_given_hyperparameters_and_custom_models_when_trainer_called_then_leader
                 {
                     GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": 1},
                     GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": 1},
-                    GenericGluonTSModelFactory(MQRNNEstimator, name="MQRNN_2"): {
-                        "epochs": 1
-                    },
+                    GenericGluonTSModelFactory(MQRNNEstimator, name="MQRNN_2"): {"epochs": 1},
                 },
                 {
                     GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": 1},
-                    GenericGluonTSModelFactory(MQRNNEstimator, name="MQRNN_2"): {
-                        "epochs": 1
-                    },
+                    GenericGluonTSModelFactory(MQRNNEstimator, name="MQRNN_2"): {"epochs": 1},
                 },
             ],
             7,
@@ -460,9 +446,7 @@ def test_given_hyperparameters_and_custom_models_when_trainer_model_templates_ca
     for model in models:
         if isinstance(model, GenericGluonTSModel):
             model_hyperparam = next(
-                hyperparameters[m]
-                for m in hyperparameters
-                if isinstance(m, GenericGluonTSModelFactory)
+                hyperparameters[m] for m in hyperparameters if isinstance(m, GenericGluonTSModelFactory)
             )
         else:
             model_hyperparam = hyperparameters[model.name]
@@ -474,14 +458,10 @@ def test_given_hyperparameters_and_custom_models_when_trainer_model_templates_ca
 def test_given_hyperparameters_with_spaces_and_custom_model_when_trainer_called_then_hpo_is_performed(
     temp_model_path,
 ):
-    hyperparameters = {
-        GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": ag.Int(1, 4)}
-    }
+    hyperparameters = {GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": ag.Int(1, 4)}}
     # mock the default hps factory to prevent preset hyperparameter configurations from
     # creeping into the test case
-    with mock.patch(
-        "autogluon.timeseries.models.presets.get_default_hps"
-    ) as default_hps_mock:
+    with mock.patch("autogluon.timeseries.models.presets.get_default_hps") as default_hps_mock:
         default_hps_mock.return_value = defaultdict(dict)
         trainer = AutoTimeSeriesTrainer(path=temp_model_path)
         trainer.fit(
@@ -513,9 +493,7 @@ def test_given_hyperparameters_with_spaces_and_custom_model_when_trainer_called_
 def test_when_trainer_fit_and_deleted_models_load_back_correctly_and_can_predict(
     temp_model_path, hyperparameters, low_memory
 ):
-    trainer = AutoTimeSeriesTrainer(
-        path=temp_model_path, eval_metric="MAPE", prediction_length=2
-    )
+    trainer = AutoTimeSeriesTrainer(path=temp_model_path, eval_metric="MAPE", prediction_length=2)
     trainer.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -1,5 +1,8 @@
 """Unit tests for trainers"""
 import copy
+import os
+import shutil
+import tempfile
 from collections import defaultdict
 from unittest import mock
 
@@ -14,17 +17,41 @@ from autogluon.timeseries.models import DeepARModel
 from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleWrapper
 from autogluon.timeseries.models.gluonts import GenericGluonTSModel
 from autogluon.timeseries.models.gluonts.models import GenericGluonTSModelFactory
-from autogluon.timeseries.models.presets import get_default_hps
 from autogluon.timeseries.trainer.auto_trainer import AutoTimeSeriesTrainer
 
 from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
 
 DUMMY_TRAINER_HYPERPARAMETERS = {"SimpleFeedForward": {"epochs": 1}}
 TEST_HYPERPARAMETER_SETTINGS = [
-    "toy",
-    DUMMY_TRAINER_HYPERPARAMETERS,
-    {"DeepAR": {"epochs": 1}, "SimpleFeedForward": {"epochs": 1}, "AutoETS": {}},
+    {"SimpleFeedForward": {"epochs": 1}},
+    {"DeepAR": {"epochs": 1}, "AutoETS": {}},
 ]
+TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS = [1, 2]
+
+
+@pytest.fixture(scope="module")
+def trained_trainers():
+    trainers = {}
+    model_paths = []
+    for hp in TEST_HYPERPARAMETER_SETTINGS:
+        temp_model_path = tempfile.mkdtemp()
+        trainer = AutoTimeSeriesTrainer(
+            path=temp_model_path + os.path.sep,
+            eval_metric="MAPE",
+            prediction_length=3,
+        )
+        trainer.fit(
+            train_data=DUMMY_TS_DATAFRAME,
+            val_data=DUMMY_TS_DATAFRAME,
+            hyperparameters=hp,
+        )
+        trainers[repr(hp)] = trainer
+        model_paths.append(temp_model_path)
+
+    yield trainers
+
+    for td in model_paths:
+        shutil.rmtree(td)
 
 
 def test_trainer_can_be_initialized(temp_model_path):
@@ -33,36 +60,15 @@ def test_trainer_can_be_initialized(temp_model_path):
 
 
 # smoke test for the short 'happy path'
-def test_when_trainer_called_then_training_is_performed(temp_model_path):
-    trainer = AutoTimeSeriesTrainer(path=temp_model_path)
-    trainer.fit(
-        train_data=DUMMY_TS_DATAFRAME,
-        val_data=DUMMY_TS_DATAFRAME,
-        hyperparameters=DUMMY_TRAINER_HYPERPARAMETERS,
-    )
-
-    assert "SimpleFeedForward" in trainer.get_model_names()
-
-
-def test_given_validation_data_when_trainer_called_then_training_is_performed(
-    temp_model_path,
-):
-    trainer = AutoTimeSeriesTrainer(path=temp_model_path)
-    trainer.fit(
-        train_data=DUMMY_TS_DATAFRAME,
-        hyperparameters=DUMMY_TRAINER_HYPERPARAMETERS,
-        val_data=DUMMY_TS_DATAFRAME,
-    )
-
-    assert "SimpleFeedForward" in trainer.get_model_names()
-    val_score = trainer.get_model_attribute("SimpleFeedForward", "val_score")
-    assert val_score is not None
+@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS)
+def test_when_trainer_called_then_training_is_performed(trained_trainers, hyperparameters):
+    assert trained_trainers[repr(hyperparameters)].get_model_names()
 
 
 @pytest.mark.parametrize("eval_metric", ["MAPE", None])
 @pytest.mark.parametrize(
     "hyperparameters, expected_board_length",
-    zip(TEST_HYPERPARAMETER_SETTINGS, [len(get_default_hps("toy", 1)), 1, 3]),
+    zip(TEST_HYPERPARAMETER_SETTINGS, TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS),
 )
 def test_given_hyperparameters_when_trainer_called_then_leaderboard_is_correct(
     temp_model_path, eval_metric, hyperparameters, expected_board_length
@@ -80,21 +86,14 @@ def test_given_hyperparameters_when_trainer_called_then_leaderboard_is_correct(
     assert np.all(leaderboard["score_val"] < 0)  # all MAPEs should be negative
 
 
-@pytest.mark.parametrize("eval_metric", ["MAPE"])
 @pytest.mark.parametrize(
     "hyperparameters, expected_board_length",
-    zip(TEST_HYPERPARAMETER_SETTINGS, [len(get_default_hps("toy", 1)), 1, 3]),
+    zip(TEST_HYPERPARAMETER_SETTINGS, TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS),
 )
 def test_given_test_data_when_trainer_called_then_leaderboard_is_correct(
-    temp_model_path, eval_metric, hyperparameters, expected_board_length
+    trained_trainers, hyperparameters, expected_board_length
 ):
-    trainer = AutoTimeSeriesTrainer(path=temp_model_path, eval_metric=eval_metric)
-    trainer.fit(
-        train_data=DUMMY_TS_DATAFRAME,
-        hyperparameters=hyperparameters,
-        val_data=DUMMY_TS_DATAFRAME,
-    )
-
+    trainer = trained_trainers[repr(hyperparameters)]
     test_data = get_data_frame_with_item_index(["A", "B", "C"])
 
     leaderboard = trainer.leaderboard(test_data)
@@ -107,20 +106,12 @@ def test_given_test_data_when_trainer_called_then_leaderboard_is_correct(
 
 @pytest.mark.parametrize(
     "hyperparameters, expected_board_length",
-    zip(TEST_HYPERPARAMETER_SETTINGS, [len(get_default_hps("toy", 1)), 1, 3]),
+    zip(TEST_HYPERPARAMETER_SETTINGS, TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS),
 )
 def test_given_hyperparameters_when_trainer_called_then_model_can_predict(
-    temp_model_path, hyperparameters, expected_board_length
+    trained_trainers, hyperparameters, expected_board_length
 ):
-    trainer = AutoTimeSeriesTrainer(
-        path=temp_model_path,
-        prediction_length=3,
-    )
-    trainer.fit(
-        train_data=DUMMY_TS_DATAFRAME,
-        hyperparameters=hyperparameters,
-        val_data=DUMMY_TS_DATAFRAME,
-    )
+    trainer = trained_trainers[repr(hyperparameters)]
     predictions = trainer.predict(DUMMY_TS_DATAFRAME)
 
     assert isinstance(predictions, TimeSeriesDataFrame)
@@ -179,7 +170,7 @@ def test_given_hyperparameters_when_trainer_fit_then_freq_set_correctly(
         assert model.freq == DUMMY_TS_DATAFRAME.freq
 
 
-@pytest.mark.parametrize("model_name", ["DeepAR", "SimpleFeedForward", "MQCNN"])
+@pytest.mark.parametrize("model_name", ["DeepAR", "SimpleFeedForward"])
 def test_given_hyperparameters_with_spaces_when_trainer_called_then_hpo_is_performed(
     temp_model_path, model_name
 ):
@@ -453,8 +444,8 @@ def test_given_repeating_model_when_trainer_called_incrementally_then_name_colli
             "SimpleFeedForward": {"epochs": 1},
         },
         {
-            GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": 2},
-            "DeepAR": {"epochs": 2},
+            GenericGluonTSModelFactory(MQRNNEstimator): {"epochs": 1},
+            "DeepAR": {"epochs": 1},
         },
     ],
 )

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -21,12 +21,8 @@ EMPTY_TARGETS = np.array([], dtype=np.int64)
 
 
 def _build_ts_dataframe(item_ids, datetime_index, target):
-    multi_inds = pd.MultiIndex.from_product(
-        [item_ids, datetime_index], names=["item_id", "timestamp"]
-    )
-    return TimeSeriesDataFrame(
-        pd.Series(target, name="target", index=multi_inds).to_frame()
-    )
+    multi_inds = pd.MultiIndex.from_product([item_ids, datetime_index], names=["item_id", "timestamp"])
+    return TimeSeriesDataFrame(pd.Series(target, name="target", index=multi_inds).to_frame())
 
 
 SAMPLE_TS_DATAFRAME = _build_ts_dataframe(ITEM_IDS, DATETIME_INDEX, TARGETS)
@@ -108,9 +104,7 @@ def test_from_gluonts_list_dataset():
 
 def test_from_data_frame():
     tsdf_from_data_frame = TimeSeriesDataFrame(SAMPLE_DATAFRAME)
-    pd.testing.assert_frame_equal(
-        tsdf_from_data_frame, SAMPLE_TS_DATAFRAME, check_dtype=True
-    )
+    pd.testing.assert_frame_equal(tsdf_from_data_frame, SAMPLE_TS_DATAFRAME, check_dtype=True)
 
 
 @pytest.mark.parametrize(
@@ -257,9 +251,7 @@ def test_subsequence(start_timestamp, end_timestamp, item_ids, datetimes, target
         (["2020-01-01 00:00:00", "2020-01-01 01:00:00", "2020-01-01 02:00:00"], "H"),
     ],
 )
-def test_when_dataset_constructed_from_dataframe_without_freq_then_freq_is_inferred(
-    timestamps, expected_freq
-):
+def test_when_dataset_constructed_from_dataframe_without_freq_then_freq_is_inferred(timestamps, expected_freq):
     df = pd.DataFrame(
         {
             "item_id": [0, 0, 0],
@@ -284,9 +276,7 @@ FREQ_TEST_CASES = [
 
 
 @pytest.mark.parametrize("start_time, freq", FREQ_TEST_CASES)
-def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(
-    start_time, freq
-):
+def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(start_time, freq):
     item_list = ListDataset(
         [{"target": [1, 2, 3], "start": pd.Timestamp(start_time)} for _ in range(3)],  # type: ignore
         freq=freq,
@@ -298,12 +288,10 @@ def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(
 
 
 @pytest.mark.parametrize("start_time, freq", FREQ_TEST_CASES)
-def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferred(
-    start_time, freq
-):
+def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferred(start_time, freq):
     item_list = ListDataset(
         [{"target": [1, 2, 3], "start": pd.Timestamp(start_time, freq=freq)} for _ in range(3)],  # type: ignore
-        freq=freq
+        freq=freq,
     )
 
     ts_df = TimeSeriesDataFrame(item_list)
@@ -312,27 +300,28 @@ def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferre
 
 
 @pytest.mark.skip("Skipped until re-enabling regularity check.")
-@pytest.mark.parametrize("list_of_timestamps", [
+@pytest.mark.parametrize(
+    "list_of_timestamps",
     [
-        ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],
+        [
+            ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],
+        ],
+        [
+            ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"],
+            ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:00:01"],
+        ],
+        [
+            ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"],
+            ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-04 00:00:00"],
+        ],
+        [
+            ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],
+            ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],
+            ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],
+        ],
     ],
-    [
-        ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"],
-        ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:00:01"],
-    ],
-    [
-        ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:00:00"],
-        ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-04 00:00:00"],
-    ],
-    [
-        ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],
-        ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],
-        ["2020-01-01 00:00:00", "2020-01-02 00:00:00", "2020-01-03 00:01:00"],
-    ]
-])
-def test_when_dataset_constructed_with_irregular_timestamps_then_constructor_raises(
-    list_of_timestamps
-):
+)
+def test_when_dataset_constructed_with_irregular_timestamps_then_constructor_raises(list_of_timestamps):
     df_tuples = []
     for i, ts in enumerate(list_of_timestamps):
         for t in ts:
@@ -435,9 +424,7 @@ def test_when_dataset_sliced_by_step_then_output_times_and_values_correct(
     assert all(ixval[1] == pd.Timestamp(expected_times[i]) for i, ixval in enumerate(dfv.index.values))  # type: ignore
 
 
-@pytest.mark.parametrize("input_df", [
-    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
-])
+@pytest.mark.parametrize("input_df", [SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY])
 def test_when_dataframe_copy_called_on_instance_then_output_correct(input_df):
     copied_df = input_df.copy()
 
@@ -445,9 +432,7 @@ def test_when_dataframe_copy_called_on_instance_then_output_correct(input_df):
     assert copied_df._data is not input_df._data
 
 
-@pytest.mark.parametrize("input_df", [
-    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
-])
+@pytest.mark.parametrize("input_df", [SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY])
 def test_when_dataframe_stdlib_copy_called_then_output_correct(input_df):
     copied_df = copy.deepcopy(input_df)
 
@@ -455,9 +440,7 @@ def test_when_dataframe_stdlib_copy_called_then_output_correct(input_df):
     assert copied_df._data is not input_df._data
 
 
-@pytest.mark.parametrize("input_df", [
-    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
-])
+@pytest.mark.parametrize("input_df", [SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY])
 def test_when_dataframe_class_copy_called_then_output_correct(input_df):
     copied_df = TimeSeriesDataFrame.copy(input_df, deep=True)
 
@@ -465,9 +448,7 @@ def test_when_dataframe_class_copy_called_then_output_correct(input_df):
     assert copied_df._data is not input_df._data
 
 
-@pytest.mark.parametrize("input_df", [
-    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
-])
+@pytest.mark.parametrize("input_df", [SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY])
 @pytest.mark.parametrize("inplace", [True, False])
 def test_when_dataframe_class_rename_called_then_output_correct(input_df, inplace):
     renamed_df = TimeSeriesDataFrame.rename(input_df, columns={"target": "mytarget"}, inplace=inplace)
@@ -481,9 +462,7 @@ def test_when_dataframe_class_rename_called_then_output_correct(input_df, inplac
         assert renamed_df._data is input_df._data
 
 
-@pytest.mark.parametrize("input_df", [
-    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
-])
+@pytest.mark.parametrize("input_df", [SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY])
 @pytest.mark.parametrize("inplace", [True, False])
 def test_when_dataframe_instance_rename_called_then_output_correct(input_df, inplace):
     renamed_df = input_df.rename(columns={"target": "mytarget"}, inplace=inplace)
@@ -497,9 +476,7 @@ def test_when_dataframe_instance_rename_called_then_output_correct(input_df, inp
         assert renamed_df._data is input_df._data
 
 
-@pytest.mark.parametrize("input_df", [
-    SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY
-])
+@pytest.mark.parametrize("input_df", [SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY])
 @pytest.mark.parametrize("read_fn", [pd.read_pickle, TimeSeriesDataFrame.from_pickle])
 def test_when_dataframe_read_pickle_called_then_output_correct(input_df, read_fn):
 


### PR DESCRIPTION
*Issue #, if available:*

- Streamline unit tests, with a 2x speedup to ~10-15 minutes, with no drop in test coverage.
- Take care of warnings during testing, and address style issues
- black the `tests/` folder. this is the last commit in this PR and can be ignored during the review.

test coverage:
```
---------- coverage: platform linux, python 3.7.10-final-0 -----------
Name                                                                    Stmts   Miss  Cover
-------------------------------------------------------------------------------------------
src/autogluon/__init__.py                                                   1      1     0%
src/autogluon/timeseries/__init__.py                                       15      4    73%
src/autogluon/timeseries/configs/__init__.py                                2      0   100%
src/autogluon/timeseries/configs/presets_configs.py                         1      0   100%
src/autogluon/timeseries/dataset/__init__.py                                2      0   100%
src/autogluon/timeseries/dataset/ts_dataframe.py                          127     20    84%
src/autogluon/timeseries/evaluator.py                                     103      4    96%
src/autogluon/timeseries/learner.py                                        51      8    84%
src/autogluon/timeseries/models/__init__.py                                 3      0   100%
src/autogluon/timeseries/models/abstract/__init__.py                        2      0   100%
src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py     126     18    86%
src/autogluon/timeseries/models/abstract/model_trial.py                    47     10    79%
src/autogluon/timeseries/models/ensemble/__init__.py                        0      0   100%
src/autogluon/timeseries/models/ensemble/greedy_ensemble.py               134     15    89%
src/autogluon/timeseries/models/gluonts/__init__.py                         2      0   100%
src/autogluon/timeseries/models/gluonts/abstract_gluonts.py               141      5    96%
src/autogluon/timeseries/models/gluonts/callback.py                        23      3    87%
src/autogluon/timeseries/models/gluonts/models.py                          66      6    91%
src/autogluon/timeseries/models/presets.py                                 75      5    93%
src/autogluon/timeseries/models/sktime/__init__.py                          3      0   100%
src/autogluon/timeseries/models/sktime/abstract_sktime.py                  58      1    98%
src/autogluon/timeseries/models/sktime/models.py                           20      0   100%
src/autogluon/timeseries/predictor.py                                     152     40    74%
src/autogluon/timeseries/trainer/__init__.py                                3      0   100%
src/autogluon/timeseries/trainer/abstract_trainer.py                      477    133    72%
src/autogluon/timeseries/trainer/auto_trainer.py                           14      0   100%
src/autogluon/timeseries/utils/__init__.py                                  0      0   100%
src/autogluon/timeseries/utils/metadata.py                                  7      1    86%
src/autogluon/timeseries/utils/warning_filters.py                          31      2    94%
src/autogluon/timeseries/version.py                                         1      0   100%
-------------------------------------------------------------------------------------------
TOTAL                                                                    1687    276    84%
```

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
