### PR TITLE
Added cascade ensemble foundation logic

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2052,7 +2052,7 @@ class AbstractTrainer:
     #  This is different from raw, where the predictions of the folds are averaged and then feature importance is computed.
     #  Consider aligning these methods so they produce the same result.
     # The output of this function is identical to non-raw when model is level 1 and non-bagged
-    def _get_feature_importance_raw(self, X, y, model: str, eval_metric=None, **kwargs) -> pd.DataFrame:
+    def _get_feature_importance_raw(self, X, y, model, eval_metric=None, **kwargs) -> pd.DataFrame:
         if eval_metric is None:
             eval_metric = self.eval_metric
         if model is None:
@@ -2061,6 +2061,7 @@ class AbstractTrainer:
             predict_func = self.predict
         else:
             predict_func = self.predict_proba
+        model: AbstractModel = self.load_model(model)
         predict_func_kwargs = dict(model=model)
         return compute_permutation_feature_importance(
             X=X, y=y, predict_func=predict_func, predict_func_kwargs=predict_func_kwargs, eval_metric=eval_metric, quantile_levels=self.quantile_levels, **kwargs

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -567,6 +567,8 @@ class AbstractTrainer:
         else:
             models = [model]
         model_pred_proba_dict = self.get_model_pred_proba_dict(X=X, models=models, model_pred_proba_dict=model_pred_proba_dict, cascade=cascade)
+        if not isinstance(model, str):
+            model = model.name
         return model_pred_proba_dict[model]
 
     # Note: model_pred_proba_dict is mutated in this function to minimize memory usage
@@ -667,8 +669,7 @@ class AbstractTrainer:
         if models_to_ignore is not None:
             model_set = model_set.difference(set(models_to_ignore))
         models_to_load = list(model_set)
-        subgraph = nx.subgraph(self.model_graph, models_to_load)
-
+        subgraph = nx.DiGraph(nx.subgraph(self.model_graph, models_to_load))  # Wrap subgraph in DiGraph to unfreeze it
         # For model in models_to_ignore, remove model node from graph and all ancestors that have no remaining descendants and are not in `models`
         models_to_ignore = [model for model in models_to_load if (model not in models) and (not list(subgraph.successors(model)))]
         while models_to_ignore:

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -854,6 +854,8 @@ class AbstractTrainer:
     def refit_ensemble_full(self, model='all') -> dict:
         if model == 'all':
             ensemble_set = self.get_model_names()
+        elif isinstance(model, list):
+            ensemble_set = self.get_minimum_models_set(model)
         else:
             if model == 'best':
                 model = self.get_model_best()
@@ -1094,7 +1096,7 @@ class AbstractTrainer:
                 else:
                     best_score = self.get_model_attribute(self.model_best, 'val_score')
                     cur_score = self.get_model_attribute(weighted_ensemble_model_name, 'val_score')
-                    if cur_score > best_score:
+                    if best_score is not None and cur_score > best_score:
                         # new best model
                         self.model_best = weighted_ensemble_model_name
         return models

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -545,18 +545,29 @@ class AbstractTrainer:
     def predict(self, X, model=None):
         if model is None:
             model = self._get_best()
-        return self._predict_model(X, model)
+        cascade = isinstance(model, list)
+        return self._predict_model(X, model, cascade=cascade)
 
     def predict_proba(self, X, model=None):
         if model is None:
             model = self._get_best()
-        return self._predict_proba_model(X, model)
+        cascade = isinstance(model, list)
+        return self._predict_proba_model(X, model, cascade=cascade)
 
     def _get_best(self):
         if self.model_best is not None:
             return self.model_best
         else:
             return self.get_model_best()
+
+    def get_pred_proba_from_model(self, model, X, model_pred_proba_dict=None, fit=False, cascade=False):
+        if isinstance(model, list):
+            models = model
+            model = models[-1]
+        else:
+            models = [model]
+        model_pred_proba_dict = self.get_model_pred_proba_dict(X=X, models=models, model_pred_proba_dict=model_pred_proba_dict, fit=fit, cascade=cascade)
+        return model_pred_proba_dict[model]
 
     # Note: model_pred_proba_dict is mutated in this function to minimize memory usage
     def get_inputs_to_model(self, model, X, model_pred_proba_dict=None, fit=False, preprocess_nonadaptive=False):
@@ -597,6 +608,81 @@ class AbstractTrainer:
         return compute_weighted_metric(y, y_pred, self.eval_metric, weights, weight_evaluation=self.weight_evaluation,
                                        quantile_levels=self.quantile_levels)
 
+    # TODO: Slow if large ensemble with many models, could cache output result to speed up cascades during inference
+    def _construct_model_pred_order(self, models: List[str]) -> List[str]:
+        """
+        Constructs a list of model names in order of inference calls required to infer on all the models.
+
+        Parameters
+        ----------
+        models : List[str]
+            The list of models to construct the prediction order from.
+            If a model has dependencies, the dependency models will be put earlier in the output list.
+            Models explicitly mentioned in the `models` input will be placed as early as possible in the output list.
+            Models earlier in `models` will attempt to be placed earlier in the output list than those later in `models`.
+                It is recommended that earlier elements do not have dependency models that are listed later in `models`.
+
+        Returns
+        -------
+        Returns list of models in inference call order, including dependency models of those specified in the input.
+        """
+        model_set = set()
+        model_order = []
+        for model in models:
+            if model in model_set:
+                continue
+            min_models_set = set(self.get_minimum_model_set(model))
+            models_to_load = list(min_models_set.difference(model_set))
+            subgraph = nx.subgraph(self.model_graph, models_to_load)
+            model_pred_order = list(nx.lexicographical_topological_sort(subgraph))
+            model_order += [m for m in model_pred_order if m not in model_set]
+            model_set = set(model_order)
+        return model_order
+
+    def _construct_model_pred_order_with_pred_dict(self, models: List[str], models_to_ignore: List[str] = None) -> List[str]:
+        """
+        Constructs a list of model names in order of inference calls required to infer on all the models.
+        Unlike `_construct_model_pred_order`, this method's output is in undefined order when multiple models are valid to infer at the same time.
+            This makes it unsuitable for cascade ensembles.
+
+        Parameters
+        ----------
+        models : List[str]
+            The list of models to construct the prediction order from.
+            If a model has dependencies, the dependency models will be put earlier in the output list.
+        models_to_ignore : List[str], optional
+            A list of models that have already been computed and can be ignored.
+            Models in this list and their dependencies (if not depended on by other models in `models`) will be pruned from the final output.
+
+        Returns
+        -------
+        Returns list of models in inference call order, including dependency models of those specified in the input.
+        """
+        model_set = set()
+        for model in models:
+            if model in model_set:
+                continue
+            min_model_set = set(self.get_minimum_model_set(model))
+            model_set = model_set.union(min_model_set)
+        if models_to_ignore is not None:
+            model_set = model_set.difference(set(models_to_ignore))
+        models_to_load = list(model_set)
+        subgraph = nx.subgraph(self.model_graph, models_to_load)
+
+        # For model in models_to_ignore, remove model node from graph and all ancestors that have no remaining descendants and are not in `models`
+        models_to_ignore = [model for model in models_to_load if (model not in models) and (not list(subgraph.successors(model)))]
+        while models_to_ignore:
+            model = models_to_ignore[0]
+            predecessors = list(subgraph.predecessors(model))
+            subgraph.remove_node(model)
+            models_to_ignore = models_to_ignore[1:]
+            for predecessor in predecessors:
+                if (predecessor not in models) and (not list(subgraph.successors(predecessor))) and (predecessor not in models_to_ignore):
+                    models_to_ignore.append(predecessor)
+
+        # Get model prediction order
+        return list(nx.lexicographical_topological_sort(subgraph))
+
     # TODO: Consider adding persist to disk functionality for pred_proba dictionary to lessen memory burden on large multiclass problems.
     #  For datasets with 100+ classes, this function could potentially run the system OOM due to each pred_proba numpy array taking significant amounts of space.
     #  This issue already existed in the previous level-based version but only had the minimum required predictions in memory at a time, whereas this has all model predictions in memory.
@@ -606,20 +692,36 @@ class AbstractTrainer:
     # fit = get oof pred proba
     # if record_pred_time is `True`, outputs tuple of dicts (model_pred_proba_dict, model_pred_time_dict), else output only model_pred_proba_dict
     def get_model_pred_proba_dict(self,
-                                  X,
-                                  models,
-                                  model_pred_proba_dict=None,
-                                  model_pred_time_dict=None,
-                                  fit=False,
-                                  record_pred_time=False,
-                                  use_val_cache: bool = False):
+                                  X: pd.DataFrame,
+                                  models: List[str],
+                                  model_pred_proba_dict: dict = None,
+                                  model_pred_time_dict: dict = None,
+                                  fit: bool = False,
+                                  record_pred_time: bool = False,
+                                  use_val_cache: bool = False,
+                                  cascade: bool = False,
+                                  cascade_threshold: float = 0.9):
         if model_pred_proba_dict is None:
             model_pred_proba_dict = {}
         if model_pred_time_dict is None:
             model_pred_time_dict = {}
