### PR TITLE
[HPO] Tabular/Timeseries ray hpo

### DIFF
--- a/core/setup.py
+++ b/core/setup.py
@@ -40,7 +40,7 @@ extras_require = {
     'ray': [
         "ray>=1.13,<1.14",
     ],
-    'ray_tune': [
+    'raytune': [
         'ray[tune]>=1.13,<1.14',
         'hyperopt>=0.2.7,<0.2.8',
         # 'GPy>=1.10.0,<1.11.0'  # TODO: Enable this once PBT/PB2 are supported by ray lightning
@@ -54,7 +54,7 @@ tests_require = [
 
 all_requires = []
 
-for extra_package in ['ray', 'ray_tune']:
+for extra_package in ['ray', 'raytune']:
     all_requires += extras_require[extra_package]
 tests_require = list(set(tests_require))
 all_requires = list(set(all_requires))

--- a/core/src/autogluon/core/hpo/constants.py
+++ b/core/src/autogluon/core/hpo/constants.py
@@ -7,3 +7,7 @@ MAX = 'max'
 
 SEARCHER_PRESETS = SearcherFactory.searcher_presets
 SCHEDULER_PRESETS = SchedulerFactory.scheduler_presets
+
+RAY_BACKEND = 'ray'
+CUSTOM_BACKEND = 'custom'
+VALID_BACKEND = [RAY_BACKEND, CUSTOM_BACKEND]

--- a/core/src/autogluon/core/hpo/exceptions.py
+++ b/core/src/autogluon/core/hpo/exceptions.py
@@ -1,0 +1,2 @@
+class EmptySearchSpace(Exception):
+    pass

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -77,7 +77,8 @@ class RayHpoExecutor(HpoExecutor):
     
     def initialize(self, hyperparameter_tune_kwargs, default_num_trials=None, time_limit=None):
         self.time_limit = time_limit
-        hyperparameter_tune_kwargs = hyperparameter_tune_kwargs.copy()
+        if isinstance(hyperparameter_tune_kwargs, dict):
+            hyperparameter_tune_kwargs = hyperparameter_tune_kwargs.copy()
         if isinstance(hyperparameter_tune_kwargs, str):
             hyperparameter_tune_kwargs = self.custom_to_ray_preset_map[hyperparameter_tune_kwargs]
         hyperparameter_tune_kwargs['scheduler'] = self.custom_to_ray_scheduler_preset_map.get(
@@ -170,8 +171,9 @@ class CustomHpoExecutor(HpoExecutor):
         return CUSTOM_BACKEND
     
     def initialize(self, hyperparameter_tune_kwargs, default_num_trials=None, time_limit=None):
-        hyperparameter_tune_kwargs = hyperparameter_tune_kwargs.copy()
         if not isinstance(hyperparameter_tune_kwargs, tuple):
+            if isinstance(hyperparameter_tune_kwargs, dict):
+                hyperparameter_tune_kwargs = hyperparameter_tune_kwargs.copy()
             num_trials = default_num_trials  # This will be ignored if hyperparameter_tune_kwargs contains num_trials
             if default_num_trials is None:
                 num_trials = 1 if time_limit is None else 1000
@@ -202,8 +204,8 @@ class CustomHpoExecutor(HpoExecutor):
                     
     def execute(self, model_trial, train_fn_kwargs, **kwargs):
         assert self.scheduler_options is not None, 'Call `initialize()` before execute'
-
         scheduler_cls, scheduler_params = self.scheduler_options  # Unpack tuple
+        print(scheduler_params)
         if scheduler_cls is None or scheduler_params is None:
             raise ValueError("scheduler_cls and scheduler_params cannot be None for hyperparameter tuning")
         train_fn_kwargs['fit_kwargs'].update(scheduler_params['resource'].copy())

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -86,7 +86,7 @@ class RayHpoExecutor(HpoExecutor):
             hyperparameter_tune_kwargs['scheduler'],
             hyperparameter_tune_kwargs['scheduler']
         )
-        hyperparameter_tune_kwargs['searcher'] = self.custom_to_ray_scheduler_preset_map.get(
+        hyperparameter_tune_kwargs['searcher'] = self.custom_to_ray_searcher_preset_map.get(
             hyperparameter_tune_kwargs['searcher'],
             hyperparameter_tune_kwargs['searcher']
         )

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -1,0 +1,241 @@
+import copy
+import logging
+import os
+import time
+
+from abc import ABC, abstractmethod
+
+from .constants import RAY_BACKEND, CUSTOM_BACKEND
+from .exceptions import EmptySearchSpace
+from .. import Space
+from ..scheduler.scheduler_factory import scheduler_factory
+
+
+logger = logging.getLogger(__name__)
+
+
+class HpoExecutor(ABC):
+    """Interface for abstract model to executor HPO runs"""
+    
+    def __init__(self):
+        self.search_space = None
+        self.time_limit = None
+    
+    @property
+    @abstractmethod
+    def executor_type(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def initialize(self, hyperparameter_tune_kwargs, time_limit=None):
+        raise NotImplementedError
+    
+    @abstractmethod
+    def register_resources(self, resources):
+        raise NotImplementedError
+    
+    @abstractmethod
+    def validate_search_space(self, search_space, model_name):
+        raise NotImplementedError
+    
+    @abstractmethod
+    def execute(self, **kwargs):
+        raise NotImplementedError
+    
+    @abstractmethod
+    def report(self, reporter, **kwargs):
+        raise NotImplementedError
+    
+    @abstractmethod
+    def get_hpo_results(self, model_name, model_path_root, **kwargs):
+        raise NotImplementedError
+
+
+class RayHpoExecutor(HpoExecutor):
+    
+    def __init__(self):
+        self.resources = None
+        self.hyperparameter_tune_kwargs = None
+        self.analysis = None
+    
+    @property
+    def executor_type(self):
+        return RAY_BACKEND
+    
+    def initialize(self, hyperparameter_tune_kwargs, time_limit=None):
+        self.time_limit = time_limit
+        self.hyperparameter_tune_kwargs = hyperparameter_tune_kwargs
+        return time_limit
+    
+    def register_resources(self, resources):
+        self.resources = resources
+        
+    def validate_search_space(self, search_space, model_name):
+        from ray.tune.sample import Domain
+        if not any(isinstance(search_space[hyperparam], (Space, Domain)) for hyperparam in search_space):
+            logger.warning(f"\tNo hyperparameter search space specified for {model_name}. Skipping HPO. "
+                           f"Will train one model based on the provided hyperparameters.")
+            raise EmptySearchSpace
+        self.search_space = search_space
+        logger.log(15, f"\tHyperparameter search space for {model_name}: ")
+        for hyperparam in search_space:
+                if isinstance(search_space[hyperparam], (Space, Domain)):
+                    logger.log(15, f"{hyperparam}:   {search_space[hyperparam]}")
+                    
+    def execute(
+            self,
+            model_trial,
+            search_space,
+            train_fn_kwargs,
+            directory,
+            minimum_cpu_per_trial,
+            minimum_gpu_per_trial,
+            model_estimate_memory_usage
+        ):
+        from .ray_hpo import (
+            run,
+            TabularRayTuneAdapter
+        )
+        analysis = run(
+            trainable=model_trial,
+            trainable_args=train_fn_kwargs,
+            search_space=self.search_space,
+            hyperparameter_tune_kwargs=self.hyperparameter_tune_kwargs,
+            metric='validation_performance',
+            mode='max',
+            save_dir=directory,
+            ray_tune_adapter=TabularRayTuneAdapter(),
+            total_resources=self.resources,
+            minimum_cpu_per_trial=minimum_cpu_per_trial,
+            minimum_gpu_per_trial=minimum_gpu_per_trial,
+            model_estimate_memory_usage=model_estimate_memory_usage,
+            time_budget_s=self.time_limit
+        )
+        self.analysis = analysis
+        
+    def report(self, reporter, **kwargs):
+        from ray import tune
+        tune.report(**kwargs)
+        
+    def get_hpo_results(self, model_name, model_path_root, **kwargs):
+        assert self.analysis is not None, 'Call `execute()` before `get_hpo_results()`'
+        hpo_models = {}
+        for trial, details in self.analysis.results.items():
+            validation_performance = details.get('validation_performance', None)
+            # when equals to -inf, trial finished with TimeLimitExceeded exception and didn't finish at least 1 epoch
+            if validation_performance is None or validation_performance == float('-inf'):
+                continue
+            trial_id = details.get('trial_id')
+            file_id = trial_id  # unique identifier to files from this trial
+            trial_model_name = model_name + os.path.sep + file_id
+            trial_model_path = model_path_root + trial_model_name + os.path.sep
+            hpo_models[trial_model_name] = trial_model_path
+
+        return hpo_models, self.analysis
+
+
+class CustomHpoExecutor(HpoExecutor):
+    
+    def __init__(self):
+        self.scheduler_options = None
+        self.scheduler = None
+        
+    @property
+    def executor_type(self):
+        return CUSTOM_BACKEND
+    
+    def initialize(self, hyperparameter_tune_kwargs, time_limit=None):
+        if not isinstance(hyperparameter_tune_kwargs, tuple):
+            num_trials = 1 if time_limit is None else 1000
+            hyperparameter_tune_kwargs = scheduler_factory(hyperparameter_tune_kwargs, num_trials=num_trials, nthreads_per_trial='auto', ngpus_per_trial='auto')
+            hyperparameter_tune_kwargs = copy.deepcopy(hyperparameter_tune_kwargs)
+            if 'time_out' not in hyperparameter_tune_kwargs[1]:
+                hyperparameter_tune_kwargs[1]['time_out'] = time_limit
+            time_limit = hyperparameter_tune_kwargs[1]['time_out']
+        self.scheduler_options = hyperparameter_tune_kwargs
+        self.time_limit = time_limit
+        
+        return time_limit
+    
+    def register_resources(self, resources):
+        assert self.scheduler_options is not None, 'Call `initialize()` before register resources'
+        self.scheduler_options[1]['resources'] = resources
+        
+    def validate_search_space(self, search_space, model_name):
+        if not any(isinstance(search_space[hyperparam], Space) for hyperparam in search_space):
+            logger.warning(f"\tNo hyperparameter search space specified for {model_name}. Skipping HPO. "
+                           f"Will train one model based on the provided hyperparameters.")
+            raise EmptySearchSpace
+        self.search_space = search_space
+        logger.log(15, f"\tHyperparameter search space for {model_name}: ")
+        for hyperparam in search_space:
+                if isinstance(search_space[hyperparam], Space):
+                    logger.log(15, f"{hyperparam}:   {search_space[hyperparam]}")
+                    
+    def execute(self, model_trial, train_fn_kwargs, **kwargs):
+        assert self.scheduler_options is not None, 'Call `initialize()` before execute'
+
+        scheduler_cls, scheduler_params = self.scheduler_options  # Unpack tuple
+        if scheduler_cls is None or scheduler_params is None:
+            raise ValueError("scheduler_cls and scheduler_params cannot be None for hyperparameter tuning")
+        train_fn_kwargs['fit_kwargs']['time_limit'] = scheduler_params['time_out']
+        train_fn_kwargs['fit_kwargs'].update(scheduler_params['resource'].copy())
+        scheduler = scheduler_cls(model_trial, search_space=self.search_space, train_fn_kwargs=train_fn_kwargs, **scheduler_params)
+        self.scheduler = scheduler
+        
+        scheduler.run()
+        scheduler.join_jobs()
+    
+    def report(self, reporter, **kwargs):
+        assert reporter is not None
+        reporter.report(**kwargs)    
+        
+    def get_hpo_results(self, model_name, model_path_root, time_start, **kwargs):
+        assert self.scheduler is not None, 'Call `execute()` before `get_hpo_results()`'
+        # Store results / models from this HPO run:
+        best_hp = self.scheduler.get_best_config()  # best_hp only contains searchable stuff
+        hpo_results = {
+            'best_reward': self.scheduler.get_best_reward(),
+            'best_config': best_hp,
+            'total_time': time.time() - time_start,
+            'metadata': self.scheduler.metadata,
+            'training_history': self.scheduler.training_history,
+            'config_history': self.scheduler.config_history,
+            'reward_attr': self.scheduler._reward_attr,
+        }
+
+        hpo_models = {}  # stores all the model names and file paths to model objects created during this HPO run.
+        hpo_model_performances = {}
+        for trial in sorted(hpo_results['config_history'].keys()):
+            # TODO: ignore models which were killed early by scheduler (eg. in Hyperband). How to ID these?
+            file_id = f"T{trial+1}"  # unique identifier to files from this trial
+            trial_model_name = model_name + os.path.sep + file_id
+            trial_model_path = model_path_root + trial_model_name + os.path.sep
+            trial_reward = self.scheduler.searcher.get_reward(hpo_results['config_history'][trial])
+
+            hpo_models[trial_model_name] = trial_model_path
+            hpo_model_performances[trial_model_name] = trial_reward
+        
+        hpo_results['hpo_model_performances'] = hpo_model_performances
+
+        logger.log(15, "Time for %s model HPO: %s" % (self.name, str(hpo_results['total_time'])))
+        logger.log(15, "Best hyperparameter configuration for %s model: " % self.name)
+        logger.log(15, str(best_hp))
+
+        return hpo_models, hpo_results
+
+
+class HpoExecutorFactory:
+    
+    __supported_executors = [
+        RayHpoExecutor,
+        CustomHpoExecutor,
+    ]
+    
+    __type_to_executor = {cls().executor_type: cls for cls in __supported_executors}
+
+    @staticmethod
+    def get_hpo_executor(hpo_executor: str) -> HpoExecutor:
+        """Return the executor"""
+        assert hpo_executor in HpoExecutorFactory.__type_to_executor, f'{hpo_executor} not supported'
+        return HpoExecutorFactory.__type_to_executor[hpo_executor]

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -63,7 +63,8 @@ class RayHpoExecutor(HpoExecutor):
     }
     custom_to_ray_searcher_preset_map = {
         'local_random': 'random',
-        'random': 'random', 
+        'random': 'random',
+        'auto': 'random',
     }
     
     def __init__(self):

--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -16,11 +16,12 @@ from .constants import (
     SEARCHER_PRESETS,
     SCHEDULER_PRESETS
 )
-from ..ray.resources_calculator import ResourceCalculatorFactory, ResourceCalculator
+from .exceptions import EmptySearchSpace
 from .scheduler_factory import SchedulerFactory
 from .searcher_factory import SearcherFactory
 from .space_converter import RaySpaceConverterFactory
 from .. import Space
+from ..ray.resources_calculator import ResourceCalculatorFactory, ResourceCalculator
 
 from ray import tune
 from ray.tune import PlacementGroupFactory
@@ -33,10 +34,6 @@ from ray.tune.suggest.hyperopt import HyperOptSearch
 
 
 logger = logging.getLogger(__name__)
-
-
-class EmptySearchSpace(Exception):
-    pass
 
 
 class RayTuneAdapter(ABC):

--- a/core/src/autogluon/core/hpo/space_converter.py
+++ b/core/src/autogluon/core/hpo/space_converter.py
@@ -80,7 +80,5 @@ class RaySpaceConverterFactory:
     @staticmethod
     def get_space_converter(converter_type: str) -> RaySpaceConverter:
         """Return the resource calculator"""
-        for i, j in RaySpaceConverterFactory.__type_to_converter.items():
-            print(i,j)
         assert converter_type in RaySpaceConverterFactory.__type_to_converter, f'{converter_type} not supported'
         return RaySpaceConverterFactory.__type_to_converter[converter_type]

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -927,7 +927,8 @@ class AbstractModel:
     def hyperparameter_tune(self, hyperparameter_tune_kwargs, time_limit=None, **kwargs):
         backend = self._get_hpo_backend()
         hpo_executor = HpoExecutorFactory.get_hpo_executor(backend)()
-        time_limit = hpo_executor.initialize(hyperparameter_tune_kwargs, time_limit)
+        default_num_trials = kwargs.pop('default_num_trials', None)
+        time_limit = hpo_executor.initialize(hyperparameter_tune_kwargs, default_num_trials=default_num_trials, time_limit=time_limit)
         kwargs = self.initialize(time_limit=time_limit, **kwargs)
         self._register_fit_metadata(**kwargs)
         self._validate_fit_memory_usage(**kwargs)

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -925,9 +925,8 @@ class AbstractModel:
         return template
 
     def hyperparameter_tune(self, hyperparameter_tune_kwargs, time_limit=None, **kwargs):
-        # Determine backend
-        backend = self._get_hpo_backend(hyperparameter_tune_kwargs)
-        hpo_executor = HpoExecutorFactory.get_hpo_executor(backend)
+        backend = self._get_hpo_backend()
+        hpo_executor = HpoExecutorFactory.get_hpo_executor(backend)()
         time_limit = hpo_executor.initialize(hyperparameter_tune_kwargs, time_limit)
         kwargs = self.initialize(time_limit=time_limit, **kwargs)
         self._register_fit_metadata(**kwargs)
@@ -999,10 +998,8 @@ class AbstractModel:
             time_start=time_start,
         )
     
-    def _get_hpo_backend(hyperparameter_tune_kwargs):
+    def _get_hpo_backend(self):
         """Choose which backend(Ray or Custom) to use for hpo"""
-        if isinstance(hyperparameter_tune_kwargs, str) and hyperparameter_tune_kwargs == 'bayesopt':
-            return RAY_BACKEND
         return CUSTOM_BACKEND
 
     # Resets metrics for the model

--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -19,6 +19,7 @@ def model_trial(args,
                 reporter=None,  # reporter only used by custom strategy, hence optional
                 time_limit=None,
                 fit_kwargs=None,
+                checkpoint_dir=None,  # Tabular doesn't support checkpoint in the middle yet. This is here to disable warning from ray tune
                 ):
     """ Training script for hyperparameter evaluation of an arbitrary model that subclasses AbstractModel."""
     try:
@@ -114,5 +115,6 @@ def skip_hpo(model, X, y, X_val, y_val, time_limit=None, **kwargs):
     )
     hpo_results = {'total_time': model.fit_time}
     hpo_model_performances = {model.name: model.val_score}
+    hpo_results['hpo_model_performances'] = hpo_model_performances
     hpo_models = {model.name: model.path}
-    return hpo_models, hpo_model_performances, hpo_results
+    return hpo_models, hpo_results

--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -404,11 +404,16 @@ class ParallelLocalFoldFittingStrategy(LocalFoldFittingStrategy):
         return num_cpus
 
     def schedule_fold_model_fit(self, fold_ctx):
-        if not self.ray.is_initialized():
-            if self.num_gpus > 0:
-                self.ray.init(log_to_driver=False, num_gpus=self.num_gpus)
-            else:
-                self.ray.init(log_to_driver=False)
+        if self.ray.is_initialized():
+        # shutdown to reinitialize resources because different model might require different total resources
+        # also, when doing bagging + hpo, ray parallel bagging would freeze if only 1 fold remains. Shutdown address the issue.
+        # TODO: need a different strategy when dealing with cluster
+        # TODO: better way to address ray freezing?
+            self.ray.shutdown()
+        ray_init_args = dict(log_to_driver=False)
+        if self.num_gpus > 0:
+            ray_init_args['num_gpus'] = self.num_gpus
+        self.ray.init(**ray_init_args)
         self.jobs.append(fold_ctx)
 
     def after_all_folds_scheduled(self):

--- a/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/stacker_ensemble_model.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import os
 import time
 from typing import Dict
 
@@ -154,9 +155,11 @@ class StackerEnsembleModel(BaggedEnsembleModel):
 
     def set_contexts(self, path_context):
         path_root_orig = self.path_root
+        abs_path_root_orig = os.path.abspath(path_root_orig) + os.path.sep
         super().set_contexts(path_context=path_context)
         for model, model_path in self.base_model_paths_dict.items():
-            model_local_path = model_path.split(path_root_orig, 1)[1]
+            model_path = os.path.abspath(model_path) + os.path.sep
+            model_local_path = model_path.split(abs_path_root_orig, 1)[1]
             self.base_model_paths_dict[model] = self.path_root + model_local_path
 
     def set_stack_columns(self, stack_column_prefix_lst):
@@ -171,12 +174,12 @@ class StackerEnsembleModel(BaggedEnsembleModel):
             num_pred_cols_per_model = 1
         return stack_columns, num_pred_cols_per_model
 
-    def _hyperparameter_tune(self, X, y, k_fold, scheduler_options, compute_base_preds=True, **kwargs):
+    def _hyperparameter_tune(self, X, y, k_fold, hpo_executor, compute_base_preds=True, **kwargs):
         if len(self.models) != 0:
             raise ValueError('self.models must be empty to call hyperparameter_tune, value: %s' % self.models)
 
         preprocess_kwargs = {'compute_base_preds': compute_base_preds}
-        return super()._hyperparameter_tune(X=X, y=y, k_fold=k_fold, scheduler_options=scheduler_options, preprocess_kwargs=preprocess_kwargs, **kwargs)
+        return super()._hyperparameter_tune(X=X, y=y, k_fold=k_fold, hpo_executor=hpo_executor, preprocess_kwargs=preprocess_kwargs, **kwargs)
 
     def get_params(self):
         init_args = dict(

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1312,7 +1312,7 @@ class AbstractTrainer:
             logger.log(20, fit_log_message)
             try:
                 if isinstance(model, BaggedEnsembleModel):
-                    hpo_models, hpo_model_performances, hpo_results = model.hyperparameter_tune(
+                    hpo_models, hpo_results = model.hyperparameter_tune(
                         X=X,
                         y=y,
                         k_fold=k_fold,
@@ -1320,7 +1320,7 @@ class AbstractTrainer:
                         **model_fit_kwargs
                     )
                 else:
-                    hpo_models, hpo_model_performances, hpo_results = model.hyperparameter_tune(
+                    hpo_models, hpo_results = model.hyperparameter_tune(
                         X=X,
                         y=y,
                         X_val=X_val,

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -11,6 +11,7 @@ import sklearn
 from autogluon.common.features.types import R_OBJECT, R_INT, R_FLOAT, R_DATETIME, R_CATEGORY, R_BOOL, S_TEXT_SPECIAL, S_TEXT_NGRAM, S_TEXT_AS_CATEGORY
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.core.constants import REGRESSION, BINARY, QUANTILE
+from autogluon.core.hpo.constants import RAY_BACKEND
 from autogluon.core.models import AbstractModel
 from autogluon.core.utils import try_import_fastai
 from autogluon.core.utils.exceptions import TimeLimitExceeded, NotEnoughMemoryError
@@ -501,6 +502,10 @@ class NNFastAiTabularModel(AbstractModel):
 
     def _estimate_memory_usage(self, X, **kwargs):
         return 10 * get_approximate_df_mem_usage(X).sum()
+    
+    def _get_hpo_backend(self):
+        """Choose which backend(Ray or Custom) to use for hpo"""
+        return RAY_BACKEND
 
     def _more_tags(self):
         return {'can_refit_full': True}

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from autogluon.common.features.types import R_BOOL, R_INT, R_FLOAT, R_CATEGORY, S_TEXT_NGRAM, S_TEXT_AS_CATEGORY
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, SOFTCLASS, QUANTILE
+from autogluon.core.hpo.constants import RAY_BACKEND
 from autogluon.core.utils import try_import_torch
 from autogluon.core.utils.exceptions import TimeLimitExceeded
 from autogluon.core.models.abstract.abstract_nn_model import AbstractNeuralNetworkModel
@@ -584,6 +585,10 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             model._architecture_desc = None
             model.model = torch.load(model.path + model.params_file_name)
         return model
+    
+    def _get_hpo_backend(self):
+        """Choose which backend(Ray or Custom) to use for hpo"""
+        return RAY_BACKEND
 
     def _more_tags(self):
         # `can_refit_full=True` because batch_size and num_epochs is communicated at end of `_fit`:

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -2766,8 +2766,6 @@ class TabularPredictor:
                     'hyperparameter_tune_kwargs was specified in both ag_args and in kwargs. Please only specify once.')
             else:
                 ag_args['hyperparameter_tune_kwargs'] = hyperparameter_tune_kwargs
-        if not self._validate_hyperparameter_tune_kwargs(ag_args.get('hyperparameter_tune_kwargs', None), time_limit):
-            ag_args.pop('hyperparameter_tune_kwargs', None)
         if ag_args.get('hyperparameter_tune_kwargs', None) is not None:
             logger.log(30,
                        'Warning: hyperparameter tuning is currently experimental and may cause the process to hang.')

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -54,6 +54,7 @@ class TimeSeriesLearner(AbstractLearner):
         val_data: TimeSeriesDataFrame = None,
         hyperparameters: Union[str, Dict] = None,
         hyperparameter_tune: bool = False,
+        hyperparameter_tune_kwargs: Optional[Union[str, dict]] = None,
         **kwargs,
     ) -> None:
         return self._fit(
@@ -61,6 +62,7 @@ class TimeSeriesLearner(AbstractLearner):
             val_data=val_data,
             hyperparameters=hyperparameters,
             hyperparameter_tune=hyperparameter_tune,
+            hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             **kwargs,
         )
 
@@ -69,8 +71,7 @@ class TimeSeriesLearner(AbstractLearner):
         train_data: TimeSeriesDataFrame,
         val_data: Optional[TimeSeriesDataFrame] = None,
         hyperparameters: Union[str, Dict] = None,
-        hyperparameter_tune: bool = False,
-        scheduler_options: Tuple[Type, Dict[str, Any]] = None,
+        hyperparameter_tune_kwargs: Optional[Union[str, dict]] = None,
         time_limit: Optional[int] = None,
         **kwargs,
     ) -> None:
@@ -89,7 +90,6 @@ class TimeSeriesLearner(AbstractLearner):
                 path=self.model_context,
                 prediction_length=self.prediction_length,
                 eval_metric=self.eval_metric,
-                scheduler_options=scheduler_options,
                 target=self.target,
                 quantile_levels=self.quantile_levels,
                 verbosity=kwargs.get("verbosity", 2)
@@ -102,8 +102,8 @@ class TimeSeriesLearner(AbstractLearner):
         self.trainer.fit(
             train_data=train_data,
             val_data=val_data,
-            hyperparameter_tune=hyperparameter_tune,
             hyperparameters=hyperparameters,
+            hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             time_limit=time_limit,
         )
         self.save_trainer(trainer=self.trainer)

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -1,9 +1,12 @@
 import copy
 import logging
+import os
 import time
 from typing import Any, Dict, Union, Tuple, Optional, List
 
 import autogluon.core as ag
+from autogluon.core.hpo.exceptions import EmptySearchSpace
+from autogluon.core.hpo.executors import HpoExecutor
 from autogluon.core.models import AbstractModel
 from autogluon.common.savers import save_pkl
 from ... import TimeSeriesEvaluator
@@ -326,7 +329,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         self,
         train_data: TimeSeriesDataFrame,
         val_data: TimeSeriesDataFrame,
-        scheduler_options: Tuple[Any, Dict],
+        hpo_executor: HpoExecutor,
         **kwargs,
     ):
         # verbosity = kwargs.get('verbosity', 2)
@@ -335,62 +338,51 @@ class AbstractTimeSeriesModel(AbstractModel):
             f"\tStarting AbstractTimeSeriesModel hyperparameter tuning for {self.name}"
         )
         search_space = self._get_search_space()
+        
+        try:
+            hpo_executor.validate_search_space(search_space, self.name)
+        except EmptySearchSpace:
+            return skip_hpo(self, train_data, val_data, time_limit=hpo_executor.time_limit)
 
-        scheduler_cls, scheduler_params = scheduler_options
-        if scheduler_cls is None or scheduler_params is None:
-            raise ValueError(
-                "scheduler_cls and scheduler_params cannot be None for hyperparameter tuning"
-            )
-        time_limit = scheduler_params.get("time_out", None)
-        if time_limit is None:
-            scheduler_params["num_trials"] = scheduler_params.get("num_trials", 9999)
-        else:
-            scheduler_params.pop("num_trials", None)
-
-        if not any(
-            isinstance(search_space[hyperparameter], ag.Space)
-            for hyperparameter in search_space
-        ):
-            logger.warning(
-                f"\tNo hyperparameter search space specified for {self.name}. Skipping HPO. "
-                f"Will train one model based on the provided hyperparameters."
-            )
-            return skip_hpo(self, train_data, val_data, time_limit=time_limit)
-        else:
-            logger.debug(f"\tHyperparameter search space for {self.name}: ")
-            for hyperparameter in search_space:
-                if isinstance(search_space[hyperparameter], ag.Space):
-                    logger.debug(f"\t{hyperparameter}: {search_space[hyperparameter]}")
-
+        self.set_contexts(os.path.abspath(self.path) + os.path.sep)
+        directory = self.path
         dataset_train_filename = "dataset_train.pkl"
-        train_path = self.path + dataset_train_filename
+        train_path = os.path.join(self.path, dataset_train_filename)
         save_pkl.save(path=train_path, object=train_data)
 
         dataset_val_filename = "dataset_val.pkl"
-        val_path = self.path + dataset_val_filename
+        val_path = os.path.join(self.path, dataset_val_filename)
         save_pkl.save(path=val_path, object=val_data)
 
+        fit_kwargs = dict()
         train_fn_kwargs = dict(
             model_cls=self.__class__,
             init_params=self.get_params(),
             time_start=time_start,
-            time_limit=time_limit,
-            fit_kwargs=scheduler_params["resource"].copy(),
+            time_limit=hpo_executor.time_limit,
+            fit_kwargs=fit_kwargs,
             train_path=train_path,
             val_path=val_path,
+            hpo_executor=hpo_executor,
         )
-
-        scheduler = scheduler_cls(
-            model_trial,
-            search_space=search_space,
+        
+        model_estimate_memory_usage = None
+        if self.estimate_memory_usage is not None:
+            model_estimate_memory_usage = self.estimate_memory_usage(X=X, **kwargs)
+        hpo_executor.execute(
+            model_trial=model_trial,
             train_fn_kwargs=train_fn_kwargs,
-            **scheduler_params,
+            directory=directory,
+            minimum_cpu_per_trial=self.get_minimum_resources().get('num_cpus', 1),
+            minimum_gpu_per_trial=self.get_minimum_resources().get('num_gpus', 0.1),
+            model_estimate_memory_usage=model_estimate_memory_usage,
         )
 
-        scheduler.run()
-        scheduler.join_jobs()
-
-        return self._get_hpo_results(scheduler, scheduler_params, time_start)
+        return hpo_executor.get_hpo_results(
+            model_name=self.name,
+            model_path_root=self.path_root,
+            time_start=time_start,
+        )
 
     def preprocess(self, data: Any, **kwargs) -> Any:
         return data

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -273,18 +273,14 @@ class TimeSeriesPredictor:
                 slice(None, -self.prediction_length)
             )
 
-        scheduler_options = self._get_scheduler_options(
-            hyperparameter_tune_kwargs, time_limit=time_limit
-        )
         time_left = (
             None if time_limit is None else time_limit - (time.time() - time_start)
         )
         self._learner.fit(
             train_data=train_data,
             val_data=tuning_data,
-            scheduler_options=scheduler_options,
             hyperparameters=hyperparameters,
-            hyperparameter_tune=all(scheduler_options),
+            hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             time_limit=time_left,
             verbosity=verbosity,
         )

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -425,7 +425,8 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             f"\tTrained {len(model_names_trained)} models while tuning {model.name}."
         )
 
-        if hpo_results:
+        # TODO: log result for ray backend
+        if hpo_results and isinstance(hpo_results, dict):
             if TimeSeriesEvaluator.METRIC_COEFFICIENTS[self.eval_metric] == -1:
                 sign_str = '-'
             else:

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -398,25 +398,19 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         val_data: Optional[TimeSeriesDataFrame] = None,
         hyperparameter_tune_kwargs: Union[str, dict] = "auto",
     ):
