### PR TITLE
Fix nightly platform test

### DIFF
--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -68,6 +68,7 @@ jobs:
           env
           cd common/
           python3 -m pytest --junitxml=results.xml --runslow tests
+
   core:
     needs: setup
     runs-on: ${{ matrix.os }}
@@ -102,6 +103,7 @@ jobs:
           env
           cd core/
           python3 -m pytest --junitxml=results.xml --runslow tests
+
   features:
     needs: setup
     runs-on: ${{ matrix.os }}
@@ -136,6 +138,7 @@ jobs:
           env
           cd features/
           python3 -m pytest --junitxml=results.xml --runslow tests
+
   tabular:
     needs: setup
     runs-on: ${{ matrix.os }}
@@ -181,6 +184,7 @@ jobs:
           env
           cd tabular/
           python3 -m pytest --junitxml=results.xml --runslow -m "not gpu" tests
+
   install:
     needs: setup
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -5,19 +5,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  tabular:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create URL to the run output
+        if: (github.event_name == 'workflow_dispatch')
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      - name: Create comment
+        if: (github.event_name == 'workflow_dispatch')
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.inputs.repository }}
+          comment-id: ${{ github.event.inputs.comment-id }}
+          body: |
+            [Platform Tests Output][1]
+            [1]: ${{ steps.vars.outputs.run-url }}
+  common:
+    needs: setup
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
     defaults:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
-        os: [windows-latest]
-    steps:
+        os: [macos-latest, windows-latest]
+    steps:  
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.pr-sha }}
       - name: Checkout repository for nightly test
         if: (github.event_name == 'schedule')
         uses: actions/checkout@v2
@@ -27,7 +48,109 @@ jobs:
           activate-environment: autogluon_py3
           environment-file: .github/workflows_env/unittest_env.yml
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.9
+      - name: unit-test
+        shell: bash -l {0}
+        run: |
+          python3 -m pip install --upgrade -e common/[tests]
+          env
+          cd common/
+          python3 -m pytest --junitxml=results.xml --runslow tests
+  core:
+    needs: setup
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository for PR
+        if: (github.event_name == 'workflow_dispatch')
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.pr-sha }}
+      - name: Checkout repository for nightly test
+        if: (github.event_name == 'schedule')
+        uses: actions/checkout@v2
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.0
+        with:
+          activate-environment: autogluon_py3
+          environment-file: .github/workflows_env/unittest_env.yml
+          auto-update-conda: true
+          python-version: 3.9
+      - name: unit-test
+        shell: bash -l {0}
+        run: |
+          python3 -m pip install --upgrade -e common/[tests]
+          python3 -m pip install --upgrade -e core/[all,tests]
+          env
+          cd core/
+          python3 -m pytest --junitxml=results.xml --runslow tests
+  features:
+    needs: setup
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository for PR
+        if: (github.event_name == 'workflow_dispatch')
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.pr-sha }}
+      - name: Checkout repository for nightly test
+        if: (github.event_name == 'schedule')
+        uses: actions/checkout@v2
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.0
+        with:
+          activate-environment: autogluon_py3
+          environment-file: .github/workflows_env/unittest_env.yml
+          auto-update-conda: true
+          python-version: 3.9
+      - name: unit-test
+        shell: bash -l {0}
+        run: |
+          python3 -m pip install --upgrade -e common/[tests]
+          python3 -m pip install --upgrade -e features/
+          env
+          cd features/
+          python3 -m pytest --junitxml=results.xml --runslow tests
+  tabular:
+    needs: setup
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository for PR
+        if: (github.event_name == 'workflow_dispatch')
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.pr-sha }}
+      - name: Checkout repository for nightly test
+        if: (github.event_name == 'schedule')
+        uses: actions/checkout@v2
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.0
+        with:
+          activate-environment: autogluon_py3
+          environment-file: .github/workflows_env/unittest_env.yml
+          auto-update-conda: true
+          python-version: 3.9
       - name: Setup OMP
         if: matrix.os == 'macos-latest'
         shell: bash -l {0}
@@ -39,7 +162,6 @@ jobs:
       - name: unit-test
         shell: bash -l {0}
         run: |
-          python3 -m pip install --upgrade "mxnet<2.0.0"
           python3 -m pip install --upgrade -e common/[tests]
           python3 -m pip install --upgrade -e core/[all]
           python3 -m pip install --upgrade -e features/
@@ -47,3 +169,41 @@ jobs:
           env
           cd tabular/
           python3 -m pytest --junitxml=results.xml --runslow -m "not gpu" tests