+        if cascade and len(models) <= 1:
+            cascade = False
+        if cascade and model_pred_proba_dict:
+            # Technically doesn't have to be an error, but logic gets extremely complicated if we allow this.
+            raise AssertionError('Cascade is not valid when model_pred_proba_dict is specified.')
+        if cascade and self.problem_type not in [BINARY, MULTICLASS]:
+            raise AssertionError(f'Ensemble Cascade not implemented for problem_type=={self.problem_type}')
 
         if fit:
+            if cascade:
+                raise AssertionError(f'Ensemble Cascade not implemented when `fit==True')
             model_pred_order = [model for model in models if model not in model_pred_proba_dict.keys()]
+        # elif not model_pred_proba_dict:
+        #     # TODO: Pre-construct order if cascade, otherwise this will slow down prediction having to recompute each inference call.
+        #     model_pred_order = self._construct_model_pred_order(models)
+        # else:
+        #     model_pred_order = self._construct_model_pred_order_with_pred_dict(models, models_to_ignore=list(model_pred_proba_dict.keys()))
         else:
             if use_val_cache:
                 _, model_pred_proba_dict = self._update_pred_proba_dict_with_val_cache(model_set=set(models), model_pred_proba_dict=model_pred_proba_dict)
@@ -635,7 +737,7 @@ class AbstractTrainer:
             models_to_load = list(model_set)
             subgraph = nx.subgraph(self.model_graph, models_to_load)
 
