### PR TITLE
Improve AutoMM's save_path logic

### DIFF
--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -95,6 +95,7 @@ from .utils import (
     tensor_to_ndarray,
     infer_dtypes_by_model_names,
     update_config_by_rules,
+    process_save_path,
 )
 from .optimization.utils import (
     get_metric,
@@ -195,6 +196,9 @@ class MultiModalPredictor:
 
         if verbosity is not None:
             set_logger_verbosity(verbosity, logger=logger)
+
+        if path is not None:
+            path = process_save_path(path=path)
 
         self._label_column = label
         self._problem_type = problem_type.lower() if problem_type is not None else None
@@ -381,19 +385,21 @@ class MultiModalPredictor:
 
         pl.seed_everything(seed, workers=True)
 
-        if self._resume or save_path is None:
-            save_path = self._save_path
-        else:
-            save_path = os.path.expanduser(save_path)
+        if self._resume:
+            assert hyperparameter_tune_kwargs is None, "You can not resume training with HPO"
+            save_path = process_save_path(path=self._save_path, resume=True)
+        elif save_path is not None:
+            save_path = process_save_path(path=save_path)
+        elif self._save_path is not None:
+            save_path = process_save_path(path=self._save_path, raise_if_exist=False)
 
         if not self._resume:
             save_path = setup_outputdir(
                 path=save_path,
                 warn_if_exist=self._warn_if_exist,
             )
-        else:
-            assert hyperparameter_tune_kwargs is None, "You can not resume training with HPO"
-        save_path = os.path.abspath(save_path)
+
+        save_path = os.path.abspath(os.path.expanduser(save_path))
         logger.debug(f"save path: {save_path}")
 
         # Generate general info that's not config specific
@@ -1770,7 +1776,7 @@ class MultiModalPredictor:
         resume: Optional[bool] = False,
         verbosity: Optional[int] = 3,
     ):
-        path = os.path.expanduser(path)
+        path = os.path.abspath(os.path.expanduser(path))
         assert os.path.isdir(path), f"'{path}' must be an existing directory."
         config = OmegaConf.load(os.path.join(path, "config.yaml"))
 
@@ -1850,7 +1856,7 @@ class MultiModalPredictor:
         -------
         The loaded predictor object.
         """
-        path = os.path.expanduser(path)
+        path = os.path.abspath(os.path.expanduser(path))
         assert os.path.isdir(path), f"'{path}' must be an existing directory."
         predictor = cls(label="dummy_label")
         predictor = cls._load_metadata(predictor=predictor, path=path, resume=resume, verbosity=verbosity)

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -85,6 +85,7 @@ from .constants import (
     FEATURES,
     MASKS,
     S3_PREFIX,
+    LAST_CHECKPOINT,
 )
 from .presets import get_automm_presets, get_basic_automm_config
 
@@ -1976,3 +1977,37 @@ def update_config_by_rules(
                 UserWarning,
             )
     return config
+
+
+def process_save_path(path, resume: Optional[bool] = False, raise_if_exist: Optional[bool] = True):
+    """
+    Convert the provided path to an absolute path and check whether it is valid.
+    If a path exists, either raise error or return None.
+    A None path can be identified by the `setup_outputdir` to generate a random path.
+
+    Parameters
+    ----------
+    path
+        A provided path.
+    resume
+        Whether this is a path to resume training.
+    raise_if_exist
+        Whether to raise error if the path exists.
+
+    Returns
+    -------
+    A complete and verified path or None.
+    """
+    path = os.path.abspath(os.path.expanduser(path))
+    if resume:
+        last_ckpt_path = os.path.join(path, LAST_CHECKPOINT)
+        assert os.path.isfile(last_ckpt_path), f"The last checkpoint {last_ckpt_path} doesn't exist."
+    elif os.path.isdir(path):
+        if raise_if_exist:
+            raise ValueError(
+                f"Path {path} already exists. Specify a new path to avoid accidentally overwriting a saved predictor."
+            )
+        else:
+            path = None
+
+    return path

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -2000,12 +2000,16 @@ def process_save_path(path, resume: Optional[bool] = False, raise_if_exist: Opti
     """
     path = os.path.abspath(os.path.expanduser(path))
     if resume:
-        last_ckpt_path = os.path.join(path, LAST_CHECKPOINT)
-        assert os.path.isfile(last_ckpt_path), f"The last checkpoint {last_ckpt_path} doesn't exist."
+        assert os.path.isfile(os.path.join(path, LAST_CHECKPOINT)), (
+            f"Trying to resume training from '{path}'. "
+            f"However, it does not contain the last checkpoint file: '{LAST_CHECKPOINT}'. "
+            "Are you using a correct path?"
+        )
     elif os.path.isdir(path):
         if raise_if_exist:
             raise ValueError(
-                f"Path {path} already exists. Specify a new path to avoid accidentally overwriting a saved predictor."
+                f"Path {path} already exists."
+                "Specify a new path to avoid accidentally overwriting a saved predictor."
             )
         else:
             path = None

--- a/multimodal/tests/unittests/test_backward_compatibility.py
+++ b/multimodal/tests/unittests/test_backward_compatibility.py
@@ -41,7 +41,7 @@ def test_load_old_checkpoint(cls):
     predictor.fit(
         dataset.train_df,
         presets="multilingual",
-        time_limit=10,
+        time_limit=30,
         hyperparameters={"optimization.top_k_average_method": "uniform_soup"},
     )
     verify_predictor_save_load(predictor, dataset.test_df, cls=cls)

