### PR TITLE
clean up flake and pep8 warnings in timeseries

### DIFF
--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -191,7 +191,7 @@ class TimeSeriesEvaluator:
         for item_id in data.iter_items():
             y_true_w_hist = data.loc[item_id][self.target_column]
 
-            target = np.array(y_true_w_hist[-self.prediction_length :])
+            target = np.array(y_true_w_hist[-self.prediction_length :])  # noqa: E203
             target_history = np.array(y_true_w_hist[: -self.prediction_length])
 
             item_metrics = {}

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from typing import Any, Dict, Optional, Tuple, Type, Union
+from typing import Any, Dict, Optional, Type, Union
 
 import pandas as pd
 

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import autogluon.core as ag
 from autogluon.common.savers import save_pkl

--- a/timeseries/src/autogluon/timeseries/models/sktime/models.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/models.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any, Dict
 
 from sktime.forecasting.arima import ARIMA, AutoARIMA
 from sktime.forecasting.ets import AutoETS

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -2,7 +2,7 @@ import logging
 import pprint
 import time
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -1,8 +1,6 @@
 import copy
-import gc
 import logging
 import os
-import pprint
 import time
 import traceback
 from pathlib import Path
@@ -15,7 +13,6 @@ from tqdm import tqdm
 
 from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.core.models import AbstractModel
-from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_json, save_pkl
 

--- a/timeseries/tests/unittests/models/test_gluonts.py
+++ b/timeseries/tests/unittests/models/test_gluonts.py
@@ -7,7 +7,6 @@ from gluonts.model.seq2seq import MQRNNEstimator
 from gluonts.model.transformer import TransformerEstimator
 
 import autogluon.core as ag
-from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 from autogluon.timeseries.models.gluonts import (  # AutoTabularModel,; MQRNNModel,; TransformerModel,
     DeepARModel,
     GenericGluonTSModel,

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -12,7 +12,6 @@ from flaky import flaky
 from gluonts.model.seq2seq import MQRNNEstimator
 
 import autogluon.core as ag
-from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
 from autogluon.timeseries.models import AutoETSModel, DeepARModel
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -5,21 +5,10 @@ import pandas as pd
 import pytest
 
 from autogluon.timeseries import TimeSeriesDataFrame
-
-try:
-    from sktime.forecasting.arima import ARIMA, AutoARIMA
-    from sktime.forecasting.ets import AutoETS
-    from sktime.forecasting.tbats import TBATS
-    from sktime.forecasting.theta import ThetaForecaster
-except ImportError:
-    pytest.skip("sktime not available", allow_module_level=True)
-
-from autogluon.timeseries.models.sktime import (
+from autogluon.timeseries.models.sktime import (  # AutoARIMAModel,; TBATSModel,
     AbstractSktimeModel,
     ARIMAModel,
-    AutoARIMAModel,
     AutoETSModel,
-    TBATSModel,
     ThetaModel,
 )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Clean up warnings that appear in `test_check_style` run. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