-            # For model in model_pred_proba_dict, remove model node from graph and all ancestors that have no remaining descendants and are not in `models`
+            # For model in models_to_ignore, remove model node from graph and all ancestors that have no remaining descendants and are not in `models`
             models_to_ignore = [model for model in models_to_load if (model not in models) and (not list(subgraph.successors(model)))]
             while models_to_ignore:
                 model = models_to_ignore[0]
@@ -648,6 +750,17 @@ class AbstractTrainer:
 
             # Get model prediction order
             model_pred_order = list(nx.lexicographical_topological_sort(subgraph))
+
+        iloc_model_dict = dict()
+        model_pred_proba_dict_cascade = dict()
+
+        if cascade:
+            num_rows = len(X)
+            unconfident_idx = np.array([i for i in range(num_rows)])
+        else:
+            num_rows = None
+            unconfident_idx = None
+        cascade_order = []
 
         # Compute model predictions in topological order
         for model_name in model_pred_order:
@@ -662,9 +775,21 @@ class AbstractTrainer:
                 else:
                     raise AssertionError(f'Model {model_name} must be a BaggedEnsembleModel to return oof_pred_proba')
             else:
+                if cascade:
+                    # Keep track of the iloc index of the current model for the rows that are predicted on
+                    iloc_model_dict[model_name] = unconfident_idx
                 model = self.load_model(model_name=model_name)
                 if isinstance(model, StackerEnsembleModel):
