### PR TITLE
Add metadata.json file to check python and package versions

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -21,6 +21,7 @@ install_requires = [
     'numpy',
     'pandas',
     'boto3',
+    'setuptools',
 ]
 
 extras_require = dict()

--- a/common/src/autogluon/common/loaders/load_json.py
+++ b/common/src/autogluon/common/loaders/load_json.py
@@ -1,0 +1,12 @@
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def load(path, *, verbose=True):
+    if verbose:
+        logger.log(15, 'Loading: %s' % path)
+    with open(path, "r") as f:
+        out = json.load(f)
+    return out

--- a/common/src/autogluon/common/utils/utils.py
+++ b/common/src/autogluon/common/utils/utils.py
@@ -3,6 +3,9 @@ from datetime import datetime
 
 import logging
 import os
+import platform
+import sys
+from typing import Dict, Any
 
 logger = logging.getLogger(__name__)
 
@@ -47,3 +50,62 @@ def setup_outputdir(path, warn_if_exist=True, create_dir=True, path_suffix=None)
     if path[-1] != os.path.sep:
         path = path + os.path.sep
     return path
+
+
+def get_python_version(include_micro=True) -> str:
+    if include_micro:
+        return f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    else:
+        return f"{sys.version_info.major}.{sys.version_info.minor}"
+
+
+def get_package_versions() -> Dict[str, str]:
+    """Gets a dictionary of package name -> package version for every package installed in the environment"""
+    import pkg_resources
+    package_dict = pkg_resources.working_set.by_key
+    package_version_dict = {key: val.version for key, val in package_dict.items()}
+    return package_version_dict
+
+
+def get_autogluon_metadata() -> Dict[str, Any]:
+    from ..version import __version__
+    metadata = dict(
+        system=platform.system(),
+        version=f'{__version__}',
+        py_version=get_python_version(include_micro=False),
+        py_version_micro=get_python_version(include_micro=True),
+        packages=get_package_versions(),
+    )
+    return metadata
+
+
+def compare_autogluon_metadata(*, original: dict, current: dict, check_packages=True) -> list:
+    logs = []
+    og = original
+    cu = current
+    if og['version'] != cu['version']:
+        logs.append((30, f"WARNING: AutoGluon version mismatch (original={og['version']}, current={cu['version']})"))
+    if og['py_version'] != cu['py_version']:
+        logs.append((30, f"WARNING: AutoGluon Python version mismatch (original={og['py_version']}, current={cu['py_version']})"))
+    elif og['py_version_micro'] != cu['py_version_micro']:
+        logs.append((30, f"INFO: AutoGluon Python micro version mismatch (original={og['py_version_micro']}, current={cu['py_version_micro']})"))
+    if og['system'] != cu['system']:
+        logs.append((30, f"WARNING: System mismatch (original={og['system']}, current={cu['system']})"))
+    if check_packages:
+        og_pac = og['packages']
+        cu_pac = cu['packages']
+        for k in og_pac.keys():
+            if k not in cu_pac:
+                logs.append((30, f"WARNING: Missing package '{k}=={og_pac[k]}'"))
+            elif og_pac[k] != cu_pac[k]:
+                logs.append((30, f"WARNING: Package version diff '{k}'\t(original={og_pac[k]}, current={cu_pac[k]})"))
+        for k in cu_pac.keys():
+            if k not in og_pac:
+                logs.append((30, f"INFO: New package '{k}=={cu_pac[k]}'"))
+
+    if len(logs) > 0:
+        logger.log(30, f'Found {len(logs)} mismatches between original and current metadata:')
+    for log in logs:
+        logger.log(log[0], f"\t{log[1]}")
+
+    return logs

