### PR TITLE
Fix AutoMM CPU inference

### DIFF
--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -897,6 +897,7 @@ class MultiModalPredictor:
             loss_func_name=OmegaConf.select(config, "optimization.loss_function"),
         )
 
+        self._config = config
         self._df_preprocessor = df_preprocessor
         self._data_processors = data_processors
         self._model = model

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -2060,6 +2060,11 @@ def compute_num_gpus(config_num_gpus: Union[int, float, List], strategy: str):
         num_gpus = detected_num_gpus
     else:
         num_gpus = min(config_num_gpus, detected_num_gpus)
+        warnings.warn(
+            f"Using the detected GPU number {detected_num_gpus}, "
+            f"smaller than the GPU number {config_num_gpus} in the config.",
+            UserWarning,
+        )
 
     if is_interactive() and num_gpus > 1 and strategy in ["ddp", "ddp_spawn"]:
         warnings.warn(


### PR DESCRIPTION
1. Fix AutoMM CPU inference. Users may customize `config.env.num_gpus` when using GPUs in training. Later, they would encounter an error if they do CPU inference.
2. Make saved `num_gpus`, `precision`, and `strategy` consistent with those used in training.
3. Add the `column_types` property to support the cloud predictor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