-                    preprocess_kwargs = dict(infer=False, model_pred_proba_dict=model_pred_proba_dict)
+                    if cascade:
+                        # Need to predict only on the unconfident rows that remain
+                        #  This requires getting the correct indices from the dependent models' prior predictions.
+                        cascade_dict = dict()
+                        for m in model_pred_proba_dict_cascade:
+                            # TODO: Can probably be done faster, unsure how expensive this is.
+                            cascade_dict[m] = model_pred_proba_dict_cascade[m][iloc_model_dict[model_name]]
+                        preprocess_kwargs = dict(infer=False, model_pred_proba_dict=cascade_dict)
+                    else:
+                        preprocess_kwargs = dict(infer=False, model_pred_proba_dict=model_pred_proba_dict)
                     model_pred_proba_dict[model_name] = model.predict_proba(X, **preprocess_kwargs)
                 else:
                     model_pred_proba_dict[model_name] = model.predict_proba(X)
@@ -672,6 +797,45 @@ class AbstractTrainer:
             if record_pred_time:
                 time_end = time.time()
                 model_pred_time_dict[model_name] = time_end - time_start
+
+            if cascade:
+                if model_name in models:
+                    cascade_order.append(model_name)
+                if self.problem_type == BINARY:
+                    tmp = np.zeros(num_rows, dtype='float32')
+                else:
+                    tmp = np.zeros((num_rows, self.num_classes), dtype='float32')
+                tmp[iloc_model_dict[model_name]] = model_pred_proba_dict[model_name]
+                model_pred_proba_dict_cascade[model_name] = tmp
+                # If model is part of cascade, keep the predictions that are confident and don't predict on these rows with further models.
+                if model_name in models and model_name != models[-1]:
+                    pred_proba = model_pred_proba_dict[model_name]
+                    # Calculate confident predictions based on cascade threshold
+                    # TODO: Support more sophisticated methods of calculating whether to keep a prediction
+                    # TODO: Support per-model confidence specification
+                    if self.problem_type == BINARY:
+                        confident = (pred_proba >= cascade_threshold) | (pred_proba <= (1-cascade_threshold))
+                    elif self.problem_type == MULTICLASS:
+                        confident = (pred_proba >= cascade_threshold).any(axis=1)
+                    else:
+                        raise AssertionError(f'Invalid cascade problem_type: {self.problem_type}')
+                    unconfident_cur = ~confident
+                    X = X.iloc[unconfident_cur]
+                    unconfident_idx = unconfident_idx[unconfident_cur]
+                    # If no rows remain that are unconfident, exit cascade logic early.
+                    if len(X) == 0:
+                        break
+
+        if cascade:
+            # TODO: How should this be output?
+            if self.problem_type == BINARY:
+                cascade_pred_proba = np.zeros(num_rows, dtype='float32')
+            else:
+                cascade_pred_proba = np.zeros((num_rows, self.num_classes), dtype='float32')
+            for m in cascade_order:
+                cascade_pred_proba[iloc_model_dict[m]] = model_pred_proba_dict[m]
+            # FIXME: Temp overwrite, unsure how we want to vend cascade results? In future maybe under its own model name.
+            model_pred_proba_dict[models[-1]] = cascade_pred_proba
 
         if record_pred_time:
             return model_pred_proba_dict, model_pred_time_dict
@@ -1692,24 +1856,12 @@ class AbstractTrainer:
             raise ValueError('AutoGluon did not successfully train any models')
         return model_names_fit
 
-    def _predict_model(self, X, model, model_pred_proba_dict=None):
-        if isinstance(model, str):
-            model = self.load_model(model)
-        X = self.get_inputs_to_model(model=model, X=X, model_pred_proba_dict=model_pred_proba_dict, fit=False)
-        y_pred = model.predict(X=X)
-        if self._regress_preds_asprobas and model.problem_type == REGRESSION:  # Convert regression preds to classes (during distillation)
-            if (len(y_pred.shape) > 1) and (y_pred.shape[1] > 1):
-                problem_type = MULTICLASS
-            else:
-                problem_type = BINARY
-            y_pred = get_pred_from_proba(y_pred_proba=y_pred, problem_type=problem_type)
-        return y_pred
+    def _predict_model(self, X, model, model_pred_proba_dict=None, cascade=False):
+        y_pred_proba = self._predict_proba_model(X=X, model=model, model_pred_proba_dict=model_pred_proba_dict, cascade=cascade)
+        return get_pred_from_proba(y_pred_proba=y_pred_proba, problem_type=self.problem_type)
 
