### PR TITLE
Assert that path have the right types and test path logic

### DIFF
--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from datetime import datetime
 
 import logging
@@ -7,6 +8,9 @@ logger = logging.getLogger(__name__)
 
 
 def setup_outputdir(path, warn_if_exist=True, create_dir=True, path_suffix=None):
+    if path:
+        assert isinstance(path, (str, Path)), \
+            f"Only str and pathlib.Path types are supported for path, got {path} of type {type(path)}."
     if path_suffix is None:
         path_suffix = ''
     if path_suffix and path_suffix[-1] == os.path.sep:

--- a/common/tests/unittests/test_setup_outputdir.py
+++ b/common/tests/unittests/test_setup_outputdir.py
@@ -1,0 +1,35 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from autogluon.common.utils.utils import setup_outputdir
+
+
+class SetupOutputDirTestCase(unittest.TestCase):
+    def test(self):
+        # checks that setup_outputdir raises when incorrect type is given
+        with self.assertRaises(Exception) as context:
+            path = 2.2
+            setup_outputdir(path, warn_if_exist=True, create_dir=False, path_suffix=None)
+
+        # checks that setup_outputdir returns a path AutogluonModels/ag-* when no path is given
+        path = None
+        returned_path = setup_outputdir(path, warn_if_exist=True, create_dir=False, path_suffix=None)
+        print(returned_path)
+        assert 'AutogluonModels/ag' in returned_path
+
+        # checks that setup_outputdir returns the path given as input when given a path of type `str`
+        path = tempfile.TemporaryDirectory().name
+        returned_path = setup_outputdir(path, warn_if_exist=True, create_dir=False, path_suffix=None)
+        print(returned_path)
+        assert str(Path(returned_path)) == path
+
+        # checks that setup_outputdir returns the path given as input when given a path of type `pathlib.Path`
+        path = Path(tempfile.TemporaryDirectory().name)
+        returned_path = setup_outputdir(path, warn_if_exist=True, create_dir=False, path_suffix=None)
+        print(returned_path)
+        assert str(Path(returned_path)) == str(path)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -82,7 +82,7 @@ class TabularPredictor:
 
         You can also pass your own evaluation function here as long as it follows formatting of the functions defined in folder `autogluon.core.metrics`.
         For detailed instructions on creating and using a custom metric, refer to https://auto.gluon.ai/stable/tutorials/tabular_prediction/tabular-custom-metric.html
-    path : str, default = None
+    path : Union[str, pathlib.Path], default = None
         Path to directory where models and intermediate outputs should be saved.
         If unspecified, a time-stamped folder called "AutogluonModels/ag-[TIMESTAMP]" will be created in the working directory to store all models.
         Note: To call `fit()` twice and save all results of each fit, you must specify different `path` locations or don't specify `path` at all.


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/autogluon/issues/2022

*Description of changes:* 
* assert that types of path are `str` or `pathlib.Path` to avoid unwanted conversion from weird types to string
* add unit-tests to check the path logic
* update doc to mention that pathlib.Path are supported


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
