### PR TITLE
Improve column type detection by supporting fallback type

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -404,11 +404,7 @@ def infer_problem_type_output_shape(
             )
 
 
-def set_fallback_column_type(
-    column_types: Dict,
-    allowable_column_types: List[str],
-    fallback_column_type: str
-) -> Dict:
+def set_fallback_column_type(column_types: Dict, allowable_column_types: List[str], fallback_column_type: str) -> Dict:
     """
     Filter the auto-detected column types to make sure that all column types are allowable.
     Use the fallback type to replace those out of the allowable_column_types.

--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -4,7 +4,7 @@ import pandas as pd
 import warnings
 import PIL
 from typing import Union, Optional, List, Dict, Tuple
-from ..constants import NULL, CATEGORICAL, NUMERICAL, TEXT, IMAGE_PATH, MULTICLASS, BINARY, REGRESSION, AUTOMM
+from ..constants import NULL, CATEGORICAL, NUMERICAL, TEXT, IMAGE, MULTICLASS, BINARY, REGRESSION, AUTOMM
 
 logger = logging.getLogger(AUTOMM)
 
@@ -194,6 +194,8 @@ def infer_column_types(
     valid_data: Optional[pd.DataFrame] = None,
     label_columns: Union[str, List[str]] = None,
     provided_column_types: Optional[Dict] = None,
+    allowable_column_types: Optional[List[str]] = None,
+    fallback_column_type: Optional[str] = None,
 ) -> Dict:
     """
     Infer the column types of a multimodal pd.DataFrame.