-    def _predict_proba_model(self, X, model, model_pred_proba_dict=None):
-        if isinstance(model, str):
-            model = self.load_model(model)
-        X = self.get_inputs_to_model(model=model, X=X, model_pred_proba_dict=model_pred_proba_dict, fit=False)
-        return model.predict_proba(X=X)
+    def _predict_proba_model(self, X, model, model_pred_proba_dict=None, cascade=False):
+        return self.get_pred_proba_from_model(model=model, X=X, model_pred_proba_dict=model_pred_proba_dict, fit=False, cascade=cascade)
 
     def _get_dummy_stacker(self, level: int, model_levels: dict, use_orig_features=True) -> StackerEnsembleModel:
         model_names = model_levels[level - 1]

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -2052,7 +2052,7 @@ class AbstractTrainer:
     #  This is different from raw, where the predictions of the folds are averaged and then feature importance is computed.
     #  Consider aligning these methods so they produce the same result.
     # The output of this function is identical to non-raw when model is level 1 and non-bagged
-    def _get_feature_importance_raw(self, X, y, model, eval_metric=None, **kwargs) -> pd.DataFrame:
+    def _get_feature_importance_raw(self, X, y, model: str, eval_metric=None, **kwargs) -> pd.DataFrame:
         if eval_metric is None:
             eval_metric = self.eval_metric
         if model is None:
@@ -2061,7 +2061,6 @@ class AbstractTrainer:
             predict_func = self.predict
         else:
             predict_func = self.predict_proba
