### PR TITLE
Fix KNN skex bug

### DIFF
--- a/tabular/src/autogluon/tabular/models/knn/_knn_loo_variants.py
+++ b/tabular/src/autogluon/tabular/models/knn/_knn_loo_variants.py
@@ -4,7 +4,6 @@ logger = logging.getLogger(__name__)
 
 import numpy as np
 from scipy import stats
-from sklearn.neighbors import KNeighborsClassifier as _KNeighborsClassifier, KNeighborsRegressor as _KNeighborsRegressor
 from sklearn.neighbors._base import _get_weights
 from sklearn.utils.extmath import weighted_mode
 
@@ -14,10 +13,11 @@ from sklearn.utils.extmath import weighted_mode
 # TODO: Code is largely identical to `predict` and `predict_proba` methods, but due to how those methods are coded, we can't call them directly.
 #  This means if code within those methods changes, the LOO equivalents may start to become outdated.
 
-__all__ = ['KNeighborsClassifier', 'KNeighborsRegressor']
+__all__ = ['KNeighborsClassifierLOOMixin', 'KNeighborsRegressorLOOMixin']
 
 
-class KNeighborsClassifier(_KNeighborsClassifier):
+class KNeighborsClassifierLOOMixin:
+    @staticmethod
     def predict_loo(self):
         """Predict the class labels for the training data via leave-one-out.
 
@@ -53,6 +53,7 @@ class KNeighborsClassifier(_KNeighborsClassifier):
 
         return y_pred
 
+    @staticmethod
     def predict_proba_loo(self):
         """Return probability estimates for the training data via leave-one-out.
 
@@ -101,7 +102,8 @@ class KNeighborsClassifier(_KNeighborsClassifier):
         return probabilities
 
 
-class KNeighborsRegressor(_KNeighborsRegressor):
+class KNeighborsRegressorLOOMixin:
+    @staticmethod
     def predict_loo(self):
         """Predict the target for the training data via leave-one-out.
 

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -6,7 +6,7 @@ import psutil
 import time
 
 from autogluon.common.features.types import R_INT, R_FLOAT, S_BOOL
-from autogluon.core.constants import REGRESSION
+from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
 from autogluon.core.utils import get_cpu_count
 from autogluon.core.utils.exceptions import NotEnoughMemoryError
 from autogluon.core.models import AbstractModel
@@ -35,11 +35,7 @@ class KNNModel(AbstractModel):
                 logger.log(15, '\tUsing sklearnex KNN backend...')
             except:
                 pass
-        try:
-            from ._knn_loo_variants import KNeighborsClassifier, KNeighborsRegressor
-        except:
-            from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
-            logger.warning('WARNING: Leave-one-out variants of KNN failed to import. Falling back to standard KNN implementations.')
+        from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
         if self.problem_type == REGRESSION:
             return KNeighborsRegressor
         else:
@@ -136,12 +132,11 @@ class KNNModel(AbstractModel):
         return y_oof_pred_proba
 
     def _get_oof_pred_proba(self, X, **kwargs):
-        if callable(getattr(self.model, "predict_proba_loo", None)):
-            y_oof_pred_proba = self.model.predict_proba_loo()
-        elif callable(getattr(self.model, "predict_loo", None)):
-            y_oof_pred_proba = self.model.predict_loo()
+        from ._knn_loo_variants import KNeighborsClassifierLOOMixin, KNeighborsRegressorLOOMixin
+        if self.problem_type in [BINARY, MULTICLASS]:
+            y_oof_pred_proba = KNeighborsClassifierLOOMixin.predict_proba_loo(self.model)
         else:
-            raise AssertionError(f'Model class {type(self.model)} does not support out-of-fold prediction generation.')
+            y_oof_pred_proba = KNeighborsRegressorLOOMixin.predict_loo(self.model)
         y_oof_pred_proba = self._convert_proba_to_unified_form(y_oof_pred_proba)
         if X is not None and self._X_unused_index:
             X_unused = X.iloc[self._X_unused_index]

--- a/tabular/src/autogluon/tabular/models/knn/knn_model.py
+++ b/tabular/src/autogluon/tabular/models/knn/knn_model.py
@@ -28,14 +28,13 @@ class KNNModel(AbstractModel):
         if self.params_aux.get('use_daal', True):
             try:
                 # TODO: Add more granular switch, currently this affects all future KNN models even if they had `use_daal=False`
-                from sklearnex import patch_sklearn
-                patch_sklearn("knn_classifier")
-                patch_sklearn("knn_regressor")
+                from sklearnex.neighbors import KNeighborsClassifier, KNeighborsRegressor
                 # sklearnex backend for KNN seems to be 20-40x+ faster than native sklearn with no downsides.
                 logger.log(15, '\tUsing sklearnex KNN backend...')
             except:
-                pass
-        from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+                from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
+        else:
+            from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
         if self.problem_type == REGRESSION:
             return KNeighborsRegressor
         else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
KNN will crash when predicting if loaded in a separate process after fitting if using scikit-learn-intelex backend. This PR fixes this issue by avoiding creating a new KNN class for efficient LOO and instead directly using the intelex knn class and not patching.

Colab notebook showcasing fix: https://colab.research.google.com/drive/1RQpmftn51jdmrwA1KxUTRPkMdIt27uyH?usp=sharing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