--- a/common/tests/unittests/utils/test_compare_autogluon_metadata.py
+++ b/common/tests/unittests/utils/test_compare_autogluon_metadata.py
@@ -1,0 +1,87 @@
+import copy
+import unittest
+
+from autogluon.common.utils.utils import get_autogluon_metadata, compare_autogluon_metadata
+
+
+class CompareAutoGluonMetadataTestCase(unittest.TestCase):
+    def test_no_warnings(self):
+        metadata = get_autogluon_metadata()
+        logs = compare_autogluon_metadata(original=metadata, current=metadata)
+        assert len(logs) == 0
+
+    def test_version_mismatch(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_cu['version'] = 'dummy_version'
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+
+    def test_py_version_mismatch(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_cu['py_version'] = 'dummy_py_version'
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+
+    def test_py_version_micro_mismatch(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_cu['py_version_micro'] = 'dummy_py_version_micro'
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+
+    def test_py_version_both_mismatch(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_cu['py_version'] = 'dummy_py_version'
+        metadata_cu['py_version_micro'] = 'dummy_py_version_micro'
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+
+    def test_system_mismatch(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_cu['system'] = 'dummy_system'
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+
+    def test_combined_mismatch(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_cu['version'] = 'dummy_version'
+        metadata_cu['py_version'] = 'dummy_py_version'
+        metadata_cu['system'] = 'dummy_system'
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 3
+
+
+    def test_new_key(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_cu['new_key'] = 'dummy_val'
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 0
+
+    def test_package_mismatch(self):
+        metadata_og = get_autogluon_metadata()
+        metadata_cu = copy.deepcopy(metadata_og)
+        metadata_og['packages']['dummy_package'] = '0.2'
+
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+        assert logs[0] == (30, "WARNING: Missing package 'dummy_package==0.2'")
+
+        metadata_cu['packages']['dummy_package'] = '0.3'
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+        assert logs[0] == (30, "WARNING: Package version diff 'dummy_package'\t(original=0.2, current=0.3)")
+
+        del metadata_og['packages']['dummy_package']
+        logs = compare_autogluon_metadata(original=metadata_og, current=metadata_cu)
+        assert len(logs) == 1
+        assert logs[0] == (30, "INFO: New package 'dummy_package==0.3'")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
*Issue #, if available:*
#2047

*Description of changes:*
- Added a variety of checks and logs that detect differences in environment between fit time and inference time.
- Raise exception by default if Python minor version differs during predictor load.

Example output (created by manually editing the metadata.json file contents to force mismatches):

```
predictor = TabularPredictor.load(path=path, check_packages=True)
```

```
Found 15 mismatches between original and current metadata:
	WARNING: AutoGluon version mismatch (original=0.5.8, current=0.3.2b20211216)
	WARNING: AutoGluon Python version mismatch (original=3.10, current=3.8)
	WARNING: System mismatch (original=Windows, current=Darwin)
	WARNING: Package version diff 'regex'	(original=2025.11.10, current=2021.11.10)
	WARNING: Package version diff 'attrs'	(original=21.1, current=21.2.0)
	WARNING: Package version diff 'notebook'	(original=12.4.6, current=6.4.6)
	WARNING: Package version diff 'threadpoolctl'	(original=3.0.1, current=3.0.0)
	WARNING: Package version diff 'fastai'	(original=4.1.2, current=2.7.6)
	WARNING: Package version diff 'torch'	(original=5.0.0, current=1.12.0)
	INFO: New package 'dask==2021.11.2'
	INFO: New package 'distributed==2021.11.2'
	INFO: New package 'certifi==2021.10.8'
	INFO: New package 'pytz==2021.3'
	INFO: New package 'setuptools==59.5.0'
	INFO: New package 'cryptography==36.0.0'
Traceback (most recent call last):
  File "/Users/neerick/workspace/virtual/autogluon/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3457, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-6-231f1544ec1b>", line 1, in <module>
    a = TabularPredictor.load(path=predictor.path, check_packages=True)
  File "/Users/neerick/workspace/code/autogluon/tabular/src/autogluon/tabular/predictor/predictor.py", line 2954, in load
    raise AssertionError(
AssertionError: Predictor was created on Python version 3.10 but is being loaded with Python version 3.8. Please ensure the versions match to avoid instability. While it is NOT recommended, this error can be bypassed by specifying `require_py_version_match=False`.

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