-        model: AbstractModel = self.load_model(model)
         predict_func_kwargs = dict(model=model)
         return compute_permutation_feature_importance(
             X=X, y=y, predict_func=predict_func, predict_func_kwargs=predict_func_kwargs, eval_metric=eval_metric, quantile_levels=self.quantile_levels, **kwargs

--- a/core/src/autogluon/core/utils/infer_utils.py
+++ b/core/src/autogluon/core/utils/infer_utils.py
@@ -1,0 +1,99 @@
+
+
+def get_model_true_infer_speed_per_row_batch(
+        data,
+        *,
+        predictor,
+        batch_size: int = 100000,
+        repeats=1,
+        silent=False):
+    """
+    Get per-model true inference speed per row for a given batch size of data.
+
+    Parameters
+    ----------
+    data : :class:`TabularDataset` or :class:`pd.DataFrame`
+        Table of the data, which is similar to a pandas DataFrame.
+        Must contain the label column to be compatible with leaderboard call.
+    predictor : TabularPredictor
+        Fitted predictor to get inference speeds for.
+    batch_size : int, default = 100000
+        Batch size to use when calculating speed. `data` will be modified to have this many rows.
+        If simulating large-scale batch inference, values of 100000+ are recommended to get genuine throughput estimates.
+    repeats : int, default = 1
+        Repeats of calling leaderboard. Repeat times are averaged to get more stable inference speed estimates.
+    silent : False
+        If False, logs information regarding the speed of each model + feature preprocessing.
+
+    Returns
+    -------
+    time_per_row_df : pd.DataFrame, time_per_row_transform : float
+        time_per_row_df contains each model as index.
+            'pred_time_test_with_transform' is the end-to-end prediction time per row in seconds if calling `predictor.predict(data, model=model)`
+            'pred_time_test' is the end-to-end prediction time per row in seconds minus the global feature preprocessing time.
+            'pred_time_test_marginal' is the prediction time needed to predict for this particular model minus dependent model inference times and global preprocessing time.
+        time_per_row_transform is the time in seconds per row to do the feature preprocessing.
+    """
+    import copy
+    import time
+    import numpy as np
+    import pandas as pd
+    data_batch = copy.deepcopy(data)
+    len_data = len(data_batch)
+    if len_data == batch_size:
+        pass
+    elif len_data < batch_size:
+        # add more rows
+        duplicate_count = int(np.ceil(batch_size / len_data))
+        data_batch = pd.concat([data_batch for _ in range(duplicate_count)])
+        len_data = len(data_batch)
+    if len_data > batch_size:
+        # sample rows
+        data_batch = data_batch.sample(n=batch_size, random_state=0)
+        len_data = len(data_batch)
+
+    if len_data != batch_size:
+        raise AssertionError(f'len(data_batch) must equal batch_size! ({len_data} != {batch_size})')
+
+    predictor.persist_models(models='all')
+
+    ts = time.time()
+    for i in range(repeats):
+        predictor.transform_features(data_batch)
+    time_transform = (time.time() - ts) / repeats
+
+    leaderboards = []
+    for i in range(repeats):
+        leaderboard = predictor.leaderboard(data_batch, silent=True)
+        leaderboard = leaderboard[leaderboard['can_infer']][['model', 'pred_time_test', 'pred_time_test_marginal']]
+        leaderboard = leaderboard.set_index('model')
+        leaderboards.append(leaderboard)
+    leaderboard = pd.concat(leaderboards)
+    time_per_batch_df = leaderboard.groupby(level=0).mean()
+    time_per_batch_df['pred_time_test_with_transform'] = time_per_batch_df['pred_time_test'] + time_transform
+    time_per_row_df = time_per_batch_df / batch_size
+    time_per_row_transform = time_transform / batch_size
+
+    if not silent:
+        for index, row in time_per_row_df.iterrows():
+            time_per_row = row['pred_time_test_with_transform']
+            time_per_row_print = time_per_row
+            unit = 's'
+            if time_per_row_print < 1e-2:
+                time_per_row_print *= 1000
+                unit = 'ms'
+                if time_per_row_print < 1e-2:
+                    time_per_row_print *= 1000
+                    unit = 'μs'
+            print(f"{round(time_per_row_print, 3)}{unit} per row | {index}")
+        time_per_row_transform_print = time_per_row_transform
+        unit = 's'
+        if time_per_row_transform_print < 1e-2:
+            time_per_row_transform_print *= 1000
+            unit = 'ms'
+            if time_per_row_transform_print < 1e-2:
+                time_per_row_transform_print *= 1000
+                unit = 'μs'
+        print(f"{round(time_per_row_transform_print, 3)}{unit} per row | transform_features")
+
+    return time_per_row_df, time_per_row_transform

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -303,7 +303,7 @@ class AbstractTabularLearner(AbstractLearner):
         all_trained_models = trainer.get_model_names()
         all_trained_models_can_infer = trainer.get_model_names(can_infer=True)
         all_trained_models_original = all_trained_models.copy()
-        model_pred_proba_dict, pred_time_test_marginal = trainer.get_model_pred_proba_dict(X=X, models=all_trained_models_can_infer, fit=False, record_pred_time=True)
+        model_pred_proba_dict, pred_time_test_marginal = trainer.get_model_pred_proba_dict(X=X, models=all_trained_models_can_infer, record_pred_time=True)
 
         if compute_oracle:
             pred_probas = list(model_pred_proba_dict.values())

--- a/tabular/tests/unittests/models/test_cascade.py
+++ b/tabular/tests/unittests/models/test_cascade.py
@@ -1,0 +1,26 @@
+
+from autogluon.tabular.models import LGBModel, TabularNeuralNetTorchModel
+
+
+def test_cascade_binary(fit_helper):
+    fit_args = dict(
+        hyperparameters={
+            LGBModel: {},
+            TabularNeuralNetTorchModel: {},
+        },
+    )
+    dataset_name = 'adult'
+    cascade = ['LightGBM', 'WeightedEnsemble_L2']
+    fit_helper.fit_and_validate_dataset_with_cascade(dataset_name=dataset_name, fit_args=fit_args, cascade=cascade, model_count=2)
+
+
+def test_cascade_multiclass(fit_helper):
+    fit_args = dict(
+        hyperparameters={
+            LGBModel: {},
+            TabularNeuralNetTorchModel: {},
+        },
+    )
+    dataset_name = 'covertype_small'
+    cascade = ['LightGBM', 'WeightedEnsemble_L2']
+    fit_helper.fit_and_validate_dataset_with_cascade(dataset_name=dataset_name, fit_args=fit_args, cascade=cascade, model_count=2)

--- a/tabular/tests/unittests/models/test_cascade.py
+++ b/tabular/tests/unittests/models/test_cascade.py
@@ -11,7 +11,7 @@ def test_cascade_binary(fit_helper):
     )
     dataset_name = 'adult'
     cascade = ['LightGBM', 'WeightedEnsemble_L2']
