### PR TITLE
[Cloud] Remove feature meatadata from tabular cloud predictor

### DIFF
--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -307,7 +307,7 @@ class CloudPredictor(ABC):
         predictor_init_args,
         predictor_fit_args,
         image_path=None,
-        image_column_name=None,
+        image_column=None,
         leaderboard=True,
         framework_version='latest',
         job_name=None,
@@ -340,7 +340,7 @@ class CloudPredictor(ABC):
             If your images live under a root directory `example_images/`, then you would provide `example_images` as the `image_path`.
             And you want to make sure in your training/tuning file, the column corresponding to the images is a relative path prefix with the root directory.
             For example, `example_images/train/image1.png`. An absolute path will NOT work as the file will be moved to a remote system.
-        image_column_name: str, default = None
+        image_column: str, default = None
             The column name in the training/tuning data that contains the image paths.
         leaderboard: bool, default = True
             Whether to include the leaderboard in the output artifact
@@ -404,8 +404,8 @@ class CloudPredictor(ABC):
             predictor_fit_args=predictor_fit_args,
             leaderboard=leaderboard,
         )
-        if image_column_name is not None:
-            config_args['image_column_name'] = image_column_name
+        if image_column is not None:
+            config_args['image_column'] = image_column
         config = self._construct_config(**config_args)
         inputs = self._upload_fit_artifact(
             train_data=train_data,

--- a/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -341,7 +341,7 @@ class CloudPredictor(ABC):
             And you want to make sure in your training/tuning file, the column corresponding to the images is a relative path prefix with the root directory.
             For example, `example_images/train/image1.png`. An absolute path will NOT work as the file will be moved to a remote system.
         image_column_name: str, default = None
-            The column name in the training/tuning data that contains the image paths. This is REQUIRED when training multimodal with image modality.
+            The column name in the training/tuning data that contains the image paths.
         leaderboard: bool, default = True
             Whether to include the leaderboard in the output artifact
         framework_version: str, default = `latest`
@@ -506,7 +506,7 @@ class CloudPredictor(ABC):
         return predictor_cls.load(local_model_path)
 
     def _upload_predictor(self, predictor_path, key_prefix):
-        cloud_bucket = s3_path_to_bucket_prefix(self.cloud_output_path)
+        cloud_bucket, _ = s3_path_to_bucket_prefix(self.cloud_output_path)
         if not is_s3_url(predictor_path):
             if os.path.isfile(predictor_path):
                 if tarfile.is_tarfile(predictor_path):
@@ -653,10 +653,10 @@ class CloudPredictor(ABC):
             raise e
 
     def predict_real_time(
-            self,
-            test_data,
-            accept='application/x-parquet'
-        ):
+        self,
+        test_data,
+        accept='application/x-parquet'
+    ):
         """
         Predict with the deployed SageMaker endpoint. A deployed SageMaker endpoint is required.
         This is intended to provide a low latency inference.

--- a/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -1,13 +1,18 @@
 import copy
+import logging
 import os
 import pandas as pd
 import yaml
 
 from autogluon.common.loaders import load_pd
+from botocore.exceptions import ClientError
 
 from .cloud_predictor import CloudPredictor
 from ..utils.constants import VALID_ACCEPT
 from ..utils.utils import convert_image_path_to_encoded_bytes_in_dataframe
+
+
+logger = logging.getLogger(__name__)
 
 
 class TabularCloudPredictor(CloudPredictor):
@@ -23,6 +28,29 @@ class TabularCloudPredictor(CloudPredictor):
         predictor_cls = TabularPredictor
         return predictor_cls
 
+    def _construct_config(self, predictor_init_args, predictor_fit_args, leaderboard, **kwargs):
+        assert self.predictor_type is not None
+        if 'feature_metadata' in predictor_fit_args:
+            predictor_fit_args = copy.deepcopy(predictor_fit_args)
+            feature_metadata = predictor_fit_args.pop('feature_metadata')
+            feature_metadata = dict(
+                type_map_raw=feature_metadata.type_map_raw,
+                type_map_special=feature_metadata.get_type_map_special(),
+            )
+            assert 'feature_metadata' not in kwargs, 'feature_metadata in both `predictor_fit_args` and kwargs. This should not happen.'
+            kwargs['feature_metadata'] = feature_metadata
+        config = dict(
+            predictor_type=self.predictor_type,
+            predictor_init_args=predictor_init_args,
+            predictor_fit_args=predictor_fit_args,
+            leaderboard=leaderboard,
+            **kwargs
+        )
+        path = os.path.join(self.local_output_path, 'utils', 'config.yaml')
+        with open(path, 'w') as f:
+            yaml.dump(config, f)
+        return path
+
     def fit(
         self,
         *,
@@ -32,8 +60,32 @@ class TabularCloudPredictor(CloudPredictor):
         image_column_name=None,
         **kwargs
     ):
+        """
+        predictor_init_args: dict
+            Init args for the predictor
+        predictor_fit_args: dict
+            Fit args for the predictor
+        image_path: str, default = None
+            A local path or s3 path to the images. This parameter is REQUIRED if you want to train predictor with image modality.
+            If you provided this parameter, the image path inside your train/tune data MUST be relative.
+            If local path, path needs to be either a compressed file containing the images or a folder containing the images.
+            If it's a folder, we will zip it for you and upload it to the s3.
+            If s3 path, the path needs to be a path to a compressed file containing the images
+
+            Example:
+            If your images live under a root directory `example_images/`, then you would provide `example_images` as the `image_path`.
+            And you want to make sure in your training/tuning file, the column corresponding to the images is a relative path prefix with the root directory.
+            For example, `example_images/train/image1.png`. An absolute path will NOT work as the file will be moved to a remote system.
+        image_column_name: str, default = None
+            The column name in the training/tuning data that contains the image paths.
+            This is REQUIRED if you want to train multimodality with image modality with one exception:
+            If you pass in an `autogluon.tabular.FeatureMetadata` object that contains `image_path` special type to `predictor_fit_args`.
+        kwargs,
+            Refer to `CloudPredictor`
+        """
         if image_path is not None:
-            assert image_column_name is not None, 'Please provide `image_column_name` when training multimodality with image modality'
+            assert image_column_name is not None or 'feature_metadata' in predictor_fit_args,\
+                'Please provide `image_column_name` when training multimodality with image modality'
         if image_column_name is not None:
             assert image_path is not None, 'Please provide `image_path` when training multimodality with image modality'
         super().fit(
@@ -45,11 +97,11 @@ class TabularCloudPredictor(CloudPredictor):
         )
 
     def predict_real_time(
-            self,
-            test_data,
-            test_data_image_column=None,
-            accept='application/x-parquet'
-        ):
+        self,
+        test_data,
+        test_data_image_column=None,
+        accept='application/x-parquet'
+    ):
         """
         Predict with the deployed SageMaker endpoint. A deployed SageMaker endpoint is required.
         This is intended to provide a low latency inference.
