### PR TITLE
Refactor time series ensemble

### DIFF
--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -122,8 +122,12 @@ class TimeSeriesEvaluator:
         self.metric_method = self.__getattribute__("_" + self.eval_metric.lower())
 
     @property
+    def coefficient(self) -> bool:
+        return self.METRIC_COEFFICIENTS[self.eval_metric]
+
+    @property
     def higher_is_better(self) -> bool:
-        return self.METRIC_COEFFICIENTS[self.eval_metric] > 0
+        return self.coefficient > 0
 
     def _safemean(self, data: Any):
         data_filled = np.nan_to_num(data, neginf=np.nan, posinf=np.nan, nan=np.nan)

--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -121,6 +121,10 @@ class TimeSeriesEvaluator:
 
         self.metric_method = self.__getattribute__("_" + self.eval_metric.lower())
 
+    @property
+    def higher_is_better(self) -> bool:
+        return self.METRIC_COEFFICIENTS[self.eval_metric] > 0
+
     def _safemean(self, data: Any):
         data_filled = np.nan_to_num(data, neginf=np.nan, posinf=np.nan, nan=np.nan)
         return np.nanmean(data_filled)

--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -122,7 +122,7 @@ class TimeSeriesEvaluator:
         self.metric_method = self.__getattribute__("_" + self.eval_metric.lower())
 
     @property
-    def coefficient(self) -> bool:
+    def coefficient(self) -> int:
         return self.METRIC_COEFFICIENTS[self.eval_metric]
 
     @property

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -88,6 +88,7 @@ class TimeSeriesLearner(AbstractLearner):
                 target=self.target,
                 quantile_levels=self.quantile_levels,
                 verbosity=kwargs.get("verbosity", 2),
+                enable_ensemble=kwargs.get("enable_ensemble", True),
             )
         )
         self.trainer = self.trainer_type(**trainer_init_kwargs)

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -225,7 +225,9 @@ class AbstractTimeSeriesModel(AbstractModel):
         if not all(0 < q < 1 for q in quantiles):
             raise ValueError("Invalid quantile value specified. Quantiles must be between 0 and 1 (exclusive).")
 
