### PR TITLE
Improve AutoMM loading checkpoints offline

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/huggingface_text.py
+++ b/multimodal/src/autogluon/multimodal/models/huggingface_text.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Tuple
 
 import torch
 from torch import nn
-from transformers import AutoModel
 from transformers import logging as hf_logging
 from transformers.models.t5 import T5PreTrainedModel
 
@@ -19,7 +18,7 @@ from ..constants import (
     TEXT_TOKEN_IDS,
     TEXT_VALID_LENGTH,
 )
-from .utils import assign_layer_ids, get_column_features, init_weights
+from .utils import assign_layer_ids, get_column_features, get_hf_config_and_model, init_weights
 
 hf_logging.set_verbosity_error()
 
@@ -48,6 +47,7 @@ class HFAutoModelForTextPrediction(nn.Module):
         num_classes: Optional[int] = 0,
         pooling_mode: Optional[str] = "cls",
         gradient_checkpointing: Optional[bool] = False,
+        pretrained: Optional[bool] = True,
     ):
         """
         Load a pretrained huggingface text transformer backbone.
@@ -74,13 +74,16 @@ class HFAutoModelForTextPrediction(nn.Module):
             The pooling mode for the Transformer. Can be "cls", or "mean"
         gradient_checkpointing
             Whether to enable gradient checkpointing
+        pretrained
+            Whether using the pretrained weights. If pretrained=True, download the pretrained model.
         """
         super().__init__()
         logger.debug(f"initializing {checkpoint_name}")
         self.checkpoint_name = checkpoint_name
         self.num_classes = num_classes
 
-        self.model = AutoModel.from_pretrained(checkpoint_name)
+        self.config, self.model = get_hf_config_and_model(checkpoint_name=checkpoint_name, pretrained=pretrained)
+
         if isinstance(self.model, T5PreTrainedModel):
             self.is_t5 = True
             # Remove the decoder in T5

--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, Tuple
 
 import torch
 from torch import nn
+from transformers import AutoConfig, AutoModel
 
 from .lora_layers import LoRALinear
 
@@ -454,3 +455,28 @@ def get_model_head(model: nn.Module):
         raise ValueError(f"Model {type(model)} doesn't have head. Need to check its implementation.")
 
     return head