-        scheduler_cls, scheduler_options = scheduler_factory(
-            hyperparameter_tune_kwargs, time_out=time_limit
-        )
-        if all(scheduler_options.get(s) is None for s in ["num_trials", "time_out"]):
-            scheduler_options["num_trials"] = 10
-
-        logger.debug(
-            f"\tTuning hyperparameters of {model.name}. scheduler "
-            f"options: {scheduler_cls.__name__}, {pprint.pformat(scheduler_options, indent=10)}. "
-        )
+        default_num_trials = None
+        if time_limit is None and ("num_samples" not in hyperparameter_tune_kwargs or isinstance(hyperparameter_tune_kwargs, str)):
+            default_num_trials = 10
 
         with disable_tqdm():
-            hpo_models, hpo_model_performances, hpo_results = model.hyperparameter_tune(
+            hpo_models, hpo_results = model.hyperparameter_tune(
                 train_data=train_data,
                 val_data=val_data,
-                scheduler_options=(scheduler_cls, scheduler_options),
+                hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
                 time_limit=time_limit,
+                default_num_trials=default_num_trials,
             )
-        hpo_results.pop("search_strategy", None)
+
         self.hpo_results[model.name] = hpo_results
         model_names_trained = []
         # add each of the trained HPO configurations to the trained models
@@ -535,7 +529,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         hyperparameters: Optional[Union[str, Dict]] = None,
         models: Optional[List[AbstractTimeSeriesModel]] = None,
         val_data: Optional[TimeSeriesDataFrame] = None,
-        hyperparameter_tune: bool = False,
+        hyperparameter_tune_kwargs: Optional[Union[str, dict]] = None,
         time_limit: Optional[float] = None,
     ) -> List[str]:
 
