### PR TITLE
Fix y_pred_proba lookup when cached_y_pred_proba_val == False

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -666,7 +666,7 @@ class AbstractTrainer:
         """For each model in model_set, check if y_pred_proba_val is cached to disk. If so, load and add it to model_pred_proba_dict"""
         for model in model_set:
             y_pred_proba = self.get_model_attribute(model, attribute='cached_y_pred_proba_val', default=None)
-            if isinstance(y_pred_proba, bool) and y_pred_proba:
+            if isinstance(y_pred_proba, bool):
                 if y_pred_proba:
                     try:
                         y_pred_proba = self._load_model_y_pred_proba_val(model)


### PR DESCRIPTION
*Issue #, if available:*
#1920 

*Description of changes:*
- Fix bug in #1920 causing a crash if cached_y_pred_proba_val == False (Never the case, but could happen in future).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
