### PR TITLE
Cap nlpaug version

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -42,7 +42,7 @@ install_requires = [
     f'autogluon.common=={version}',
     'autogluon-contrib-nlp==0.0.1b20220208',
     'pytorch-metric-learning>=1.3.0,<1.4.0',
-    'nlpaug>=1.1.10,<2.0.0',
+    'nlpaug>=1.1.10,<=1.1.10',
     'nltk>=3.4.5,<4.0.0',
 ]
 


### PR DESCRIPTION

Due to the upgrade of nlpaug (https://github.com/makcedward/nlpaug), specifying model.hf_text.text_train_augment_types with a list of augmentation operators causes exceptions. We temporarily cap the version to the last one to workaround this. Will investigate the reasons later.