### PR TITLE
Fix MultiWindowSplitter for timeseries and use faster presets

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -73,11 +73,11 @@ def get_default_hps(key, prediction_length):
                 "trend": "add",
                 "seasonal": "add",
                 "auto": False,
-                "initialization_method": "heuristic",
+                "initialization_method": "estimated",
             },
             "ARIMA": {
                 "maxiter": 50,
-                "order": (1, 1, 1),
+                "order": (1, 0, 0),
                 "seasonal_order": (0, 0, 0),
                 "suppress_warnings": True,
             },
@@ -117,7 +117,7 @@ def get_default_hps(key, prediction_length):
             },
             "ARIMA": {
                 "maxiter": ag.Categorical(50),
-                "order": (1, 1, 1),
+                "order": (1, 0, 0),
                 "seasonal_order": (0, 0, 0),
                 "suppress_warnings": True,
                 "fail_if_misconfigured": True,

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -181,8 +181,10 @@ class MultiWindowSplitter(AbstractTimeSeriesSplitter):
             validation_dataframes.append(next_val_dataframe)
 
         train_data = ts_dataframe.slice_by_timestep(slice(None, -prediction_length))
+        val_data = pd.concat(validation_dataframes)
+        val_data._cached_freq = train_data._cached_freq
 
-        return train_data, pd.concat(validation_dataframes)
+        return train_data, val_data
 
 
 class LastWindowSplitter(MultiWindowSplitter):

--- a/timeseries/src/autogluon/timeseries/utils/seasonality.py
+++ b/timeseries/src/autogluon/timeseries/utils/seasonality.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import pandas as pd
 
 DEFAULT_SEASONALITIES = {
@@ -11,10 +13,13 @@ DEFAULT_SEASONALITIES = {
 }
 
 
-def get_seasonality(freq: str) -> int:
+def get_seasonality(freq: Union[str, None]) -> int:
     """Return the seasonality of a given frequency. Adapted from
     ``gluonts.time_feature.seasonality``.
     """
+    if freq is None:
+        return 1
+
     offset = pd.tseries.frequencies.to_offset(freq)
     norm_freq_str = offset.name.split("-")[0]
     base_seasonality = DEFAULT_SEASONALITIES.get(norm_freq_str, 1)

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -12,6 +12,7 @@ from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.models import DeepARModel
 from autogluon.timeseries.models.gluonts.models import GenericGluonTSModelFactory
 from autogluon.timeseries.predictor import TimeSeriesPredictor
+from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter
 
 from .common import DUMMY_TS_DATAFRAME
 
@@ -384,3 +385,14 @@ def test_when_predictor_called_and_loaded_back_then_ignore_time_index_persists(t
 
     loaded_predictor = TimeSeriesPredictor.load(temp_model_path)
     assert loaded_predictor.ignore_time_index == ignore_time_index
+
+
+@pytest.mark.parametrize(
+    "splitter_string, expected_splitter_class",
+    [("last_window", LastWindowSplitter), ("multi_window", MultiWindowSplitter)],
+)
+def test_when_passing_magic_string_as_validation_splitter_then_correct_splitter_object_is_created(
+    splitter_string, expected_splitter_class
+):
+    predictor = TimeSeriesPredictor(validation_splitter=splitter_string)
+    assert isinstance(predictor.validation_splitter, expected_splitter_class)


### PR DESCRIPTION
Minor fixes for problems revealed by the latest benchmarking run for timeseries:
- Keep `_cached_freq` during splitting with `MultiWindowSplitter`
- Fix bug in `get_seasonality`
- Add test for the `validation_splitter` argument in `TimeSeriesPredictor`
- Use presets that don't lead to OOM issues on large datasets with ARIMA (band-aid fix until we implement better local models)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
