### PR TITLE
Update imodels_models.py

### DIFF
--- a/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
+++ b/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
@@ -31,6 +31,8 @@ class _IModelsModel(AbstractModel):
                 self._ohe = OneHotEncoder(dtype=np.uint8, handle_unknown='ignore')
                 self._ohe.fit(X=X[self._categorical_featnames])
                 self._ohe_columns = self._ohe.get_feature_names_out()
+            else:
+                self._ohe=None # otherwise no model is fitted when there are not self._categorical_featnames
 
         if self._ohe is not None:
             X_index = X.index


### PR DESCRIPTION
Fitting model: RuleFit_2 ...
	Warning: Exception caused RuleFit_2 to fail during training... Skipping this model.
		'RuleFitModel' object has no attribute '_ohe'
...
ValueError: AutoGluon did not successfully train any models

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