+
+
+def get_hf_config_and_model(checkpoint_name: str, pretrained: Optional[bool] = True):
+    """
+    Get a Huggingface config and model based on a checkpoint name.
+
+    Parameters
+    ----------
+    checkpoint_name
+        A model checkpoint name.
+    pretrained
+         Whether using the pretrained weights. If pretrained=True, download the pretrained model.
+
+    Returns
+    -------
+    A Huggingface config and model.
+    """
+    config = AutoConfig.from_pretrained(checkpoint_name)
+
+    if pretrained:
+        model = AutoModel.from_pretrained(checkpoint_name)
+    else:
+        model = AutoModel.from_config(config)
+
+    return config, model

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -83,12 +83,12 @@ from .utils import (
     average_checkpoints,
     compute_num_gpus,
     compute_score,
-    convert_checkpoint_name,
     create_model,
     data_to_df,
     extract_from_output,
     filter_search_space,
     get_config,
+    get_local_pretrained_config_paths,
     get_minmax_mode,
     get_mixup,
     infer_dtypes_by_model_names,
@@ -100,7 +100,7 @@ from .utils import (
     logits_to_prob,
     modify_duplicate_model_names,
     process_save_path,
-    save_pretrained_models,
+    save_pretrained_model_configs,
     save_text_tokenizers,
     select_model,
     tensor_to_ndarray,
@@ -1785,7 +1785,7 @@ class MultiModalPredictor:
         }
         return state_dict_processed
 
-    def save(self, path: str, standalone: Optional[bool] = False):
+    def save(self, path: str, standalone: Optional[bool] = True):
         """
         Save this predictor to file in directory specified by `path`.
 
@@ -1801,7 +1801,7 @@ class MultiModalPredictor:
         """
 
         if standalone:
-            self._config = save_pretrained_models(model=self._model, config=self._config, path=path)
+            self._config = save_pretrained_model_configs(model=self._model, config=self._config, path=path)
 
         os.makedirs(path, exist_ok=True)
         OmegaConf.save(config=self._config, f=os.path.join(path, "config.yaml"))
@@ -1860,9 +1860,9 @@ class MultiModalPredictor:
         assert os.path.isdir(path), f"'{path}' must be an existing directory."
         config = OmegaConf.load(os.path.join(path, "config.yaml"))
 
-        config = convert_checkpoint_name(
+        config = get_local_pretrained_config_paths(
             config=config, path=path
-        )  # check the config for loading offline pretrained models
+        )  # check the config to load offline pretrained model configs
 
         with open(os.path.join(path, "assets.json"), "r") as fp:
             assets = json.load(fp)

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1800,11 +1800,12 @@ class MultiModalPredictor:
             When standalone = False, the saved artifact may require an online environment to process in load().
         """
 
+        config = copy.deepcopy(self._config)
         if standalone:
-            self._config = save_pretrained_model_configs(model=self._model, config=self._config, path=path)
+            config = save_pretrained_model_configs(model=self._model, config=config, path=path)
 
         os.makedirs(path, exist_ok=True)
-        OmegaConf.save(config=self._config, f=os.path.join(path, "config.yaml"))
+        OmegaConf.save(config=config, f=os.path.join(path, "config.yaml"))
 
         with open(os.path.join(path, "df_preprocessor.pkl"), "wb") as fp:
             pickle.dump(self._df_preprocessor, fp)

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -705,6 +705,7 @@ def create_model(
                 prefix=model_name,
                 checkpoint_name=model_config.checkpoint_name,
                 num_classes=num_classes,
+                pretrained=pretrained,
             )
         elif model_name.lower().startswith(TIMM_IMAGE):
             model = TimmAutoModelForImagePrediction(
@@ -721,6 +722,7 @@ def create_model(
                 num_classes=num_classes,
                 pooling_mode=OmegaConf.select(model_config, "pooling_mode", default="cls"),
                 gradient_checkpointing=OmegaConf.select(model_config, "gradient_checkpointing"),
+                pretrained=pretrained,
             )
         elif model_name.lower().startswith(NUMERICAL_MLP):
             model = NumericalMLP(
@@ -872,15 +874,14 @@ def apply_model_adaptation(model: nn.Module, config: DictConfig) -> nn.Module:
     return model
 
 
-def save_pretrained_models(
+def save_pretrained_model_configs(
     model: nn.Module,
     config: DictConfig,
     path: str,
 ) -> DictConfig:
     """
-    Save the pretrained models and configs to local to make future loading not dependent on Internet access.
-    By loading local checkpoints, Huggingface doesn't need to download pretrained checkpoints from Internet.
-    It is called by setting "standalone=True" in "AutoMMPredictor.load()".
+    Save the pretrained model configs to local to make future loading not dependent on Internet access.
+    By initializing models with local configs, Huggingface doesn't need to download pretrained weights from Internet.
 
     Parameters
     ----------
@@ -889,7 +890,7 @@ def save_pretrained_models(
     config
         A DictConfig object. The model config should be accessible by "config.model".
     path
-        The path to save pretrained checkpoints.
+        The path to save pretrained model configs.
     """
     requires_saving = any([model_name.lower().startswith((CLIP, HF_TEXT)) for model_name in config.model.names])
     if not requires_saving:
@@ -901,25 +902,24 @@ def save_pretrained_models(
         model = model.model
     for per_model in model:
         if per_model.prefix.lower().startswith((CLIP, HF_TEXT)):
-            per_model.model.save_pretrained(os.path.join(path, per_model.prefix))
+            per_model.config.save_pretrained(os.path.join(path, per_model.prefix))
             model_config = getattr(config.model, per_model.prefix)
             model_config.checkpoint_name = os.path.join("local://", per_model.prefix)
 
     return config
 
 
-def convert_checkpoint_name(config: DictConfig, path: str) -> DictConfig:
+def get_local_pretrained_config_paths(config: DictConfig, path: str) -> DictConfig:
     """
-    Convert the checkpoint name from relative path to absolute path for
-    loading the pretrained weights in offline deployment.
-    It is called by setting "standalone=True" in "AutoMMPredictor.load()".
+    Get the local config paths of hugginface pretrained models. With a local config,
+    Hugginface can initialize a model without having to download its pretrained weights.
 
     Parameters
     ----------
     config
         A DictConfig object. The model config should be accessible by "config.model".
     path
-        The saving path to the pretrained Huggingface models.
+        The saving path to the pretrained model configs.
     """
     for model_name in config.model.names:
         if model_name.lower().startswith((CLIP, HF_TEXT)):
@@ -929,7 +929,6 @@ def convert_checkpoint_name(config: DictConfig, path: str) -> DictConfig:
                 assert os.path.exists(
                     os.path.join(model_config.checkpoint_name, "config.json")
                 )  # guarantee the existence of local configs
-                assert os.path.exists(os.path.join(model_config.checkpoint_name, "pytorch_model.bin"))
 
     return config
 

--- a/text/src/autogluon/text/text_prediction/predictor.py
+++ b/text/src/autogluon/text/text_prediction/predictor.py
@@ -370,7 +370,7 @@ class TextPredictor:
             as_pandas=as_pandas,
         )
 
-    def save(self, path, standalone=False):
+    def save(self, path, standalone=True):
         """
         Save this Predictor to file in directory specified by `path`.
         The relevant files will be saved in two parts:
@@ -386,9 +386,9 @@ class TextPredictor:
         ----------
         path: str
             The path to directory in which to save this Predictor.
-        standalone: bool, default = False
-            Whether to save the downloaded model for offline deployment. 
-            If `standalone = True`, save the transformers.CLIPModel and transformers.AutoModel to os.path.join(path,model_name).
+        standalone: bool, default = True
+            Whether to save the Huggingface's pretrained model config for offline deployment.
+            If `standalone = True`, save the Huggingface's pretrained model config to os.path.join(path, model_name).
             Also, see `MultiModalPredictor.save()` for more detials.
             Note that `standalone = True` only works for `backen = pytorch` and does noting in `backen = mxnet`.
         """


### PR DESCRIPTION
1. Change `standalone=True` by default to support the cloud predictors.
2. If `standalone=True`, save only the pretrained model config instead of the model weights. This can significantly reduce the disk usages.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
