### PR TITLE
Cleanup HPO artifacts

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -996,7 +996,21 @@ class AbstractModel:
         scheduler.run()
         scheduler.join_jobs()
 
-        return self._get_hpo_results(scheduler=scheduler, scheduler_params=scheduler_params, time_start=time_start)
+        hpo_results = self._get_hpo_results(scheduler=scheduler, scheduler_params=scheduler_params, time_start=time_start)
+
+        # cleanup artifacts
+        for data_file in [train_path, val_path]:
+            try:
+                os.remove(data_file)
+            except FileNotFoundError:
+                pass
+
+        return hpo_results
+
+    @property
+    def _path_v2(self) -> str:
+        """Path as a property, replace old path logic with this eventually"""
+        return self.path_root + self.path_suffix
 
     def _get_hpo_results(self, scheduler, scheduler_params: dict, time_start):
         # Store results / models from this HPO run:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Cleanup HPO artifacts
- Previously, train and val datasets were pickled to disk and not removed for every model that underwent HPO. This led to >20 copies of the train and val data cached to disk. With this PR, the dataset caches are deleted directly after HPO for a given model, ensuring only 1 copy is saved to disk at a time, and 0 copies are saved after training is completed.
- Previously when HPO was conducted with bagging enabled, the HPO artifact of the first fold model of each trial would be duplicated on disk and not deleted. Now the duplicate is deleted after HPO finishes for a given model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