-    def predict(self, data: TimeSeriesDataFrame, **kwargs) -> TimeSeriesDataFrame:
+    def predict(
+        self, data: Union[TimeSeriesDataFrame, Dict[str, TimeSeriesDataFrame]], **kwargs
+    ) -> TimeSeriesDataFrame:
         """Given a dataset, predict the next `self.prediction_length` time steps.
         This method produces predictions for the forecast horizon *after* the individual time series.
 
@@ -235,8 +237,9 @@ class AbstractTimeSeriesModel(AbstractModel):
 
         Parameters
         ----------
-        data: TimeSeriesDataFrame
-            The dataset where each time series is the "context" for predictions.
+        data: Union[TimeSeriesDataFrame, Dict[str, TimeSeriesDataFrame]]
+            The dataset where each time series is the "context" for predictions. For ensemble models that depend on
+            the predictions of other models, this method may accept a dictionary of previous models' predictions.
 
         Other Parameters
         ----------------

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -315,7 +315,7 @@ class AbstractTimeSeriesModel(AbstractModel):
         predictions = self.predict_for_scoring(data)
         metric_value = evaluator(data, predictions)
 
-        return metric_value * TimeSeriesEvaluator.METRIC_COEFFICIENTS[metric]
+        return metric_value * evaluator.coefficient
 
     def _hyperparameter_tune(
         self,

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -8,6 +8,8 @@ import autogluon.core as ag
 from autogluon.core.models.greedy_ensemble.ensemble_selection import AbstractWeightedEnsemble, EnsembleSelection
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+from autogluon.timeseries.evaluator import TimeSeriesEvaluator
+
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +18,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
     def __init__(
         self,
         ensemble_size: int,
-        metric,
+        metric: TimeSeriesEvaluator,
         problem_type: str = ag.constants.QUANTILE,
         sorted_initialization: bool = False,
         bagging: bool = False,

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -48,8 +48,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
     def _calculate_regret(self, y_true, y_pred_proba, metric, dummy_pred=None, sample_weight=None):  # noqa
         dummy_pred = copy.deepcopy(self.dummy_pred if dummy_pred is None else dummy_pred)
         dummy_pred[list(dummy_pred.columns)] = y_pred_proba
-        sign = 1 if metric.higher_is_better else -1
-        return sign * metric(y_true, dummy_pred)
+        return metric(y_true, dummy_pred) * metric.coefficient
 
 
 class SimpleTimeSeriesWeightedEnsemble(AbstractWeightedEnsemble):

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -44,6 +44,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
             time_limit=time_limit,
             sample_weight=sample_weight,
         )
+        self.dummy_pred = None
 
     def _calculate_regret(self, y_true, y_pred_proba, metric, dummy_pred=None, sample_weight=None):  # noqa
         dummy_pred = copy.deepcopy(self.dummy_pred if dummy_pred is None else dummy_pred)

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -1,11 +1,14 @@
 import copy
 import logging
-import time
 from typing import List
 
 import numpy as np
 
-from autogluon.core.models.greedy_ensemble.ensemble_selection import AbstractWeightedEnsemble, EnsembleSelection
+import autogluon.core as ag
+from autogluon.core.models.greedy_ensemble.ensemble_selection import (
+    AbstractWeightedEnsemble,
+    EnsembleSelection,
+)
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 
@@ -13,156 +16,42 @@ logger = logging.getLogger(__name__)
 
 
 class TimeSeriesEnsembleSelection(EnsembleSelection):
-    def __init__(  # noqa
+    def __init__(
         self,
         ensemble_size: int,
-        problem_type: str,
         metric,
-        higher_is_better=False,
+        problem_type: str = ag.constants.QUANTILE,
         sorted_initialization: bool = False,
         bagging: bool = False,
         tie_breaker: str = "random",
         random_state: np.random.RandomState = None,
         **kwargs,
     ):
-        # TODO: call super init?
-        self.ensemble_size = ensemble_size
-        self.problem_type = problem_type
-        self.metric = metric
-        self.higher_is_better = higher_is_better
-        self.sorted_initialization = sorted_initialization
-        self.bagging = bagging
-        self.use_best = True
-        if tie_breaker not in ["random", "second_metric"]:
-            raise ValueError(f"Unknown tie_breaker value: {tie_breaker}. Must be one of: ['random', 'second_metric']")
-        self.tie_breaker = tie_breaker
-        if random_state is not None:
-            self.random_state = random_state
-        else:
-            self.random_state = np.random.RandomState(seed=0)
-        self.quantile_levels = kwargs.get("quantile_levels", None)
+        super().__init__(
+            ensemble_size=ensemble_size,
+            metric=metric,
+            problem_type=problem_type,
+            sorted_initialization=sorted_initialization,
+            bagging=bagging,
+            tie_breaker=tie_breaker,
+            random_state=random_state,
+            **kwargs,
+        )
 
-    def fit(self, predictions, labels, time_limit=None, identifiers=None, sample_weight=None):
-        self.ensemble_size = int(self.ensemble_size)
-        if self.ensemble_size < 1:
-            raise ValueError("Ensemble size cannot be less than one!")
-        self._fit(
-            predictions=predictions,
+    def _fit(self, predictions, labels, time_limit=None, sample_weight=None):
+        self.dummy_pred = copy.deepcopy(predictions[0])
+        super()._fit(
+            predictions=[d.values for d in predictions],
             labels=labels,
             time_limit=time_limit,
             sample_weight=sample_weight,
         )
-        self._calculate_weights()
-        logger.log(10, "Ensemble weights: ")
-        logger.log(10, self.weights_)
-        return self
 
-    # TODO: Consider having a removal stage, remove each model and see if
-    #  score is affected, if improves or not effected, remove it.
-    def _fit(self, predictions, labels, time_limit=None, sample_weight=None):
-        ensemble_size = self.ensemble_size
-        self.num_input_models_ = len(predictions)
-        ensemble = []
-        trajectory = []
-        order = []
-        used_models = set()
-
-        time_start = time.time()
-        round_scores = False
-        epsilon = 1e-4
-        round_decimals = 6
-        dummy_pred = copy.deepcopy(predictions[0])
-        for i in range(ensemble_size):
-            scores = np.zeros((len(predictions)))
-            s = len(ensemble)
-            if s == 0:
-                weighted_ensemble_prediction = np.zeros(predictions[0].shape)
-            else:
-                # Memory-efficient averaging!
-                ensemble_prediction = np.zeros(ensemble[0].shape)
-                for pred in ensemble:
-                    ensemble_prediction += pred.values
-                ensemble_prediction /= s
-
-                weighted_ensemble_prediction = (s / float(s + 1)) * ensemble_prediction
-            fant_ensemble_prediction = np.zeros(weighted_ensemble_prediction.shape)
-            for j, pred in enumerate(predictions):
-                fant_ensemble_prediction[:] = weighted_ensemble_prediction + (1.0 / float(s + 1)) * pred.values
-                scores[j] = self._calculate_regret(
-                    y_true=labels,
-                    y_pred_proba=fant_ensemble_prediction,
-                    metric=self.metric,
-                    sample_weight=sample_weight,
-                    dummy_pred=dummy_pred,
-                )
-                if round_scores:
-                    scores[j] = scores[j].round(round_decimals)
-
-            all_best = np.argwhere(scores == np.nanmin(scores)).flatten()
-
-            if (len(all_best) > 1) and used_models:
-                # If tie, prioritize models already in ensemble to avoid unnecessarily large ensemble
-                new_all_best = []
-                for m in all_best:
-                    if m in used_models:
-                        new_all_best.append(m)
-                if new_all_best:
-                    all_best = new_all_best
-
-            best = self.random_state.choice(all_best)
-            best_score = scores[best]
-
-            # If first iteration
-            if i == 0:
-                # If abs value of min score is large enough, round to 6 decimal places to avoid
-                # floating point error deciding the best index.  This avoids 2 models with the same pred
-                # proba both being used in the ensemble due to floating point error
-                if np.abs(best_score) > epsilon:
-                    round_scores = True
-                    best_score = best_score.round(round_decimals)
-
-            ensemble.append(predictions[best])
-            trajectory.append(best_score)
-            order.append(best)
-            used_models.add(best)
-
-            # Handle special case
-            if len(predictions) == 1:
-                break
-
-            if time_limit is not None:
-                time_elapsed = time.time() - time_start
-                time_left = time_limit - time_elapsed
-                if time_left <= 0:
-                    logger.warning(
-                        f"Warning: Ensemble Selection ran out of time, early stopping at iteration {i+1}. This "
-                        f"may mean that the time_limit specified is very small for this problem."
-                    )
-                    break
-
-        min_score = np.min(trajectory)
-        first_index_of_best = trajectory.index(min_score)
-
-        if self.use_best:
-            self.indices_ = order[: first_index_of_best + 1]
-            self.trajectory_ = trajectory[: first_index_of_best + 1]
-            self.train_score_ = trajectory[first_index_of_best]
-            self.ensemble_size = first_index_of_best + 1
-            logger.log(15, "Ensemble size: %s" % self.ensemble_size)
-        else:
-            self.indices_ = order
-            self.trajectory_ = trajectory
-            self.train_score_ = trajectory[-1]
-
-        logger.debug("Ensemble indices: " + str(self.indices_))
-
-    def _calculate_regret(self, y_true, y_pred_proba, metric, dummy_pred, sample_weight=None):  # noqa
-        dummy_pred = copy.deepcopy(dummy_pred)
+    def _calculate_regret(self, y_true, y_pred_proba, metric, dummy_pred=None, sample_weight=None):  # noqa
+        dummy_pred = copy.deepcopy(self.dummy_pred if dummy_pred is None else dummy_pred)
         dummy_pred[list(dummy_pred.columns)] = y_pred_proba
-        score = metric(y_true, dummy_pred)
-        if self.higher_is_better:
-            score = -score
-        return score
+        sign = 1 if metric.higher_is_better else -1
+        return sign * metric(y_true, dummy_pred)
 
 
 class SimpleTimeSeriesWeightedEnsemble(AbstractWeightedEnsemble):
@@ -186,8 +75,6 @@ class SimpleTimeSeriesWeightedEnsemble(AbstractWeightedEnsemble):
         preds: List[TimeSeriesDataFrame],
         weights: List[float],
     ) -> TimeSeriesDataFrame:
-        # TODO: this is a hack. indices may not match, which should be checked or better,
-        # TODO: weighted accordingly
         assert len(set(v.shape for v in preds)) == 1
 
         # TODO: handle NaNs
@@ -204,16 +91,7 @@ class TimeSeriesEnsembleWrapper(AbstractTimeSeriesModel):
         self.fit_time = None
         self.val_score = None
 
-    def _fit(
-        self,
-        train_data,
-        val_data=None,
-        time_limit=None,
-        num_cpus=None,
-        num_gpus=None,
-        verbosity=2,
-        **kwargs,
-    ) -> None:
+    def _fit(self, *args, **kwargs) -> None:
         raise NotImplementedError
 
     @property

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -5,10 +5,7 @@ from typing import List
 import numpy as np
 
 import autogluon.core as ag
-from autogluon.core.models.greedy_ensemble.ensemble_selection import (
-    AbstractWeightedEnsemble,
-    EnsembleSelection,
-)
+from autogluon.core.models.greedy_ensemble.ensemble_selection import AbstractWeightedEnsemble, EnsembleSelection
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -252,7 +252,7 @@ class TimeSeriesPredictor:
         hyperparameter_tune_kwargs : str or dict, default = None
             # TODO
         enable_ensemble: bool, default = True
-            If True, the ``TimeSeriesPredictor`` will fit all models specified via ``hyperparameters``, and also fit a 
+            If True, the ``TimeSeriesPredictor`` will fit all models specified via ``hyperparameters``, and also fit a
             simple weighted ensemble on trained models.
         References
         ----------

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -194,6 +194,7 @@ class TimeSeriesPredictor:
         presets: Optional[str] = None,
         hyperparameters: Dict[Union[str, Type], Any] = None,
         hyperparameter_tune_kwargs: Optional[Union[str, Dict]] = None,
+        enable_ensemble: bool = True,
         **kwargs,
     ) -> "TimeSeriesPredictor":
         """Fit models to predict distributional forecasts of multiple related time series