@@ -84,4 +136,40 @@ class TabularCloudPredictor(CloudPredictor):
             if test_data_image_column is not None:
                 test_data = convert_image_path_to_encoded_bytes_in_dataframe(test_data, test_data_image_column)
 
-        return self._predict_real_time(test_data=test_data, accept=accept)
+        try:
+            return self._predict_real_time(test_data=test_data, accept=accept)
+        except ClientError as e:
+            fail_to_load_on_cpu_error_msg = "GPUAccelerator can not run on your system since the accelerator is not available. The following accelerator(s) is available and can be passed into `accelerator` argument of `Trainer`: ['cpu']."
+            if fail_to_load_on_cpu_error_msg in e.response['Error']['Message']:
+                logger.warning(e.response['Error']['Message'])
+                logger.warning('Warning: Having trouble load gpu trained model on a cpu machine. This is a known issue of AutoGluon and will be fixed in future containers')
+                logger.warning('Warning: You can either try deploy on a gpu machine')
+                logger.warning('Warning: or download the trained artifact and modify `num_gpus` to be `-1` in the config file located at `models/TextPredictor/config.yaml`')
+                logger.warning('Warning: then try to deploy with the modified artifact')
+                return None
+            raise e
+
+    def predict(
+        self,
+        test_data,
+        test_data_image_column=None,
+        **kwargs,
+    ):
+        """
+        test_data: Union(str, pandas.DataFrame)
+            The test data to be inferenced. Can be a pandas.DataFrame, a local path or a s3 path.
+        test_data_image_column: Optional(str)
+            If test_data involves image modality, you must specify the column name corresponding to image paths.
+            Images have to live in the same directory specified by the column.
+        kwargs:
+            Refer to `CloudPredictor.predict()`
+        """
+        # TODO: remove this after fix is out for 0.6 release
+        # This is because text predictor cannot be saved standalone with current autogluon tabular setting.
+        # And sagemaker batch inference container has trouble connecting to hugging face; hence not able to load the model
+        logger.warning('Tabular does not support multimodal batch inference yet.')
+        super().predict(
+            test_data,
+            test_data_image_column=test_data_image_column,
+            **kwargs
+        )

