### PR TITLE
Remove mxnet install in platform tests

### DIFF
--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -197,4 +197,7 @@ jobs:
       - name: unit-test
         shell: bash -l {0}
         run: |
-          chmod +x ./.github/workflow_scripts/test_install.sh && ./.github/workflow_scripts/test_install.sh
+          # test_install.sh script will install mxnet, which doesn't work on Windows.
+          source .github/workflow_scripts/env_setup.sh
+          setup_build_env
+          install_all


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* https://github.com/awslabs/autogluon/pull/1991 unified the script being used by CI and platform tests but introduced an issue. mxnet cannot be installed on Windows; hence failing install test. 
* Changes will only take effect after merging in

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