-    fit_helper.fit_and_validate_dataset_with_cascade(dataset_name=dataset_name, fit_args=fit_args, cascade=cascade, model_count=2)
+    fit_helper.fit_and_validate_dataset_with_cascade(dataset_name=dataset_name, fit_args=fit_args, cascade=cascade, expected_model_count=3)
 
 
 def test_cascade_multiclass(fit_helper):
@@ -23,4 +23,4 @@ def test_cascade_multiclass(fit_helper):
     )
     dataset_name = 'covertype_small'
     cascade = ['LightGBM', 'WeightedEnsemble_L2']
-    fit_helper.fit_and_validate_dataset_with_cascade(dataset_name=dataset_name, fit_args=fit_args, cascade=cascade, model_count=2)
+    fit_helper.fit_and_validate_dataset_with_cascade(dataset_name=dataset_name, fit_args=fit_args, cascade=cascade, expected_model_count=3)


### PR DESCRIPTION
*Issue #, if available:*
- Updated version of #1682

*Description of changes:*

### Added cascade ensemble PoC.

The goal of a cascade ensemble is to expand the Accuracy - Inference Latency Pareto Frontier by finding a middle ground between single models and full ensembles that gets the majority of the accuracy improvement of ensembles combined with the majority of the inference speed of single models.

Currently, usage / existence of cascade ensemble support is not user-facing. It will be documented once it has been further tested and optimized. Currently the cascade threshold is fixed at 0.9 and the cascade must be manually defined. Next steps are to automatically define the cascade and the thresholds.

The below example script shows how to use cascades to get 80% of the log loss improvement (97% of the accuracy improvement) of the ensemble over a single model with only 35% the inference cost, thus expanding the Pareto Frontier, without any tuning.

Example Script:

```
from autogluon.tabular import TabularPredictor, TabularDataset


if __name__ == '__main__':
    path_prefix = 'https://autogluon.s3.amazonaws.com/datasets/CoverTypeMulticlassClassification/'
    path_train = path_prefix + 'train_data.csv'
    path_test = path_prefix + 'test_data.csv'

    label = 'Cover_Type'
    sample = 50000  # Number of rows to use to train
    train_data = TabularDataset(path_train)

    if sample is not None and (sample < len(train_data)):
        train_data = train_data.sample(n=sample, random_state=0).reset_index(drop=True)

    test_data = TabularDataset(path_test)

    fit_kwargs = dict(
        train_data=train_data,
        hyperparameters={
            'NN_TORCH': {},
            'GBM': {},
            'KNN': {},
        },
    )

    predictor = TabularPredictor(
        label=label,
        eval_metric='log_loss',
    )

    predictor.fit(**fit_kwargs)

    predictor.persist_models('all')

    leaderboard = predictor.leaderboard(test_data)

    import time

    ts = time.time()
    pred_proba = predictor.predict_proba(test_data, model='WeightedEnsemble_L2')
    te = time.time()

    print('--------')
    print('Normal: ')
    print(predictor.evaluate_predictions(y_true=test_data[label], y_pred=pred_proba, silent=True))
    print(f'{te - ts}s')
    print('--------')

    ts = time.time()
    pred_proba = predictor.predict_proba(test_data, model=['NeuralNetTorch', 'WeightedEnsemble_L2'])
    te = time.time()

    print('--------')
    print('Cascade:')
    print(predictor.evaluate_predictions(y_true=test_data[label], y_pred=pred_proba, silent=True))
    print(f'{te - ts}s')
    print('--------')

```