@@ -250,7 +251,9 @@ class TimeSeriesPredictor:
             choices for each of the recommended models can be found in the references.
         hyperparameter_tune_kwargs : str or dict, default = None
             # TODO
-
+        enable_ensemble: bool, default = True
+            If True, the ``TimeSeriesPredictor`` will fit all models specified via ``hyperparameters``, and also fit a 
+            simple weighted ensemble on trained models.
         References
         ----------
             - DeepAR: https://ts.gluon.ai/api/gluonts/gluonts.model.deepar.html
@@ -283,6 +286,7 @@ class TimeSeriesPredictor:
             evaluation_metric=self.eval_metric,
             hyperparameters=hyperparameters,
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+            enable_ensemble=enable_ensemble,
             **kwargs,
         )
         logger.info("================ TimeSeriesPredictor ================")
@@ -325,6 +329,7 @@ class TimeSeriesPredictor:
             hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
             time_limit=time_left,
             verbosity=verbosity,
+            enable_ensemble=enable_ensemble,
         )
 
         self.save()

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -252,8 +252,8 @@ class TimeSeriesPredictor:
         hyperparameter_tune_kwargs : str or dict, default = None
             # TODO
         enable_ensemble: bool, default = True
-            If True, the ``TimeSeriesPredictor`` will fit all models specified via ``hyperparameters``, and also fit a
-            simple weighted ensemble on trained models.
+            If True, the ``TimeSeriesPredictor`` will fit a simple weighted ensemble on top of the models specified via
+            ``hyperparameters``.
         References
         ----------
             - DeepAR: https://ts.gluon.ai/api/gluonts/gluonts.model.deepar.html

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -582,7 +582,14 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                     "Time left: {time_left_for_ensemble:.2f} seconds"
                 )
             elif len(models_available_for_ensemble) <= 1:
