### PR TITLE
Improve sktime models API

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -48,6 +48,7 @@ DEFAULT_MODEL_PRIORITY = dict(
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 
 
+# TODO: Should we include TBATS to the presets?
 def get_default_hps(key, prediction_length):
     default_model_hps = {
         "toy": {
@@ -58,7 +59,7 @@ def get_default_hps(key, prediction_length):
             },
             "Transformer": {"epochs": 10, "num_batches_per_epoch": 10, "context_length": 5},
             "DeepAR": {"epochs": 10, "num_batches_per_epoch": 10, "context_length": 5},
-            "AutoETS": {"maxiter": 20, "seasonality": None},
+            "AutoETS": {"maxiter": 20, "seasonal": None},
             "ARIMA": {
                 "maxiter": 10,
                 "order": (1, 0, 0),
@@ -70,7 +71,7 @@ def get_default_hps(key, prediction_length):
             "AutoETS": {
                 "maxiter": 200,
                 "trend": "add",
-                "seasonality": "add",
+                "seasonal": "add",
                 "auto": False,
                 "initialization_method": "heuristic",
             },
@@ -108,14 +109,14 @@ def get_default_hps(key, prediction_length):
             "AutoETS": {
                 "error": ag.Categorical("add", "mul"),
                 "trend": ag.Categorical("add", "mul"),
-                "seasonality": ag.Categorical("add", "mul", None),
+                "seasonal": ag.Categorical("add", "mul", None),
                 "auto": False,
                 "initialization_method": "estimated",
                 "maxiter": 200,
                 "fail_if_misconfigured": True,
             },
             "ARIMA": {
-                "maxiter": ag.Categorical(50),
+                "maxiter": 50,
                 "order": ag.Categorical((1, 1, 1), (2, 0, 1)),
                 "seasonal_order": ag.Categorical((1, 0, 0), (1, 0, 1), (1, 1, 1)),
                 "suppress_warnings": True,

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -58,10 +58,11 @@ def get_default_hps(key, prediction_length):
             },
             "Transformer": {"epochs": 10, "num_batches_per_epoch": 10, "context_length": 5},
             "DeepAR": {"epochs": 10, "num_batches_per_epoch": 10, "context_length": 5},
-            "AutoETS": {"maxiter": 20},
+            "AutoETS": {"maxiter": 20, "seasonality": None},
             "ARIMA": {
                 "maxiter": 10,
                 "order": (1, 0, 0),
+                "seasonal_order": (0, 0, 0),
                 "suppress_warnings": True,
             },
         },
@@ -69,13 +70,14 @@ def get_default_hps(key, prediction_length):
             "AutoETS": {
                 "maxiter": 200,
                 "trend": "add",
+                "seasonality": "add",
                 "auto": False,
-                "initialization_method": "estimated",
+                "initialization_method": "heuristic",
             },
             "ARIMA": {
                 "maxiter": 50,
                 "order": (1, 1, 1),
-                "seasonal_order": (0, 0, 0, 0),
+                "seasonal_order": (1, 0, 0),
                 "suppress_warnings": True,
             },
             "SimpleFeedForward": {
@@ -106,15 +108,18 @@ def get_default_hps(key, prediction_length):
             "AutoETS": {
                 "error": ag.Categorical("add", "mul"),
                 "trend": ag.Categorical("add", "mul"),
+                "seasonality": ag.Categorical("add", "mul", None),
                 "auto": False,
                 "initialization_method": "estimated",
                 "maxiter": 200,
+                "fail_if_misconfigured": True,
             },
             "ARIMA": {
                 "maxiter": ag.Categorical(50),
-                "order": (1, 1, 1),
-                "seasonal_order": (0, 0, 0, 0),
+                "order": ag.Categorical((1, 1, 1), (2, 0, 1)),
+                "seasonal_order": ag.Categorical((1, 0, 0), (1, 0, 1), (1, 1, 1)),
                 "suppress_warnings": True,
+                "fail_if_misconfigured": True,
             },
         },
     }

--- a/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
@@ -70,14 +70,9 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
         self.sktime_forecaster: Optional[BaseForecaster] = None
         self._fit_index: Optional[pd.Index] = None
 
-    def _get_sktime_forecaster_init_args(
-        self, model_params: Dict[str, Any], min_length: int, inferred_period: int = 1
-    ):
-        """Get arguments that will be passed to the sktime forecaster at initialization.
-
-        model_params may be modified in-place based on the length of training series and inferred seasonality.
-        """
-        return model_params
+    def _get_sktime_forecaster_init_args(self, min_length: int, inferred_period: int = 1):
+        """Get arguments that will be passed to the sktime forecaster at initialization."""
+        return self._get_model_params().copy()
 
     def _get_sktime_forecaster(self, sktime_forecaster_init_args: dict) -> BaseForecaster:
         """Create an sktime forecaster object for the model with given args."""
@@ -135,7 +130,7 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
         min_length = train_data.index.get_level_values(0).value_counts(sort=False).min()
         inferred_period = get_seasonality(train_data.freq)
         sktime_forecaster_init_args = self._get_sktime_forecaster_init_args(
-            model_params=self._get_model_params().copy(), min_length=min_length, inferred_period=inferred_period
+            min_length=min_length, inferred_period=inferred_period
         )
         self.sktime_forecaster = self._get_sktime_forecaster(sktime_forecaster_init_args)
 

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -33,57 +33,6 @@ TESTABLE_MODELS = [
 ]
 
 
-@pytest.mark.parametrize(
-    "model_class, sktime_forecaster_class, good_params, bad_params",
-    [
-        (
-            ThetaModel,
-            ThetaForecaster,
-            dict(sp=2),
-            dict(some_bad_param="A"),
-        ),
-        (
-            AutoARIMAModel,
-            AutoARIMA,
-            dict(sp=2, max_q=4),
-            dict(some_bad_param="A", some_other_bad_param=10),
-        ),
-        (
-            ARIMAModel,
-            ARIMA,
-            dict(order=(1, 1, 1)),
-            dict(some_bad_param="A", some_other_bad_param=10),
-        ),
-        (
-            TBATSModel,
-            TBATS,
-            dict(use_box_cox=False),
-            dict(some_bad_param="A", some_other_bad_param=10),
-        ),
-        (
-            AutoETSModel,
-            AutoETS,
-            dict(error="mul", trend=None),
-            dict(some_bad_param="A"),
-        ),
-    ],
-)
-def test_when_sktime_models_fitted_then_allowed_hyperparameters_are_passed_to_sktime_forecasters(
-    model_class, sktime_forecaster_class, good_params, bad_params
-):
-    hyperparameters = good_params.copy()
-    hyperparameters.update(bad_params)
-    model = model_class(hyperparameters=hyperparameters)
-
-    with mock.patch.object(target=sktime_forecaster_class, attribute="__init__") as const_mock:
-        try:
-            model.fit(train_data=DUMMY_TS_DATAFRAME)
-        except TypeError:
-            pass
-        finally:
-            const_mock.assert_called_with(**good_params)
-
-
 def test_when_sktime_converts_dataframe_then_data_not_duplicated_and_index_correct():
     model = AutoETSModel()
 

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -37,55 +37,55 @@ def test_when_sktime_converts_dataframe_then_data_not_duplicated_and_index_corre
     model = AutoETSModel()
 
     df = DUMMY_TS_DATAFRAME.copy(deep=True)
-    skt_df = model._to_skt_data_frame(df)
+    sktime_df = model._to_sktime_data_frame(df)
 
-    assert isinstance(skt_df, pd.DataFrame)
-    assert not isinstance(skt_df, TimeSeriesDataFrame)
+    assert isinstance(sktime_df, pd.DataFrame)
+    assert not isinstance(sktime_df, TimeSeriesDataFrame)
 
-    assert len(df) == len(skt_df)
-    assert isinstance(skt_df.index.levels[-1], pd.PeriodIndex)
+    assert len(df) == len(sktime_df)
+    assert isinstance(sktime_df.index.levels[-1], pd.PeriodIndex)
     assert (
         a.to_timestamp() == b
         for a, b in zip(
-            skt_df.index.get_level_values(-1),
+            sktime_df.index.get_level_values(-1),
             df.index.get_level_values(-1),
         )
     )
 
     # data is not copied
-    assert df.values.base is skt_df.values.base
+    assert df.values.base is sktime_df.values.base
 
 
 def test_when_sktime_converts_from_dataframe_then_data_not_duplicated_and_index_correct():
     model = AutoETSModel()
 
-    skt_df = model._to_skt_data_frame(DUMMY_TS_DATAFRAME.copy(deep=True))
-    df = model._to_time_series_data_frame(skt_df)
+    sktime_df = model._to_sktime_data_frame(DUMMY_TS_DATAFRAME.copy(deep=True))
+    df = model._to_time_series_data_frame(sktime_df)
 
     assert isinstance(df, TimeSeriesDataFrame)
     assert isinstance(df.index.levels[-1], pd.DatetimeIndex)
     assert (
         a.to_timestamp() == b
         for a, b in zip(
-            skt_df.index.get_level_values(-1),
+            sktime_df.index.get_level_values(-1),
             df.index.get_level_values(-1),
         )
     )
 
     # data is not copied
-    assert df.values.base is skt_df.values.base
+    assert df.values.base is sktime_df.values.base
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_skt_models_saved_then_forecasters_can_be_loaded(model_class, temp_model_path):
+def test_when_sktime_models_saved_then_forecasters_can_be_loaded(model_class, temp_model_path):
     model = model_class()
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     model.save()
 
     loaded_model = model.__class__.load(path=model.path)
 
-    assert isinstance(model.skt_forecaster, loaded_model.skt_forecaster.__class__)
-    assert repr(loaded_model.skt_forecaster) == repr(model.skt_forecaster)
+    assert isinstance(model.sktime_forecaster, loaded_model.sktime_forecaster.__class__)
+    assert repr(loaded_model.sktime_forecaster) == repr(model.sktime_forecaster)
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
@@ -162,4 +162,4 @@ def test_when_fit_called_with_then_seasonality_period_set_correctly(
 
     model.fit(train_data=train_data)
 
-    assert model.skt_forecaster.sp == expected_sp
+    assert model.sktime_forecaster.sp == expected_sp


### PR DESCRIPTION
This PR fixes several problems with `sktime` models (`ThetaModel`, `TBATSModel`, `AutoETSModel`, `ARIMAModel`, `AutoARIMAModel`) in the timeseries module:
- Suppress `RuntimeWarning`s during prediction that flooded the model output in some cases.
- Add docstrings for `sktime` models. These describe the possible hyperparameters that can be passed to the models.
- A warning is made if user provides a hyperparameter that isn't recognized by the model.
- New method `AbstractSktimeModel._get_skt_forecaster_init_args` 
  - allows us to decouple the API exposed to AG users (via `hyperparameters`) from the API of `sktime` that sometimes uses inconsistent / cryptic parameter names.
  - gives us flexibility to change the hyperparameters in some cases to make the model more robust (e.g., turn off seasonality if we know that the model will fail with the current config).
- Improve seasonality support
  - All `sktime` models now exposes a `Optional[int]` hyperparameter `seasonal_period`. When `seasonal_period=None` (default), the seasonal period will be inferred automatically from the data.
  - User can now turn off seasonality and override the seasonal period for different models (before seasonality couldn't be turned off, `sp` was always inferred automatically)
  - `ARIMA` now also supports seasonality.
- Replace all occurrences of `*skt_*` with `*sktime_*` for better consistency.


Discussion points
1. Is decoupling the AG API from `sktime` API worth it or can it have some potential side effects?

To do
- [x] Add tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