+  install:
+    needs: setup
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Checkout repository for PR
+        if: (github.event_name == 'workflow_dispatch')
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.pr-sha }}
+      - name: Checkout repository for nightly test
+        if: (github.event_name == 'schedule')
+        uses: actions/checkout@v2
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v2.0.0
+        with:
+          activate-environment: autogluon_py3
+          environment-file: .github/workflows_env/unittest_env.yml
+          auto-update-conda: true
+          python-version: 3.9
+      - name: unit-test
+        shell: bash -l {0}
+        run: |
+          python3 -m pip install --upgrade -e common/[tests]
+          python3 -m pip install --upgrade -e core/[all]
+          python3 -m pip install --upgrade -e features/
+          python3 -m pip install --upgrade -e tabular/[all,tests]
+          python3 -m pip install --upgrade -e multimodal/
+          python3 -m pip install --upgrade -e text/
+          python3 -m pip install --upgrade -e vision/
+          python3 -m pip install --upgrade -e timeseries/
+          python3 -m pip install --upgrade -e autogluon/

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   tabular:
-    needs: setup
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -3,13 +3,38 @@ on:
   schedule:
     - cron: '59 07 * * *'  #  UTC 7:59(23:59 PST Winter Time) everyday
   workflow_dispatch:
+    inputs:
+      repository:
+        description: 'The repository from which the slash command was dispatched'
+        required: true
+      comment-id:
+        description: 'The comment-id of the slash command'
+        required: true
+      pr-sha:
+        description: 'The pr-sha of which the slash command was dispatched'
+        required: true
 
 jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
       - name: Create URL to the run output
-        run: echo temp
+        if: (github.event_name == 'workflow_dispatch')
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+      - name: Create comment
+        if: (github.event_name == 'workflow_dispatch')
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.inputs.repository }}
+          comment-id: ${{ github.event.inputs.comment-id }}
+          body: |
+            [Platform Tests Output][1]
+
+            [1]: ${{ steps.vars.outputs.run-url }}
+
   common:
     needs: setup
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -13,7 +13,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [windows-latest]
     steps:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -33,6 +33,7 @@ jobs:
         shell: bash -l {0}
         run: |
           wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
+          brew unlink libomp
           brew install libomp.rb
           rm libomp.rb
       - name: unit-test

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -9,20 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create URL to the run output
-        if: (github.event_name == 'workflow_dispatch')
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      - name: Create comment
-        if: (github.event_name == 'workflow_dispatch')
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          token: ${{ secrets.PAT }}
-          repository: ${{ github.event.inputs.repository }}
-          comment-id: ${{ github.event.inputs.comment-id }}
-          body: |
-            [Platform Tests Output][1]
-            [1]: ${{ steps.vars.outputs.run-url }}
+        run: echo temp
   common:
     needs: setup
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -27,7 +27,14 @@ jobs:
           activate-environment: autogluon_py3
           environment-file: .github/workflows_env/unittest_env.yml
           auto-update-conda: true
-          python-version: 3.9
+          python-version: 3.8
+      - name: Setup OMP
+        if: matrix.os == 'macos-latest'
+        shell: bash -l {0}
+        run: |
+          wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
+          brew install libomp.rb
+          rm libomp.rb
       - name: unit-test
         shell: bash -l {0}
         run: |

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -19,8 +19,6 @@ jobs:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.pr-sha }}
       - name: Checkout repository for nightly test
         if: (github.event_name == 'schedule')
         uses: actions/checkout@v2

--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -3,138 +3,8 @@ on:
   schedule:
     - cron: '59 07 * * *'  #  UTC 7:59(23:59 PST Winter Time) everyday
   workflow_dispatch:
-    inputs:
-      repository:
-        description: 'The repository from which the slash command was dispatched'
-        required: true
-      comment-id:
-        description: 'The comment-id of the slash command'
-        required: true
-      pr-sha:
-        description: 'The pr-sha of which the slash command was dispatched'
-        required: true
+
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create URL to the run output
-        if: (github.event_name == 'workflow_dispatch')
-        id: vars
-        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      - name: Create comment
-        if: (github.event_name == 'workflow_dispatch')
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          token: ${{ secrets.PAT }}
-          repository: ${{ github.event.inputs.repository }}
-          comment-id: ${{ github.event.inputs.comment-id }}
-          body: |
-            [Platform Tests Output][1]
-
-            [1]: ${{ steps.vars.outputs.run-url }}
-
-  common:
-    needs: setup
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-    steps:  
-      - name: Checkout repository for PR
-        if: (github.event_name == 'workflow_dispatch')
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.pr-sha }}
-      - name: Checkout repository for nightly test
-        if: (github.event_name == 'schedule')
-        uses: actions/checkout@v2
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.0.0
-        with:
-          activate-environment: autogluon_py3
-          environment-file: .github/workflows_env/unittest_env.yml
-          auto-update-conda: true
-          python-version: 3.9
-      - name: unit-test
-        shell: bash -l {0}
-        run: |
-          python3 -m pip install --upgrade -e common/[tests]
-          env
-          cd common/
-          python3 -m pytest --junitxml=results.xml --runslow tests
-
-  core:
-    needs: setup
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-    steps:
-      - name: Checkout repository for PR
-        if: (github.event_name == 'workflow_dispatch')
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.pr-sha }}
-      - name: Checkout repository for nightly test
-        if: (github.event_name == 'schedule')
-        uses: actions/checkout@v2
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.0.0
-        with:
-          activate-environment: autogluon_py3
-          environment-file: .github/workflows_env/unittest_env.yml
-          auto-update-conda: true
-          python-version: 3.9
-      - name: unit-test
-        shell: bash -l {0}
-        run: |
-          python3 -m pip install --upgrade -e common/[tests]
-          python3 -m pip install --upgrade -e core/[all,tests]
-          env
-          cd core/
-          python3 -m pytest --junitxml=results.xml --runslow tests
-
-  features:
-    needs: setup
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-    steps:
-      - name: Checkout repository for PR
-        if: (github.event_name == 'workflow_dispatch')
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.pr-sha }}
-      - name: Checkout repository for nightly test
-        if: (github.event_name == 'schedule')
-        uses: actions/checkout@v2
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.0.0
-        with:
-          activate-environment: autogluon_py3
-          environment-file: .github/workflows_env/unittest_env.yml
-          auto-update-conda: true
-          python-version: 3.9
-      - name: unit-test
-        shell: bash -l {0}
-        run: |
-          python3 -m pip install --upgrade -e common/[tests]
-          python3 -m pip install --upgrade -e features/
-          env
-          cd features/
-          python3 -m pytest --junitxml=results.xml --runslow tests
-
   tabular:
     needs: setup
     runs-on: ${{ matrix.os }}
@@ -144,7 +14,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest]
     steps:
       - name: Checkout repository for PR
         if: (github.event_name == 'workflow_dispatch')
@@ -161,13 +31,6 @@ jobs:
           environment-file: .github/workflows_env/unittest_env.yml
           auto-update-conda: true
           python-version: 3.9
-      - name: Setup OMP
-        if: matrix.os == 'macos-latest'
-        shell: bash -l {0}
-        run: |
-          wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
-          brew install libomp.rb
-          rm libomp.rb
       - name: unit-test
         shell: bash -l {0}
         run: |
@@ -179,41 +42,3 @@ jobs:
           env
           cd tabular/
           python3 -m pytest --junitxml=results.xml --runslow -m "not gpu" tests
-
-  install:
-    needs: setup
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-    steps:
-      - name: Checkout repository for PR
-        if: (github.event_name == 'workflow_dispatch')
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.pr-sha }}
-      - name: Checkout repository for nightly test
-        if: (github.event_name == 'schedule')
-        uses: actions/checkout@v2
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v2.0.0
-        with:
-          activate-environment: autogluon_py3
-          environment-file: .github/workflows_env/unittest_env.yml
-          auto-update-conda: true
-          python-version: 3.9
-      - name: unit-test
-        shell: bash -l {0}
-        run: |
-          python3 -m pip install --upgrade -e common/[tests]
-          python3 -m pip install --upgrade -e core/[all]
-          python3 -m pip install --upgrade -e features/
-          python3 -m pip install --upgrade -e tabular/[all,tests]
-          python3 -m pip install --upgrade -e multimodal/
-          python3 -m pip install --upgrade -e text/
-          python3 -m pip install --upgrade -e vision/
-          python3 -m pip install --upgrade -e timeseries/
-          python3 -m pip install --upgrade -e autogluon/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Github action started to install libomp by default, previous script didn't remove the existing installation. So the libomp 11.1 wasn't correctly installed and caused segfault.
* Set fail fast to be false, so that different OS won't be affected by failure status of each other.

Tested on the fork:
https://github.com/yinweisu/autogluon/actions/runs/2659133804


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