--- a/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -23,28 +23,26 @@ class TabularCloudPredictor(CloudPredictor):
         predictor_cls = TabularPredictor
         return predictor_cls
 
-    def _construct_config(self, predictor_init_args, predictor_fit_args, leaderboard, **kwargs):
-        assert self.predictor_type is not None
-        if 'feature_metadata' in predictor_fit_args:
-            predictor_fit_args = copy.deepcopy(predictor_fit_args)
-            feature_metadata = predictor_fit_args.pop('feature_metadata')
-            feature_metadata = dict(
-                type_map_raw=feature_metadata.type_map_raw,
-                type_map_special=feature_metadata.get_type_map_special(),
-            )
-            assert 'feature_metadata' not in kwargs, 'feature_metadata in both `predictor_fit_args` and kwargs. This should not happen.'
-            kwargs['feature_metadata'] = feature_metadata
-        config = dict(
-            predictor_type=self.predictor_type,
+    def fit(
+        self,
+        *,
+        predictor_init_args,
+        predictor_fit_args,
+        image_path=None,
+        image_column_name=None,
+        **kwargs
+    ):
+        if image_path is not None:
+            assert image_column_name is not None, 'Please provide `image_column_name` when training multimodality with image modality'
+        if image_column_name is not None:
+            assert image_path is not None, 'Please provide `image_path` when training multimodality with image modality'
+        super().fit(
             predictor_init_args=predictor_init_args,
             predictor_fit_args=predictor_fit_args,
-            leaderboard=leaderboard,
+            image_path=image_path,
+            image_column_name=image_column_name,
             **kwargs
         )
-        path = os.path.join(self.local_output_path, 'utils', 'config.yaml')
-        with open(path, 'w') as f:
-            yaml.dump(config, f)
-        return path
 
     def predict_real_time(
             self,

--- a/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/cloud/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -57,7 +57,7 @@ class TabularCloudPredictor(CloudPredictor):
         predictor_init_args,
         predictor_fit_args,
         image_path=None,
-        image_column_name=None,
+        image_column=None,
         **kwargs
     ):
         """
@@ -76,7 +76,7 @@ class TabularCloudPredictor(CloudPredictor):
             If your images live under a root directory `example_images/`, then you would provide `example_images` as the `image_path`.
             And you want to make sure in your training/tuning file, the column corresponding to the images is a relative path prefix with the root directory.
             For example, `example_images/train/image1.png`. An absolute path will NOT work as the file will be moved to a remote system.
-        image_column_name: str, default = None
+        image_column: str, default = None
             The column name in the training/tuning data that contains the image paths.
             This is REQUIRED if you want to train multimodality with image modality with one exception:
             If you pass in an `autogluon.tabular.FeatureMetadata` object that contains `image_path` special type to `predictor_fit_args`.
@@ -84,15 +84,15 @@ class TabularCloudPredictor(CloudPredictor):
             Refer to `CloudPredictor`
         """
         if image_path is not None:
-            assert image_column_name is not None or 'feature_metadata' in predictor_fit_args,\
-                'Please provide `image_column_name` when training multimodality with image modality'
-        if image_column_name is not None:
+            assert image_column is not None or 'feature_metadata' in predictor_fit_args,\
+                'Please provide `image_column` when training multimodality with image modality'
+        if image_column is not None:
             assert image_path is not None, 'Please provide `image_path` when training multimodality with image modality'
         super().fit(
             predictor_init_args=predictor_init_args,
             predictor_fit_args=predictor_fit_args,
             image_path=image_path,
-            image_column_name=image_column_name,
+            image_column=image_column,
             **kwargs
         )
 

--- a/cloud/src/autogluon/cloud/scripts/image_serve.py
+++ b/cloud/src/autogluon/cloud/scripts/image_serve.py
@@ -47,13 +47,13 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         )
 
     if model._problem_type != REGRESSION:
-        pred_proba = model.predict_proba(image_paths)
+        pred_proba = model.predict_proba(image_paths, as_pandas=True)
         pred = get_pred_from_proba_df(pred_proba, problem_type=model._problem_type)
         pred_proba.columns = [str(c) + '_proba' for c in pred_proba.columns]
         pred.name = str(pred.name) + '_pred' if pred.name is not None else 'pred'
         prediction = pd.concat([pred, pred_proba], axis=1)
     else:
-        prediction = model.predict(image_paths)
+        prediction = model.predict(image_paths, as_pandas=True)
     if isinstance(prediction, pd.Series):
         prediction = prediction.to_frame()
 

--- a/cloud/src/autogluon/cloud/scripts/multimodal_serve.py
+++ b/cloud/src/autogluon/cloud/scripts/multimodal_serve.py
@@ -30,6 +30,7 @@ def _save_image_and_update_dataframe_column(bytes):
     im_name = f'multimodal_image_{image_index}.png'
     im.save(im_name)
     image_index += 1
+    print(f'Image saved as {im_name}')
 
     return im_name
 
@@ -115,7 +116,7 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         # find image column
         image_column = None
         for column_name, column_type in model._column_types.items():
-            if column_type == 'image_path':
+            if column_type in ('image_path', 'image'):
                 image_column = column_name
                 break
         # save image column bytes to disk and update the column with saved path
@@ -124,7 +125,7 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
             data[image_column] = [_save_image_and_update_dataframe_column(bytes) for bytes in data[image_column]]
 
     if model.problem_type == BINARY or model.problem_type == MULTICLASS:
-        pred_proba = model.predict_proba(data)
+        pred_proba = model.predict_proba(data, as_pandas=True)
         pred = get_pred_from_proba_df(pred_proba, problem_type=model.problem_type)
         pred_proba.columns = [str(c) + '_proba' for c in pred_proba.columns]
         pred.name = str(pred.name) + '_pred' if pred.name is not None else 'pred'

--- a/cloud/src/autogluon/cloud/scripts/multimodal_serve.py
+++ b/cloud/src/autogluon/cloud/scripts/multimodal_serve.py
@@ -131,7 +131,7 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         pred.name = str(pred.name) + '_pred' if pred.name is not None else 'pred'
         prediction = pd.concat([pred, pred_proba], axis=1)
     else:
-        prediction = model.predict(data)
+        prediction = model.predict(data, as_pandas=True)
 
     if isinstance(prediction, pd.Series):
         prediction = prediction.to_frame()

--- a/cloud/src/autogluon/cloud/scripts/tabular_serve.py
+++ b/cloud/src/autogluon/cloud/scripts/tabular_serve.py
@@ -64,13 +64,13 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         data[image_column] = [_save_image_and_update_dataframe_column(bytes) for bytes in data[image_column]]
 
     if model.problem_type != REGRESSION:
-        pred_proba = model.predict_proba(data)
+        pred_proba = model.predict_proba(data, as_pandas=True)
         pred = get_pred_from_proba_df(pred_proba, problem_type=model.problem_type)
         pred_proba.columns = [str(c) + '_proba' for c in pred_proba.columns]
         pred.name = str(pred.name) + '_pred' if pred.name is not None else 'pred'
         prediction = pd.concat([pred, pred_proba], axis=1)
     else:
-        prediction = model.predict(data)
+        prediction = model.predict(data, as_pandas=True)
     if isinstance(prediction, pd.Series):
         prediction = prediction.to_frame()
 

--- a/cloud/src/autogluon/cloud/scripts/text_serve_automm.py
+++ b/cloud/src/autogluon/cloud/scripts/text_serve_automm.py
@@ -60,13 +60,13 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
             data.columns = column_names
 
     if model.problem_type == BINARY or model.problem_type == MULTICLASS:
-        pred_proba = model.predict_proba(data)
+        pred_proba = model.predict_proba(data, as_pandas=True)
         pred = get_pred_from_proba_df(pred_proba, problem_type=model.problem_type)
         pred_proba.columns = [str(c) + '_proba' for c in pred_proba.columns]
         pred.name = str(pred.name) + '_pred' if pred.name is not None else 'pred'
         prediction = pd.concat([pred, pred_proba], axis=1)
     else:
-        prediction = model.predict(data)
+        prediction = model.predict(data, as_pandas=True)
     if isinstance(prediction, pd.Series):
         prediction = prediction.to_frame()
     if output_content_type == "application/json":

--- a/cloud/src/autogluon/cloud/scripts/train.py
+++ b/cloud/src/autogluon/cloud/scripts/train.py
@@ -99,11 +99,11 @@ if __name__ == "__main__":
 
     train_file = get_input_path(args.training_dir)
     training_data = TabularDataset(train_file)
-    if predictor_type == 'tabular' and 'image_column_name' in config:
+    if predictor_type == 'tabular' and 'image_column' in config:
         feature_metadata = predictor_fit_args.get('feature_metadata', None)
         if feature_metadata is None:
             feature_metadata = FeatureMetadata.from_df(training_data)
-        feature_metadata = feature_metadata.add_special_types({config['image_column_name']: ['image_path']})
+        feature_metadata = feature_metadata.add_special_types({config['image_column']: ['image_path']})
         predictor_fit_args['feature_metadata'] = feature_metadata
 
     tuning_data = None

--- a/cloud/src/autogluon/cloud/scripts/train.py
+++ b/cloud/src/autogluon/cloud/scripts/train.py
@@ -7,7 +7,7 @@ from autogluon.tabular import TabularPredictor, TabularDataset, FeatureMetadata
 from autogluon.vision import ImagePredictor
 from autogluon.text import TextPredictor
 
-# Not following import style because importing autogluon.tet before other module would cause segfault
+# Not following import style because importing autogluon.text before other module would cause segfault
 # https://github.com/awslabs/autogluon/issues/2042
 import autogluon.text
 

--- a/cloud/src/autogluon/cloud/scripts/train.py
+++ b/cloud/src/autogluon/cloud/scripts/train.py
@@ -86,8 +86,6 @@ if __name__ == "__main__":
     assert predictor_type in valid_predictor_types, f'predictor_type {predictor_type} not supported. Valid options are {valid_predictor_types}'
     if predictor_type == 'tabular':
         predictor_cls = TabularPredictor
-        if 'feature_meatadata' in predictor_fit_args:
-            predictor_fit_args['feature_meatadata'] = FeatureMetadata(**predictor_fit_args['feature_meatadata'])
     elif predictor_type == 'text':
         predictor_cls = TextPredictor
     elif predictor_type == 'image':
@@ -97,6 +95,10 @@ if __name__ == "__main__":
 
     train_file = get_input_path(args.training_dir)
     training_data = TabularDataset(train_file)
+    if predictor_type == 'tabular' and 'image_column_name' in config:
+        feature_metadata = FeatureMetadata.from_df(training_data)
+        feature_metadata = feature_metadata.add_special_types({config['image_column_name']: ['image_path']})
+        predictor_fit_args['feature_meatadata'] = feature_metadata
 
     tuning_data = None
     if args.tune_dir:

--- a/cloud/tests/unittests/test_tabular_cloud_predictor.py
+++ b/cloud/tests/unittests/test_tabular_cloud_predictor.py
@@ -84,7 +84,7 @@ def test_tabular_tabular_text_image():
             test_data,
             image_path='tabular_text_image_images.zip',
             fit_instance_type='ml.g4dn.2xlarge',
-            fit_kwargs=dict(image_column_name='Images'),
+            fit_kwargs=dict(image_column='Images'),
             deploy_kwargs=dict(
                 instance_type='ml.g4dn.2xlarge',
             ),

