### PR TITLE
MMdetection integration - inference

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -56,6 +56,9 @@ function install_tabular_all {
 
 function install_multimodal {
     # launch different process for each test to make sure memory is released
+    python3 -m pip install --upgrade openmim
+    mim install mmcv-full
+    python3 -m pip install --upgrade mmdet
     python3 -m pip install --upgrade pytest-xdist
     python3 -m pip install --upgrade -e multimodal/[tests]
 }

--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -56,11 +56,10 @@ function install_tabular_all {
 
 function install_multimodal {
     # launch different process for each test to make sure memory is released
-    python3 -m pip install --upgrade openmim
-    mim install mmcv-full
-    python3 -m pip install --upgrade mmdet
     python3 -m pip install --upgrade pytest-xdist
     python3 -m pip install --upgrade -e multimodal/[tests]
+    mim install mmcv-full
+    python3 -m pip install --upgrade mmdet
 }
 
 function install_text {

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -48,7 +48,7 @@ install_requires = [
     "pytorch-metric-learning>=1.3.0,<1.4.0",
     "nlpaug>=1.1.10,<=1.1.10",
     "nltk>=3.4.5,<4.0.0",
-    "openmim",
+    "openmim>0.1.5,<=0.2.1",
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -49,7 +49,7 @@ install_requires = [
     "nlpaug>=1.1.10,<=1.1.10",
     "nltk>=3.4.5,<4.0.0",
     "openmim",
-    "mmcv-full",
+    "mmcv",
     "mmdet",
 ]
 

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -49,8 +49,6 @@ install_requires = [
     "nlpaug>=1.1.10,<=1.1.10",
     "nltk>=3.4.5,<4.0.0",
     "openmim",
-    "mmcv",
-    "mmdet",
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -48,6 +48,9 @@ install_requires = [
     "pytorch-metric-learning>=1.3.0,<1.4.0",
     "nlpaug>=1.1.10,<=1.1.10",
     "nltk>=3.4.5,<4.0.0",
+    "openmim",
+    "mmcv-full",
+    "mmdet",
 ]
 
 install_requires = ag.get_dependency_version_ranges(install_requires)

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -1,5 +1,5 @@
 env:
-  num_gpus: 0
+  num_gpus: -1
   num_nodes: 1
   batch_size: 128  # this is a desired batch size; pl trainer will accumulate gradients when per step batch is smaller.
   per_gpu_batch_size: 8  # training per gpu batch size

--- a/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/environment/default.yaml
@@ -1,5 +1,5 @@
 env:
-  num_gpus: -1
+  num_gpus: 0
   num_nodes: 1
   batch_size: 128  # this is a desired batch size; pl trainer will accumulate gradients when per step batch is smaller.
   per_gpu_batch_size: 8  # training per gpu batch size

--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -93,7 +93,7 @@ model:
     max_img_num_per_col: 2
 
   mmdet_image:
-    checkpoint_name: "faster_rcnn_r50_fpn_1x_coco"
+    checkpoint_name: "yolov3_mobilenetv2_320_300e_coco"
     data_types:
       - "image"
     train_transform_types:

--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -89,6 +89,22 @@ model:
     image_norm: "imagenet"
     image_size: 224
     max_img_num_per_col: 2
+
+  mmdet_image:
+    checkpoint_name: "yolov3_mobilenetv2_320_300e_coco"
+    data_types:
+      - "image"
+    train_transform_types:
+      - "resize_shorter_side"
+      - "center_crop"
+      - "trivial_augment"
+    val_transform_types:
+      - "resize_shorter_side"
+      - "center_crop"
+    image_norm: "imagenet"
+    image_size: 224
+    max_img_num_per_col: 2
+
   clip:
     checkpoint_name: "openai/clip-vit-base-patch32"
     data_types:

--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -91,7 +91,7 @@ model:
     max_img_num_per_col: 2
 
   mmdet_image:
-    checkpoint_name: "yolov3_mobilenetv2_320_300e_coco"
+    checkpoint_name: "faster_rcnn_r50_fpn_1x_coco"
     data_types:
       - "image"
     train_transform_types:

--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -35,6 +35,7 @@ FEATURES = "features"
 MASKS = "masks"
 PROBABILITY = "probability"
 COLUMN_FEATURES = "column_features"
+BBOX = "bbox"
 
 
 # Metric
@@ -79,6 +80,7 @@ PREDICT = "predict"
 # Model sources
 HUGGINGFACE = "huggingface"
 TIMM = "timm"
+MMDET = "mmdet"
 
 # Modality keys. may need to update here if new modality keys are added in above.
 ALL_MODALITIES = [IMAGE, TEXT, CATEGORICAL, NUMERICAL]
@@ -132,6 +134,7 @@ NUMERICAL_TRANSFORMER = "numerical_transformer"
 CATEGORICAL_TRANSFORMER = "categorical_transformer"
 FUSION_MLP = "fusion_mlp"
 FUSION_TRANSFORMER = "fusion_transformer"
+MMDET_IMAGE = "mmdet_image"
 
 # metric learning loss type
 CONTRASTIVE_LOSS = "contrastive_loss"

--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -11,6 +11,7 @@ BINARY = "binary"
 MULTICLASS = "multiclass"
 REGRESSION = "regression"
 ZERO_SHOT = "zero_shot"
+OBJECT_DETECTION = "object_detection"
 
 # Input keys
 IMAGE = "image"

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -8,8 +8,8 @@ import numpy as np
 import PIL
 import torch
 from mmcv.parallel import collate
-from mmdet.datasets.pipelines import Compose
 from mmdet.datasets import replace_ImageToTensor
+from mmdet.datasets.pipelines import Compose
 from timm import create_model
 from timm.data.constants import (
     IMAGENET_DEFAULT_MEAN,

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -123,10 +123,13 @@ class ImageProcessor:
             except:
                 raise RuntimeError(
                     "If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full."
-                )
+                )  
 
         if checkpoint_name is not None:
-            self.size, self.mean, self.std = self.extract_default(checkpoint_name, cfg=cfg)
+            if self.prefix == MMDET_IMAGE:
+                self.size, self.mean, self.std = self.extract_default(checkpoint_name, cfg=cfg)
+            else:
+                self.size, self.mean, self.std = self.extract_default(checkpoint_name)
         if self.size is None:
             if size is not None:
                 self.size = size

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -3,9 +3,13 @@ import logging
 import warnings
 from typing import Dict, List, Optional
 
+import mmcv
 import numpy as np
 import PIL
 import torch
+from mmcv.parallel import collate
+from mmdet.datasets.pipelines import Compose
+from mmdet.datasets import replace_ImageToTensor
 from timm import create_model
 from timm.data.constants import (
     IMAGENET_DEFAULT_MEAN,
@@ -15,10 +19,6 @@ from timm.data.constants import (
 )
 from torchvision import transforms
 from transformers import AutoConfig
-import mmcv
-from mmcv.parallel import collate
-from mmdet.datasets.pipelines import Compose
-from mmdet.datasets import replace_ImageToTensor
 
 from .randaug import RandAugment
 

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -405,12 +405,7 @@ class ImageProcessor:
                 )
                 column_start = len(images)
         if self.prefix == MMDET_IMAGE:
-            ret.update(
-                {
-                    self.image_key: images[0]
-        
-                }
-            )
+            ret.update({self.image_key: images[0]})
         else:
             ret.update(
                 {

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -134,6 +134,7 @@ class ImageProcessor:
 
         self.task_type = "detection"
         if self.task_type == "detection":
+            # TODO: change after fix in mmdet_image
             cfg = 'yolov3_mobilenetv2_320_300e_coco.py'
             if isinstance(cfg, str):
                 cfg = mmcv.Config.fromfile(cfg)
@@ -261,6 +262,7 @@ class ImageProcessor:
                 try:
                     # config_url = 'https://raw.githubusercontent.com/open-mmlab/mmdetection/master/configs/yolo/yolov3_mobilenetv2_320_300e_coco.py'
                     # config = download(config_url)
+                    # TODO: change after fix in mmdet_image
                     config = 'yolov3_mobilenetv2_320_300e_coco.py'
                     if isinstance(config, str):
                         config = mmcv.Config.fromfile(config)

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -18,6 +18,7 @@ from transformers import AutoConfig
 import mmcv
 from mmcv.parallel import collate
 from mmdet.datasets.pipelines import Compose
+from mmdet.datasets import replace_ImageToTensor
 
 from .randaug import RandAugment
 
@@ -140,6 +141,7 @@ class ImageProcessor:
                 cfg = mmcv.Config.fromfile(cfg)
             cfg.data.test.pipeline = replace_ImageToTensor(cfg.data.test.pipeline)
             self.val_processor = Compose(cfg.data.test.pipeline)
+            self.train_processor = Compose(cfg.data.test.pipeline)
         else:
             self.train_processor = self.construct_processor(self.train_transform_types)
             self.val_processor = self.construct_processor(self.val_transform_types)

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -15,6 +15,7 @@ from timm.data.constants import (
 )
 from torchvision import transforms
 from transformers import AutoConfig
+
 from .randaug import RandAugment
 
 try:

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -120,7 +120,9 @@ class ImageProcessor:
                 if isinstance(cfg, str):
                     cfg = mmcv.Config.fromfile(cfg)
             except:
-                raise RuntimeError("MMDetection requires MMCV dependency, please install mmcv-full by: mim install mmcv-full.")
+                raise RuntimeError(
+                    "If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full."
+                )
 
         if checkpoint_name is not None:
             self.size, self.mean, self.std = self.extract_default(checkpoint_name, cfg=cfg)
@@ -154,7 +156,9 @@ class ImageProcessor:
                 self.val_processor = Compose(cfg.data.test.pipeline)
                 self.train_processor = Compose(cfg.data.test.pipeline)
             except:
-                raise RuntimeError("Please install MMDetection by: pip install mmdet.")
+                raise RuntimeError(
+                    "If encounterd mmdet related error, please install MMDetection by: pip install mmdet."
+                )
         else:
             self.train_processor = self.construct_processor(self.train_transform_types)
             self.val_processor = self.construct_processor(self.val_transform_types)
@@ -196,7 +200,9 @@ class ImageProcessor:
                     }
                 )
             except:
-                raise RuntimeError("MMDetection requires MMCV dependency, please install mmcv-full by: mim install mmcv-full.")
+                raise RuntimeError(
+                    "If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full."
+                )
         else:
             fn.update(
                 {

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -123,7 +123,7 @@ class ImageProcessor:
             except:
                 raise RuntimeError(
                     "If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full."
-                )  
+                )
 
         if checkpoint_name is not None:
             if self.prefix == MMDET_IMAGE:

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -25,6 +25,7 @@ except ImportError:
     mmcv = None
 
 try:
+    import mmdet
     from mmdet.datasets import replace_ImageToTensor
     from mmdet.datasets.pipelines import Compose
 except ImportError:
@@ -116,14 +117,10 @@ class ImageProcessor:
 
         if self.prefix == MMDET_IMAGE:
             # TODO: can we pass the config information here when we build the model?
-            try:
-                cfg = checkpoint_name + ".py"
-                if isinstance(cfg, str):
-                    cfg = mmcv.Config.fromfile(cfg)
-            except:
-                raise RuntimeError(
-                    "If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full."
-                )
+            assert mmcv is not None, "Please install mmcv-full by: mim install mmcv-full."
+            cfg = checkpoint_name + ".py"
+            if isinstance(cfg, str):
+                cfg = mmcv.Config.fromfile(cfg)
 
         if checkpoint_name is not None:
             if self.prefix == MMDET_IMAGE:
@@ -155,14 +152,10 @@ class ImageProcessor:
         logger.debug(f"max_img_num_per_col: {max_img_num_per_col}")
 
         if self.prefix == MMDET_IMAGE:
-            try:
-                cfg.data.test.pipeline = replace_ImageToTensor(cfg.data.test.pipeline)
-                self.val_processor = Compose(cfg.data.test.pipeline)
-                self.train_processor = Compose(cfg.data.test.pipeline)
-            except:
-                raise RuntimeError(
-                    "If encounterd mmdet related error, please install MMDetection by: pip install mmdet."
-                )
+            assert mmdet is not None, "Please install MMDetection by: pip install mmdet."
+            cfg.data.test.pipeline = replace_ImageToTensor(cfg.data.test.pipeline)
+            self.val_processor = Compose(cfg.data.test.pipeline)
+            self.train_processor = Compose(cfg.data.test.pipeline)
         else:
             self.train_processor = self.construct_processor(self.train_transform_types)
             self.val_processor = self.construct_processor(self.val_transform_types)
@@ -197,16 +190,12 @@ class ImageProcessor:
                 fn[f"{self.image_column_prefix}_{col_name}"] = Stack()
 
         if self.prefix == MMDET_IMAGE:
-            try:
-                fn.update(
-                    {
-                        self.image_key: collate,
-                    }
-                )
-            except:
-                raise RuntimeError(
-                    "If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full."
-                )
+            assert mmcv is not None, "Please install mmcv-full by: mim install mmcv-full."
+            fn.update(
+                {
+                    self.image_key: collate,
+                }
+            )
         else:
             fn.update(
                 {

--- a/multimodal/src/autogluon/multimodal/models/__init__.py
+++ b/multimodal/src/autogluon/multimodal/models/__init__.py
@@ -7,4 +7,4 @@ from .huggingface_text import HFAutoModelForTextPrediction
 from .numerical_mlp import NumericalMLP
 from .numerical_transformer import NumericalTransformer
 from .timm_image import TimmAutoModelForImagePrediction
-from .mmdet_image import MMdetAutoModelForObjectDetection
+from .mmdet_image import MMDetAutoModelForObjectDetection

--- a/multimodal/src/autogluon/multimodal/models/__init__.py
+++ b/multimodal/src/autogluon/multimodal/models/__init__.py
@@ -7,3 +7,4 @@ from .huggingface_text import HFAutoModelForTextPrediction
 from .numerical_mlp import NumericalMLP
 from .numerical_transformer import NumericalTransformer
 from .timm_image import TimmAutoModelForImagePrediction
+from .mmdet_image import MMdetAutoModelForObjectDetection

--- a/multimodal/src/autogluon/multimodal/models/__init__.py
+++ b/multimodal/src/autogluon/multimodal/models/__init__.py
@@ -4,7 +4,7 @@ from .categorical_transformer import CategoricalTransformer
 from .clip import CLIPForImageText
 from .fusion import MultimodalFusionMLP, MultimodalFusionTransformer
 from .huggingface_text import HFAutoModelForTextPrediction
+from .mmdet_image import MMDetAutoModelForObjectDetection
 from .numerical_mlp import NumericalMLP
 from .numerical_transformer import NumericalTransformer
 from .timm_image import TimmAutoModelForImagePrediction
-from .mmdet_image import MMDetAutoModelForObjectDetection

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -13,6 +13,7 @@ except ImportError:
     mmcv = None
 
 try:
+    import mmdet
     from mmdet.core import get_classes
     from mmdet.models import build_detector
 except ImportError:
@@ -60,18 +61,14 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         checkpoints = download(package="mmdet", configs=[checkpoint_name], dest_root=".")
 
         # read config files
-        try:
-            config_file = checkpoint_name + ".py"
-            if isinstance(config_file, str):
-                self.config = mmcv.Config.fromfile(config_file)
-        except:
-            raise RuntimeError("If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full.")
+        assert mmcv is not None, "Please install mmcv-full by: mim install mmcv-full."
+        config_file = checkpoint_name + ".py"
+        if isinstance(config_file, str):
+            self.config = mmcv.Config.fromfile(config_file)
 
         # build model and load pretrained weights
-        try:
-            self.model = build_detector(self.config.model, test_cfg=self.config.get("test_cfg"))
-        except:
-            raise RuntimeError("If encounterd mmdet related error, please install MMDetection by: pip install mmdet.")
+        assert mmdet is not None, "Please install MMDetection by: pip install mmdet."
+        self.model = build_detector(self.config.model, test_cfg=self.config.get("test_cfg"))
 
         checkpoint = checkpoints[0]
         if checkpoint is not None:

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -65,17 +65,13 @@ class MMDetAutoModelForObjectDetection(nn.Module):
             if isinstance(config_file, str):
                 self.config = mmcv.Config.fromfile(config_file)
         except:
-            raise RuntimeError(
-                "If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full."
-            )
+            raise RuntimeError("If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full.")
 
         # build model and load pretrained weights
         try:
             self.model = build_detector(self.config.model, test_cfg=self.config.get("test_cfg"))
         except:
-            raise RuntimeError(
-                "If encounterd mmdet related error, please install MMDetection by: pip install mmdet."
-            )
+            raise RuntimeError("If encounterd mmdet related error, please install MMDetection by: pip install mmdet.")
 
         checkpoint = checkpoints[0]
         if checkpoint is not None:

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -7,10 +7,10 @@ import torch
 from mim.commands.download import download
 from mmcv.runner import load_checkpoint
 from mmdet.core import get_classes
-from torch import nn
 from mmdet.models import build_detector
+from torch import nn
 
-from ..constants import AUTOMM, COLUMN, COLUMN_FEATURES, FEATURES, IMAGE, IMAGE_VALID_NUM, LABEL, LOGITS, MASKS, BBOX
+from ..constants import AUTOMM, BBOX, COLUMN, COLUMN_FEATURES, FEATURES, IMAGE, IMAGE_VALID_NUM, LABEL, LOGITS, MASKS
 from .utils import assign_layer_ids, get_column_features, get_model_head
 
 logger = logging.getLogger(AUTOMM)

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -10,13 +10,13 @@ import warnings
 from mmdet.core import get_classes
 from mim.commands.download import download
 
-from ..constants import AUTOMM, COLUMN, COLUMN_FEATURES, FEATURES, IMAGE, IMAGE_VALID_NUM, LABEL, LOGITS, MASKS
+from ..constants import AUTOMM, COLUMN, COLUMN_FEATURES, FEATURES, IMAGE, IMAGE_VALID_NUM, LABEL, LOGITS, MASKS, BBOX
 from .utils import assign_layer_ids, get_column_features, get_model_head
 
 logger = logging.getLogger(AUTOMM)
 
 
-class MMdetAutoModelForObjectDetection(nn.Module):
+class MMDetAutoModelForObjectDetection(nn.Module):
     """
     Support MMDET object detection models.
     Refer to https://github.com/open-mmlab/mmdetection
@@ -50,24 +50,23 @@ class MMdetAutoModelForObjectDetection(nn.Module):
 
         # download config and checkpoint files using openmim
         checkpoints = download(package="mmdet", configs=[checkpoint_name], dest_root=".")
-        
+
         # read config files
-        config_file = checkpoint_name + '.py'
+        config_file = checkpoint_name + ".py"
         if isinstance(config_file, str):
             self.config = mmcv.Config.fromfile(config_file)
 
         # build model and load pretrained weights
-        self.model = build_detector(self.config.model, test_cfg=self.config.get('test_cfg'))
+        self.model = build_detector(self.config.model, test_cfg=self.config.get("test_cfg"))
         checkpoint = checkpoints[0]
         if checkpoint is not None:
-            checkpoint = load_checkpoint(self.model, checkpoint, map_location='cpu')
-        if 'CLASSES' in checkpoint.get('meta', {}):
-            self.model.CLASSES = checkpoint['meta']['CLASSES']
+            checkpoint = load_checkpoint(self.model, checkpoint, map_location="cpu")
+        if "CLASSES" in checkpoint.get("meta", {}):
+            self.model.CLASSES = checkpoint["meta"]["CLASSES"]
         else:
-            warnings.simplefilter('once')
-            warnings.warn('Class names are not saved in the checkpoint\'s '
-                          'meta data, use COCO classes by default.')
-            self.model.CLASSES = get_classes('coco')
+            warnings.simplefilter("once")
+            warnings.warn("Class names are not saved in the checkpoint's " "meta data, use COCO classes by default.")
+            self.model.CLASSES = get_classes("coco")
         self.model.cfg = self.config  # save the config in the model for convenience
 
         self.prefix = prefix
@@ -108,12 +107,12 @@ class MMdetAutoModelForObjectDetection(nn.Module):
             A dictionary with bounding boxes.
         """
         data = batch[self.image_key]
-        data['img_metas'] = [img_metas.data[0] for img_metas in data['img_metas']]
-        data['img'] = [img.data[0] for img in data['img']]
+        data["img_metas"] = [img_metas.data[0] for img_metas in data["img_metas"]]
+        data["img"] = [img.data[0] for img in data["img"]]
         with torch.no_grad():
             results = self.model(return_loss=False, rescale=True, **data)
 
-        ret = {"bbox": results}
+        ret = {BBOX: results}
         return {self.prefix: ret}
 
     def get_layer_ids(
@@ -124,30 +123,14 @@ class MMdetAutoModelForObjectDetection(nn.Module):
         Basically, id gradually increases when going from the output end to
         the input end. The layers defined in this class, e.g., head, have id 0.
 
-        Due to different backbone architectures in TIMM, this function may not always return the correct result.
-        Thus, you can use "print(json.dumps(name_to_id, indent=2))" to manually check whether
-        the layer ids are reasonable.
+        Setting all layers as the same id 0 for now.
+        TODO: Need to investigate mmdetection's model definitions
 
         Returns
         -------
         A dictionary mapping the layer names (keys) to their ids (values).
         """
-        model_prefix = "model"
-        pre_encoder_patterns = ("embed", "cls_token", "stem", "bn1", "conv1")
-        post_encoder_patterns = ("head", "norm", "bn2")
-        names = [n for n, _ in self.named_parameters()]
-
-        name_to_id, names = assign_layer_ids(
-            names=names,
-            pre_encoder_patterns=pre_encoder_patterns,
-            post_encoder_patterns=post_encoder_patterns,
-            model_pre=model_prefix,
-        )
-
-        if len(names) > 0:
-            logger.debug(f"outer layers are treated as head: {names}")
-        for n in names:
-            assert n not in name_to_id
+        name_to_id = {}
+        for n, _ in self.named_parameters():
             name_to_id[n] = 0
-
         return name_to_id

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -1,0 +1,135 @@
+import logging
+from typing import Optional
+
+import torch
+from torch import nn
+from mmdet.models import build_detector
+import mmcv
+
+from ..constants import AUTOMM, COLUMN, COLUMN_FEATURES, FEATURES, IMAGE, IMAGE_VALID_NUM, LABEL, LOGITS, MASKS
+from .utils import assign_layer_ids, get_column_features, get_model_head
+from ..utils import download
+
+logger = logging.getLogger(AUTOMM)
+
+
+class MMdetAutoModelForObjectDetection(nn.Module):
+    """
+    Support MMDET object detection models.
+    Refer to https://github.com/open-mmlab/mmdetection
+    """
+
+    def __init__(
+        self,
+        prefix: str,
+        checkpoint_name: str,
+        num_classes: Optional[int] = None,
+        pretrained: Optional[bool] = True,
+    ):
+        """
+        Load a pretrained object detector from MMdetection.
+
+        Parameters
+        ----------
+        prefix
+            The prefix of the MMdetAutoModelForObjectDetection model.
+        checkpoint_name
+            Name of the mmdet checkpoint.
+        num_classes
+            The number of classes.
+        pretrained
+            Whether using the pretrained mmdet models. If pretrained=True, download the pretrained model.
+        """
+        super().__init__()
+        logger.debug(f"initializing {checkpoint_name}")
+        self.checkpoint_name = checkpoint_name
+        self.pretrained = pretrained
+        # TODO: model name to config
+        # config = get_mmdet_model_config(checkpoint_name)
+        config_url = 'https://raw.githubusercontent.com/open-mmlab/mmdetection/master/configs/yolo/yolov3_mobilenetv2_320_300e_coco.py'
+        config_file = download(config_url)
+        if isinstance(config_file, str):
+            self.config = mmcv.Config.fromfile(config_file)
+        self.model = build_detector(self.config.model, test_cfg=self.config.get('test_cfg'))
+        self.prefix = prefix
+
+    @property
+    def image_key(self):
+        return f"{self.prefix}_{IMAGE}"
+
+    @property
+    def image_valid_num_key(self):
+        return f"{self.prefix}_{IMAGE_VALID_NUM}"
+
+    @property
+    def label_key(self):
+        return f"{self.prefix}_{LABEL}"
+
+    @property
+    def image_column_prefix(self):
+        return f"{self.image_key}_{COLUMN}"
+
+    @property
+    def image_feature_dim(self):
+        return self.model.num_features
+
+    def forward(
+        self,
+        batch: dict,
+    ):
+        """
+        Parameters
+        ----------
+        batch
+            A dictionary containing the input mini-batch data.
+            We need to use the keys with the model prefix to index required data.
+
+        Returns
+        -------
+            A dictionary with logits and features.
+        """
+        data = batch[self.image_key]
+        data['img_metas'] = [img_metas.data[0] for img_metas in data['img_metas']]
+        data['img'] = [img.data[0] for img in data['img']]
+        with torch.no_grad():
+            results = self.model(return_loss=False, rescale=True, **data)
+            print(results)
+            exit()
+
+        return {self.prefix: ret}
+
+    def get_layer_ids(
+        self,
+    ):
+        """
+        Assign an id to each layer. Layer ids will be used in layer-wise lr decay.
+        Basically, id gradually increases when going from the output end to
+        the input end. The layers defined in this class, e.g., head, have id 0.
+
+        Due to different backbone architectures in TIMM, this function may not always return the correct result.
+        Thus, you can use "print(json.dumps(name_to_id, indent=2))" to manually check whether
+        the layer ids are reasonable.
+
+        Returns
+        -------
+        A dictionary mapping the layer names (keys) to their ids (values).
+        """
+        model_prefix = "model"
+        pre_encoder_patterns = ("embed", "cls_token", "stem", "bn1", "conv1")
+        post_encoder_patterns = ("head", "norm", "bn2")
+        names = [n for n, _ in self.named_parameters()]
+
+        name_to_id, names = assign_layer_ids(
+            names=names,
+            pre_encoder_patterns=pre_encoder_patterns,
+            post_encoder_patterns=post_encoder_patterns,
+            model_pre=model_prefix,
+        )
+
+        if len(names) > 0:
+            logger.debug(f"outer layers are treated as head: {names}")
+        for n in names:
+            assert n not in name_to_id
+            name_to_id[n] = 0
+
+        return name_to_id

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -93,8 +93,6 @@ class MMdetAutoModelForObjectDetection(nn.Module):
         data['img'] = [img.data[0] for img in data['img']]
         with torch.no_grad():
             results = self.model(return_loss=False, rescale=True, **data)
-            print(results)
-            exit()
 
         return {self.prefix: ret}
 

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -1,14 +1,14 @@
 import logging
+import warnings
 from typing import Optional
 
+import mmcv
 import torch
+from mim.commands.download import download
+from mmcv.runner import load_checkpoint
+from mmdet.core import get_classes
 from torch import nn
 from mmdet.models import build_detector
-import mmcv
-from mmcv.runner import load_checkpoint
-import warnings
-from mmdet.core import get_classes
-from mim.commands.download import download
 
 from ..constants import AUTOMM, COLUMN, COLUMN_FEATURES, FEATURES, IMAGE, IMAGE_VALID_NUM, LABEL, LOGITS, MASKS, BBOX
 from .utils import assign_layer_ids, get_column_features, get_model_head

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -65,13 +65,17 @@ class MMDetAutoModelForObjectDetection(nn.Module):
             if isinstance(config_file, str):
                 self.config = mmcv.Config.fromfile(config_file)
         except:
-            raise RuntimeError("MMDetection requires MMCV dependency, please install mmcv-full by: mim install mmcv-full.")
+            raise RuntimeError(
+                "If encounterd mmcv related error, please install mmcv-full by: mim install mmcv-full."
+            )
 
         # build model and load pretrained weights
         try:
             self.model = build_detector(self.config.model, test_cfg=self.config.get("test_cfg"))
         except:
-            raise RuntimeError("Please install MMDetection by: pip install mmdet.")
+            raise RuntimeError(
+                "If encounterd mmdet related error, please install MMDetection by: pip install mmdet."
+            )
 
         checkpoint = checkpoints[0]
         if checkpoint is not None:

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -121,8 +121,7 @@ class MMDetAutoModelForObjectDetection(nn.Module):
         data = batch[self.image_key]
         data["img_metas"] = [img_metas.data[0] for img_metas in data["img_metas"]]
         data["img"] = [img.data[0] for img in data["img"]]
-        with torch.no_grad():
-            results = self.model(return_loss=False, rescale=True, **data)
+        results = self.model(return_loss=False, rescale=True, **data)
 
         ret = {BBOX: results}
         return {self.prefix: ret}

--- a/multimodal/src/autogluon/multimodal/models/mmdet_image.py
+++ b/multimodal/src/autogluon/multimodal/models/mmdet_image.py
@@ -11,7 +11,6 @@ from mmdet.core import get_classes
 
 from ..constants import AUTOMM, COLUMN, COLUMN_FEATURES, FEATURES, IMAGE, IMAGE_VALID_NUM, LABEL, LOGITS, MASKS
 from .utils import assign_layer_ids, get_column_features, get_model_head
-# from ..utils import download
 
 logger = logging.getLogger(AUTOMM)
 
@@ -102,7 +101,7 @@ class MMdetAutoModelForObjectDetection(nn.Module):
 
         Returns
         -------
-            A dictionary with logits and features.
+            A dictionary with bounding boxes.
         """
         data = batch[self.image_key]
         data['img_metas'] = [img_metas.data[0] for img_metas in data['img_metas']]
@@ -110,7 +109,7 @@ class MMdetAutoModelForObjectDetection(nn.Module):
         with torch.no_grad():
             results = self.model(return_loss=False, rescale=True, **data)
 
-        ret = {"bbx": results}
+        ret = {"bbox": results}
         return {self.prefix: ret}
 
     def get_layer_ids(

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -31,6 +31,7 @@ from . import version as ag_version
 from .constants import (
     AUTOMM,
     AUTOMM_TUTORIAL_MODE,
+    BBOX,
     BEST,
     BEST_K_MODELS_FILE,
     BINARY,
@@ -51,6 +52,7 @@ from .constants import (
     MODEL,
     MODEL_CHECKPOINT,
     MULTICLASS,
+    OBJECT_DETECTION,
     PROBABILITY,
     RAY_TUNE_CHECKPOINT,
     REGRESSION,
@@ -59,9 +61,7 @@ from .constants import (
     Y_PRED,
     Y_PRED_PROB,
     Y_TRUE,
-    OBJECT_DETECTION,
     ZERO_SHOT_IMAGE_CLASSIFICATION,
-    BBOX,
 )
 from .data.datamodule import BaseDataModule
 from .data.infer_types import (

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1603,8 +1603,8 @@ class MultiModalPredictor:
         else:
             ret_type = LOGITS
         
-        if self._problem_type == "object_detection":
-            ret_type = "bbx"
+        if self._pipeline == OBJECT_DETECTION:
+            ret_type = "bbox"
 
         if candidate_data:
             pred = self._match_queries_and_candidates(

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -61,6 +61,7 @@ from .constants import (
     Y_TRUE,
     OBJECT_DETECTION,
     ZERO_SHOT_IMAGE_CLASSIFICATION,
+    BBOX,
 )
 from .data.datamodule import BaseDataModule
 from .data.infer_types import (
@@ -1602,9 +1603,9 @@ class MultiModalPredictor:
             ret_type = PROBABILITY
         else:
             ret_type = LOGITS
-        
+
         if self._pipeline == OBJECT_DETECTION:
-            ret_type = "bbox"
+            ret_type = BBOX
 
         if candidate_data:
             pred = self._match_queries_and_candidates(

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -58,6 +58,7 @@ from .constants import (
     Y_PRED_PROB,
     Y_TRUE,
     ZERO_SHOT,
+    OBJECT_DETECTION,
 )
 from .data.datamodule import BaseDataModule
 from .data.infer_types import (
@@ -91,6 +92,7 @@ from .utils import (
     init_data_processors,
     init_df_preprocessor,
     init_zero_shot,
+    init_object_detection,
     is_interactive,
     load_text_tokenizers,
     logits_to_prob,
@@ -219,6 +221,9 @@ class MultiModalPredictor:
 
         if problem_type is not None and problem_type.lower() == ZERO_SHOT:
             self._config, self._model, self._data_processors = init_zero_shot(hyperparameters=hyperparameters)
+
+        if problem_type is not None and problem_type.lower() == OBJECT_DETECTION:
+            self._config, self._model, self._data_processors = init_object_detection(hyperparameters=hyperparameters)
 
     @property
     def path(self):

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -73,8 +73,9 @@ def zero_shot_image_classification():
 def object_detection():
     return {
         "model.names": ["mmdet_image"],
-        "model.mmdet_image.checkpoint_name": "yolov3_mobilenetv2_320_300e_coco", 
+        "model.mmdet_image.checkpoint_name": "yolov3_mobilenetv2_320_300e_coco",
         "env.eval_batch_size_ratio": 1,
+        "env.num_gpus": 0,
     }
 
 

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -59,6 +59,15 @@ def zero_shot():
     }
 
 
+@automm_presets.register()
+def object_detection():
+    return {
+        "model.names": ["mmdet_image"],
+        "model.mmdet_image.checkpoint_name": "yolov3_mobilenetv2_320_300e_coco",
+        "env.eval_batch_size_ratio": 1,
+    }
+
+
 def list_automm_presets(verbose: bool = False):
     """
     List all available presets.

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -73,7 +73,7 @@ def zero_shot_image_classification():
 def object_detection():
     return {
         "model.names": ["mmdet_image"],
-        "model.mmdet_image.checkpoint_name": "yolov3_mobilenetv2_320_300e_coco",
+        "model.mmdet_image.checkpoint_name": "yolov3_mobilenetv2_320_300e_coco", 
         "env.eval_batch_size_ratio": 1,
     }
 

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -1665,6 +1665,40 @@ def init_zero_shot(
     return config, model, data_processors
 
 
+def init_object_detectin(
+    hyperparameters: Optional[Union[str, Dict, List[str]]] = None,
+):
+    """
+    Object detection initialization.
+
+    Parameters
+    ----------
+    hyperparameters
+        The customized hyperparameters used to override the default.
+        Users need to use it to choose one model, e.g., {"model.names": ["yolov3_mobilenetv2_320_300e_coco"]}.
+
+    Returns
+    -------
+    config
+        A DictConfig object containing the configurations for object detection.
+    model
+        The model with pre-trained weights.
+    data_processors
+        The data processors associated with the pre-trained model.
+    """
+    config = get_config(presets="zero_shot", overrides=hyperparameters)
+    assert (
+        len(config.model.names) == 1
+    ), f"Zero shot mode only supports using one model, but detects multiple models {config.model.names}"
+    model = create_model(config=config, pretrained=True)
+
+    data_processors = init_data_processors(
+        config=config,
+    )
+
+    return config, model, data_processors
+
+
 class AutoMMModelCheckpoint(pl.callbacks.ModelCheckpoint):
     """
     Class that inherits pl.callbacks.ModelCheckpoint. The purpose is to resolve the potential issues in lightning.

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -67,6 +67,8 @@ from .constants import (
     Y_PRED,
     Y_PRED_PROB,
     Y_TRUE,
+    MMDET_IMAGE,
+    BBOX,
 )
 from .data import (
     CategoricalProcessor,
@@ -87,7 +89,7 @@ from .models import (
     NumericalMLP,
     NumericalTransformer,
     TimmAutoModelForImagePrediction,
-    MMdetAutoModelForObjectDetection,
+    MMDetAutoModelForObjectDetection,
 )
 from .models.utils import inject_lora_to_linear_layer
 from .presets import get_automm_presets, get_basic_automm_config
@@ -785,8 +787,8 @@ def create_model(
                 num_classes=num_classes,
                 cls_token=True if len(names) == 1 else False,
             )
-        elif model_name.lower().startswith("mmdet_image"):
-            model = MMdetAutoModelForObjectDetection(
+        elif model_name.lower().startswith(MMDET_IMAGE):
+            model = MMDetAutoModelForObjectDetection(
                 prefix=model_name,
                 checkpoint_name=model_config.checkpoint_name,
             )
@@ -1626,8 +1628,8 @@ def extract_from_output(outputs: List[Dict], ret_type: str, as_ndarray: Optional
         feature_masks = [ele[COLUMN_FEATURES][MASKS] for ele in outputs]  # a list of dicts
         for feature_name in feature_masks[0].keys():
             ret[feature_name] = torch.cat([ele[feature_name] for ele in feature_masks])
-    elif ret_type == "bbox":
-        return [ele["bbox"] for ele in outputs]
+    elif ret_type == BBOX:
+        return [ele[BBOX] for ele in outputs]
     else:
         raise ValueError(f"Unknown return type: {ret_type}")
 

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -1626,8 +1626,8 @@ def extract_from_output(outputs: List[Dict], ret_type: str, as_ndarray: Optional
         feature_masks = [ele[COLUMN_FEATURES][MASKS] for ele in outputs]  # a list of dicts
         for feature_name in feature_masks[0].keys():
             ret[feature_name] = torch.cat([ele[feature_name] for ele in feature_masks])
-    elif ret_type == "bbx":
-        return [ele["bbx"] for ele in outputs]
+    elif ret_type == "bbox":
+        return [ele["bbox"] for ele in outputs]
     else:
         raise ValueError(f"Unknown return type: {ret_type}")
 

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -34,6 +34,7 @@ from .constants import (
     ALL_MODALITIES,
     AUTOMM,
     AVERAGE_PRECISION,
+    BBOX,
     BINARY,
     CATEGORICAL,
     CATEGORICAL_MLP,
@@ -51,6 +52,7 @@ from .constants import (
     LOGITS,
     MASKS,
     METRIC_MODE_MAP,
+    MMDET_IMAGE,
     MULTICLASS,
     NUMERICAL,
     NUMERICAL_MLP,
@@ -67,8 +69,6 @@ from .constants import (
     Y_PRED,
     Y_PRED_PROB,
     Y_TRUE,
-    MMDET_IMAGE,
-    BBOX,
 )
 from .data import (
     CategoricalProcessor,
@@ -84,12 +84,12 @@ from .models import (
     CategoricalTransformer,
     CLIPForImageText,
     HFAutoModelForTextPrediction,
+    MMDetAutoModelForObjectDetection,
     MultimodalFusionMLP,
     MultimodalFusionTransformer,
     NumericalMLP,
     NumericalTransformer,
     TimmAutoModelForImagePrediction,
-    MMDetAutoModelForObjectDetection,
 )
 from .models.utils import inject_lora_to_linear_layer
 from .presets import get_automm_presets, get_basic_automm_config

--- a/multimodal/tests/unittests/test_object_detection.py
+++ b/multimodal/tests/unittests/test_object_detection.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+import requests
+from PIL import Image
+
+from autogluon.multimodal import MultiModalPredictor
+
+
+def download_sample_images():
+    url = "https://raw.githubusercontent.com/open-mmlab/mmdetection/master/demo/demo.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+    mmdet_image_name = "demo.jpg"
+    image.save(mmdet_image_name)
+
+    return mmdet_image_name
+
+
+@pytest.mark.parametrize(
+    "checkpoint_name",
+    [
+        "faster_rcnn_r50_fpn_2x_coco",
+        "yolov3_mobilenetv2_320_300e_coco",
+        "cascade_rcnn_x101_64x4d_fpn_20e_coco",
+        "detr_r50_8x2_150e_coco",
+    ],
+)
+def test_mmdet_object_detection_inference(checkpoint_name):
+    mmdet_image_name = download_sample_images()
+
+    predictor = MultiModalPredictor(
+        hyperparameters={
+            "model.names": ["mmdet_image"],
+            "model.mmdet_image.checkpoint_name": checkpoint_name,
+        },
+        pipeline="object_detection",
+    )
+
+    pred = predictor.predict({"image": [mmdet_image_name]})
+    assert len(pred[0][0]) == 80    # COCO has 80 classes
+    assert pred[0][0][0].ndim == 2    # two dimensions, (# of proposals, 5)

--- a/multimodal/tests/unittests/test_object_detection.py
+++ b/multimodal/tests/unittests/test_object_detection.py
@@ -36,5 +36,5 @@ def test_mmdet_object_detection_inference(checkpoint_name):
     )
 
     pred = predictor.predict({"image": [mmdet_image_name]})
-    assert len(pred[0][0]) == 80    # COCO has 80 classes
-    assert pred[0][0][0].ndim == 2    # two dimensions, (# of proposals, 5)
+    assert len(pred[0][0]) == 80  # COCO has 80 classes
+    assert pred[0][0][0].ndim == 2  # two dimensions, (# of proposals, 5)

--- a/multimodal/tests/unittests/test_object_detection.py
+++ b/multimodal/tests/unittests/test_object_detection.py
@@ -29,7 +29,6 @@ def test_mmdet_object_detection_inference(checkpoint_name):
 
     predictor = MultiModalPredictor(
         hyperparameters={
-            "model.names": ["mmdet_image"],
             "model.mmdet_image.checkpoint_name": checkpoint_name,
         },
         pipeline="object_detection",


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
This PR aims to enable object detection in MultimodalPredictor by integrating MMdetection. 
```
from autogluon.multimodal import MultiModalPredictor

od = MultiModalPredictor(pipeline="object_detection")
results = od.predict({"image": ["demo.jpg"]})

from mmdet.apis import show_result_pyplot
show_result_pyplot(
        od._model.model,
        'demo.jpg',
        results[0][0],
        palette='coco',
        out_file='./demo_results.jpg')
```


Will add data handling and model training in following PRs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
