### PR TITLE
Fix timeseries failing silently on irregularly sampled time series

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -468,7 +468,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         except Exception as err:  # noqa
             raise IOError(f"Could not load pickled data set due to error: {str(err)}")
 
-    def get_reindexed_view(self, freq: str = "s") -> TimeSeriesDataFrame:
+    def get_reindexed_view(self, freq: str = "S") -> TimeSeriesDataFrame:
         """Returns a new TimeSeriesDataFrame object with the same underlying data and
         static features as the current data frame, except the time index is replaced by
         a new "dummy" time series index with the given frequency. This is useful when

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -39,6 +39,7 @@ class SimpleGluonTSDataset(GluonTSDataset):
         target_field_name: str = "target",
     ):
         assert time_series_df is not None
+        assert time_series_df.freq, "Initializing GluonTS data sets without freq is not allowed"
         self.time_series_df = time_series_df
         self.target_field_name = target_field_name
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -158,7 +158,8 @@ class TimeSeriesPredictor:
             raise ValueError(
                 "Frequency not provided and cannot be inferred. This is often due to the "
                 "time index of the data being irregularly sampled. Please ensure that the "
-                "data set used has a uniform time index."
+                "data set used has a uniform time index, or create the `TimeSeriesPredictor` "
+                "setting `ignore_time_index=True`."
             )
         return df
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -2,7 +2,7 @@ import logging
 import pprint
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 
@@ -84,6 +84,11 @@ class TimeSeriesPredictor:
         If ``path`` and ``eval_metric`` are re-specified within ``learner_kwargs``, these are ignored.
     quantiles: List[float]
         Alias for :attr:`quantile_levels`.
+    ignore_time_index: bool, default = False
+        If True, AutoGluon-TimeSeries will ignore any date time indexes given in any dataset in train and test time,
+        and replace any input data indexes with dummy timestamps in second frequency. In this case, sktime models
+        will not activate any seasonality inference if not specified explicitly in ``hyperparameters``, and the
+        forecast output time indexes will be arbitrary values.
 
     Attributes
     ----------
@@ -109,6 +114,7 @@ class TimeSeriesPredictor:
         set_logger_verbosity(self.verbosity, logger=logger)
         self.path = setup_outputdir(path)
 
+        self.ignore_time_index = kwargs.get("ignore_time_index", False)
         if target is not None and kwargs.get("label") is not None:
             raise ValueError(
                 "Both `label` and `target` are specified. Please specify at most one of these. " "arguments."
@@ -139,6 +145,26 @@ class TimeSeriesPredictor:
     @property
     def _trainer(self) -> AbstractTimeSeriesTrainer:
         return self._learner.load_trainer()  # noqa
+
+    def _check_and_prepare_data_frames(self, *args) -> Iterable[TimeSeriesDataFrame]:
+        """Given a sequence of ``TimeSeriesDataFrame``s, replace their time indexes if
+        ``self.ignore_time_index`` is set, and ensure their frequencies are available.
+        """
+        data_frames = []
+        for df in args:
+            if df is None:
+                data_frames.append(None)
+            else:
+                if self.ignore_time_index:
+                    df = df.get_reindexed_view(freq="s")
+                if df.freq is None:
+                    raise ValueError(
+                        "Frequency not provided and cannot be inferred. This is often due to the "
+                        "time index of the data being irregularly sampled. Please ensure that the "
+                        "data set used has a uniform time index."
+                    )
+                data_frames.append(df)
+        return data_frames
 
     @apply_presets(TIMESERIES_PRESETS_CONFIGS)
     def fit(
@@ -218,6 +244,8 @@ class TimeSeriesPredictor:
             raise ValueError(f"Target column `{self.target}` not found in the tuning data set.")
         if hyperparameters is None:
             hyperparameters = "default"
+
+        train_data, tuning_data = self._check_and_prepare_data_frames(train_data, tuning_data)
 
         verbosity = kwargs.get("verbosity", self.verbosity)
         set_logger_verbosity(verbosity, logger=logger)
@@ -342,6 +370,7 @@ class TimeSeriesPredictor:
             Name of the model that you would like to use for forecasting. If None, it will by default use the
             best model from trainer.
         """