--- a/cloud/tests/unittests/test_tabular_cloud_predictor.py
+++ b/cloud/tests/unittests/test_tabular_cloud_predictor.py
@@ -79,6 +79,7 @@ def test_tabular_tabular_text_image():
             test_data,
             image_path='tabular_text_image_images.zip',
             fit_instance_type='ml.g4dn.2xlarge',
+            fit_kwargs=dict(image_column_name='Images'),
             predict_real_time_kwargs=dict(test_data_image_column='Images'),
             predict_kwargs=dict(test_data_image_column='Images')
         )

--- a/cloud/tests/unittests/test_tabular_cloud_predictor.py
+++ b/cloud/tests/unittests/test_tabular_cloud_predictor.py
@@ -54,14 +54,19 @@ def test_tabular_tabular_text_image():
         _prepare_data(train_data, test_data, images)
         with zipfile.ZipFile(images, 'r') as zip_ref:
             zip_ref.extractall('.')
-        time_limit = 120
+        time_limit = 600
 
         predictor_init_args = dict(
             label='AdoptionSpeed',
         )
         predictor_fit_args = dict(
             train_data=train_data,
-            time_limit=time_limit
+            time_limit=time_limit,
+            hyperparameters={
+                'XGB': {},
+                'AG_TEXT_NN': {'presets': 'medium_quality_faster_train'},
+                'AG_IMAGE_NN': {},
+            }
         )
         cloud_predictor = TabularCloudPredictor(
             cloud_output_path='s3://ag-cloud-predictor/test-tabular-tabular-text-image',
@@ -80,8 +85,17 @@ def test_tabular_tabular_text_image():
             image_path='tabular_text_image_images.zip',
             fit_instance_type='ml.g4dn.2xlarge',
             fit_kwargs=dict(image_column_name='Images'),
-            predict_real_time_kwargs=dict(test_data_image_column='Images'),
-            predict_kwargs=dict(test_data_image_column='Images')
+            deploy_kwargs=dict(
+                instance_type='ml.g4dn.2xlarge',
+            ),
+            predict_real_time_kwargs=dict(
+                test_data_image_column='Images',
+            ),
+            predict_kwargs=dict(
+                instance_type='ml.g4dn.2xlarge',
+                test_data_image_column='Images',
+            ),
+            skip_predict=True  # TODO: remove this after autogluon 0.6 release. Currently, some issues cause some module's batch inference to fail
         )
 
 
@@ -91,14 +105,18 @@ def test_tabular_tabular_text():
     test_data = 'tabular_text_test.csv'
     with tempfile.TemporaryDirectory() as root:
         _prepare_data(train_data, test_data)
-        time_limit = 60
+        time_limit = 120
 
         predictor_init_args = dict(
             label='Sentiment',
         )
         predictor_fit_args = dict(
             train_data=train_data,
-            time_limit=time_limit
+            time_limit=time_limit,
+            hyperparameters={
+                'XGB': {},
+                'AG_TEXT_NN': {'presets': 'medium_quality_faster_train'},
+            }
         )
         cloud_predictor = TabularCloudPredictor(
             cloud_output_path='s3://ag-cloud-predictor/test-tabular-tabular-text',
@@ -115,4 +133,11 @@ def test_tabular_tabular_text():
             cloud_predictor_no_train,
             test_data,
             fit_instance_type='ml.g4dn.2xlarge',
+            deploy_kwargs=dict(
+                instance_type='ml.g4dn.2xlarge',
+            ),
+            predict_kwargs=dict(
+                instance_type='ml.g4dn.2xlarge',
+            ),
+            skip_predict=True  # TODO: remove this after autogluon 0.6 release. Currently, some issues cause some module's batch inference to fail
         )

--- a/cloud/tests/unittests/utils.py
+++ b/cloud/tests/unittests/utils.py
@@ -25,8 +25,10 @@ def _test_functionality(
     image_path=None,
     fit_instance_type='ml.m5.2xlarge',
     fit_kwargs=None,
+    deploy_kwargs=None,
     predict_real_time_kwargs=None,
-    predict_kwargs=None
+    predict_kwargs=None,
+    skip_predict=False,  # TODO: remove this after autogluon 0.6 release. Currently, some issues cause some module's batch inference to fail
 ):
     if fit_kwargs is None:
         fit_kwargs = dict()