-                logger.info(f"Not fitting ensemble as only {len(models_available_for_ensemble)} models were trained.")
+                logger.info(
+                    f"Not fitting ensemble as "
+                    + (
+                        "no models were successfully trained."
+                        if not models_available_for_ensemble
+                        else "only 1 model was trained."
+                    )
+                )
             else:
                 try:
                     model_names_trained.append(

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -578,9 +578,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                     )
             else:
                 try:
-                    model_names_trained.append(
-                        self.fit_ensemble(val_data=val_data, model_names=model_names_trained)
-                    )
+                    model_names_trained.append(self.fit_ensemble(val_data=val_data, model_names=model_names_trained))
                 except Exception as e:  # noqa
                     logger.error(f"\tEnsemble training failed with error \n{traceback.format_exc()}.")
 

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -569,6 +569,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 )
 
         if self.enable_ensemble:
+            models_available_for_ensemble = self.get_model_names()
             if time_limit is not None:
                 time_left_for_ensemble = time_limit - (time.time() - time_start)
                 if time_left_for_ensemble <= 0:
@@ -576,9 +577,11 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                         "Not fitting ensemble due to lack of time remaining. "
                         "Time left: {time_left_for_ensemble:.2f} seconds"
                     )
+            elif len(models_available_for_ensemble) <= 1:
+                logger.info(f"Not fitting ensemble as only {len(models_available_for_ensemble)} models were trained.")
             else:
                 try:
-                    model_names_trained.append(self.fit_ensemble(val_data=val_data, model_names=model_names_trained))
+                    model_names_trained.append(self.fit_ensemble(val_data=val_data, model_names=models_available_for_ensemble))
                 except Exception as e:  # noqa
                     logger.error(f"\tEnsemble training failed with error \n{traceback.format_exc()}.")
 

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -71,7 +71,8 @@ def test_given_hyperparameters_when_learner_called_then_leaderboard_is_correct(
     learner = trained_learners[repr(hyperparameters)]
     leaderboard = learner.leaderboard()
 
-    expected_board_length += int(learner.load_trainer().enable_ensemble)
+    if learner.load_trainer().enable_ensemble and len(hyperparameters) > 1:
+        expected_board_length += 1
 
     assert len(leaderboard) == expected_board_length
     assert np.all(leaderboard["score_val"] < 0)  # all MAPEs should be negative
@@ -148,7 +149,8 @@ def test_given_hyperparameters_and_custom_models_when_learner_called_then_leader
     )
     leaderboard = learner.leaderboard()
 
-    expected_board_length += int(learner.load_trainer().enable_ensemble)
+    if learner.load_trainer().enable_ensemble and len(hyperparameters) > 1:
+        expected_board_length += 1
 
     assert len(leaderboard) == expected_board_length
     assert np.all(leaderboard["score_val"] < 0)  # all MAPEs should be negative

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -9,8 +9,7 @@ import autogluon.core as ag
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.models import DeepARModel
-from autogluon.timeseries.models.gluonts.models import MQRNNEstimator
-from autogluon.timeseries.models.gluonts.models import GenericGluonTSModelFactory
+from autogluon.timeseries.models.gluonts.models import GenericGluonTSModelFactory, MQRNNEstimator
 from autogluon.timeseries.predictor import TimeSeriesPredictor
 from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter
 
@@ -398,9 +397,7 @@ def test_when_passing_magic_string_as_validation_splitter_then_correct_splitter_
     assert isinstance(predictor.validation_splitter, expected_splitter_class)
 
 
-def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_fitted(
-    temp_model_path
-):
+def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_fitted(temp_model_path):
     predictor = TimeSeriesPredictor(
         path=temp_model_path,
         eval_metric="MAPE",
@@ -413,11 +410,11 @@ def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_fitt
             "DeepAR": {"epochs": 1},
         },
     )
-    assert any("ensemble" in n.lower() for n in predictor.get_model_names()) 
+    assert any("ensemble" in n.lower() for n in predictor.get_model_names())
 
 
 def test_given_enable_ensemble_true_and_only_one_model_when_predictor_called_then_ensemble_is_not_fitted(
-    temp_model_path
+    temp_model_path,
 ):
     predictor = TimeSeriesPredictor(
         path=temp_model_path,
@@ -428,12 +425,10 @@ def test_given_enable_ensemble_true_and_only_one_model_when_predictor_called_the
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters={"SimpleFeedForward": {"epochs": 1}},
     )
