### PR TITLE
Fix calculation of feature importances on Quantile Models

### DIFF
--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1888,7 +1888,7 @@ class AbstractTrainer:
         model: AbstractModel = self.load_model(model)
         predict_func_kwargs = dict(model=model)
         return compute_permutation_feature_importance(
-            X=X, y=y, predict_func=predict_func, predict_func_kwargs=predict_func_kwargs, eval_metric=eval_metric, **kwargs
+            X=X, y=y, predict_func=predict_func, predict_func_kwargs=predict_func_kwargs, eval_metric=eval_metric, quantile_levels=self.quantile_levels, **kwargs
         )
 
     def _get_models_load_info(self, model_names):

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -572,7 +572,8 @@ def compute_permutation_feature_importance(X: pd.DataFrame,
                                            silent=False,
                                            log_prefix='',
                                            importance_as_list=False,
-                                           random_state=0) -> pd.DataFrame:
+                                           random_state=0,
+                                           **kwargs) -> pd.DataFrame:
     """
     Computes a trained model's feature importance via permutation shuffling (https://explained.ai/rf-importance/).
     A feature's importance score represents the performance drop that results when the model makes predictions on a perturbed copy of the dataset where this feature's values have been randomly shuffled across rows.
@@ -709,7 +710,7 @@ def compute_permutation_feature_importance(X: pd.DataFrame,
             time_start_score = time.time()
             X_transformed = X if transform_func is None else transform_func(X, **transform_func_kwargs)
             y_pred = predict_func(X_transformed, **predict_func_kwargs)
-            score_baseline = eval_metric(y, y_pred)
+            score_baseline = eval_metric(y, y_pred, **kwargs)
             if shuffle_repeat == 0:
                 if not silent:
                     time_score = time.time() - time_start_score
@@ -762,7 +763,7 @@ def compute_permutation_feature_importance(X: pd.DataFrame,
                 # calculating importance score for given feature
                 row_index_end = row_index + row_count
                 y_pred_cur = y_pred[row_index:row_index_end]
-                score = eval_metric(y, y_pred_cur)
+                score = eval_metric(y, y_pred_cur, **kwargs)
                 fi[feature_name] = score_baseline - score
 
                 # resetting to original values for processed feature

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -658,6 +658,9 @@ def compute_permutation_feature_importance(X: pd.DataFrame,
             A p-value of 0.99 indicates that there is a 99% chance that the feature is useless or harmful, and a 1% chance that the feature is useful.
         'n': The number of shuffles performed to estimate importance score (corresponds to sample-size used to determine confidence interval for true score).
     """
+    if not eval_metric.needs_quantile:
+        kwargs.pop('quantile_levels', None)
+
     if num_shuffle_sets is None:
         num_shuffle_sets = 1 if time_limit is None else 10
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/autogluon/issues/1794

*Description of changes:*
- Just passes `quantile_levels` to `compute_permutation_feature_importance` like how we do it in `AbstractTrainer.score`