@@ -209,6 +211,10 @@ def infer_column_types(
     provided_column_types
         Additional dictionary that you can use to specify the columns types that you know.
         {'col_name': TYPE, ...}
+    allowable_column_types
+        What column types are allowed. This is the prior knowledge inferred from the model type.
+    fallback_column_type
+        What's the fallback column type if the detected type if out of the allowable_column_types.
 
     Returns
     -------
@@ -250,11 +256,18 @@ def infer_column_types(
         elif is_numerical_column(data[col_name], valid_data[col_name]):  # Infer numerical column
             column_types[col_name] = NUMERICAL
         elif is_imagepath_column(data[col_name], col_name):  # Infer image-path column
-            column_types[col_name] = IMAGE_PATH
+            column_types[col_name] = IMAGE
         elif is_text_column(data[col_name]):  # Infer text column
             column_types[col_name] = TEXT
         else:  # All the other columns are treated as categorical
             column_types[col_name] = CATEGORICAL
+
+    if allowable_column_types and fallback_column_type:
+        column_types = set_fallback_column_type(
+            column_types=column_types,
+            allowable_column_types=allowable_column_types,
+            fallback_column_type=fallback_column_type,
+        )
 
     return column_types
 
@@ -389,3 +402,28 @@ def infer_problem_type_output_shape(
                 f"The label column '{label_column}' has type"
                 f" '{column_types[label_column]}', which is not supported yet."
             )
+
+
+def set_fallback_column_type(column_types: Dict, allowable_column_types: List[str], fallback_column_type: str):
+    """
+    Filter the auto-detected column types to make sure that all column types are allowable.
+    Use the fallback type to replace those out of the allowable_column_types.
+
+    Parameters
+    ----------
+    column_types
+        The inferred column types.
+    allowable_column_types
+        The column types which are allowed by the model type.
+    fallback_column_type
+        Fallback to this type if some invalid column type is found.
+
+    Returns
+    -------
+    The filtered column types.
+    """
+    for col_name, col_type in column_types.items():
+        if col_type not in allowable_column_types:
+            column_types[col_name] = fallback_column_type
+
+    return column_types

--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -404,7 +404,11 @@ def infer_problem_type_output_shape(
             )
 
 
-def set_fallback_column_type(column_types: Dict, allowable_column_types: List[str], fallback_column_type: str):
+def set_fallback_column_type(
+    column_types: Dict,
+    allowable_column_types: List[str],
+    fallback_column_type: str
+) -> Dict:
     """
     Filter the auto-detected column types to make sure that all column types are allowable.
     Use the fallback type to replace those out of the allowable_column_types.

--- a/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
+++ b/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
@@ -74,7 +74,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
         for col_name, col_type in self._column_types.items():
             if col_name == self._label_column:
                 continue
-            if col_type in [TEXT, IMAGE_PATH, NULL]:
+            if col_type in [TEXT, IMAGE, IMAGE_PATH, NULL]:
                 continue
             elif col_type == CATEGORICAL:
                 generator = CategoryFeatureGenerator(
@@ -256,7 +256,7 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
                     generator = self._feature_generators[col_name]
                     generator.fit(np.expand_dims(processed_data.to_numpy(), axis=-1))
                     self._numerical_feature_names.append(col_name)
-            elif col_type == IMAGE_PATH:
+            elif col_type == IMAGE or col_type == IMAGE_PATH:
                 self._image_path_names.append(col_name)
             else:
                 raise NotImplementedError(

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -235,7 +235,7 @@ class ImageProcessor:
                 )
                 if len(extracted) == 0:
                     image_size = None
-                elif len(extracted) == 1:
+                elif len(extracted) >= 1:
                     image_size = extracted[0]
                     if isinstance(image_size, tuple):
                         image_size = image_size[-1]

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -94,6 +94,7 @@ from .utils import (
     extract_from_output,
     init_zero_shot,
     tensor_to_ndarray,
+    infer_dtypes_by_model_names,
 )
 from .optimization.utils import (
     get_metric,
@@ -1340,7 +1341,8 @@ class MultiModalPredictor:
         data = data_to_df(data=data)
 
         if self._column_types is None:
-            column_types = infer_column_types(data=data)
+            allowable_dtypes, fallback_dtype = infer_dtypes_by_model_names(model_config=self._config.model)
+            column_types = infer_column_types(data=data, allowable_column_types=allowable_dtypes, fallback_column_type=fallback_dtype)
         else:  # called .fit() or .load()
             column_types = self._column_types
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1342,7 +1342,9 @@ class MultiModalPredictor:
 
         if self._column_types is None:
             allowable_dtypes, fallback_dtype = infer_dtypes_by_model_names(model_config=self._config.model)
-            column_types = infer_column_types(data=data, allowable_column_types=allowable_dtypes, fallback_column_type=fallback_dtype)
+            column_types = infer_column_types(
+                data=data, allowable_column_types=allowable_dtypes, fallback_column_type=fallback_dtype
+            )
         else:  # called .fit() or .load()
             column_types = self._column_types
 

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -60,6 +60,7 @@ def zero_shot():
     return {
         "model.clip.checkpoint_name": "openai/clip-vit-large-patch14-336",
         "model.clip.max_text_len": 0,
+        "env.eval_batch_size_ratio": 1,
     }
 
 

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -58,7 +58,7 @@ def multilingual():
 @automm_presets.register()
 def zero_shot():
     return {
-        "model.clip.checkpoint_name": "openai/clip-vit-large-patch14",
+        "model.clip.checkpoint_name": "openai/clip-vit-large-patch14-336",
         "model.clip.max_text_len": 0,
     }
 

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -1913,3 +1913,30 @@ def download(
                 )
 
     return fname
+
+
+def infer_dtypes_by_model_names(model_config: DictConfig):
+    """
+    Get data types according to model types.
+
+    Parameters
+    ----------
+    model_config
+        Model config from `config.model`.
+
+    Returns
+    -------
+    The data types allowed by models and the default fallback data type.
+    """
+    allowable_dtypes = []
+    fallback_dtype = None
+    for per_model in model_config.names:
+        per_model_dtypes = OmegaConf.select(model_config, f"{per_model}.data_types")
+        if per_model_dtypes:
+            allowable_dtypes.extend(per_model_dtypes)
+
+    allowable_dtypes = set(allowable_dtypes)
+    if allowable_dtypes == set([IMAGE, TEXT]):
+        fallback_dtype = TEXT
+
+    return allowable_dtypes, fallback_dtype


### PR DESCRIPTION
1. Get data types based on model types.
2. Filter auto-detected columns types to make sure all types are allowed. Replace the invalid types with a default fallback type.
3. Use the CLIP large@336 in zero-shot learning by default.
