### PR TITLE
Fix single label error

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/infer_types.py
+++ b/multimodal/src/autogluon/multimodal/data/infer_types.py
@@ -345,9 +345,9 @@ def infer_label_column_type_by_problem_type(
             check_missing_values(data=data, column_name=col_name, split="training")
         if valid_data is not None:
             check_missing_values(data=valid_data, column_name=col_name, split="validation")
-        if col_name in column_types and column_types[col_name] == NULL:
-            warnings.warn(
-                f"Label column '{col_name}' contains only one label. You may need to check your dataset again."
+        if column_types[col_name] == NULL:
+            raise ValueError(
+                f"Label column '{col_name}' contains only one label class. Make sure it has at least two label classes."
             )
         if problem_type in [MULTICLASS, BINARY, CLASSIFICATION]:
             column_types[col_name] = CATEGORICAL


### PR DESCRIPTION
Training encounters error if the label column has only 1 label class. Since training with 1 label is meaningless, we can raise error if detecting so.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