--- a/multimodal/tests/unittests/test_data_augmentation.py
+++ b/multimodal/tests/unittests/test_data_augmentation.py
@@ -1,6 +1,8 @@
+import os
 import tempfile
 import copy
 import pickle
+import shutil
 
 from autogluon.multimodal import MultiModalPredictor
 from autogluon.multimodal.constants import (
@@ -60,10 +62,12 @@ def test_mixup():
     }
 
     with tempfile.TemporaryDirectory() as save_path:
+        if os.path.isdir(save_path):
+            shutil.rmtree(save_path)
         predictor.fit(
             train_data=dataset.train_df,
             config=config,
-            time_limit=30,
+            time_limit=10,
             save_path=save_path,
             hyperparameters=hyperparameters,
         )
@@ -99,6 +103,8 @@ def test_textagumentor_deepcopy():
     }
 
     with tempfile.TemporaryDirectory() as save_path:
+        if os.path.isdir(save_path):
+            shutil.rmtree(save_path)
         predictor.fit(
             train_data=dataset.train_df,
             config=config,
@@ -159,10 +165,12 @@ def test_trivialaugment():
     }
 
     with tempfile.TemporaryDirectory() as save_path:
+        if os.path.isdir(save_path):
+            shutil.rmtree(save_path)
         predictor.fit(
             train_data=dataset.train_df,
             config=config,
-            time_limit=30,
+            time_limit=10,
             save_path=save_path,
             hyperparameters=hyperparameters,
         )

--- a/multimodal/tests/unittests/test_predictor.py
+++ b/multimodal/tests/unittests/test_predictor.py
@@ -521,6 +521,8 @@ def test_model_configs():
     }
 
     with tempfile.TemporaryDirectory() as save_path:
+        if os.path.isdir(save_path):
+            shutil.rmtree(save_path)
         predictor.fit(
             train_data=dataset.train_df,
             config=config,

--- a/multimodal/tests/unittests/test_save_path.py
+++ b/multimodal/tests/unittests/test_save_path.py
@@ -1,0 +1,69 @@
+import os
+import shutil
+import pytest
+from autogluon.multimodal import MultiModalPredictor
+
+from unittest_datasets import PetFinderDataset
+
+
+@pytest.mark.parametrize(
+    "save_path",
+    [
+        "an_existing_path",
+        "~/an_existing_path",
+        os.path.join(os.path.expanduser("~"), "an_existing_path"),
+    ],
+)
+def test_existing_save_path(save_path):
+    abs_path = os.path.abspath(os.path.expanduser(save_path))
+    os.makedirs(abs_path, exist_ok=True)
+    with pytest.raises(ValueError):
+        predictor = MultiModalPredictor(path=save_path)
+
+    dataset = PetFinderDataset()
+    predictor = MultiModalPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=dataset.metric,
+    )
+    with pytest.raises(ValueError):
+        predictor.fit(train_data=dataset.train_df, save_path=save_path)
+
+    shutil.rmtree(abs_path)
+
+
+def test_continuous_training_save_path():
+    save_path = "a_tmp_path"
+    abs_path = os.path.abspath(os.path.expanduser(save_path))
+    if os.path.exists(abs_path):
+        shutil.rmtree(abs_path)
+
+    dataset = PetFinderDataset()
+    predictor = MultiModalPredictor(
+        label=dataset.label_columns[0],
+        problem_type=dataset.problem_type,
+        eval_metric=dataset.metric,
+    )
+
+    hyperparameters = {
+        "env.num_workers": 0,
+        "env.num_workers_evaluation": 0,
+        "model.names": ["timm_image", "hf_text", "fusion_mlp"],
+        "model.hf_text.checkpoint_name": "prajjwal1/bert-tiny",
+        "model.timm_image.checkpoint_name": "swin_tiny_patch4_window7_224",
+    }
+    predictor.fit(train_data=dataset.train_df, save_path=save_path, hyperparameters=hyperparameters, time_limit=10)
+
+    assert predictor.path == abs_path
+
+    with pytest.raises(ValueError):
+        predictor.fit(train_data=dataset.train_df, save_path=save_path, time_limit=10)
+
+    # continue training
+    predictor.fit(train_data=dataset.train_df, time_limit=10)
+    assert predictor.path != abs_path and "AutogluonModels/ag-" in predictor.path
+
+    # load a saved predictor and continue training
+    predictor_loaded = MultiModalPredictor.load(save_path)
+    predictor_loaded.fit(train_data=dataset.train_df, time_limit=10)
+    assert predictor_loaded.path != abs_path and "AutogluonModels/ag-" in predictor.path

--- a/text/tests/unittests/test_backward_compatibility.py
+++ b/text/tests/unittests/test_backward_compatibility.py
@@ -59,7 +59,7 @@ def test_load_old_checkpoint():
     predictor.fit(
         dataset.train_df,
         presets="multilingual",
-        time_limit=10,
+        time_limit=30,
         hyperparameters={"optimization.top_k_average_method": "uniform_soup"},
     )
     verify_predictor_save_load(predictor, dataset.test_df)


### PR DESCRIPTION
*Issue #1969 *

1. Support generating random paths in continuous training if `save_path` is not specified.
2. Avoid overwriting if old paths are detected.
3. Add unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
