### PR TITLE
Support timm zero shot learning

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/timm_image.py
+++ b/multimodal/src/autogluon/multimodal/models/timm_image.py
@@ -65,7 +65,12 @@ class TimmAutoModelForImagePrediction(nn.Module):
         self.model = create_model(checkpoint_name, pretrained=pretrained, num_classes=num_classes)
         self.num_classes = self.model.num_classes
         self.out_features = self.model.num_features
-        self.head = self.model.head  # move the head outside
+        if hasattr(self.model, "head"):
+            self.head = self.model.head  # move the head outside
+        elif hasattr(self.model, "last_linear"):
+            self.head = self.model.last_linear
+        else:
+            raise ValueError(f"Model {checkpoint_name} doesn't have head. Need to check its TIMM implementation.")
         self.model.reset_classifier(0)  # remove the internal head
 
         self.mix_choice = mix_choice

--- a/multimodal/src/autogluon/multimodal/models/timm_image.py
+++ b/multimodal/src/autogluon/multimodal/models/timm_image.py
@@ -5,8 +5,8 @@ from torch import nn
 from timm import create_model
 from .utils import (
     assign_layer_ids,
-    init_weights,
     get_column_features,
+    get_model_head,
 )
 from ..constants import (
     IMAGE,
@@ -65,12 +65,7 @@ class TimmAutoModelForImagePrediction(nn.Module):
         self.model = create_model(checkpoint_name, pretrained=pretrained, num_classes=num_classes)
         self.num_classes = self.model.num_classes
         self.out_features = self.model.num_features
-        if hasattr(self.model, "head"):
-            self.head = self.model.head  # move the head outside
-        elif hasattr(self.model, "last_linear"):
-            self.head = self.model.last_linear
-        else:
-            raise ValueError(f"Model {checkpoint_name} doesn't have head. Need to check its TIMM implementation.")
+        self.head = get_model_head(model=self.model)
         self.model.reset_classifier(0)  # remove the internal head
 
         self.mix_choice = mix_choice

--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -427,3 +427,28 @@ def inject_lora_to_linear_layer(
             setattr(model, n, lora_layer)
 
     return model  # return model to enable method chaining
+
+
+def get_model_head(model: nn.Module):
+    """
+    Return the model's head. Different models may have different head names.
+
+    Parameters
+    ----------
+    model
+        A Pytorch model.
+
+    Returns
+    -------
+    The model's head.
+    """
+    if hasattr(model, "head"):
+        head = model.head  # move the head outside
+    elif hasattr(model, "last_linear"):
+        head = model.last_linear
+    elif hasattr(model, "fc"):
+        head = model.fc
+    else:
+        raise ValueError(f"Model {type(model)} doesn't have head. Need to check its implementation.")
+
+    return head

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1528,7 +1528,10 @@ class MultiModalPredictor:
                     y_pred=logits_or_prob,
                 )
             else:
-                pred = logits_or_prob
+                if logits_or_prob.ndim == 2:
+                    pred = logits_or_prob.argmax(axis=1)
+                else:
+                    pred = logits_or_prob
 
         if (as_pandas is None and isinstance(data, pd.DataFrame)) or as_pandas is True:
             pred = self._as_pandas(data=data, to_be_converted=pred)

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -1652,7 +1652,7 @@ def init_zero_shot(
     assert (
         len(config.model.names) == 1
     ), f"Zero shot mode only supports using one model, but detects multiple models {config.model.names}"
-    model = create_model(config=config)
+    model = create_model(config=config, pretrained=True)
 
     data_processors = init_data_processors(
         config=config,

--- a/multimodal/tests/unittests/test_zero_shot.py
+++ b/multimodal/tests/unittests/test_zero_shot.py
@@ -1,12 +1,11 @@
 from PIL import Image
 import requests
 import pytest
+import numpy as np
 from autogluon.multimodal import MultiModalPredictor
 
-pytest.skip("Temporarily skip this test to pass the Jenkins build.", allow_module_level=True)
 
-
-def test_clip_zero_shot():
+def download_sample_images():
     url = "http://images.cocodataset.org/val2017/000000039769.jpg"
     image = Image.open(requests.get(url, stream=True).raw)
     cat_image_name = "cat.jpg"
@@ -16,6 +15,12 @@ def test_clip_zero_shot():
     image = Image.open(requests.get(url, stream=True).raw)
     dog_image_name = "dog.jpg"
     image.save(dog_image_name)
+
+    return cat_image_name, dog_image_name
+
+
+def test_clip_zero_shot():
+    cat_image_name, dog_image_name = download_sample_images()
 
     cat_text = "a photo of a cat"
     dog_text = "a photo of a dog"
@@ -98,3 +103,36 @@ def test_clip_zero_shot():
     # invalid API usage 2: predicting probability with only one dictionary as input.
     with pytest.raises(AssertionError):
         prob = predictor.predict_proba({"image": [cat_image_name], "text": [cat_text]})
+
+
+def test_timm_zero_shot():
+    cat_image_name, dog_image_name = download_sample_images()
+
+    predictor = MultiModalPredictor(
+        hyperparameters={
+            "model.names": ["timm_image"],
+            "model.timm_image.checkpoint_name": "swin_tiny_patch4_window7_224",
+        },
+        problem_type="zero_shot",
+    )
+
+    pred = predictor.predict({"image": [cat_image_name, dog_image_name]})
+    assert pred.shape == (2,)
+
+    prob = predictor.predict_proba({"image": [cat_image_name, dog_image_name]})
+    assert prob.shape == (2, 1000)
+
+    features = predictor.extract_embedding({"abc": [cat_image_name, dog_image_name]})
+    assert features["abc"].shape == (2, 768)
+
+    features, masks = predictor.extract_embedding({"abc": [cat_image_name, dog_image_name]}, return_masks=True)
+    assert features["abc"].shape == (2, 768)
+    assert np.all(masks["abc"] == np.array([1, 1]))
+
+    features, masks = predictor.extract_embedding(
+        {"abc": [cat_image_name], "123": [dog_image_name]}, return_masks=True
+    )
+    assert features["abc"].shape == (1, 768)
+    assert features["123"].shape == (1, 768)
+    assert np.all(masks["abc"] == np.array([1]))
+    assert np.all(masks["123"] == np.array([1]))


### PR DESCRIPTION
1. Use timm to create head to cover the case that, if the provided `num_classes` is the same as the pre-trained `num_classes`, we can reuse the pre-trained head.
2. Move the timm head outside since we need to get the pooled features for late fusion sometimes.
3. Output logits only if the `num_classes` > 0.
4. Add a unit test for timm zero shot learning.
