### PR TITLE
Improved logging of infer_limit

### DIFF
--- a/common/src/autogluon/common/utils/log_utils.py
+++ b/common/src/autogluon/common/utils/log_utils.py
@@ -95,3 +95,35 @@ def fix_logging_if_kaggle():
         _add_stream_handler()
     # After the fix is performed, or it is determined we are not in Kaggle, no need to fix again.
     __FIXED_KAGGLE_LOGGING = True
+
+
+def convert_time_in_s_to_log_friendly(time_in_sec: float, min_value: float = 0.01):
+    """
+    Converts a time in seconds to a logging friendly version with updated units.
+
+    Parameters
+    ----------
+    time_in_sec : float
+        The original time in seconds to convert.
+    min_value : float, default = 0.01
+        The minimum value time_adjusted should be.
+        If the value is greater than this, it will use a smaller time_unit until the value is greater than min_value or the smallest time_unit is reached.
+
+    Returns
+    -------
+    Returns a tuple of time_adjusted: float, time_unit: str that is the log friendly version of the time with corresponding time unit.
+
+    """
+    values = [
+        ('s', 1),
+        ('ms', 1e3),
+        ('μs', 1e6),
+        ('ns', 1e9),
+    ]
+    time_adjusted = time_in_sec
+    time_unit = 's'
+    for time_unit, time_factor in values:
+        time_adjusted = time_in_sec * time_factor
+        if time_adjusted >= min_value:
+            break
+    return time_adjusted, time_unit

--- a/common/tests/unittests/test_log_utils.py
+++ b/common/tests/unittests/test_log_utils.py
@@ -1,0 +1,68 @@
+from numpy.testing import assert_almost_equal
+
+from autogluon.common.utils.log_utils import convert_time_in_s_to_log_friendly
+
+
+def test_convert_time_in_s_to_log_friendly():
+	og_time = 1
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(og_time, ne_time)
+	assert time_unit == 's'
+
+	og_time = 10
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(og_time, ne_time)
+	assert time_unit == 's'
+
+	og_time = 10000
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(og_time, ne_time)
+	assert time_unit == 's'
+
+	og_time = 0.1
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(og_time, ne_time)
+	assert time_unit == 's'
+
+	og_time = 0.01
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(og_time, ne_time)
+	assert time_unit == 's'
+
+	og_time = 0.0099
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(9.9, ne_time)
+	assert time_unit == 'ms'
+
+	og_time = 0.00001
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(0.01, ne_time)
+	assert time_unit == 'ms'
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time, min_value=1)
+	assert_almost_equal(10, ne_time)
+	assert time_unit == 'μs'
+
+	og_time = 0.0000099
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(9.9, ne_time)
+	assert time_unit == 'μs'
+
+	og_time = 0.00000001
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(0.01, ne_time)
+	assert time_unit == 'μs'
+
+	og_time = 0.0000000099
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(9.9, ne_time)
+	assert time_unit == 'ns'
+
+	og_time = 0.00000000001
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(0.01, ne_time)
+	assert time_unit == 'ns'
+
+	og_time = 0.0000000000099
+	ne_time, time_unit = convert_time_in_s_to_log_friendly(og_time)
+	assert_almost_equal(0.0099, ne_time)
+	assert time_unit == 'ns'

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -13,6 +13,7 @@ import shutil
 from pathlib import Path
 
 from autogluon.common.features.feature_metadata import FeatureMetadata
+from autogluon.common.utils.log_utils import convert_time_in_s_to_log_friendly
 
 from .utils import process_hyperparameters
 from ..augmentation.distill_utils import format_distillation_labels, augment_data
@@ -362,7 +363,9 @@ class AbstractTrainer:
                 base_model_names.remove(base_model_name)
                 predict_1_time_full_set = self.get_model_attribute_full(model=base_model_names, attribute=attribute)
                 if verbose:
-                    messages_to_log.append(f'\t{round(predict_1_time_full_set_old, 4)}s -> {round(predict_1_time_full_set, 4)}s ({base_model_name})')
+                    predict_1_time_full_set_log, time_unit = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time_full_set)
+                    predict_1_time_full_set_old_log, time_unit_old = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time_full_set_old)
+                    messages_to_log.append(f'\t{round(predict_1_time_full_set_old_log, 3)}{time_unit_old}\t-> {round(predict_1_time_full_set_log, 3)}{time_unit}\t({base_model_name})')
 
         score_val_dict = self.get_models_attribute_dict(attribute='val_score', models=base_model_names)
         sorted_scores = sorted(score_val_dict.items(), key=lambda x: x[1])
@@ -376,11 +379,14 @@ class AbstractTrainer:
             i += 1
             predict_1_time_full_set = self.get_model_attribute_full(model=base_model_names, attribute=attribute)
             if verbose:
-                messages_to_log.append(f'\t{round(predict_1_time_full_set_old, 4)}s -> {round(predict_1_time_full_set, 4)}s ({base_model_to_remove})')
+                predict_1_time_full_set_log, time_unit = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time_full_set)
+                predict_1_time_full_set_old_log, time_unit_old = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time_full_set_old)
+                messages_to_log.append(f'\t{round(predict_1_time_full_set_old_log, 3)}{time_unit_old}\t-> {round(predict_1_time_full_set_log, 3)}{time_unit}\t({base_model_to_remove})')
 
         if messages_to_log:
+            infer_limit_threshold_log, time_unit_threshold = convert_time_in_s_to_log_friendly(time_in_sec=infer_limit_threshold)
             logger.log(20, f'Removing {len(messages_to_log)}/{num_models_og} base models to satisfy inference constraint '
-                           f'(constraint={round(infer_limit_threshold, 4)}s) ...')
+                           f'(constraint={round(infer_limit_threshold_log, 3)}{time_unit_threshold}) ...')
             for msg in messages_to_log:
                 logger.log(20, msg)
 
