### PR TITLE
Fix build docs saving path

### DIFF
--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -31,7 +31,7 @@ else
         fi
     fi
     bucket='autogluon.mxnet.io'
-    site=$bucket/$path  # Needed for sed substitution
+    site=$bucket/$path  # site is the actual bucket location that will serve the doc
 fi
 
 other_doc_version_text='Stable Version Documentation'

--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -50,7 +50,7 @@ then
 else
     BUCKET=autogluon-ci-push
     BUILD_DOCS_PATH=s3://$BUCKET/build_docs/$BRANCH/$COMMIT_SHA
-    S3_PATH=s3://$BUCKET/build_docs/${path}/$COMMIT_SHA/all
+    S3_PATH=s3://$BUCKET/build_docs/$BRANCH/$COMMIT_SHA/all
 fi
 
 mkdir -p docs/_build/rst/tutorials/
@@ -80,5 +80,5 @@ write_to_s3 $BUCKET $DOC_PATH $S3_PATH
 # Write root_index to s3 if master
 if [[ ($BRANCH == 'master') && ($GIT_REPO == awslabs/autogluon) ]]
 then
-    write_to_s3 $BUCKET root_index.html s3://$BUCKET/build_docs/${path}/$COMMIT_SHA/root_index.html
+    write_to_s3 $BUCKET root_index.html s3://$BUCKET/build_docs/$BRANCH/$COMMIT_SHA/root_index.html
 fi

--- a/.github/workflow_scripts/build_all_docs.sh
+++ b/.github/workflow_scripts/build_all_docs.sh
@@ -31,7 +31,7 @@ else
         fi
     fi
     bucket='autogluon.mxnet.io'
-    site=$bucket/$path
+    site=$bucket/$path  # Needed for sed substitution
 fi
 
 other_doc_version_text='Stable Version Documentation'
@@ -50,7 +50,7 @@ then
 else
     BUCKET=autogluon-ci-push
     BUILD_DOCS_PATH=s3://$BUCKET/build_docs/$BRANCH/$COMMIT_SHA
-    S3_PATH=s3://$BUCKET/build_docs/$BRANCH/$COMMIT_SHA/all
+    S3_PATH=s3://$BUCKET/build_docs/$BRANCH/$COMMIT_SHA/all  # We still write to BRANCH so copy_docs.sh knows where to find it
 fi
 
 mkdir -p docs/_build/rst/tutorials/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* While building the doc, we don't need to substitute the branch when saving to our private bucket, for example, 'master' -> 'dev'. We only need to do it when we move docs to our official web bucket. Previously, doing this cause docs got written to PRIVATE_BUCKET/dev/xxx when it's on master branch, and the copy docs script will try to look at PRIVATE_BUCKET/master/xxx, which doesn't exists. This PR should fix this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
