### PR TITLE
Optimize LightGBM DART retraining

### DIFF
--- a/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
+++ b/tabular/src/autogluon/tabular/models/lgb/lgb_model.py
@@ -205,7 +205,9 @@ class LGBModel(AbstractModel):
                             retrain = False
                     if retrain:
                         logger.log(15, f"Retraining LGB model to optimal iterations ('dart' mode).")
-                        train_params.pop('callbacks')
+                        train_params.pop('callbacks', None)
+                        train_params.pop('valid_sets', None)
+                        train_params.pop('valid_names', None)
                         train_params['num_boost_round'] = self.model.best_iteration
                         self.model = lgb.train(**train_params)
                     else:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Optimize LightGBM DART retraining by not calculating stopping metric scores on val data on each iteration, since we aren't using early stopping and are training to a fixed number of iterations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