@@ -559,7 +553,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         if models is None:
             models = self.construct_model_templates(
                 hyperparameters=hyperparameters,
-                hyperparameter_tune=hyperparameter_tune,
+                hyperparameter_tune=hyperparameter_tune_kwargs is not None,
                 freq=train_data.freq,
             )
 
@@ -571,7 +565,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         model_names_trained = []
         for i, model in enumerate(models):
-            if hyperparameter_tune:
+            if hyperparameter_tune_kwargs is not None:
                 time_left = time_limit_model_split
 
                 fit_log_message = f"Hyperparameter tuning model: {model.name}. "
@@ -588,6 +582,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                         time_limit=time_left,
                         train_data=train_data,
                         val_data=val_data,
+                        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
                     )
             else:
                 time_left = None
@@ -865,7 +860,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 train_data=refit_full_data,
                 val_data=None,
                 hyperparameters=None,
-                hyperparameter_tune=False,
+                hyperparameter_tune_kwargs=None,
                 models=[model_full],
             )
 

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -32,7 +32,7 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
         train_data: TimeSeriesDataFrame,
         hyperparameters: Union[str, Dict[Any, Dict]],
         val_data: Optional[TimeSeriesDataFrame] = None,
-        hyperparameter_tune: bool = False,
+        hyperparameter_tune_kwargs: Optional[Union[str, Dict]] = None,
         time_limit: float = None,
     ):
         """
@@ -50,8 +50,8 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             presets.
         val_data: TimeSeriesDataFrame
             Optional validation data set to report validation scores on.
-        hyperparameter_tune
-            Whether to perform hyperparameter tuning when learning individual models.
+        hyperparameter_tune_kwargs
+            Args for hyperparameter tuning
         time_limit
             Time limit for training
         """
