### PR TITLE
Multi-window backtesting for TimeSeriesPredictor

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -208,11 +208,13 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if df[TIMESTAMP].isnull().any():
             raise ValueError(f"`{TIMESTAMP}` column can not have nan")
         if not df[TIMESTAMP].dtype == "datetime64[ns]":
-            raise ValueError(f"for {TIMESTAMP}, the only pandas dtype allowed is ‘datetime64[ns]’.")
-
-        # TODO: check if time series are irregularly sampled. this check was removed as
-        # TODO: pandas is inconsistent in identifying freq when period-end timestamps
-        # TODO: are provided.
+            raise ValueError(f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64[ns]`.")
+        item_id_column = df[ITEMID]
+        # workaround for pd.api.types.is_string_dtype issue https://github.com/pandas-dev/pandas/issues/15585
+        item_id_is_string = (item_id_column == item_id_column.astype(str)).all()
+        item_id_is_int = pd.api.types.is_integer_dtype(item_id_column)
+        if not (item_id_is_string or item_id_is_int):
+            raise ValueError(f"all entries in column `{ITEMID}` must be of integer or string dtype")
 
     @classmethod
     def _validate_multi_index_data_frame(cls, data: pd.DataFrame):
@@ -229,9 +231,15 @@ class TimeSeriesDataFrame(pd.DataFrame):
         if not isinstance(data.index, pd.MultiIndex):
             raise ValueError(f"data must have pd.MultiIndex, got {type(data.index)}")
         if not data.index.dtypes.array[1] == "datetime64[ns]":
-            raise ValueError(f"for {TIMESTAMP}, the only pandas dtype allowed is ‘datetime64[ns]’.")
+            raise ValueError(f"for {TIMESTAMP}, the only pandas dtype allowed is `datetime64[ns]`.")
         if not data.index.names == (f"{ITEMID}", f"{TIMESTAMP}"):
             raise ValueError(f"data must have index names as ('{ITEMID}', '{TIMESTAMP}'), got {data.index.names}")
+        item_id_index = data.index.get_level_values(level=ITEMID)
+        # workaround for pd.api.types.is_string_dtype issue https://github.com/pandas-dev/pandas/issues/15585
+        item_id_is_string = (item_id_index == item_id_index.astype(str)).all()
+        item_id_is_int = pd.api.types.is_integer_dtype(item_id_index)
+        if not (item_id_is_string or item_id_is_int):
+            raise ValueError(f"all entries in index `{ITEMID}` must be of integer or string dtype")
 
     @classmethod
     def _construct_pandas_frame_from_iterable_dataset(cls, iterable_dataset: Iterable) -> pd.DataFrame:

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -313,9 +313,9 @@ class TimeSeriesPredictor:
         if tuning_data is None:
             logger.warning(
                 "Validation data is None. "
-                + self._splitter.describe_validation_strategy(prediction_length=self.prediction_length)
+                + self.validation_splitter.describe_validation_strategy(prediction_length=self.prediction_length)
             )
-            train_data, tuning_data = self._splitter.split(
+            train_data, tuning_data = self.validation_splitter.split(
                 ts_dataframe=train_data, prediction_length=self.prediction_length
             )
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -41,12 +41,12 @@ class TimeSeriesPredictor:
 
     Parameters
     ----------
-    target: str, default = "target"
+    target : str, default = "target"
         Name of column that contains the target values to forecast (i.e., numeric observations of the
         time series). This column must contain numeric values, and missing target values
         should be in a pandas compatible format:
         https://pandas.pydata.org/pandas-docs/stable/user_guide/missing_data.html
-    eval_metric: str, default = None
+    eval_metric : str, default = None
         Metric by which predictions will be ultimately evaluated on future test data. AutoGluon tunes hyperparameters
         in order to improve this metric on validation data, and ranks models (on validation data) according to this
         metric. Available options include: "MASE", "MAPE", "sMAPE", "mean_wQuantileLoss".
@@ -54,7 +54,7 @@ class TimeSeriesPredictor:
         If ``eval_metric is None``, it is set by default to "mean_wQuantileLoss".
         For more information about these options, see ``autogluon.timeseries.TimeSeriesEvaluator`` and GluonTS
         docs at https://ts.gluon.ai/api/gluonts/gluonts.evaluation.metrics.html
-    path: str, default = None
+    path : str, default = None
         Path to directory where models and intermediate outputs should be saved. If unspecified, a timestamped folder
         ``AutogluonModels/ag-[TIMESTAMP]`` will be created in the working directory to store all models.
     verbosity : int, default = 2
@@ -63,11 +63,11 @@ class TimeSeriesPredictor:
         If using ``logging``, you can alternatively control amount of information printed via ``logger.setLevel(L)``,
         where ``L`` ranges from 0 to 50 (Note: higher values of ``L`` correspond to fewer print statements,
         opposite of verbosity levels).
-    prediction_length: int, default = 1
+    prediction_length : int, default = 1
         The forecast horizon, i.e., How many time points into the future forecasters should be trained to predict.
         For example, if time series contain daily observations, setting ``prediction_length=3`` will train
         models that predict up to 3 days in the future from the most recent observation.
-    quantile_levels: List[float], default = None
+    quantile_levels : List[float], default = None
         List of increasing decimals that specifies which quantiles should be estimated
         when making distributional forecasts. Can alternatively be provided with the keyword
         argument ``quantiles``. If ``None``, defaults to ``[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]``.
@@ -77,34 +77,32 @@ class TimeSeriesPredictor:
     learner_type : AbstractLearner, default = TimeSeriesLearner
         A class which inherits from ``AbstractLearner``. The learner specifies the inner logic of the
         ``TimeSeriesPredictor``.
-    label: str
+    label : str
         Alias for :attr:`target`.
     learner_kwargs : dict, default = None
         Keyword arguments to send to the learner (for advanced users only). Options include ``trainer_type``, a
         class inheriting from ``AbstractTrainer`` which controls training of multiple models.
         If ``path`` and ``eval_metric`` are re-specified within ``learner_kwargs``, these are ignored.
-    quantiles: List[float]
+    quantiles : List[float]
         Alias for :attr:`quantile_levels`.
-    ignore_time_index: bool, default = False
+    ignore_time_index : bool, default = False
         If True, AutoGluon-TimeSeries will ignore any date time indexes given in any dataset in train and test time,
         and replace any input data indexes with dummy timestamps in second frequency. In this case, sktime models
         will not activate any seasonality inference if not specified explicitly in ``hyperparameters``, and the
         forecast output time indexes will be arbitrary values.
-    validation_splitter: Union[str, AbstractTimeSeriesSplitter], default = "last_window"
+    validation_splitter : Union[str, AbstractTimeSeriesSplitter], default = "last_window"
         Strategy for splitting ``train_data`` into trainining and validation parts during
         :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit`. If ``tuning_data`` is passed to
         :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit`, validation_splitter is ignored. Possible choices:
 
         - ``"last_window"`` - use last ``prediction_length`` time steps of each time series for validation.
-        - ``"multi_window"`` - use last 3 non-overlapping windows of length ``prediction_length`` of each time series
-            for validation.
-        - object of type :class:`~autogluon.timeseries.splitter.AbstractTimeSeriesSplitter` implementing a custom
-            splitting strategy (for advanced users only).
+        - ``"multi_window"`` - use last 3 non-overlapping windows of length ``prediction_length`` of each time series for validation.
+        - object of type :class:`~autogluon.timeseries.splitter.AbstractTimeSeriesSplitter` implementing a custom splitting strategy (for advanced users only).
 
 
     Attributes
     ----------
-    target: str
+    target : str
         Name of column in training/validation data that contains the target time-series value to be predicted. If
         not specified explicitly during :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit`, this will default to
         ``"target"``.
@@ -203,9 +201,9 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        train_data: TimeSeriesDataFrame
+        train_data : TimeSeriesDataFrame
             Training data in the :class:`~autogluon.timeseries.TimeSeriesDataFrame` format.
-        tuning_data: TimeSeriesDataFrame, default = None
+        tuning_data : TimeSeriesDataFrame, default = None
             Data reserved for model selection and hyperparameter tuning, rather than training individual models. Also
             used to compute the validation scores. Note that only the last ``prediction_length`` time steps of each
             time series are used for computing the validation score.
@@ -214,11 +212,11 @@ class TimeSeriesPredictor:
             ``self.validation_splitter``. If ``tuning_data`` is provided, ``self.validation_splitter`` will be ignored.
             See the description of ``validation_splitter`` in the docstring for
             :class:`~autogluon.timeseries.TimeSeriesPredictor` for more details.
-        time_limit: int, default = None
+        time_limit : int, default = None
             Approximately how long :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` will run for (wall-clock
             time in seconds). If not specified, :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` will
             run until all models have completed training.
-        presets: str, default = None
+        presets : str, default = None
             Optional preset configurations for various arguments in
             :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit`.
 
@@ -236,7 +234,7 @@ class TimeSeriesPredictor:
             ``autogluon/timeseries/configs/presets_configs.py``. If not provided, user-provided values for other
             arguments (specifically, ``hyperparameters`` and ``hyperparameter_tune_kwargs`` will be used (defaulting
             to their default values specified below).
-        hyperparameters: str or dict, default = "default"
+        hyperparameters : str or dict, default = "default"
             Determines the hyperparameters used by each model.
             If str is passed, will use a preset hyperparameter configuration, can be one of "default", "default_hpo",
             "toy", or "toy_hpo", where "toy" settings correspond to models only intended for prototyping.
@@ -250,7 +248,7 @@ class TimeSeriesPredictor:
             hyperparameter-tuning is utilized). Any omitted hyperparameters not specified here will be set to default
             values which are given in``autogluon/timeseries/trainer/models/presets.py``. Specific hyperparameter
             choices for each of the recommended models can be found in the references.
-        hyperparameter_tune_kwargs: str or dict, default = None
+        hyperparameter_tune_kwargs : str or dict, default = None
             # TODO
 
         References
@@ -391,9 +389,9 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        data: TimeSeriesDataFrame
+        data : TimeSeriesDataFrame
             Time series data to forecast with.
-        model: str, default=None
+        model : str, default=None
             Name of the model that you would like to use for forecasting. If None, it will by default use the
             best model from trainer.
         """
@@ -406,22 +404,22 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        data: TimeSeriesDataFrame
+        data : TimeSeriesDataFrame
             The data to evaluate the best model on. The last ``prediction_length`` time steps of the
             data set, for each item, will be held out for prediction and forecast accuracy will be calculated
             on these time steps.
 
         Other Parameters
         ----------------
-        model: str, default=None
+        model : str, default=None
             Name of the model to predict with. If None, the best model during training (according to validation
             score) will be used for evaluation.
-        metric: str, default=None
+        metric : str, default=None
             Name of the evaluation metric to compute scores with. If None, defaults to ``self.eval_metric``
 
         Returns
         -------
-        score: float
+        score : float
             A forecast accuracy score, where higher values indicate better quality. For consistency, error metrics
             will have their signs flipped to obey this convention. For example, negative MAPE values will be reported.
         """
@@ -438,13 +436,13 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        path: str
+        path : str
             Path where the predictor was saved via
             :meth:`~autogluon.timeseries.TimeSeriesPredictor.save`.
 
         Returns
         -------
-        predictor: TimeSeriesPredictor
+        predictor : TimeSeriesPredictor
         """
         if not path:
             raise ValueError("`path` cannot be None or empty in load().")
@@ -494,7 +492,7 @@ class TimeSeriesPredictor:
 
         Parameters
         ----------
-        data: TimeSeriesDataFrame
+        data : TimeSeriesDataFrame
             dataset used for additional evaluation. If None, the validation set used during training will
             be used.
         silent : bool, default = False
@@ -502,7 +500,7 @@ class TimeSeriesPredictor:
 
         Returns
         -------
-        leaderboard: pandas.DataFrame
+        leaderboard : pandas.DataFrame
             The leaderboard containing information on all models and in order of best model to worst in terms of
             validation performance.
         """
@@ -524,7 +522,7 @@ class TimeSeriesPredictor:
 
         Returns
         -------
-        summary_dict: Dict[str, Any]
+        summary_dict : Dict[str, Any]
             Dict containing various detailed information. We do not recommend directly printing this dict as it may
             be very large.
         """

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -70,11 +70,11 @@ def append_suffix_to_item_id(ts_dataframe: TimeSeriesDataFrame, suffix: str) -> 
 class MultiWindowSplitter(AbstractTimeSeriesSplitter):
     """Slide window from the end of each series to generate validation series.
 
-    The first valdation series contains the entire series (i.e. the last `prediction_length` elements are used for
-    computing the validation score). The end of each following validation series is moved `prediction_length - overlap`
-    steps to the left.
+    The first valdation series contains the entire series (i.e. the last ``prediction_length`` elements are used for
+    computing the validation score). The end of each following validation series is moved
+    ``prediction_length - overlap`` steps to the left.
 
-    The validation set has up to `self.num_windows` as many items as the input dataset (can have fewer items if some
+    The validation set has up to ``self.num_windows`` as many items as the input dataset (can have fewer items if some
     training series are too short to split into `self.num_windows` many windows).
 
     Example: input_series = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], prediction_length = 3, overlap = 1, num_windows = 2

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -51,6 +51,9 @@ class AbstractTimeSeriesSplitter:
     def name(self):
         return self.__class__.__name__
 
+    def __repr__(self):
+        return f"{self.name}()"
+
 
 def append_suffix_to_item_id(ts_dataframe: TimeSeriesDataFrame, suffix: str) -> TimeSeriesDataFrame:
     """Append a suffix to each item_id in a TimeSeriesDataFrame."""
@@ -64,7 +67,7 @@ def append_suffix_to_item_id(ts_dataframe: TimeSeriesDataFrame, suffix: str) -> 
     return result
 
 
-class SlidingWindowSplitter(AbstractTimeSeriesSplitter):
+class MultiWindowSplitter(AbstractTimeSeriesSplitter):
     """Slide window from the end of each series to generate validation series.
 
     The first valdation series contains the entire series (i.e. the last `prediction_length` elements are used for
@@ -182,7 +185,7 @@ class SlidingWindowSplitter(AbstractTimeSeriesSplitter):
         return train_data, pd.concat(validation_dataframes)
 
 
-class LastWindowSplitter(SlidingWindowSplitter):
+class LastWindowSplitter(MultiWindowSplitter):
     """Reserves the last prediction_length steps of each time series for validation."""
 
     def __init__(self):

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -1,22 +1,11 @@
-from typing import Optional, Tuple
+import logging
+from typing import Tuple
+
 import pandas as pd
 
 from .dataset import TimeSeriesDataFrame
 
-
-def append_suffix_to_item_id(ts_dataframe: TimeSeriesDataFrame, suffix: str) -> TimeSeriesDataFrame:
-    """Append a suffix to each item_id in a TimeSeriesDataFrame.
-
-    Returns a copy of the data, the original TimeSeriesDataFrame is not modified.
-    """
-
-    def add_suffix(multiindex_element):
-        item_id, timestamp = multiindex_element
-        return (f"{item_id}{suffix}", timestamp)
-
-    result = ts_dataframe.copy()
-    result.index = result.index.map(add_suffix)
-    return result
+logger = logging.getLogger(__name__)
 
 
 class AbstractTimeSeriesSplitter:
@@ -31,8 +20,8 @@ class AbstractTimeSeriesSplitter:
         the `item_id` of the input series, and `start` and `end` correspond to the slice parameters used to generate
         the validation series.
 
-        For example, the series `val_data.loc["0_slice(None, -10)"]` in the validation dataset can equivalently be
-        obtained as `ts_dataframe.loc[0].slice_by_timestep(slice(None, -10))`.
+        For example, the series `val_data.loc["0_[None:-10]"]` in the validation dataset can equivalently be
+        obtained as `ts_dataframe.loc[0][None:-10]`.
 
         Parameters
         ----------
@@ -55,23 +44,53 @@ class AbstractTimeSeriesSplitter:
     ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
         raise NotImplementedError
 
+    def describe_validation_strategy(self, prediction_length: int) -> None:
+        raise NotImplementedError
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+
+def append_suffix_to_item_id(ts_dataframe: TimeSeriesDataFrame, suffix: str) -> TimeSeriesDataFrame:
+    """Append a suffix to each item_id in a TimeSeriesDataFrame."""
+
+    def add_suffix(multiindex_element):
+        item_id, timestamp = multiindex_element
+        return (f"{item_id}{suffix}", timestamp)
+
+    result = ts_dataframe.copy(deep=False)
+    result.index = result.index.map(add_suffix)
+    return result
+
 
 class SlidingWindowSplitter(AbstractTimeSeriesSplitter):
     """Slide window from the end of each series to generate validation series.
 
-    Each val sequence has length `prediction_length`. We start by selecting the last `prediction_length` elements,
-    an then end of each following val seqience gets shifted by `prediction_length - overlap` steps to the left.
+    The first valdation series contains the entire series (i.e. the last `prediction_length` elements are used for
+    computing the validation score). The end of each following validation series is moved `prediction_length - overlap`
+    steps to the left.
 
     The validation set has up to `self.num_windows` as many items as the input dataset (can have fewer items if some
     training series are too short to split into `self.num_windows` many windows).
+
+    Example: input_series = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], prediction_length = 3, overlap = 1, num_windows = 2
+
+    Validation:
+        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]  # val score computed on [8, 9, 10]
+        [1, 2, 3, 4, 5, 6, 7, 8]  # val score computed on [6, 7, 8]
+
+    Train:
+        [1, 2, 3, 4, 5]  # train loss computed on [1, 2, 3, 4, 5]
+
 
     Parameters
     ----------
     num_windows: int
         Number of windows to generate from each time series in the dataset.
-    overlap: Optional[int], default = None
-        Number of steps shared between two consecutive validation windows. When set to None, overlap is set
-        automatically to `prediction_length // 2`.
+    overlap: int, default = 0
+        Number of steps shared between two consecutive validation windows. Can be used to increase the # of validation
+        windows while keeping more data for training.
 
     Example
     -------
@@ -91,7 +110,7 @@ class SlidingWindowSplitter(AbstractTimeSeriesSplitter):
                 1970-01-09       9
                 1970-01-10      10
         >>> splitter = SlidingWindowSplitter(num_windows=2, overlap=1)
-        >>> train_data, tuning_data = splitter.split(ts_dataframe, prediction_length=3)
+        >>> train_data, val_data = splitter.split(ts_dataframe, prediction_length=3)
         >>> print(train_data)
                                 target
         item_id timestamp
@@ -100,47 +119,62 @@ class SlidingWindowSplitter(AbstractTimeSeriesSplitter):
                 1970-01-03       3
                 1970-01-04       4
                 1970-01-05       5
-        >>> print(tuning_data)
-                                            target
-        item_id             timestamp
-        0_slice(None, None) 1970-01-01       1
-                            1970-01-02       2
-                            1970-01-03       3
-                            1970-01-04       4
-                            1970-01-05       5
-                            1970-01-06       6
-                            1970-01-07       7
-                            1970-01-08       8
-                            1970-01-09       9
-                            1970-01-10      10
-        0_slice(None, -2)   1970-01-01       1
-                            1970-01-02       2
-                            1970-01-03       3
-                            1970-01-04       4
-                            1970-01-05       5
-                            1970-01-06       6
-                            1970-01-07       7
-                            1970-01-08       8
+        >>> print(val_data)
+                                    target
+        item_id       timestamp
+        0_[None:None] 1970-01-01       1
+                      1970-01-02       2
+                      1970-01-03       3
+                      1970-01-04       4
+                      1970-01-05       5
+                      1970-01-06       6
+                      1970-01-07       7
+                      1970-01-08       8
+                      1970-01-09       9
+                      1970-01-10      10
+        0_[None:-2]   1970-01-01       1
+                      1970-01-02       2
+                      1970-01-03       3
+                      1970-01-04       4
+                      1970-01-05       5
+                      1970-01-06       6
+                      1970-01-07       7
+                      1970-01-08       8
     """
 
-    def __init__(self, num_windows: int, overlap: Optional[int] = None):
+    def __init__(self, num_windows: int, overlap: int = 0):
         self.num_windows = num_windows
         self.overlap = overlap
+
+    def describe_validation_strategy(self, prediction_length):
+        return (
+            f"Will use the last {self.num_windows} windows (each with prediction_length {prediction_length} "
+            f"time steps and overlap {self.overlap}) as a hold-out validation set."
+        )
 
     def _split(
         self, ts_dataframe: TimeSeriesDataFrame, prediction_length: int
     ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
-        if self.overlap is None:
-            overlap = prediction_length // 2
-        else:
-            overlap = self.overlap
-        step_size = prediction_length - overlap
-        validation_dataframes = [append_suffix_to_item_id(ts_dataframe, "_slice(None, None)")]
+        if self.overlap >= prediction_length:
+            raise ValueError(
+                f"SlidingWindowSplitter.overlap {self.overlap} must be < prediction_length {prediction_length}"
+            )
+        step_size = prediction_length - self.overlap
+
+        length_per_series = ts_dataframe.index.get_level_values(0).value_counts(sort=False)
+        num_total_validation_steps = prediction_length + step_size * (self.num_windows - 1)
+        num_too_short_series = (length_per_series <= num_total_validation_steps).sum()
+        if num_too_short_series > 0:
+            logger.warning(f"{num_too_short_series} are too short and won't appear in the training set")
+        if num_too_short_series == ts_dataframe.num_items:
+            raise ValueError(f"{self.name} produced an empty training set since all sequences are too short")
+
+        validation_dataframes = [append_suffix_to_item_id(ts_dataframe, "_[None:None]")]
 
         for window_idx in range(1, self.num_windows):
             ts_dataframe = ts_dataframe.slice_by_timestep(slice(None, -step_size))
             total_offset = step_size * window_idx
-            next_val_dataframe = append_suffix_to_item_id(ts_dataframe, f"_slice(None, {-total_offset})")
+            next_val_dataframe = append_suffix_to_item_id(ts_dataframe, f"_[None:{-total_offset}]")
             validation_dataframes.append(next_val_dataframe)
 
         train_data = ts_dataframe.slice_by_timestep(slice(None, -prediction_length))
@@ -149,7 +183,10 @@ class SlidingWindowSplitter(AbstractTimeSeriesSplitter):
 
 
 class LastWindowSplitter(SlidingWindowSplitter):
-    """Reserves the last prediction interval of each time series for validation."""
+    """Reserves the last prediction_length steps of each time series for validation."""
 
     def __init__(self):
         super().__init__(num_windows=1)
+
+    def describe_validation_strategy(self, prediction_length: int):
+        return f"Will use the last prediction_length {prediction_length} time steps as a hold-out validation set."

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -16,7 +16,7 @@ class AbstractTimeSeriesSplitter:
     ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
         """Split each series in the input dataset into one train and potentially multiple validation series.
 
-        The `item_id` of each validation series is a string of format `f"{idx}_slice({start}, {end})". Here `idx` is
+        The `item_id` of each validation series is a string of format `f"{idx}_[{start}:{end}]". Here `idx` is
         the `item_id` of the input series, and `start` and `end` correspond to the slice parameters used to generate
         the validation series.
 

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -16,12 +16,12 @@ class AbstractTimeSeriesSplitter:
     ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
         """Split each series in the input dataset into one train and potentially multiple validation series.
 
-        The `item_id` of each validation series is a string of format `f"{idx}_[{start}:{end}]". Here `idx` is
-        the `item_id` of the input series, and `start` and `end` correspond to the slice parameters used to generate
+        The ``item_id`` of each validation series is a string of format ``f"{idx}_[{start}:{end}]"``. Here ``idx`` is
+        the ``item_id`` of the input series, and ``start`` and ``end`` correspond to the slice parameters used to generate
         the validation series.
 
-        For example, the series `val_data.loc["0_[None:-10]"]` in the validation dataset can equivalently be
-        obtained as `ts_dataframe.loc[0][None:-10]`.
+        For example, the series ``val_data.loc["0_[None:-10]"]`` in the validation dataset can equivalently be
+        obtained as ``ts_dataframe.loc[0][None:-10]``.
 
         Parameters
         ----------
@@ -75,7 +75,7 @@ class MultiWindowSplitter(AbstractTimeSeriesSplitter):
     ``prediction_length - overlap`` steps to the left.
 
     The validation set has up to ``self.num_windows`` as many items as the input dataset (can have fewer items if some
-    training series are too short to split into `self.num_windows` many windows).
+    training series are too short to split into ``self.num_windows`` many windows).
 
     Example: input_series = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], prediction_length = 3, overlap = 1, num_windows = 2
 
@@ -89,7 +89,7 @@ class MultiWindowSplitter(AbstractTimeSeriesSplitter):
 
     Parameters
     ----------
-    num_windows: int
+    num_windows: int, default = 3
         Number of windows to generate from each time series in the dataset.
     overlap: int, default = 0
         Number of steps shared between two consecutive validation windows. Can be used to increase the # of validation
@@ -145,7 +145,7 @@ class MultiWindowSplitter(AbstractTimeSeriesSplitter):
                       1970-01-08       8
     """
 
-    def __init__(self, num_windows: int, overlap: int = 0):
+    def __init__(self, num_windows: int = 3, overlap: int = 0):
         self.num_windows = num_windows
         self.overlap = overlap
 

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -1,0 +1,155 @@
+from typing import Optional, Tuple
+import pandas as pd
+
+from .dataset import TimeSeriesDataFrame
+
+
+def append_suffix_to_item_id(ts_dataframe: TimeSeriesDataFrame, suffix: str) -> TimeSeriesDataFrame:
+    """Append a suffix to each item_id in a TimeSeriesDataFrame.
+
+    Returns a copy of the data, the original TimeSeriesDataFrame is not modified.
+    """
+
+    def add_suffix(multiindex_element):
+        item_id, timestamp = multiindex_element
+        return (f"{item_id}{suffix}", timestamp)
+
+    result = ts_dataframe.copy()
+    result.index = result.index.map(add_suffix)
+    return result
+
+
+class AbstractTimeSeriesSplitter:
+    """A class that handles train / validation splitting of timeseries datasets."""
+
+    def split(
+        self, ts_dataframe: TimeSeriesDataFrame, prediction_length: int
+    ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
+        """Split each series in the input dataset into one train and potentially multiple validation series.
+
+        The `item_id` of each validation series is a string of format `f"{idx}_slice({start}, {end})". Here `idx` is
+        the `item_id` of the input series, and `start` and `end` correspond to the slice parameters used to generate
+        the validation series.
+
+        For example, the series `val_data.loc["0_slice(None, -10)"]` in the validation dataset can equivalently be
+        obtained as `ts_dataframe.loc[0].slice_by_timestep(slice(None, -10))`.
+
+        Parameters
+        ----------
+        ts_dataframe: TimeSeriesDataFrame
+            Dataset containing of series that should be split.
+        prediction_length: int
+            The forecast horizon, i.e., how many time points into the future forecasters should be trained to predict.
+
+        Returns
+        -------
+        train_data: TimeSeriesDataFrame
+            Time series used for training. Has the same number of items as in the input dataset.
+        val_data: TimeSeriesDataFrame
+            Time series used for tuning / validation.
+        """
+        return self._split(ts_dataframe=ts_dataframe, prediction_length=prediction_length)
+
+    def _split(
+        self, ts_dataframe: TimeSeriesDataFrame, prediction_length: int
+    ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
+        raise NotImplementedError
+
+
+class SlidingWindowSplitter(AbstractTimeSeriesSplitter):
+    """Slide window from the end of each series to generate validation series.
+
+    Each val sequence has length `prediction_length`. We start by selecting the last `prediction_length` elements,
+    an then end of each following val seqience gets shifted by `prediction_length - overlap` steps to the left.
+
+    The validation set has up to `self.num_windows` as many items as the input dataset (can have fewer items if some
+    training series are too short to split into `self.num_windows` many windows).
+
+    Parameters
+    ----------
+    num_windows: int
+        Number of windows to generate from each time series in the dataset.
+    overlap: Optional[int], default = None
+        Number of steps shared between two consecutive validation windows. When set to None, overlap is set
+        automatically to `prediction_length // 2`.
+
+    Example
+    -------
+    .. code-block:: python
+
+        >>> print(ts_dataframe)
+                            target
+        item_id timestamp
+        0       1970-01-01       1
+                1970-01-02       2
+                1970-01-03       3
+                1970-01-04       4
+                1970-01-05       5
+                1970-01-06       6
+                1970-01-07       7
+                1970-01-08       8
+                1970-01-09       9
+                1970-01-10      10
+        >>> splitter = SlidingWindowSplitter(num_windows=2, overlap=1)
+        >>> train_data, tuning_data = splitter.split(ts_dataframe, prediction_length=3)
+        >>> print(train_data)
+                                target
+        item_id timestamp
+        0       1970-01-01       1
+                1970-01-02       2
+                1970-01-03       3
+                1970-01-04       4
+                1970-01-05       5
+        >>> print(tuning_data)
+                                            target
+        item_id             timestamp
+        0_slice(None, None) 1970-01-01       1
+                            1970-01-02       2
+                            1970-01-03       3
+                            1970-01-04       4
+                            1970-01-05       5
+                            1970-01-06       6
+                            1970-01-07       7
+                            1970-01-08       8
+                            1970-01-09       9
+                            1970-01-10      10
+        0_slice(None, -2)   1970-01-01       1
+                            1970-01-02       2
+                            1970-01-03       3
+                            1970-01-04       4
+                            1970-01-05       5
+                            1970-01-06       6
+                            1970-01-07       7
+                            1970-01-08       8
+    """
+
+    def __init__(self, num_windows: int, overlap: Optional[int] = None):
+        self.num_windows = num_windows
+        self.overlap = overlap
+
+    def _split(
+        self, ts_dataframe: TimeSeriesDataFrame, prediction_length: int
+    ) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
+        if self.overlap is None:
+            overlap = prediction_length // 2
+        else:
+            overlap = self.overlap
+        step_size = prediction_length - overlap
+        validation_dataframes = [append_suffix_to_item_id(ts_dataframe, "_slice(None, None)")]
+
+        for window_idx in range(1, self.num_windows):
+            ts_dataframe = ts_dataframe.slice_by_timestep(slice(None, -step_size))
+            total_offset = step_size * window_idx
+            next_val_dataframe = append_suffix_to_item_id(ts_dataframe, f"_slice(None, {-total_offset})")
+            validation_dataframes.append(next_val_dataframe)
+
+        train_data = ts_dataframe.slice_by_timestep(slice(None, -prediction_length))
+
+        return train_data, pd.concat(validation_dataframes)
+
+
+class LastWindowSplitter(SlidingWindowSplitter):
+    """Reserves the last prediction interval of each time series for validation."""
+
+    def __init__(self):
+        super().__init__(num_windows=1)

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -1,0 +1,104 @@
+import logging
+import random
+from ast import literal_eval
+from typing import Dict
+
+import pandas as pd
+import pytest
+
+from autogluon.timeseries.dataset import TimeSeriesDataFrame
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
+from autogluon.timeseries.splitter import LastWindowSplitter, SlidingWindowSplitter
+
+SPLITTERS = [
+    LastWindowSplitter(),
+    SlidingWindowSplitter(num_windows=2, overlap=0),
+    SlidingWindowSplitter(num_windows=5, overlap=2),
+]
+
+
+def get_data_frame_with_variable_lengths(item_id_to_length: Dict[str, int]):
+    tuples = []
+    for item_id, length in item_id_to_length.items():
+        for ts in pd.date_range(pd.Timestamp("2022-01-01"), periods=length):
+            tuples.append((item_id, ts))
+    index = pd.MultiIndex.from_tuples(tuples, names=[ITEMID, TIMESTAMP])
+    return TimeSeriesDataFrame(
+        pd.DataFrame(
+            index=index,
+            data=[random.random() for _ in index],
+            columns=["target"],
+        )
+    )
+
+
+DUMMY_VARIABLE_LENGTH_TS_DATAFRAME = get_data_frame_with_variable_lengths(
+    item_id_to_length={"A": 22, "B": 50, "C": 10, "D": 17}
+)
+
+
+def get_original_item_id_and_slice(tuning_item_id: str):
+    """Extract information from tuning set item_id that has format f"{item_id}_[{start}:{end}]"."""
+    item_id, slice_info = tuning_item_id.rsplit("_", maxsplit=1)
+    start, end = slice_info.strip("[]").split(":")
+    return item_id, literal_eval(start), literal_eval(end)
+
+
+@pytest.mark.parametrize("item_id_to_length", ({"A": 22, "B": 50, "C": 10}, {"A": 23}))
+@pytest.mark.parametrize("prediction_length, num_windows, overlap", [(5, 2, 0), (2, 5, 1), (8, 1, 0)])
+def test_when_sliding_window_splitter_splits_then_lengths_and_val_index_are_correct(
+    item_id_to_length, prediction_length, num_windows, overlap
+):
+    splitter = SlidingWindowSplitter(num_windows=num_windows, overlap=overlap)
+    ts_dataframe = get_data_frame_with_variable_lengths(item_id_to_length=item_id_to_length)
+    original_lengths = ts_dataframe.index.get_level_values(0).value_counts(sort=False)
+
+    train_data, val_data = splitter.split(ts_dataframe=ts_dataframe, prediction_length=prediction_length)
+    num_total_validation_steps = num_windows * (prediction_length - overlap) + overlap
+
+    # Training series are as long as expected
+    for item_id in train_data.iter_items():
+        new_length = len(train_data.loc[item_id])
+        expected_length = original_lengths.loc[item_id] - num_total_validation_steps
+        assert expected_length == new_length
+
+    # Validation series are as long as implied by their item_id
+    for new_item_id in val_data.iter_items():
+        old_item_id, start, end = get_original_item_id_and_slice(new_item_id)
+        new_length = len(val_data.loc[new_item_id])
+        expected_length = len(ts_dataframe.loc[old_item_id][start:end])
+        assert expected_length == new_length
+
+
+@pytest.mark.parametrize("splitter", SPLITTERS)
+def test_when_some_series_too_short_then_they_disappear_from_train_data(splitter):
+    prediction_length = 10
+    train_data, val_data = splitter.split(
+        ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=prediction_length
+    )
+    remaining_items = train_data.index.get_level_values(ITEMID)
+
+    original_lengths = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.index.get_level_values(0).value_counts(sort=False)
+    num_total_validation_steps = splitter.num_windows * (prediction_length - splitter.overlap) + splitter.overlap
+    should_be_missing = original_lengths.index[original_lengths <= num_total_validation_steps]
+
+    for item_id in should_be_missing:
+        assert item_id not in remaining_items
+
+    should_be_present = original_lengths.index[original_lengths > num_total_validation_steps]
+    for item_id in should_be_present:
+        assert item_id in remaining_items
+
+
+@pytest.mark.parametrize("splitter", SPLITTERS)
+def test_when_some_series_too_short_then_warning_is_raised(splitter, caplog):
+    with caplog.at_level(logging.WARNING):
+        splitter.split(ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=10)
+        assert "are too short and won't appear in the training set" in caplog.text
+
+
+def test_when_all_series_too_short_then_sliding_window_splitter_raises_exception():
+    splitter = SlidingWindowSplitter(num_windows=5, overlap=0)
+    with pytest.raises(ValueError):
+        splitter.split(ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=10)
+        pytest.fail(f"{splitter.name} should raise ValueError since the training set is empty")

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -8,12 +8,12 @@ import pytest
 
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
-from autogluon.timeseries.splitter import LastWindowSplitter, SlidingWindowSplitter
+from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter
 
 SPLITTERS = [
     LastWindowSplitter(),
-    SlidingWindowSplitter(num_windows=2, overlap=0),
-    SlidingWindowSplitter(num_windows=5, overlap=2),
+    MultiWindowSplitter(num_windows=2, overlap=0),
+    MultiWindowSplitter(num_windows=5, overlap=2),
 ]
 
 
@@ -49,7 +49,7 @@ def get_original_item_id_and_slice(tuning_item_id: str):
 def test_when_sliding_window_splitter_splits_then_lengths_and_val_index_are_correct(
     item_id_to_length, prediction_length, num_windows, overlap
 ):
-    splitter = SlidingWindowSplitter(num_windows=num_windows, overlap=overlap)
+    splitter = MultiWindowSplitter(num_windows=num_windows, overlap=overlap)
     ts_dataframe = get_data_frame_with_variable_lengths(item_id_to_length=item_id_to_length)
     original_lengths = ts_dataframe.index.get_level_values(0).value_counts(sort=False)
 
@@ -98,7 +98,7 @@ def test_when_some_series_too_short_then_warning_is_raised(splitter, caplog):
 
 
 def test_when_all_series_too_short_then_sliding_window_splitter_raises_exception():
-    splitter = SlidingWindowSplitter(num_windows=5, overlap=0)
+    splitter = MultiWindowSplitter(num_windows=5, overlap=0)
     with pytest.raises(ValueError):
         splitter.split(ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=10)
         pytest.fail(f"{splitter.name} should raise ValueError since the training set is empty")

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -676,3 +676,25 @@ def test_when_dataframe_sliced_by_item_array_then_static_features_stay_consisten
 def test_when_dataframe_reindexed_view_called_then_static_features_stay_consistent():
     view = SAMPLE_TS_DATAFRAME_STATIC.get_reindexed_view()
     assert view._static_features is SAMPLE_TS_DATAFRAME_STATIC._static_features
+
+
+SAMPLE_DATAFRAME_WITH_MIXED_INDEX = pd.DataFrame(
+    [
+        {ITEMID: 2, TIMESTAMP: pd.Timestamp("2020-01-01"), "target": 2.5},
+        {ITEMID: 2, TIMESTAMP: pd.Timestamp("2020-01-02"), "target": 3.5},
+        {ITEMID: "a", TIMESTAMP: pd.Timestamp("2020-01-01"), "target": 2.5},
+        {ITEMID: "a", TIMESTAMP: pd.Timestamp("2020-01-02"), "target": 3.5},
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    "input_df",
+    [
+        SAMPLE_DATAFRAME_WITH_MIXED_INDEX,
+        SAMPLE_DATAFRAME_WITH_MIXED_INDEX.set_index([ITEMID, TIMESTAMP]),
+    ],
+)
+def test_when_item_id_index_has_mixed_dtype_then_value_error_is_raied(input_df):
+    with pytest.raises(ValueError, match="must be of integer or string dtype"):
+        TimeSeriesDataFrame(input_df)


### PR DESCRIPTION
Currently, if no `tuning_data` is passed to `autogluon.timeseries.TimeSeriesPredictor.fit`, we use the last `prediction_length` timesteps of `train_data` as hold-out validation set. This PR enables new train / val splitting strategies for timeseries datasets, such as multi-window backtesting.

- New abstract class `autogluon.timeseries.splitter.AbstractTimeSeriesSplitter` that encapsulates the train / val split logic in its `split` method.
- Two currently supported strategies:
  - `LastWindowSplitter` - reserve last `prediction_length` steps (default, same as before)
  - `SlidingWindowSplitter` - reserve multiple windows of length `prediction_length` (potentially overlapping) for validation
- `autogluon.timeseries.TimeSeriesPredictor` now accepts an optional argument `splitter`.
- `tuning_data.index` is now different from `train_data.index` (a suffix `_[{start}:{end}]` is appended to show how the original series was split). We do this because a single item in `train_data` may now correspond to multiple items in `tuning_data`.  This shouldn't affect users since `tuning_data` is not exposed in the public API.

----
Updates:
- `autogluon.timeseries.dataset.ts_dataframe.TimeSeriesDataFrame` now makes sure that the provided `item_id` index either has all string or all integer types.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