-    assert not any("ensemble" in n.lower() for n in predictor.get_model_names()) 
+    assert not any("ensemble" in n.lower() for n in predictor.get_model_names())
 
 
-def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_not_fitted(
-    temp_model_path
-):
+def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_not_fitted(temp_model_path):
     predictor = TimeSeriesPredictor(
         path=temp_model_path,
         eval_metric="MAPE",
@@ -443,4 +438,4 @@ def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_not_
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters={"SimpleFeedForward": {"epochs": 1}},
     )
-    assert not any("ensemble" in n.lower() for n in predictor.get_model_names()) 
+    assert not any("ensemble" in n.lower() for n in predictor.get_model_names())

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -4,12 +4,12 @@ import copy
 import numpy as np
 import pandas as pd
 import pytest
-from gluonts.model.seq2seq import MQRNNEstimator
 
 import autogluon.core as ag
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
 from autogluon.timeseries.models import DeepARModel
+from autogluon.timeseries.models.gluonts.models import MQRNNEstimator
 from autogluon.timeseries.models.gluonts.models import GenericGluonTSModelFactory
 from autogluon.timeseries.predictor import TimeSeriesPredictor
 from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter
@@ -134,7 +134,7 @@ def test_given_hyperparameters_and_quantiles_when_predictor_called_then_model_ca
 def test_given_hyperparameters_and_custom_models_when_predictor_called_then_leaderboard_is_correct(
     temp_model_path, eval_metric, hyperparameters, expected_board_length
 ):
-    predictor = TimeSeriesPredictor(path=temp_model_path)
+    predictor = TimeSeriesPredictor(path=temp_model_path, eval_metric=eval_metric)
     predictor.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters=hyperparameters,
@@ -142,7 +142,7 @@ def test_given_hyperparameters_and_custom_models_when_predictor_called_then_lead
     )
     leaderboard = predictor.leaderboard()
 
-    if predictor._trainer.enable_ensemble:
+    if predictor._trainer.enable_ensemble and len(hyperparameters) > 1:
         expected_board_length += 1
 
     assert len(leaderboard) == expected_board_length
@@ -396,3 +396,51 @@ def test_when_passing_magic_string_as_validation_splitter_then_correct_splitter_
 ):
     predictor = TimeSeriesPredictor(validation_splitter=splitter_string)
     assert isinstance(predictor.validation_splitter, expected_splitter_class)
+
+
+def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_fitted(
+    temp_model_path
+):
+    predictor = TimeSeriesPredictor(
+        path=temp_model_path,
+        eval_metric="MAPE",
+        enable_ensemble=True,
+    )
+    predictor.fit(
+        train_data=DUMMY_TS_DATAFRAME,
+        hyperparameters={
+            "SimpleFeedForward": {"epochs": 1},
+            "DeepAR": {"epochs": 1},
+        },
+    )
+    assert any("ensemble" in n.lower() for n in predictor.get_model_names()) 
+
+
+def test_given_enable_ensemble_true_and_only_one_model_when_predictor_called_then_ensemble_is_not_fitted(
+    temp_model_path
+):
+    predictor = TimeSeriesPredictor(
+        path=temp_model_path,
+        eval_metric="MAPE",
+        enable_ensemble=True,
+    )
+    predictor.fit(
+        train_data=DUMMY_TS_DATAFRAME,
+        hyperparameters={"SimpleFeedForward": {"epochs": 1}},
+    )
+    assert not any("ensemble" in n.lower() for n in predictor.get_model_names()) 
+
+
+def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_not_fitted(
+    temp_model_path
+):
+    predictor = TimeSeriesPredictor(
+        path=temp_model_path,
+        eval_metric="MAPE",
+        enable_ensemble=False,
+    )
+    predictor.fit(
+        train_data=DUMMY_TS_DATAFRAME,
+        hyperparameters={"SimpleFeedForward": {"epochs": 1}},
+    )
+    assert not any("ensemble" in n.lower() for n in predictor.get_model_names()) 

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -397,7 +397,7 @@ def test_when_passing_magic_string_as_validation_splitter_then_correct_splitter_
     assert isinstance(predictor.validation_splitter, expected_splitter_class)
 
 