@@ -59,6 +59,6 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
             train_data,
             val_data=val_data,
             hyperparameters=hyperparameters,
-            hyperparameter_tune=hyperparameter_tune,
+            hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             time_limit=time_limit,
         )

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -160,19 +160,19 @@ def test_when_prophet_model_saved_then_prophet_parameters_are_loaded(
 def test_when_hyperparameter_tune_called_on_prophet_then_hyperparameters_are_passed_to_underlying_model(
     temp_model_path,
 ):
-    scheduler_options = scheduler_factory(hyperparameter_tune_kwargs="auto")
-
     model = ProphetModel(
         path=temp_model_path,
         freq="H",
         prediction_length=4,
         hyperparameters={"growth": "linear", "n_changepoints": ag.Int(3, 4)},
     )
-    _, _, results = model.hyperparameter_tune(
-        scheduler_options=scheduler_options,
+    hyperparameter_tune_kwargs = 'auto'
+
+    models, results = model.hyperparameter_tune(
         time_limit=100,
         train_data=DUMMY_TS_DATAFRAME,
         val_data=DUMMY_TS_DATAFRAME,
+        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
     )
 
     assert len(results["config_history"]) == 2

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -95,7 +95,6 @@ def test_when_models_saved_then_they_can_be_loaded(model_class, temp_model_path)
 def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct(
     model_class, temp_model_path
 ):
-    scheduler_options = scheduler_factory(hyperparameter_tune_kwargs="auto")
 
     model = model_class(
         path=temp_model_path,
@@ -106,9 +105,11 @@ def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct
         },
     )
 
-    _, _, results = model.hyperparameter_tune(
-        scheduler_options=scheduler_options,
-        time_limit=300,
+    hyperparameter_tune_kwargs = 'auto'
+
+    models, results = model.hyperparameter_tune(
+        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+        time_limit=100,
         train_data=DUMMY_TS_DATAFRAME,
         val_data=DUMMY_TS_DATAFRAME,
     )

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -99,15 +99,19 @@ def test_given_hyperparameters_with_spaces_when_learner_called_then_hpo_is_perfo
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hyperparameters,
             val_data=DUMMY_TS_DATAFRAME,
-            hyperparameter_tune=True,
+            hyperparameter_tune_kwargs={
+                "searcher": "random",
+                "scheduler": "local",
+                "num_trials": 2,
+            },
         )
 
         leaderboard = learner.leaderboard()
 
-    assert len(leaderboard) == 3 + 1  # include ensemble
+    assert len(leaderboard) == 2 + 1  # include ensemble
 
     config_history = learner.load_trainer().hpo_results[model_name]["config_history"]
-    assert len(config_history) == 3
+    assert len(config_history) == 2
     assert all(1 <= model["epochs"] <= 3 for model in config_history.values())
 
 

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -180,29 +180,34 @@ def test_given_hyperparameters_when_trainer_fit_then_freq_set_correctly(
 
 
 @pytest.mark.parametrize("model_name", ["DeepAR", "SimpleFeedForward", "MQCNN"])
+@mock.patch("autogluon.timeseries.models.presets.get_default_hps")
 def test_given_hyperparameters_with_spaces_when_trainer_called_then_hpo_is_performed(
-    temp_model_path, model_name
+    mock_default_hps, temp_model_path, model_name
 ):
     hyperparameters = {model_name: {"epochs": ag.Int(1, 4)}}
     # mock the default hps factory to prevent preset hyperparameter configurations from
     # creeping into the test case
-    with mock.patch(
-        "autogluon.timeseries.models.presets.get_default_hps"
-    ) as default_hps_mock:
-        default_hps_mock.return_value = defaultdict(dict)
-        trainer = AutoTimeSeriesTrainer(path=temp_model_path)
-        trainer.fit(
-            train_data=DUMMY_TS_DATAFRAME,
-            hyperparameters=hyperparameters,
-            val_data=DUMMY_TS_DATAFRAME,
-            hyperparameter_tune=True,
-        )
-        leaderboard = trainer.leaderboard()
+    mock_default_hps.return_value = defaultdict(dict)
+    trainer = AutoTimeSeriesTrainer(
+        path=temp_model_path,
+        freq="H",
+    )
+    trainer.fit(
+        train_data=DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        val_data=DUMMY_TS_DATAFRAME,
+        hyperparameter_tune_kwargs={
+            "num_trials": 2,
+            "searcher": "random",
+            "scheduler": "local",
+        },
+    )
+    leaderboard = trainer.leaderboard()
 
-    assert len(leaderboard) == 4 + 1
-
-    config_history = trainer.hpo_results[model_name]["config_history"]
-    assert len(config_history) == 4
+    assert len(leaderboard) == 2 + 1  # include ensemble
+    
+    config_history = next(iter(trainer.hpo_results.values()))["config_history"]
+    assert len(config_history) == 2
     assert all(1 <= model["epochs"] <= 4 for model in config_history.values())
 
 
@@ -265,15 +270,18 @@ def test_given_hyperparameters_with_spaces_to_prophet_when_trainer_called_then_h
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters=hyperparameters,
             val_data=DUMMY_TS_DATAFRAME,
-            hyperparameter_tune=True,
+            hyperparameter_tune_kwargs={
+                "num_samples": 2,
+                "searcher": "random",
+                "scheduler": "local",
+            },
         )
         leaderboard = trainer.leaderboard()
 
-    assert len(leaderboard) == 4 + 1
-
-    config_history = trainer.hpo_results["Prophet"]["config_history"]
-    assert len(config_history) == 4
-    assert all(1 <= model["n_changepoints"] <= 4 for model in config_history.values())
+    assert len(leaderboard) == 2 + 1  # include ensemble
+    assert all(
+        [1 <= v["params"]["epochs"] < 5 for k, v in trainer.model_graph.nodes.items()]
+    )
 
 
 @pytest.mark.parametrize("eval_metric", ["MAPE", None])
@@ -480,7 +488,9 @@ def test_given_hyperparameters_and_custom_models_when_trainer_model_templates_ca
             assert model._user_params[k] == v
 
 
+@mock.patch("autogluon.timeseries.models.presets.get_default_hps")
 def test_given_hyperparameters_with_spaces_and_custom_model_when_trainer_called_then_hpo_is_performed(
+    mock_default_hps,
     temp_model_path,
 ):
     hyperparameters = {
@@ -488,23 +498,26 @@ def test_given_hyperparameters_with_spaces_and_custom_model_when_trainer_called_
     }
     # mock the default hps factory to prevent preset hyperparameter configurations from
     # creeping into the test case
-    with mock.patch(
-        "autogluon.timeseries.models.presets.get_default_hps"
-    ) as default_hps_mock:
-        default_hps_mock.return_value = defaultdict(dict)
-        trainer = AutoTimeSeriesTrainer(path=temp_model_path)
-        trainer.fit(
-            train_data=DUMMY_TS_DATAFRAME,
-            hyperparameters=hyperparameters,
-            val_data=DUMMY_TS_DATAFRAME,
-            hyperparameter_tune=True,
-        )
-        leaderboard = trainer.leaderboard()
+    mock_default_hps.return_value = defaultdict(dict)
+    trainer = AutoTimeSeriesTrainer(
+        path=temp_model_path,
+        freq="H",
+    )
+    trainer.fit(
+        train_data=DUMMY_TS_DATAFRAME,
+        hyperparameters=hyperparameters,
+        val_data=DUMMY_TS_DATAFRAME,
+        hyperparameter_tune_kwargs={
+            "num_trials": 2,
+            "searcher": "random",
+            "scheduler": "local",
+        },
+    )
+    leaderboard = trainer.leaderboard()
 
-    assert len(leaderboard) == 4 + 1  # ensemble
-
+    assert len(leaderboard) == 2 + 1  # include ensemble
     config_history = next(iter(trainer.hpo_results.values()))["config_history"]
-    assert len(config_history) == 4
+    assert len(config_history) == 2
     assert all(1 <= model["epochs"] <= 4 for model in config_history.values())
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Implemented interface for both ray hpo and custom hpo logics.
* Models except NN_Torch and FASTAI will use custom hpo logics for now as they are observed to benefit the most from ray hpo: 
45% faster on datasets with <= 10,000 rows with no time limit. Winrate could be random, but previous benchmark on ray hpo shows higher winrate compared to custom logic constantly.

| framework                                       | winrate            | >   | <   | = | % Less Avg. Errors | time_train_s       | metric_error       | time_infer_s       | bestdiff            | loss_rescaled      | time_train_s_rescaled | time_infer_s_rescaled | rank               | rank=1_count | rank=2_count | rank=3_count | rank>3_count | error_count |
| ----------------------------------------------- | ------------------ | --- | --- | - | ------------------ | ------------------ | ------------------ | ------------------ | ------------------- | ------------------ | --------------------- | --------------------- | ------------------ | ------------ | ------------ | ------------ | ------------ | ----------- |
| AutoGluon_hpo_24h16c_ag-2022_06_29_ray_hpo      | 0.5292504570383912 | 285 | 253 | 9 | -0.736224047516082 | 167.3234003656307  | 144812.8704610056  | 0.6442413162705729 | 0.05384145514654432 | 0.4625228519195612 | 1.0224073180634572    | 1.179575686894241     | 1.4707495429616089 | 287          | 262          | 0            | 0            | 1           |
| AutoGluon_hpo_24h16c_ag-2022_06_29_ray_hpo_main | 0.0                | 0   | 548 | 0 |                    | 309.22870201096896 | 145594.01601904936 | 0.618098720292511  | 0.0464792146713835  | 0.5246800731261426 | 1.8487519280350746    | 1.0896260908332926    | 1.5292504570383911 | 254          | 294          | 0            | 0            | 2           |
|                                                 |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
