### PR TITLE
Speed up TimeSeriesDataFrame.slice_by_timestep

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -508,12 +508,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
         indexes = []
         for i in self._item_index:
             idx = pd.MultiIndex.from_product(
-                [(i,), pd.date_range(self.DUMMY_INDEX_START_TIME, periods=len(self.loc[i]), freq=freq)],
-                names=["item_id", "timestamp"],
+                [(i,), pd.date_range(self.DUMMY_INDEX_START_TIME, periods=len(self.loc[i]), freq=freq)]
             )
             indexes.append(idx)
 
-        new_index = pd.MultiIndex.from_tuples(np.concatenate(indexes))
+        new_index = pd.MultiIndex.from_tuples(np.concatenate(indexes), names=[ITEMID, TIMESTAMP])
         df_view.set_index(new_index, inplace=True)
         df_view._cached_freq = freq
 

--- a/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/abstract_sktime.py
@@ -127,7 +127,7 @@ class AbstractSktimeModel(AbstractTimeSeriesModel):
 
         self._check_fit_params()
 
-        min_length = train_data.index.get_level_values(0).value_counts(sort=False).min()
+        min_length = train_data.num_timesteps_per_item().min()
         inferred_period = get_seasonality(train_data.freq)
         sktime_forecaster_init_args = self._get_sktime_forecaster_init_args(
             min_length=min_length, inferred_period=inferred_period

--- a/timeseries/tests/unittests/test_ts_dataset.py
+++ b/timeseries/tests/unittests/test_ts_dataset.py
@@ -437,6 +437,25 @@ def test_when_dataset_sliced_by_step_then_output_times_and_values_correct(
     assert all(ixval[1] == pd.Timestamp(expected_times[i]) for i, ixval in enumerate(dfv.index.values))  # type: ignore
 
 
+@pytest.mark.parametrize(
+    "input_iterable, input_slice",
+    [
+        (SAMPLE_ITERABLE, slice(None, 2)),
+        (SAMPLE_ITERABLE, slice(1, 2)),
+        (SAMPLE_ITERABLE_2, slice(None, 2)),
+        (SAMPLE_ITERABLE_2, slice(-2, None)),
+        (SAMPLE_ITERABLE_2, slice(-1000, 2)),
+    ],
+)
+def test_when_dataset_sliced_by_step_then_order_of_item_index_is_preserved(input_iterable, input_slice):
+    df = TimeSeriesDataFrame.from_iterable_dataset(input_iterable)
+    new_idx = df._item_index[::-1]
+    df.index = df.index.set_levels(new_idx, level=ITEMID)
+    dfv = df.slice_by_timestep(input_slice)
+
+    assert dfv._item_index.equals(new_idx)
+
+
 @pytest.mark.parametrize("input_df", [SAMPLE_TS_DATAFRAME, SAMPLE_TS_DATAFRAME_EMPTY])
 def test_when_dataframe_copy_called_on_instance_then_output_correct(input_df):
     copied_df = input_df.copy()


### PR DESCRIPTION
Several changes to `autogluon.timeseries.dataset.ts_dataframe.TimeSeriesDataFrame`
- Speed up `slice_by_timestep` - use a Boolean mask instead of slicing each series individually in a for loop
  - Train / val split for the `m4_quarterly` dataset (24000 time series) is now ~1000x faster (used to be 178 seconds, now 0.15 seconds).
- Add method `num_timesteps_per_item` that returns the length of each individual time series in the dataset.
- Slightly cleaner code for `_item_index`.
- Refer to index levels using their names `ITEMID` and `TIMESTAMP` (instead of `0` and `1`).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