-def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_fitted(temp_model_path):
+def test_given_enable_ensemble_true_when_predictor_called_then_ensemble_is_fitted(temp_model_path):
     predictor = TimeSeriesPredictor(
         path=temp_model_path,
         eval_metric="MAPE",

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -417,9 +417,9 @@ def test_given_repeating_model_when_trainer_called_incrementally_then_name_colli
 
     model_names = trainer.get_model_names()
 
-    # account for the ensemble if it should be fitted
+    # account for the ensemble if it should be fitted, and drop ensemble names
     if trainer.enable_ensemble and sum(len(hp) for hp in hyperparameter_list) > 1:
-        expected_number_of_unique_names += 1
+        model_names = [n for n in model_names if "WeightedEnsemble" not in n]
     assert len(model_names) == expected_number_of_unique_names
     for suffix in expected_suffixes:
         assert any(name.endswith(suffix) for name in model_names)

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -98,7 +98,7 @@ def test_given_test_data_when_trainer_called_then_leaderboard_is_correct(
     test_data = get_data_frame_with_item_index(["A", "B", "C"])
 
     leaderboard = trainer.leaderboard(test_data)
-    
+
     if len(hyperparameters) > 1:
         expected_board_length += int(trainer.enable_ensemble)
 
@@ -416,7 +416,7 @@ def test_given_repeating_model_when_trainer_called_incrementally_then_name_colli
         )
 
     model_names = trainer.get_model_names()
-  
+
     # account for the ensemble if it should be fitted
     if trainer.enable_ensemble and sum(len(hp) for hp in hyperparameter_list) > 1:
         expected_number_of_unique_names += 1

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -81,7 +81,8 @@ def test_given_hyperparameters_when_trainer_called_then_leaderboard_is_correct(
     )
     leaderboard = trainer.leaderboard()
 
-    expected_board_length += int(trainer.enable_ensemble)
+    if len(hyperparameters) > 1:
+        expected_board_length += int(trainer.enable_ensemble)
     assert len(leaderboard) == expected_board_length
     assert np.all(leaderboard["score_val"] < 0)  # all MAPEs should be negative
 
@@ -97,7 +98,9 @@ def test_given_test_data_when_trainer_called_then_leaderboard_is_correct(
     test_data = get_data_frame_with_item_index(["A", "B", "C"])
 
     leaderboard = trainer.leaderboard(test_data)
-    expected_board_length += int(trainer.enable_ensemble)
+    
+    if len(hyperparameters) > 1:
+        expected_board_length += int(trainer.enable_ensemble)
 
     assert len(leaderboard) == expected_board_length
     assert not np.any(np.isnan(leaderboard["score_test"]))
@@ -289,7 +292,8 @@ def test_given_hyperparameters_and_custom_models_when_trainer_called_then_leader
     )
     leaderboard = trainer.leaderboard()
 
-    expected_board_length += int(trainer.enable_ensemble)
+    if len(hyperparameters) > 1:  # account for ensemble
+        expected_board_length += int(trainer.enable_ensemble)
     assert len(leaderboard) == expected_board_length
     assert np.all(leaderboard["score_val"] < 0)  # all MAPEs should be negative
 
@@ -412,8 +416,9 @@ def test_given_repeating_model_when_trainer_called_incrementally_then_name_colli
         )
 
     model_names = trainer.get_model_names()
-
-    if trainer.enable_ensemble:
+  
+    # account for the ensemble if it should be fitted
+    if trainer.enable_ensemble and sum(len(hp) for hp in hyperparameter_list) > 1:
         expected_number_of_unique_names += 1
     assert len(model_names) == expected_number_of_unique_names
     for suffix in expected_suffixes:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR removes duplicated code from the timeseries module for the weighted ensemble, and refactors the ensemble APIs to be simpler and safer. It also adds an option to the predictor (public API change) to disable the ensemble (currently the ensemble is still enabled by default and for all presets), and automatically disables ensemble fitting if only one model was fitted. We also make minor changes to the evaluator for simpler handling of coefficients and `higher_is_better`. 

TODO:

- [x] run the quick benchmark to check for regressions in performance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
