### PR TITLE
revise timeseries presets to minimum context length of 10

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import hashlib
 import itertools
 from collections.abc import Iterable
 from typing import Any, Optional, Tuple, Type

--- a/timeseries/src/autogluon/timeseries/models/gluonts/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/models.py
@@ -57,32 +57,30 @@ class DeepARModel(AbstractGluonTSModel):
 
     Other Parameters
     ----------------
-    context_length
+    context_length : int, optional
         Number of steps to unroll the RNN for before computing predictions
         (default: None, in which case context_length = prediction_length)
-    num_layers: int
-        Number of RNN layers (default: 2)
-    num_cells: int
-        Number of RNN cells for each layer (default: 40)
-    epochs: int
-        Number of epochs the model will be trained for (default: 100)
-    cell_type: str
-        Type of recurrent cells to use (available: 'lstm' or 'gru';
-        default: 'lstm')
-    dropoutcell_type: typing.Type
+    num_layers : int, default = 2
+        Number of RNN layers
+    num_cells : int, default = 40
+        Number of RNN cells for each layer
+    epochs : int, default = 100
+        Number of epochs the model will be trained for
+    cell_type : str, default = "lstm"
+        Type of recurrent cells to use (available: 'lstm' or 'gru')
+    dropoutcell_type : typing.Type, default = ZoneoutCell
         Type of dropout cells to use
         (available: 'ZoneoutCell', 'RNNZoneoutCell', 'VariationalDropoutCell' or
-        'VariationalZoneoutCell', default: 'ZoneoutCell')
-    dropout_rate: float
-        Dropout regularization parameter (default: 0.1)
-    embedding_dimension: int
+        'VariationalZoneoutCell')
+    dropout_rate : float, default = 0.1
+        Dropout regularization parameter
+    embedding_dimension : int, optional
         Dimension of the embeddings for categorical features