@@ -43,9 +45,11 @@ def _test_functionality(
     assert info['fit_job']['name'] is not None
     assert info['fit_job']['status'] == 'Completed'
 
+    if deploy_kwargs is None:
+        deploy_kwargs = dict()
     if predict_real_time_kwargs is None:
         predict_real_time_kwargs = dict()
-    cloud_predictor.deploy()
+    cloud_predictor.deploy(**deploy_kwargs)
     _test_endpoint(cloud_predictor, test_data, **predict_real_time_kwargs)
     detached_endpoint = cloud_predictor.detach_endpoint()
     cloud_predictor.attach_endpoint(detached_endpoint)
@@ -63,15 +67,17 @@ def _test_functionality(
 
     if predict_kwargs is None:
         predict_kwargs = dict()
-    cloud_predictor.predict(test_data, **predict_kwargs)
-    info = cloud_predictor.info()
-    assert info['recent_transform_job']['status'] == 'Completed'
+    if not skip_predict:
+        cloud_predictor.predict(test_data, **predict_kwargs)
+        info = cloud_predictor.info()
+        assert info['recent_transform_job']['status'] == 'Completed'
 
     # Test deploy with already trained predictor
     trained_predictor_path = cloud_predictor._fit_job.get_output_path()
-    cloud_predictor_no_train.deploy(predictor_path=trained_predictor_path)
+    cloud_predictor_no_train.deploy(predictor_path=trained_predictor_path, **deploy_kwargs)
     _test_endpoint(cloud_predictor_no_train, test_data, **predict_real_time_kwargs)
     cloud_predictor_no_train.cleanup_deployment()
-    cloud_predictor_no_train.predict(test_data, predictor_path=trained_predictor_path, **predict_kwargs)
-    info = cloud_predictor_no_train.info()
-    assert info['recent_transform_job']['status'] == 'Completed'
+    if not skip_predict:
+        cloud_predictor_no_train.predict(test_data, predictor_path=trained_predictor_path, **predict_kwargs)
+        info = cloud_predictor_no_train.info()
+        assert info['recent_transform_job']['status'] == 'Completed'

--- a/cloud/tests/unittests/utils.py
+++ b/cloud/tests/unittests/utils.py
@@ -24,14 +24,18 @@ def _test_functionality(
     test_data,
     image_path=None,
     fit_instance_type='ml.m5.2xlarge',
+    fit_kwargs=None,
     predict_real_time_kwargs=None,
     predict_kwargs=None
 ):
+    if fit_kwargs is None:
+        fit_kwargs = dict()
     cloud_predictor.fit(
         predictor_init_args=predictor_init_args,
         predictor_fit_args=predictor_fit_args,
         image_path=image_path,
-        instance_type=fit_instance_type
+        instance_type=fit_instance_type,
+        **fit_kwargs
     )
     info = cloud_predictor.info()
     assert info['local_output_path'] is not None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* This PR removes FeatureMetadata as a required input to train tabular with image modality as this would force Tabular to be a dependency of Cloud module.
  * Added `image_column` parameter to `fit()` api instead.
* Updated training script to accommodate 0.5.2 container seg fault issue.
* Updated multimodal serving script to include `'image'` as valid `image_path` too.
* Updated serving script to force `as_pandas = True` while doing inference to avoid bugs.
* Fixed an issue in previous tabular multimodality unit tests where the hyperparameter is not correctly set.
  * The updated tests revealed two issues from multimodal module:
    1. Tabular predictor in multimodal setting trained on gpu machine cannot be loaded on cpu machine. Discussed with @zhiqiangdon  and the issue has been addressed in https://github.com/awslabs/autogluon/pull/2051
       1. Try and catched the error and prompt the user on potential solution for now until 0.6 container release
    2. Tabular predictor in multimodal setting CANNOT do batch inference because Text predictor trained under Tabular predictor cannot be saved standalone; therefore, requiring loading from hugging face. However, the batch inference container cannot connect to hugging face correctly. This leads to unable to load the trained model in batch inference.
       1. Added a warning to warn user tabular doesn't support multimodal batch inference yet for now. And synced with @zhiqiangdon  on solution.
       2. Skipped batch inference test for tabular multimodal settings temporarily until 0.6 container release
  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
