### PR TITLE
Disable multilayer stacking in binary

### DIFF
--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -681,9 +681,20 @@ class AbstractTabularLearner(AbstractLearner):
             X = X.loc[y.index]
         return X, y
 
+    def infer_problem_type(self, y: Series, silent=False):
+        problem_type = self._infer_problem_type(y, silent=silent)
+        if self.quantile_levels is not None:
+            if problem_type == REGRESSION:
+                problem_type = QUANTILE
+            else:
+                raise ValueError("autogluon infers this to be classification problem for which quantile_levels "
+                                 "cannot be specified. If it is truly a quantile regression problem, "
+                                 "please specify:problem_type='quantile'")
+        return problem_type
+
     @staticmethod
-    def infer_problem_type(y: Series):
-        return infer_problem_type(y=y)
+    def _infer_problem_type(y: Series, silent=False):
+        return infer_problem_type(y=y, silent=silent)
 
     # Loads models in memory so that they don't have to be loaded during predictions
     def persist_trainer(self, low_memory=False, models='all', with_ancestors=False, max_memory=None) -> list:

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -683,13 +683,16 @@ class AbstractTabularLearner(AbstractLearner):
 
     def infer_problem_type(self, y: Series, silent=False):
         problem_type = self._infer_problem_type(y, silent=silent)
-        if self.quantile_levels is not None:
+        if problem_type == QUANTILE:
+            if self.quantile_levels is None:
+                raise AssertionError(f'problem_type is inferred to be {QUANTILE}, yet quantile_levels is not specified.')
+        elif self.quantile_levels is not None:
             if problem_type == REGRESSION:
                 problem_type = QUANTILE
             else:
-                raise ValueError("autogluon infers this to be classification problem for which quantile_levels "
-                                 "cannot be specified. If it is truly a quantile regression problem, "
-                                 "please specify:problem_type='quantile'")
+                raise AssertionError(f"autogluon infers this to be classification problem ('{problem_type}'), yet quantile_levels is not None."
+                                     "If it is truly a quantile regression problem, "
+                                     f"please specify problem_type='{QUANTILE}'.")
         return problem_type
 
     @staticmethod

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -785,10 +785,18 @@ class TabularPredictor:
         self._set_feature_generator(feature_generator=feature_generator, feature_metadata=feature_metadata,
                                     init_kwargs=feature_generator_init_kwargs)
 
+        if self.problem_type is not None:
+            inferred_problem_type = self.problem_type
+        else:
+            inferred_problem_type = self._learner.infer_problem_type(y=train_data[self.label], silent=True)
+
         num_bag_folds, num_bag_sets, num_stack_levels = self._sanitize_stack_args(
             num_bag_folds=num_bag_folds, num_bag_sets=num_bag_sets, num_stack_levels=num_stack_levels,
-            time_limit=time_limit, auto_stack=auto_stack, num_train_rows=len(train_data),
+            time_limit=time_limit, auto_stack=auto_stack, num_train_rows=len(train_data), problem_type=inferred_problem_type,
         )
+        if auto_stack:
+            logger.log(20, f'Stack configuration (auto_stack={auto_stack}): '
+                           f'num_stack_levels={num_stack_levels}, num_bag_folds={num_bag_folds}, num_bag_sets={num_bag_sets}')
 
         if holdout_frac is None:
             holdout_frac = default_holdout_frac(len(train_data),
@@ -3132,14 +3140,24 @@ class TabularPredictor:
                                                                         init_kwargs=init_kwargs)
 
     def _sanitize_stack_args(self, num_bag_folds, num_bag_sets, num_stack_levels, time_limit, auto_stack,
-                             num_train_rows):
+                             num_train_rows, problem_type):
         if auto_stack:
             # TODO: What about datasets that are 100k+? At a certain point should we not bag?
             # TODO: What about time_limit? Metalearning can tell us expected runtime of each model, then we can select optimal folds + stack levels to fit time constraint
             if num_bag_folds is None:
                 num_bag_folds = min(8, max(5, math.floor(num_train_rows / 100)))
+            # TODO: Leverage use_bag_holdout when data is large to enable multi-layer stacking
+            #  if num_train_rows >= 100000 and num_val_rows is None and use_bag_holdout is None:
+            #      use_bag_holdout = True
             if num_stack_levels is None:
-                num_stack_levels = min(1, max(0, math.floor(num_train_rows / 750)))
+                if problem_type == BINARY:
+                    # Disable multi-layer stacking to avoid stack info leakage
+                    num_stack_levels = 0
+                    # TODO:
+                    #  if use_bag_holdout:
+                    #      num_stack_levels = min(1, max(0, math.floor(num_train_rows / 750)))
+                else:
+                    num_stack_levels = min(1, max(0, math.floor(num_train_rows / 750)))
         if num_bag_folds is None:
             num_bag_folds = 0
         if num_stack_levels is None:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Disable multilayer stacking in binary when `auto_stack=True`
- This avoids the stack info leakage problem that can commonly occur in binary classification.
- While this makes results worse on some datasets, it greatly improves results on others.
- In general, inference speed is improved significantly for binary problems.

Benchmark: 172 Binary datasets with >=10,000 rows

```
AutoGluon_bq_4h64c_2022_06_25_nn VS all
                              framework   winrate   >   <    =  % Less Avg. Errors  Avg Inf Speed Diff  time_train_s  time_infer_s  loss_rescaled  time_train_s_rescaled  time_infer_s_rescaled      rank  rank=1_count  rank=2_count  rank=3_count  rank>3_count  error_count
0  AutoGluon_bq_4h64c_2022_06_26_binary  0.531977  88  77    7            1.754443            2.354029   8079.973256      0.008257       0.459302               1.000447               1.048294  1.468023            97            84             0             0            2
1      AutoGluon_bq_4h64c_2022_06_25_nn  0.500000   0   0  174            0.000000                 NaN  11301.577907      0.021823       0.523256               1.670676               3.402322  1.531977            79            95             0             0            9

```

Results: 3.4x inference speedup, 53.2% win-rate.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