-        (default: [min(50, (cat+1)//2) for cat in cardinality])
-    distr_output: gluonts.mx.DistributionOutput()
+        (if None, defaults to [min(50, (cat+1)//2) for cat in cardinality])
+    distr_output : gluonts.mx.DistributionOutput, default = StudentTOutput()
         Distribution to use to evaluate observations and sample predictions
-        (default: StudentTOutput())
-    scaling: bool
-        Whether to automatically scale the target values (default: true)
+    scaling: bool, default = True
+        Whether to automatically scale the target values
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = DeepAREstimator
@@ -111,47 +109,45 @@ class MQCNNModel(AbstractGluonTSSeq2SeqModel):
 
     Other Parameters
     ----------------
-    context_length
+    context_length : int, optional
         Number of steps to unroll the RNN for before computing predictions
         (default: None, in which case context_length = prediction_length)
-    embedding_dimension: int
+    embedding_dimension : int, optional
         Dimension of the embeddings for categorical features. (default: [min(50, (cat+1)//2) for cat in cardinality])
-    add_time_feature: bool
-        Adds a set of time features. (default: True)
-    add_age_feature: bool
-        Adds an age feature. (default: False)
+    add_time_feature : bool, default = True
+        Adds a set of time features.
+    add_age_feature : bool, default = False
+        Adds an age feature.
         The age feature starts with a small value at the start of the time series and grows over time.
-    epochs: int
-        Number of epochs the model will be trained for (default: 100)
-    seed: int
-        Will set the specified int seed for numpy and MXNet if specified. (default: None)
-    decoder_mlp_dim_seq: List[int]
+    epochs : int, default = 100
+        Number of epochs the model will be trained for
+    seed : int, optional
+        Will set the specified int seed for numpy and MXNet if specified.
+    decoder_mlp_dim_seq : List[int], default = [30]
         The dimensionalities of the Multi Layer Perceptron layers of the decoder.
-        (default: [30])
-    channels_seq: List[int]
+    channels_seq : List[int], default = [30, 30, 30]
         The number of channels (i.e. filters or convolutions) for each layer of the HierarchicalCausalConv1DEncoder.
         More channels usually correspond to better performance and larger network size.
-        (default: [30, 30, 30])
-    dilation_seq: List[int]
+    dilation_seq : List[int], default = [1, 3, 5]
         The dilation of the convolutions in each layer of the HierarchicalCausalConv1DEncoder.
         Greater numbers correspond to a greater receptive field of the network, which is usually
-        better with longer context_length. (Same length as channels_seq) (default: [1, 3, 5])
-    kernel_size_seq: List[int]
+        better with longer context_length. (Same length as channels_seq)
+    kernel_size_seq : List[int], default = [7, 3, 3]
         The kernel sizes (i.e. window size) of the convolutions in each layer of the HierarchicalCausalConv1DEncoder.
-        (Same length as channels_seq) (default: [7, 3, 3])
-    use_residual: bool
+        (Same length as channels_seq)
+    use_residual : bool, default = True
         Whether the hierarchical encoder should additionally pass the unaltered
-        past target to the decoder. (default: True)
-    quantiles: List[float]
+        past target to the decoder.
+    quantiles : List[float], default = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
         The list of quantiles that will be optimized for, and predicted by, the model.
         Optimizing for more quantiles than are of direct interest to you can result
         in improved performance due to a regularizing effect.
-        (default: [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
-    distr_output: gluonts.mx.DistributionOutput()
+    distr_output : gluonts.mx.DistributionOutput, optional
         DistributionOutput to use. Only one between `quantile` and `distr_output`
-        can be set. (Default: None)
-    scaling: bool
-        Whether to automatically scale the target values. (default: False if quantile_output is used, True otherwise)
+        can be set.
+    scaling : bool, optional
+        Whether to automatically scale the target values. (default: False if quantile_output is used,
+        True otherwise)
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = MQCNNEstimator
@@ -162,9 +158,6 @@ class MQRNNModel(AbstractGluonTSSeq2SeqModel):
     recurrent neural network and the decoder is a multilayer perceptron.
 
     See `AbstractGluonTSModel` for common parameters.
-
-    Other Parameters
-    ----------------
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = MQRNNEstimator
@@ -178,20 +171,20 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
 
     Other Parameters
     ----------------
-    num_hidden_dimensions: int
-        Number of hidden nodes in each layer (default: [40, 40])
-    context_length: int
+    num_hidden_dimensions : int, default = [40, 40]
+        Number of hidden nodes in each layer
+    context_length : int, optional
         Number of time units that condition the predictions
         (default: None, in which case context_length = prediction_length)
-    distr_output: gluonts.mx.DistributionOutput
-        Distribution to fit (default: StudentTOutput())
-    batch_normalization: bool
-        Whether to use batch normalization (default: False)
-    mean_scaling: bool
+    distr_output : gluonts.mx.DistributionOutput, default = StudentTOutput()
+        Distribution to fit
+    batch_normalization : bool, default = False
+        Whether to use batch normalization
+    mean_scaling : bool, default = True
         Scale the network input by the data mean and the network output by
-        its inverse (default: True)
-    epochs: int
-        Number of epochs the model will be trained for (default: 100)
+        its inverse
+    epochs : int, default = 100
+        Number of epochs the model will be trained for
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = SimpleFeedForwardEstimator
@@ -208,33 +201,31 @@ class TransformerModel(AbstractGluonTSModel):
 
     Other Parameters
     ----------------
-    context_length
+    context_length : int, optional
         Number of steps to unroll the RNN for before computing predictions
         (default: None, in which case context_length = prediction_length)
-    trainer
-        Trainer object to be used (default: Trainer())
-    dropout_rate
-        Dropout regularization parameter (default: 0.1)
-    distr_output
+    trainer : Trainer, default = Trainer()
+        Trainer object to be used
+    dropout_rate : float, default = 0.1
+        Dropout regularization parameter
+    distr_output : gluonts.mx.DistributionOutput, default = StudentTOutput()
         Distribution to use to evaluate observations and sample predictions
-        (default: StudentTOutput())
-    model_dim
+    model_dim : int, default = 32
         Dimension of the transformer network, i.e., embedding dimension of the
-        input (default: 32)
-    inner_ff_dim_scale
+        input
+    inner_ff_dim_scale : int, default = 4
         Dimension scale of the inner hidden layer of the transformer's
-        feedforward network (default: 4)
-    pre_seq
+        feedforward network
+    pre_seq : str, default = "dn"
         Sequence that defined operations of the processing block before the
         main transformer network. Available operations: 'd' for dropout, 'r'
-        for residual connections and 'n' for normalization (default: 'dn')
-    post_seq
+        for residual connections and 'n' for normalization
+    post_seq : str, default = "drn"
         Sequence that defined operations of the processing block in and after
         the main transformer network. Available operations: 'd' for
         dropout, 'r' for residual connections and 'n' for normalization
-        (default: 'drn').
-    epochs: int
-        Number of epochs the model will be trained for (default: 100)
+    epochs : int, default = 100
+        Number of epochs the model will be trained for
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = TransformerEstimator
@@ -251,7 +242,7 @@ class GenericGluonTSModel(AbstractGluonTSModel):
 
     Parameters
     ----------
-    gluonts_estimator_class:
+    gluonts_estimator_class : Type[gluonts.model.estimator.Estimator]
         The class object of the GluonTS estimator to be used.
     """
 
@@ -307,7 +298,7 @@ class ProphetModel(AbstractGluonTSModel):
 
     Other Parameters
     ----------------
-    hyperparameters
+    hyperparameters : Dict[str, Any]
         Model hyperparameters that will be passed directly to the `Prophet`
         class. See Prophet documentation for available parameters.
     """
@@ -351,14 +342,14 @@ class AutoTabularModel(AbstractGluonTSModel):
 
     Other Parameters
     ----------------
-    lag_indices: List[int]
+    lag_indices : List[int], optional
         List of indices of the lagged observations to use as features. If
         None, this will be set automatically based on the frequency.
-    scaling: bool
+    scaling : Callable[[pd.Series], Tuple[pd.Series, float]], optional
         Function to be used to scale time series. This should take a pd.Series object
         as input, and return a scaled pd.Series and the scale (float). By default,
         this divides a series by the mean of its absolute value.
-    disable_auto_regression: bool
+    disable_auto_regression : bool, default = False
         Weather to forcefully disable auto-regression in the model. If ``True``,
         this will remove any lag index which is smaller than ``prediction_length``.
         This will make predictions more efficient, but may impact their accuracy.

--- a/timeseries/src/autogluon/timeseries/models/gluonts/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/models.py
@@ -64,6 +64,8 @@ class DeepARModel(AbstractGluonTSModel):
         Number of RNN layers (default: 2)
     num_cells: int
         Number of RNN cells for each layer (default: 40)
+    epochs: int
+        Number of epochs the model will be trained for (default: 100)
     cell_type: str
         Type of recurrent cells to use (available: 'lstm' or 'gru';
         default: 'lstm')
@@ -119,6 +121,8 @@ class MQCNNModel(AbstractGluonTSSeq2SeqModel):
     add_age_feature: bool
         Adds an age feature. (default: False)
         The age feature starts with a small value at the start of the time series and grows over time.
+    epochs: int
+        Number of epochs the model will be trained for (default: 100)
     seed: int
         Will set the specified int seed for numpy and MXNet if specified. (default: None)
     decoder_mlp_dim_seq: List[int]
@@ -186,6 +190,8 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
     mean_scaling: bool
         Scale the network input by the data mean and the network output by
         its inverse (default: True)
+    epochs: int
+        Number of epochs the model will be trained for (default: 100)
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = SimpleFeedForwardEstimator
@@ -227,6 +233,8 @@ class TransformerModel(AbstractGluonTSModel):
         the main transformer network. Available operations: 'd' for
         dropout, 'r' for residual connections and 'n' for normalization
         (default: 'drn').
+    epochs: int
+        Number of epochs the model will be trained for (default: 100)
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = TransformerEstimator

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -46,10 +46,12 @@ DEFAULT_MODEL_PRIORITY = dict(
     AutoETS=60,
 )
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
+MINIMUM_CONTEXT_LENGTH = 10
 
 
 # TODO: Should we include TBATS to the presets?
 def get_default_hps(key, prediction_length):
+    context_length = max(prediction_length * 2, MINIMUM_CONTEXT_LENGTH) 
     default_model_hps = {
         "toy": {
             "SimpleFeedForward": {
@@ -82,13 +84,13 @@ def get_default_hps(key, prediction_length):
                 "suppress_warnings": True,
             },
             "SimpleFeedForward": {
-                "context_length": prediction_length * 2,
+                "context_length": context_length,
             },
             "Transformer": {
-                "context_length": prediction_length * 2,
+                "context_length": context_length,
             },
             "DeepAR": {
-                "context_length": prediction_length * 2,
+                "context_length": context_length,
             },
         },
         "default_hpo": {
@@ -96,15 +98,15 @@ def get_default_hps(key, prediction_length):
                 "cell_type": ag.Categorical("gru", "lstm"),
                 "num_layers": ag.Int(1, 4),
                 "num_cells": ag.Categorical(20, 30, 40, 50),
-                "context_length": prediction_length * 2,
+                "context_length": context_length,
             },
             "SimpleFeedForward": {
                 "batch_normalization": ag.Categorical(True, False),
-                "context_length": prediction_length * 2,
+                "context_length": context_length,
             },
             "Transformer": {
                 "model_dim": ag.Categorical(8, 16, 32),
-                "context_length": prediction_length * 2,
+                "context_length": context_length,
             },
             "AutoETS": {
                 "error": ag.Categorical("add", "mul"),

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -51,7 +51,7 @@ MINIMUM_CONTEXT_LENGTH = 10
 
 # TODO: Should we include TBATS to the presets?
 def get_default_hps(key, prediction_length):
-    context_length = max(prediction_length * 2, MINIMUM_CONTEXT_LENGTH) 
+    context_length = max(prediction_length * 2, MINIMUM_CONTEXT_LENGTH)
     default_model_hps = {
         "toy": {
             "SimpleFeedForward": {

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -623,7 +623,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 )
             elif len(models_available_for_ensemble) <= 1:
                 logger.info(
-                    f"Not fitting ensemble as "
+                    "Not fitting ensemble as "
                     + (
                         "no models were successfully trained."
                         if not models_available_for_ensemble


### PR DESCRIPTION
*Issue #, if available:*

- revise minimum context length to 10 for gluonts models. this doesn't lead to a major change in benchmarks as all baseline datasets default to greater than 10. longer minimums did not lead to improvements.
- add `epochs` to gluonts docstrings.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
