### PR TITLE
Bump sktime to 0.13.1 and roll back presets for time series

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -46,7 +46,7 @@ except (ImportError, AssertionError):
 
 extras_require = {
     "tests": ["pytest", "flake8~=4.0", "flaky~=3.7", "pytest-timeout~=2.1", "isort>=5.10", "black~=22.0,>=22.3"],
-    "sktime": ["sktime~=0.11.4", "pmdarima~=1.8.2", "tbats~=1.1"],
+    "sktime": ["sktime~=0.13,>=0.13.1", "pmdarima~=1.8.2", "tbats~=1.1"],
 }
 
 all_requires = []

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -78,7 +78,7 @@ def get_default_hps(key, prediction_length):
             "ARIMA": {
                 "maxiter": 50,
                 "order": (1, 1, 1),
-                "seasonal_order": (1, 0, 0),
+                "seasonal_order": (0, 0, 0),
                 "suppress_warnings": True,
             },
             "SimpleFeedForward": {
@@ -116,9 +116,9 @@ def get_default_hps(key, prediction_length):
                 "fail_if_misconfigured": True,
             },
             "ARIMA": {
-                "maxiter": 50,
-                "order": ag.Categorical((1, 1, 1), (2, 0, 1)),
-                "seasonal_order": ag.Categorical((1, 0, 0), (1, 0, 1), (1, 1, 1)),
+                "maxiter": ag.Categorical(50),
+                "order": (1, 1, 1),
+                "seasonal_order": (0, 0, 0),
                 "suppress_warnings": True,
                 "fail_if_misconfigured": True,
             },


### PR DESCRIPTION
This PR contains two changes:
1. It bumps the `sktime` dependency to `~=0.13,>=0.13.1`, which will allow us to also bump the `numpy` version.
2. It rolls back the presets to the version that we had in `0.5.2` release of AG. I discovered some problems with high disk/memory usage of the current version of the presets (last modified in #2001 but not included in any release yet). I want to fix these problems before we update the presets to avoid impacting the user experience in a negative way.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