@@ -1313,19 +1319,13 @@ class AbstractTrainer:
             fit_metadata = model.get_fit_metadata()
             predict_1_batch_size = fit_metadata.get('predict_1_batch_size', None)
             assert predict_1_batch_size is not None, "predict_1_batch_size cannot be None if predict_1_time is not None"
-            time_unit = "s"
             predict_1_time = model.predict_1_time
-            if round(predict_1_time, 2) == 0:
-                # TODO: Consider moving this to a dedicated function and using across package for nicer logging of time
-                time_unit = 'ms'
-                predict_1_time = predict_1_time*1000
-            logger.log(20, f'\t{round(predict_1_time, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size)')
+            predict_1_time_log, time_unit = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time)
+            logger.log(20, f'\t{round(predict_1_time_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size)')
+
             predict_1_time_full = self.get_model_attribute_full(model=model.name, attribute='predict_1_time')
-            time_unit = "s"
-            if round(predict_1_time_full, 2) == 0:
-                time_unit = 'ms'
-                predict_1_time_full = predict_1_time_full * 1000
-            logger.log(20, f'\t{round(predict_1_time_full, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size | FULL)')
+            predict_1_time_full_log, time_unit = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time_full)
+            logger.log(20, f'\t{round(predict_1_time_full_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size | FULL)')
 
     # TODO: Split this to avoid confusion, HPO should go elsewhere?
     def _train_single_full(self,

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1321,11 +1321,11 @@ class AbstractTrainer:
             assert predict_1_batch_size is not None, "predict_1_batch_size cannot be None if predict_1_time is not None"
             predict_1_time = model.predict_1_time
             predict_1_time_log, time_unit = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time)
-            logger.log(20, f'\t{round(predict_1_time_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size)')
+            logger.log(20, f'\t{round(predict_1_time_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size | MARGINAL)')
 
             predict_1_time_full = self.get_model_attribute_full(model=model.name, attribute='predict_1_time')
             predict_1_time_full_log, time_unit = convert_time_in_s_to_log_friendly(time_in_sec=predict_1_time_full)
-            logger.log(20, f'\t{round(predict_1_time_full_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size | FULL)')
+            logger.log(20, f'\t{round(predict_1_time_full_log, 3)}{time_unit}\t = Validation runtime (1 row | {predict_1_batch_size} batch size)')
 
     # TODO: Split this to avoid confusion, HPO should go elsewhere?
     def _train_single_full(self,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Improved logging of infer_limit

Mainline logs:
```
	0.0s	= Feature Preprocessing Time (1 row | 10000 batch size)
		Feature Preprocessing requires 14.02% of the overall inference constraint (5e-05s)
		0.0s inference time budget remaining for models...

Fitting model: LightGBMLarge ...
	0.9078	 = Validation score   (roc_auc)
	0.57s	 = Training   runtime
	0.01s	 = Validation runtime
	0.004ms	 = Validation runtime (1 row | 10000 batch size)
	0.004ms	 = Validation runtime (1 row | 10000 batch size | FULL)
Removing 6/13 base models to satisfy inference constraint (constraint=0.0s) ...
	0.0001s -> 0.0001s (KNeighborsUnif)
	0.0001s -> 0.0001s (KNeighborsDist)
	0.0001s -> 0.0001s (NeuralNetTorch)
	0.0001s -> 0.0001s (NeuralNetFastAI)
	0.0001s -> 0.0s (ExtraTreesGini)
	0.0s -> 0.0s (ExtraTreesEntr)
Fitting model: WeightedEnsemble_L2 ...
	0.9196	 = Validation score   (roc_auc)
	0.84s	 = Training   runtime
	0.0s	 = Validation runtime
	0.002ms	 = Validation runtime (1 row | 10000 batch size)
	0.033ms	 = Validation runtime (1 row | 10000 batch size | FULL)
```

This PR: (Also refer to http://autogluon-staging.s3-website-us-west-2.amazonaws.com/PR-2014/9a1ce0c/tutorials/tabular_prediction/tabular-indepth.html#inference-speed-as-a-fit-constraint)
```
	5.925μs	= Feature Preprocessing Time (1 row | 10000 batch size)
		Feature Preprocessing requires 11.85% of the overall inference constraint (0.05ms)
		0.044ms inference time budget remaining for models...

Fitting model: LightGBMLarge ...
	0.9078	 = Validation score   (roc_auc)
	0.55s	 = Training   runtime
	0.01s	 = Validation runtime
	3.343μs	 = Validation runtime (1 row | 10000 batch size | MARGINAL)
	3.343μs	 = Validation runtime (1 row | 10000 batch size)
Removing 6/13 base models to satisfy inference constraint (constraint=0.042ms) ...
	0.092ms	-> 0.085ms	(KNeighborsUnif)
	0.085ms	-> 0.081ms	(KNeighborsDist)
	0.081ms	-> 0.066ms	(NeuralNetTorch)
	0.066ms	-> 0.052ms	(NeuralNetFastAI)
	0.052ms	-> 0.044ms	(ExtraTreesGini)
	0.044ms	-> 0.035ms	(ExtraTreesEntr)
Fitting model: WeightedEnsemble_L2 ...
	0.9196	 = Validation score   (roc_auc)
	0.77s	 = Training   runtime
	0.0s	 = Validation runtime
	1.37μs	 = Validation runtime (1 row | 10000 batch size | MARGINAL)
	0.028ms	 = Validation runtime (1 row | 10000 batch size)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