+        (data,) = self._check_and_prepare_data_frames(data)
         return self._learner.predict(data, model=model, **kwargs)
 
     def evaluate(self, data: TimeSeriesDataFrame, **kwargs):
@@ -369,7 +398,7 @@ class TimeSeriesPredictor:
             A forecast accuracy score, where higher values indicate better quality. For consistency, error metrics
             will have their signs flipped to obey this convention. For example, negative MAPE values will be reported.
         """
-
+        (data,) = self._check_and_prepare_data_frames(data)
         return self._learner.score(data, **kwargs)
 
     def score(self, data: TimeSeriesDataFrame, **kwargs):
@@ -450,6 +479,7 @@ class TimeSeriesPredictor:
             The leaderboard containing information on all models and in order of best model to worst in terms of
             validation performance.
         """
+        (data,) = self._check_and_prepare_data_frames(data)
         leaderboard = self._learner.leaderboard(data)
         if not silent:
             with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 1000):

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -156,7 +156,7 @@ class TimeSeriesPredictor:
                 data_frames.append(None)
             else:
                 if self.ignore_time_index:
-                    df = df.get_reindexed_view(freq="s")
+                    df = df.get_reindexed_view(freq="S")
                 if df.freq is None:
                     raise ValueError(
                         "Frequency not provided and cannot be inferred. This is often due to the "

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -290,10 +290,10 @@ def test_given_irregular_time_series_when_predictor_called_with_ignore_then_trai
     )
     predictor.fit(
         train_data=df,
-        hyperparameters={"SimpleFeedForward": {"epochs": 1}},
+        hyperparameters={"DeepAR": {"epochs": 1}},
         tuning_data=df,
     )
-    assert "SimpleFeedForward" in predictor.get_model_names()
+    assert "DeepAR" in predictor.get_model_names()
 
 
 def test_given_irregular_time_series_and_no_tuning_when_predictor_called_with_ignore_then_training_is_performed(
@@ -308,7 +308,6 @@ def test_given_irregular_time_series_and_no_tuning_when_predictor_called_with_ig
     predictor.fit(
         train_data=df,
         hyperparameters={"SimpleFeedForward": {"epochs": 1}},
-        # tuning_data=df,
     )
     assert "SimpleFeedForward" in predictor.get_model_names()
 

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -220,7 +220,9 @@ def test_subsequence(start_timestamp, end_timestamp, item_ids, datetimes, target
         (["2020-01-01 00:00:00", "2020-01-01 01:00:00", "2020-01-01 02:00:00"], "H"),
     ],
 )