Out:

```
                 model  score_test  score_val  pred_time_test  pred_time_val     fit_time  pred_time_test_marginal  pred_time_val_marginal  fit_time_marginal  stack_level  can_infer  fit_order
0  WeightedEnsemble_L2   -0.234278  -0.260248       14.950171       0.715236  1270.274406                 0.048993                0.001165           0.486316            2       True          4
1             LightGBM   -0.295047  -0.324501       13.393521       0.607209    11.692870                13.393521                0.607209          11.692870            1       True          2
2       NeuralNetTorch   -0.297718  -0.327164        0.851722       0.072343  1258.052863                 0.851722                0.072343        1258.052863            1       True          3
3           KNeighbors   -0.496720  -0.456807        0.655935       0.034519     0.042357                 0.655935                0.034519           0.042357            1       True          1


--------
Normal: 
{'log_loss': -0.23427786256734967, 'accuracy': 0.9106477457552731, 'balanced_accuracy': 0.8266616778634864, 'mcc': 0.8558472797101921}
15.58s
--------
--------
Cascade:
{'log_loss': -0.25118394508483005, 'accuracy': 0.9099506897412287, 'balanced_accuracy': 0.8307863237257622, 'mcc': 0.8547748671813279}
6.10s
--------
```

### Additionally added infer_utils to calculate rows per second inference throughput by batch size.

Example Code:


```
from autogluon.tabular import TabularPredictor, TabularDataset
from autogluon.core.utils.infer_utils import get_model_true_infer_speed_per_row_batch


if __name__ == '__main__':
    train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
    subsample_size = 10000  # subsample subset of data for faster demo, try setting this to much larger values
    if subsample_size is not None and subsample_size < len(train_data):
        train_data = train_data.sample(n=subsample_size, random_state=0)
    train_data.head()
    label = 'class'

    hyperparameters = {
        'XGB': {},
        'GBM': {},
        'CAT': {},
        'RF': {},
    }

    predictor = TabularPredictor(
        label=label,
    )

    predictor.fit(
        train_data,
        presets='high',
        hyperparameters=hyperparameters,
    )

    test_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')

    predictor.persist_models('all')
    leaderboard = predictor.leaderboard(test_data)

    repeats = 2
    infer_dfs = dict()
    for batch_size in [1, 10, 100, 1000, 10000, 100000, 1000000]:
        infer_df, _ = get_model_true_infer_speed_per_row_batch(data=test_data, predictor=predictor, batch_size=batch_size, repeats=repeats)
        infer_dfs[batch_size] = infer_df
    for key in infer_dfs.keys():
        infer_dfs[key] = infer_dfs[key].reset_index()
        infer_dfs[key]['batch_size'] = key
    import pandas as pd
    infer_df_full = pd.concat([infer_dfs[key] for key in infer_dfs.keys()])
    infer_df_full['rows_per_second'] = 1 / infer_df_full['pred_time_test_with_transform']

    import matplotlib.pyplot as plt

    fig, ax = plt.subplots()
    fig.set_size_inches(12, 12)
    fig.set_dpi(300)

    plt.xscale('log')
    plt.yscale('log')

    models = list(infer_df_full['model'].unique())
    batch_sizes = list(infer_df_full['batch_size'].unique())
    for model in models:
        infer_df_model = infer_df_full[infer_df_full['model'] == model]
        ax.plot(infer_df_model['batch_size'].values, infer_df_model['rows_per_second'].values, label=model)

    ax.set(xlabel='batch_size', ylabel='rows_per_second',
           title='Rows per second inference throughput by data batch_size (AdultIncome)')
    ax.grid()
    ax.legend()
    fig.savefig('infer_speed_adult.png', dpi=300)
    plt.show()

```

Output Graph shows near linear inference speedup as batch size increases up-to 10,000 batch_size, capping speedup at ~100,000 batch_size.
![infer_speed_adult](https://user-images.githubusercontent.com/16392542/177914844-b4c6d570-bb61-47dc-8980-b77de5d82834.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