-def test_when_dataset_constructed_from_dataframe_without_freq_then_freq_is_inferred(timestamps, expected_freq):
+def test_when_dataset_constructed_from_dataframe_without_freq_then_freq_is_inferred(
+    timestamps, expected_freq
+):
     df = pd.DataFrame(
         {
             "item_id": [0, 0, 0],
@@ -245,7 +247,9 @@ FREQ_TEST_CASES = [
 
 
 @pytest.mark.parametrize("start_time, freq", FREQ_TEST_CASES)
-def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(start_time, freq):
+def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(
+    start_time, freq
+):
     item_list = ListDataset(
         [{"target": [1, 2, 3], "start": pd.Timestamp(start_time)} for _ in range(3)],  # type: ignore
         freq=freq,
@@ -257,7 +261,9 @@ def test_when_dataset_constructed_from_iterable_with_freq_then_freq_is_inferred(
 
 
 @pytest.mark.parametrize("start_time, freq", FREQ_TEST_CASES)
-def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferred(start_time, freq):
+def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferred(
+    start_time, freq
+):
     item_list = ListDataset(
         [{"target": [1, 2, 3], "start": pd.Timestamp(start_time, freq=freq)} for _ in range(3)],  # type: ignore
         freq=freq,
@@ -268,7 +274,6 @@ def test_when_dataset_constructed_via_constructor_with_freq_then_freq_is_inferre
     assert ts_df.freq == freq
 
 
-@pytest.mark.skip("Skipped until re-enabling regularity check.")
 @pytest.mark.parametrize(
     "list_of_timestamps",
     [
@@ -300,8 +305,9 @@ def test_when_dataset_constructed_with_irregular_timestamps_then_constructor_rai
 
     df = pd.DataFrame(df_tuples, columns=[ITEMID, TIMESTAMP, "target"])
 
-    with pytest.raises(ValueError, match="uniformly sampled"):
-        TimeSeriesDataFrame.from_data_frame(df)
+    with pytest.raises(ValueError, match="irregularly sampled"):
+        tsdf = TimeSeriesDataFrame.from_data_frame(df)
+        _ = tsdf.freq
 
 
 SAMPLE_ITERABLE_2 = [
@@ -422,7 +428,9 @@ def test_when_dataframe_class_copy_called_then_output_correct(input_df):
 @pytest.mark.parametrize("input_df", [SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY])
 @pytest.mark.parametrize("inplace", [True, False])
 def test_when_dataframe_class_rename_called_then_output_correct(input_df, inplace):
-    renamed_df = TimeSeriesDataFrame.rename(input_df, columns={"target": "mytarget"}, inplace=inplace)
+    renamed_df = TimeSeriesDataFrame.rename(
+        input_df, columns={"target": "mytarget"}, inplace=inplace
+    )
     if inplace:
         renamed_df = input_df
 

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -311,7 +311,7 @@ def test_when_dataset_constructed_via_constructor_with_freq_and_persisted_then_c
         ],
     ],
 )
-def test_when_dataset_constructed_with_irregular_timestamps_then_freq_call_raises_error(
+def test_when_dataset_constructed_with_irregular_timestamps_then_freq_call_returns_none(
     list_of_timestamps,
 ):
     df_tuples = []
@@ -321,9 +321,8 @@ def test_when_dataset_constructed_with_irregular_timestamps_then_freq_call_raise
 
     df = pd.DataFrame(df_tuples, columns=[ITEMID, TIMESTAMP, "target"])
 
-    with pytest.raises(ValueError, match="irregularly sampled"):
-        tsdf = TimeSeriesDataFrame.from_data_frame(df)
-        _ = tsdf.freq
+    tsdf = TimeSeriesDataFrame.from_data_frame(df)
+    assert tsdf.freq is None
 
 
 SAMPLE_ITERABLE_2 = [
@@ -632,3 +631,8 @@ def test_when_dataframe_sliced_by_item_array_then_static_features_stay_consisten
 
     assert set(left.static_features.index) == set(left_index)
     assert set(right.static_features.index) == set(right_index)
+
+
+def test_when_dataframe_reindexed_view_called_then_static_features_stay_consistent():
+    view = SAMPLE_TS_DATAFRAME_STATIC.get_reindexed_view()
+    assert view._static_features is SAMPLE_TS_DATAFRAME_STATIC._static_features


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

AG-TS failed silently on irregularly sampled time series that also can't be inferred as business day-frequency by pandas. As we depend on pandas for frequency inference, this will continue to be the case. However, we can also add a `fit` argument to the predictor called `ignore_time_indexes` to enable customers using irregular timestamps as is (as if they are irregularly sampled), but this would somewhat break API semantics during predict (where a "dummy" time index will be output). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## TODO

- [x] add `ignore_time_indexes` logic to `TimeSeriesPredictor` and corresponding view logic to data frames
- [x] add unit tests.
