### PR TITLE
Implement wrappers for local models from statsmodels

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -23,6 +23,7 @@ version = ag.update_version(version)
 submodule = "timeseries"
 install_requires = [
     # version ranges added in ag.get_dependency_version_ranges()
+    "joblib~=1.2",
     "numpy",
     "scipy",
     "pandas",

--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -23,7 +23,7 @@ version = ag.update_version(version)
 submodule = "timeseries"
 install_requires = [
     # version ranges added in ag.get_dependency_version_ranges()
-    "joblib~=1.2",
+    "joblib~=1.1",
     "numpy",
     "scipy",
     "pandas",

--- a/timeseries/src/autogluon/timeseries/models/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/__init__.py
@@ -1,6 +1,6 @@
 from .gluonts import AutoTabularModel, DeepARModel, MQCNNModel, SimpleFeedForwardModel, TransformerModel
-from .sktime import ARIMAModel, AutoARIMAModel, AutoETSModel, TBATSModel, ThetaModel
-from .statsmodels import StatsmodelsARIMAModel, StatsmodelsETSModel
+from .sktime import SktimeARIMAModel, SktimeAutoARIMAModel, SktimeAutoETSModel, SktimeTBATSModel, SktimeThetaModel
+from .statsmodels import ARIMAModel, ETSModel
 
 __all__ = [
     "AutoTabularModel",
@@ -8,11 +8,11 @@ __all__ = [
     "SimpleFeedForwardModel",
     "MQCNNModel",
     "TransformerModel",
+    "SktimeARIMAModel",
+    "SktimeAutoARIMAModel",
+    "SktimeAutoETSModel",
+    "SktimeTBATSModel",
+    "SktimeThetaModel",
     "ARIMAModel",
-    "AutoARIMAModel",
-    "AutoETSModel",
-    "TBATSModel",
-    "ThetaModel",
-    "StatsmodelsARIMAModel",
-    "StatsmodelsETSModel",
+    "ETSModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/__init__.py
@@ -1,5 +1,6 @@
 from .gluonts import AutoTabularModel, DeepARModel, MQCNNModel, SimpleFeedForwardModel, TransformerModel
 from .sktime import ARIMAModel, AutoARIMAModel, AutoETSModel, TBATSModel, ThetaModel
+from .statsmodels import StatsmodelsARIMAModel, StatsmodelsETSModel
 
 __all__ = [
     "AutoTabularModel",
@@ -12,4 +13,6 @@ __all__ = [
     "AutoETSModel",
     "TBATSModel",
     "ThetaModel",
+    "StatsmodelsARIMAModel",
+    "StatsmodelsETSModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -16,8 +16,7 @@ from .gluonts import (
     TransformerModel,
 )
 from .sktime import ARIMAModel, AutoARIMAModel, AutoETSModel
-from .statsmodels import StatsmodelsETSModel, StatsmodelsARIMAModel
-
+from .statsmodels import StatsmodelsARIMAModel, StatsmodelsETSModel
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +47,8 @@ DEFAULT_MODEL_PRIORITY = dict(
     AutoARIMA=20,
     ARIMA=50,
     AutoETS=60,
+    StatsmodelsARIMA=50,
+    StatsmodelsETS=60,
 )
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 MINIMUM_CONTEXT_LENGTH = 10

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -15,8 +15,8 @@ from .gluonts import (
     SimpleFeedForwardModel,
     TransformerModel,
 )
-from .sktime import ARIMAModel, AutoARIMAModel, AutoETSModel
-from .statsmodels import StatsmodelsARIMAModel, StatsmodelsETSModel
+from .sktime import SktimeARIMAModel, SktimeAutoARIMAModel, SktimeAutoETSModel
+from .statsmodels import ARIMAModel, ETSModel
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +29,11 @@ MODEL_TYPES = dict(
     AutoTabular=AutoTabularModel,
     Prophet=ProphetModel,
     Transformer=TransformerModel,
+    SktimeARIMA=SktimeARIMAModel,
+    SktimeAutoARIMA=SktimeAutoARIMAModel,
+    SktimeAutoETS=SktimeAutoETSModel,
+    ETS=ETSModel,
     ARIMA=ARIMAModel,
-    AutoARIMA=AutoARIMAModel,
-    AutoETS=AutoETSModel,
-    StatsmodelsETS=StatsmodelsETSModel,
-    StatsmodelsARIMA=StatsmodelsARIMAModel,
 )
 DEFAULT_MODEL_NAMES = {v: k for k, v in MODEL_TYPES.items()}
 DEFAULT_MODEL_PRIORITY = dict(
@@ -44,11 +44,11 @@ DEFAULT_MODEL_PRIORITY = dict(
     DeepAR=50,
     Prophet=10,
     AutoTabular=10,
-    AutoARIMA=20,
+    SktimeAutoARIMA=20,
+    SktimeARIMA=50,
+    SktimeAutoETS=60,
     ARIMA=50,
-    AutoETS=60,
-    StatsmodelsARIMA=50,
-    StatsmodelsETS=60,
+    ETS=60,
 )
 DEFAULT_CUSTOM_MODEL_PRIORITY = 0
 MINIMUM_CONTEXT_LENGTH = 10
@@ -66,21 +66,20 @@ def get_default_hps(key, prediction_length):
             },
             "Transformer": {"epochs": 10, "num_batches_per_epoch": 10, "context_length": 5},
             "DeepAR": {"epochs": 10, "num_batches_per_epoch": 10, "context_length": 5},
-            "AutoETS": {"maxiter": 20, "seasonal": None},
+            "ETS": {"maxiter": 20, "seasonal": None},
             "ARIMA": {
                 "maxiter": 10,
                 "order": (1, 0, 0),
                 "seasonal_order": (0, 0, 0),
-                "suppress_warnings": True,
             },
         },
         "default": {
-            "StatsmodelsETS": {
+            "ETS": {
                 "maxiter": 200,
                 "trend": "add",
                 "seasonal": "add",
             },
-            "StatsmodelsARIMA": {
+            "ARIMA": {
                 "maxiter": 50,
                 "order": (1, 1, 1),
                 "seasonal_order": (0, 0, 0),
@@ -110,15 +109,15 @@ def get_default_hps(key, prediction_length):
                 "model_dim": ag.Categorical(8, 16, 32),
                 "context_length": context_length,
             },
-            "StatsmodelsETS": {
+            "ETS": {
+                "maxiter": 200,
                 "error": ag.Categorical("add", "mul"),
                 "trend": ag.Categorical("add", "mul", None),
                 "seasonal": ag.Categorical("add", None),
-                "maxiter": 200,
             },
-            "StatsmodelsARIMA": {
+            "ARIMA": {
                 "maxiter": 50,
-                "order": ag.Categorical((2, 0, 1), (2, 1, 1)),
+                "order": ag.Categorical((2, 0, 1), (2, 1, 1), (1, 1, 1)),
                 "seasonal_order": ag.Categorical((0, 0, 0), (1, 0, 1)),
             },
         },

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -82,7 +82,7 @@ def get_default_hps(key, prediction_length):
             },
             "StatsmodelsARIMA": {
                 "maxiter": 50,
-                "order": (2, 0, 0),
+                "order": (1, 1, 1),
                 "seasonal_order": (0, 0, 0),
             },
             "SimpleFeedForward": {

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -16,6 +16,8 @@ from .gluonts import (
     TransformerModel,
 )
 from .sktime import ARIMAModel, AutoARIMAModel, AutoETSModel
+from .statsmodels import StatsmodelsETSModel, StatsmodelsARIMAModel
+
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +33,8 @@ MODEL_TYPES = dict(
     ARIMA=ARIMAModel,
     AutoARIMA=AutoARIMAModel,
     AutoETS=AutoETSModel,
+    StatsmodelsETS=StatsmodelsETSModel,
+    StatsmodelsARIMA=StatsmodelsARIMAModel,
 )
 DEFAULT_MODEL_NAMES = {v: k for k, v in MODEL_TYPES.items()}
 DEFAULT_MODEL_PRIORITY = dict(
@@ -70,18 +74,15 @@ def get_default_hps(key, prediction_length):
             },
         },
         "default": {
-            "AutoETS": {
+            "StatsmodelsETS": {
                 "maxiter": 200,
                 "trend": "add",
                 "seasonal": "add",
-                "auto": False,
-                "initialization_method": "estimated",
             },
-            "ARIMA": {
+            "StatsmodelsARIMA": {
                 "maxiter": 50,
-                "order": (1, 0, 0),
+                "order": (2, 0, 0),
                 "seasonal_order": (0, 0, 0),
-                "suppress_warnings": True,
             },
             "SimpleFeedForward": {
                 "context_length": context_length,
@@ -108,21 +109,16 @@ def get_default_hps(key, prediction_length):
                 "model_dim": ag.Categorical(8, 16, 32),
                 "context_length": context_length,
             },
-            "AutoETS": {
+            "StatsmodelsETS": {
                 "error": ag.Categorical("add", "mul"),
-                "trend": ag.Categorical("add", "mul"),
-                "seasonal": ag.Categorical("add", "mul", None),
-                "auto": False,
-                "initialization_method": "estimated",
+                "trend": ag.Categorical("add", "mul", None),
+                "seasonal": ag.Categorical("add", None),
                 "maxiter": 200,
-                "fail_if_misconfigured": True,
             },
-            "ARIMA": {
-                "maxiter": ag.Categorical(50),
-                "order": (1, 0, 0),
-                "seasonal_order": (0, 0, 0),
-                "suppress_warnings": True,
-                "fail_if_misconfigured": True,
+            "StatsmodelsARIMA": {
+                "maxiter": 50,
+                "order": ag.Categorical((2, 0, 1), (2, 1, 1)),
+                "seasonal_order": ag.Categorical((0, 0, 0), (1, 0, 1)),
             },
         },
     }

--- a/timeseries/src/autogluon/timeseries/models/sktime/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/__init__.py
@@ -1,10 +1,10 @@
 from .abstract_sktime import AbstractSktimeModel
-from .models import ARIMAModel, AutoARIMAModel, AutoETSModel, TBATSModel, ThetaModel
+from .models import SktimeARIMAModel, SktimeAutoARIMAModel, SktimeAutoETSModel, SktimeTBATSModel, SktimeThetaModel
 
 __all__ = [
-    "ARIMAModel",
-    "AutoARIMAModel",
-    "AutoETSModel",
-    "TBATSModel",
-    "ThetaModel",
+    "SktimeARIMAModel",
+    "SktimeAutoARIMAModel",
+    "SktimeAutoETSModel",
+    "SktimeTBATSModel",
+    "SktimeThetaModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/sktime/models.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/models.py
@@ -10,7 +10,7 @@ from . import AbstractSktimeModel
 logger = logging.getLogger(__name__)
 
 
-class ThetaModel(AbstractSktimeModel):
+class SktimeThetaModel(AbstractSktimeModel):
     """Theta model for forecasting.
 
     This is a special case of AutoETS model that can only be applied to positive data.
@@ -68,7 +68,7 @@ class ThetaModel(AbstractSktimeModel):
         return sktime_init_args
 
 
-class TBATSModel(AbstractSktimeModel):
+class SktimeTBATSModel(AbstractSktimeModel):
     """TBATS forecaster with multiple seasonalities.
 
     See `AbstractSktimeModel` for common parameters.
@@ -127,7 +127,7 @@ class TBATSModel(AbstractSktimeModel):
         return sktime_init_args
 
 
-class AutoETSModel(AbstractSktimeModel):
+class SktimeAutoETSModel(AbstractSktimeModel):
     """AutoETS model from sktime.
 
     See `AbstractSktimeModel` for common parameters.
@@ -237,7 +237,7 @@ class AutoETSModel(AbstractSktimeModel):
         return sktime_init_args
 
 
-class ARIMAModel(AbstractSktimeModel):
+class SktimeARIMAModel(AbstractSktimeModel):
     """ARIMA model from sktime.
 
     See `AbstractSktimeModel` for common parameters.
@@ -322,7 +322,7 @@ class ARIMAModel(AbstractSktimeModel):
         return sktime_init_args
 
 
-class AutoARIMAModel(AbstractSktimeModel):
+class SktimeAutoARIMAModel(AbstractSktimeModel):
     """AutoARIMA model from sktime.
 
     This model automatically selects the (p, d, q) and (P, D, Q) parameters of ARIMA by

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/__init__.py
@@ -1,7 +1,7 @@
 from .abstract_statsmodels import AbstractStatsmodelsModel
-from .models import StatsmodelsARIMAModel, StatsmodelsETSModel
+from .models import ARIMAModel, ETSModel
 
 __all__ = [
-    "StatsmodelsETSModel",
-    "StatsmodelsARIMAModel",
+    "ETSModel",
+    "ARIMAModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/__init__.py
@@ -1,0 +1,7 @@
+from .abstract_statsmodels import AbstractStatsmodelsModel
+from .models import StatsmodelsARIMAModel, StatsmodelsETSModel
+
+__all__ = [
+    "StatsmodelsETSModel",
+    "StatsmodelsARIMAModel",
+]

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import pandas as pd
 
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
+from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.hashing import hash_ts_dataframe_items
 from autogluon.timeseries.utils.warning_filters import statsmodels_warning_filter
-from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 
 logger = logging.getLogger(__name__)
 

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -1,0 +1,140 @@
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from ...dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
+from ...utils.hashing import hash_ts_dataframe_items
+from ...utils.warning_filters import statsmodels_warning_filter
+from ..abstract import AbstractTimeSeriesModel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelFitSummary:
+    """Stores the parameters of a fitted Statsmodels time series model.
+
+    ModelFitSummary doesn't store intermediate results and therefore takes up very little disk space when pickled. In
+    contrast, StatsmodelsFittedModel stores the intermediate results and therefore can often take several gigabytes
+    when pickled.
+
+    ModelFitSummary is consumed by AbstractStatsmodelsModel._predict_local_model to generate predictions.
+    """
+
+    model_name: str
+    model_init_args: Dict[str, Any]
+    parameters: Dict[str, Any]
+
+
+class AbstractStatsmodelsModel(AbstractTimeSeriesModel):
+    statsmodels_allowed_init_args: List[str] = []
+    statsmodels_allowed_fit_args: List[str] = []
+    quantile_method_name: str = "pred_int"
+
+    def __init__(
+        self,
+        freq: Optional[str] = None,
+        prediction_length: int = 1,
+        path: Optional[str] = None,
+        name: Optional[str] = None,
+        eval_metric: str = None,
+        hyperparameters: Dict[str, Any] = None,
+        **kwargs,  # noqa
+    ):
+        name = name or re.sub(r"Model$", "", self.__class__.__name__)
+        super().__init__(
+            path=path,
+            freq=freq,
+            prediction_length=prediction_length,
+            name=name,
+            eval_metric=eval_metric,
+            hyperparameters=hyperparameters,
+            **kwargs,
+        )
+        self._fitted_models: Dict[str, ModelFitSummary] = {}
+
+    def _get_default_model_init_and_fit_args(self) -> Tuple[dict, dict]:
+        default_model_init_args = {}
+        default_model_fit_args = {}
+        unused_args = []
+        for key, value in self._get_model_params().items():
+            if key in self.statsmodels_allowed_init_args:
+                default_model_init_args[key] = value
+            elif key in self.statsmodels_allowed_fit_args:
+                default_model_fit_args[key] = value
+            else:
+                unused_args.append(key)
+        if len(unused_args) > 0:
+            logger.warning(
+                f" {self.name} ignores the following hyperparameters: {unused_args}. "
+                f"See the docstring of {self.name} for the list of supported hyperparameters."
+            )
+        return default_model_init_args, default_model_fit_args
+
+    def _fit_local_model(
+        self, timeseries: TimeSeriesDataFrame, model_init_args: dict, model_fit_args: dict
+    ) -> ModelFitSummary:
+        """Fit a single local model to the time series."""
+        raise NotImplementedError
+
+    def _fit(self, train_data: TimeSeriesDataFrame, time_limit: int = None, **kwargs):
+        train_hash = hash_ts_dataframe_items(train_data)
+        items_to_fit = [item_id for item_id, ts_hash in train_hash.iteritems() if ts_hash not in self._fitted_models]
+        default_model_init_args, default_model_fit_args = self._get_default_model_init_and_fit_args()
+        # TODO: Parallelize fitting
+        with statsmodels_warning_filter():
+            for item_id in items_to_fit:
+                self._fitted_models[train_hash.loc[item_id]] = self._fit_local_model(
+                    timeseries=train_data.loc[item_id],
+                    default_model_init_args=default_model_init_args,
+                    default_model_fit_args=default_model_fit_args,
+                )
+
+    def predict(self, data: TimeSeriesDataFrame, quantile_levels: List[float] = None, **kwargs) -> TimeSeriesDataFrame:
+        self._check_predict_inputs(data, quantile_levels=quantile_levels, **kwargs)
+        if quantile_levels is None:
+            quantile_levels = self.quantile_levels
+        # Make sure that we fitted a local model to each time series in data
+        self._fit(train_data=data)
+
+        data_hash = hash_ts_dataframe_items(data)
+        # TODO: Parallelize prediction
+        predictions_per_item = {}
+        with statsmodels_warning_filter():
+            for item_id, ts_hash in data_hash.iteritems():
+                predictions_per_item[item_id] = self._predict_using_fit_summary(
+                    fit_summary=self._fitted_models[ts_hash],
+                    timeseries=data.loc[item_id],
+                    quantile_levels=quantile_levels,
+                )
+        result_df = pd.concat(predictions_per_item)
+        result_df.index.rename([ITEMID, TIMESTAMP], inplace=True)
+        return TimeSeriesDataFrame(result_df)
+
+    def _predict_using_fit_summary(
+        self,
+        fit_summary: ModelFitSummary,
+        timeseries: TimeSeriesDataFrame,
+        quantile_levels: List[float],
+    ) -> pd.DataFrame:
+        raise NotImplementedError
+
+    def _get_predictions_from_fitted_model(self, fitted_model, cutoff, quantile_levels):
+        start = cutoff + pd.tseries.frequencies.to_offset(self.freq)
+        end = cutoff + self.prediction_length * pd.tseries.frequencies.to_offset(self.freq)
+        predictions = fitted_model.get_prediction(start=start, end=end)
+        results = [predictions.predicted_mean.rename("mean")]
+        for q in quantile_levels:
+            if q < 0.5:
+                coverage = 2 * q
+                column_index = 0
+            else:
+                coverage = 2 * (1 - q)
+                column_index = 1
+            quantile_pred = getattr(predictions, self.quantile_method_name)(alpha=coverage)
+            # Select lower bound of the confidence interval if q < 0.5, upper bound otherwise
+            results.append(quantile_pred.iloc[:, column_index].rename(str(q)))
+        return pd.concat(results, axis=1)

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -5,10 +5,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 
-from ...dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
-from ...utils.hashing import hash_ts_dataframe_items
-from ...utils.warning_filters import statsmodels_warning_filter
-from ..abstract import AbstractTimeSeriesModel
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
+from autogluon.timeseries.utils.hashing import hash_ts_dataframe_items
+from autogluon.timeseries.utils.warning_filters import statsmodels_warning_filter
+from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ class AbstractStatsmodelsModel(AbstractTimeSeriesModel):
         return default_model_init_args, default_model_fit_args
 
     def _fit_local_model(
-        self, timeseries: TimeSeriesDataFrame, model_init_args: dict, model_fit_args: dict
+        self, timeseries: TimeSeriesDataFrame, default_model_init_args: dict, default_model_fit_args: dict
     ) -> ModelFitSummary:
         """Fit a single local model to the time series."""
         raise NotImplementedError

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -80,6 +80,8 @@ class AbstractStatsmodelsModel(AbstractTimeSeriesModel):
             hyperparameters=hyperparameters,
             **kwargs,
         )
+        if hyperparameters is None:
+            hyperparameters = {}
         # Use 50% of the available CPU cores by default
         n_jobs = hyperparameters.get("n_jobs", 0.5)
         if isinstance(n_jobs, float) and 0 < n_jobs <= 1.0:

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -98,9 +98,12 @@ class AbstractStatsmodelsModel(AbstractTimeSeriesModel):
         if quantile_levels is None:
             quantile_levels = self.quantile_levels
         # Make sure that we fitted a local model to each time series in data
-        self._fit(train_data=data)
-
         data_hash = hash_ts_dataframe_items(data)
+        items_to_fit = [item_id for item_id, ts_hash in data_hash.iteritems() if ts_hash not in self._fitted_models]
+        if len(items_to_fit) > 0:
+            logger.info(f"{self.name} received {len(items_to_fit)} items not seen during training, re-running fit")
+            self._fit(train_data=data)
+
         # TODO: Parallelize prediction
         predictions_per_item = {}
         with statsmodels_warning_filter():

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -110,7 +110,7 @@ class AbstractStatsmodelsModel(AbstractTimeSeriesModel):
                 unused_args.append(key)
         if len(unused_args) > 0:
             logger.warning(
-                f" {self.name} ignores the following hyperparameters: {unused_args}. "
+                f" {self.name} ignores following hyperparameters: {unused_args}. "
                 f"See the docstring of {self.name} for the list of supported hyperparameters."
             )
         return default_model_init_args, default_model_fit_args
@@ -144,6 +144,7 @@ class AbstractStatsmodelsModel(AbstractTimeSeriesModel):
         model_init_args, model_fit_args = self._update_model_init_and_fit_args(
             default_model_init_args=default_model_init_args, default_model_fit_args=default_model_fit_args
         )
+        print("model_init_args", model_init_args)
 
         # Fit models in parallel
         fit_fn = partial(self._fit_local_model, model_fit_args=model_fit_args, model_init_args=model_init_args)

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -144,7 +144,8 @@ class AbstractStatsmodelsModel(AbstractTimeSeriesModel):
         else:
             if self.freq != train_data.freq:
                 raise RuntimeError(
-                    f"Frequency of train_data {train_data.freq} must match the frequency {self.freq} of {self.name}"
+                    f"Frequency {train_data.freq} of the dataset must match the frequency "
+                    f"{self.freq} of the {self.name} model"
                 )
 
         # Select timeseries that don't have a fitted local model

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -10,7 +10,6 @@ from joblib import Parallel, delayed
 from statsmodels.tsa.base.tsa_model import TimeSeriesModelResults as StatsmodelsTSModelResults
 
 from autogluon.common.utils.log_utils import set_logger_verbosity
-
 from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.utils.hashing import hash_ts_dataframe_items

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/abstract_statsmodels.py
@@ -21,7 +21,7 @@ class ModelFitSummary:
     contrast, StatsmodelsFittedModel stores the intermediate results and therefore can often take several gigabytes
     when pickled.
 
-    ModelFitSummary is consumed by AbstractStatsmodelsModel._predict_local_model to generate predictions.
+    ModelFitSummary is consumed by AbstractStatsmodelsModel._predict_using_fit_summary to generate predictions.
     """
 
     model_name: str

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -110,9 +110,9 @@ class ETSModel(AbstractStatsmodelsModel):
             base_model = StatsmodelsETS(endog=timeseries, freq=self.freq, **fitted_model.model_init_args)
             parameters = np.array(list(fitted_model.parameters.values()))
             # This is a hack that allows us to set the parameters to their estimated values & initialize the model
-            initialized_model = base_model.fit(start_params=parameters, maxiter=0, disp=False)
-        return self._get_predictions_from_initialized_model(
-            initialized_model=initialized_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
+            sm_model = base_model.fit(start_params=parameters, maxiter=0, disp=False)
+        return self._get_predictions_from_statsmodels_model(
+            sm_model=sm_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
         )
 
 
@@ -204,7 +204,7 @@ class ARIMAModel(AbstractStatsmodelsModel):
         with statsmodels_warning_filter():
             base_model = StatsmodelsSARIMAX(endog=timeseries, freq=self.freq, **fitted_model.model_init_args)
             # This is a hack that allows us to set the parameters to their estimated values & initialize the model
-            initialized_model = base_model.fit(start_params=parameters, maxiter=0, disp=False)
-        return self._get_predictions_from_initialized_model(
-            initialized_model=initialized_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
+            sm_model = base_model.fit(start_params=parameters, maxiter=0, disp=False)
+        return self._get_predictions_from_statsmodels_model(
+            sm_model=sm_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
         )

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -74,6 +74,7 @@ class ETSModel(AbstractStatsmodelsModel):
             seasonal_period = get_seasonality(self.freq)
 
         seasonal = model_init_args.setdefault("seasonal", "add")
+        # Disable seaasonality if seasonal_period is too short
         if seasonal is not None:
             if seasonal_period <= 1:
                 logger.warning(

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -12,7 +12,7 @@ from autogluon.timeseries.utils.warning_filters import statsmodels_warning_filte
 from .abstract_statsmodels import AbstractStatsmodelsModel, FittedLocalModel
 
 
-class StatsmodelsETSModel(AbstractStatsmodelsModel):
+class ETSModel(AbstractStatsmodelsModel):
     """Exponential smoothing with trend and seasonality model.
 
     Based on `statsmodels.tsa.exponential_smoothing.ets.ETSModel`.
@@ -54,7 +54,6 @@ class StatsmodelsETSModel(AbstractStatsmodelsModel):
     ]
     statsmodels_allowed_fit_args = [
         "maxiter",
-        "n_jobs",
     ]
 
     def _fit_local_model(
@@ -93,7 +92,7 @@ class StatsmodelsETSModel(AbstractStatsmodelsModel):
         )
 
 
-class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
+class ARIMAModel(AbstractStatsmodelsModel):
     """Autoregressive Integrated Moving Average (ARIMA) model.
 
     Based on `statsmodels.tsa.statespace.sarimax.SARIMAX`
@@ -131,7 +130,6 @@ class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
     ]
     statsmodels_allowed_fit_args = [
         "maxiter",
-        "n_jobs",
     ]
 
     def _fit_local_model(

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -2,13 +2,12 @@ from typing import List
 
 import numpy as np
 import pandas as pd
-from statsmodels.tools.sm_exceptions import ConvergenceWarning, ValueWarning
 from statsmodels.tsa.exponential_smoothing.ets import ETSModel
-from statsmodels.tsa.statespace.mlemodel import MLEResults
 from statsmodels.tsa.statespace.sarimax import SARIMAX
 
-from ... import TimeSeriesDataFrame
-from ...utils.seasonality import get_seasonality
+from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
+from autogluon.timeseries.utils.seasonality import get_seasonality
+
 from .abstract_statsmodels import AbstractStatsmodelsModel, ModelFitSummary
 
 

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -1,19 +1,21 @@
-from typing import List
+import logging
+from typing import List, Tuple
 
 import numpy as np
 import pandas as pd
-from statsmodels.tsa.exponential_smoothing.ets import ETSModel
-from statsmodels.tsa.statespace.sarimax import SARIMAX
+from statsmodels.tsa.exponential_smoothing.ets import ETSModel as StatsmodelsETS
+from statsmodels.tsa.statespace.sarimax import SARIMAX as StatsmodelsSARIMAX
 
-from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.utils.seasonality import get_seasonality
 from autogluon.timeseries.utils.warning_filters import statsmodels_warning_filter
 
 from .abstract_statsmodels import AbstractStatsmodelsModel, FittedLocalModel
 
+logger = logging.getLogger(__name__)
+
 
 class ETSModel(AbstractStatsmodelsModel):
-    """Exponential smoothing with trend and seasonality model.
+    """Exponential smoothing with trend and seasonality.
 
     Based on `statsmodels.tsa.exponential_smoothing.ets.ETSModel`.
 
@@ -23,15 +25,16 @@ class ETSModel(AbstractStatsmodelsModel):
     Other Parameters
     ----------------
     error : str, default = "add"
-        Error model. Allowed values are "add" and "mul".
-        Note that "mul" is only applicable for time series with positive values.
+        Error model. Allowed values are "add" (additive) and "mul" (multiplicative).
+        Note that "mul" is only applicable to time series with positive values.
     trend : str or None, default = "add"
-        Trend component model. Allowed values are "add", "mul" and None.
-        Note that "mul" is only applicable for time series with positive values.
+        Trend component model. Allowed values are "add" (additive), "mul" (multiplicative) and None (disabled).
+        Note that "mul" is only applicable to time series with positive values.
     damped_trend : bool, default = False
         Whether or not the included trend component is damped.
-    seasonal : bool, default = True
-        Whether to enable additive seasonality.
+    seasonal : str or None, default = "add"
+        Seasonal component model. Allowed values are "add" (additive), "mul" (multiplicative) and None (disabled).
+        Note that "mul" is only applicable to time series with positive values.
     seasonal_periods : int or None, default = None
         Number of time steps in a complete seasonal cycle for seasonal models. For example, 7 for daily data with a
         weekly cycle or 12 for monthly data with an annual cycle.
@@ -40,8 +43,11 @@ class ETSModel(AbstractStatsmodelsModel):
         If seasonal_periods (inferred or provided) is equal to 1, seasonality will be disabled.
     maxiter : int, default = 1000
         Number of iterations during optimization.
-    n_jobs : int, default = -1
-        Number of CPU cores used to fit the models in parallel. When set to -1, all CPU cores are used.
+    n_jobs : int or float, default = 0.5
+        Number of CPU cores used to fit the models in parallel.
+        When set to a float between 0 and 1, that fraction of available CPU cores is used.
+        When set to a positive integer, that many cores are used.
+        When set to -1, all CPU cores are used.
     """
 
     quantile_method_name = "pred_int"
@@ -56,24 +62,40 @@ class ETSModel(AbstractStatsmodelsModel):
         "maxiter",
     ]
 
-    def _fit_local_model(
-        self, timeseries: pd.Series, default_model_init_args: dict, default_model_fit_args: dict
-    ) -> FittedLocalModel:
+    def _update_model_init_and_fit_args(
+        self, default_model_init_args: dict, default_model_fit_args: dict
+    ) -> Tuple[dict, dict]:
         model_init_args = default_model_init_args.copy()
+        model_init_args.setdefault("trend", "add")
+
         # Infer seasonal_periods if seasonal_periods is not given / is set to None
         seasonal_periods = model_init_args.pop("seasonal_periods", None)
         if seasonal_periods is None:
             seasonal_periods = get_seasonality(self.freq)
-        # Disable seasonality if the model cannot be fit with seasonality
-        if len(timeseries) < 2 * seasonal_periods or seasonal_periods == 1:
+
+        seasonal = model_init_args.setdefault("seasonal", "add")
+        if seasonal is not None:
+            if seasonal_periods <= 1:
+                logger.warning(
+                    f"{self.name} with seasonal = {seasonal} requires seasonal_periods > 1 "
+                    f"(received seasonal_periods = {seasonal_periods}). Disabling seasonality."
+                )
+                model_init_args["seasonal"] = None
+            else:
+                model_init_args["seasonal_periods"] = seasonal_periods
+
+        model_fit_args = default_model_fit_args.copy()
+        return model_init_args, model_fit_args
+
+    def _fit_local_model(self, timeseries: pd.Series, model_init_args: dict, model_fit_args: dict) -> FittedLocalModel:
+        # Disable seasonality if timeseries is too short for given seasonal_periods
+        if len(timeseries) < 2 * model_init_args.get("seasonal_periods"):
+            model_init_args = model_init_args.copy()
             model_init_args["seasonal"] = None
-            model_init_args["seasonal_periods"] = 1
-        else:
-            model_init_args["seasonal_periods"] = seasonal_periods
 
         with statsmodels_warning_filter():
-            model = ETSModel(endog=timeseries, freq=self.freq, **model_init_args)
-            fit_result = model.fit(full_output=False, disp=False, **default_model_fit_args)
+            model = StatsmodelsETS(endog=timeseries, freq=self.freq, **model_init_args)
+            fit_result = model.fit(full_output=False, disp=False, **model_fit_args)
         # Only save the parameters of the trained model, not the model itself
         parameters = dict(zip(fit_result.param_names, fit_result.params))
         return FittedLocalModel(model_name=self.name, model_init_args=model_init_args, parameters=parameters)
@@ -83,7 +105,7 @@ class ETSModel(AbstractStatsmodelsModel):
     ) -> pd.DataFrame:
         assert fitted_model.model_name == self.name
         with statsmodels_warning_filter():
-            base_model = ETSModel(endog=timeseries, freq=self.freq, **fitted_model.model_init_args)
+            base_model = StatsmodelsETS(endog=timeseries, freq=self.freq, **fitted_model.model_init_args)
             parameters = np.array(list(fitted_model.parameters.values()))
             # This is a hack that allows us to set the parameters to their estimated values & initialize the model
             initialized_model = base_model.fit(start_params=parameters, maxiter=0, disp=False)
@@ -117,43 +139,57 @@ class ARIMAModel(AbstractStatsmodelsModel):
         False or increase the differencing parameter `d` in `order`.
     maxiter : int, default = 1000
         Number of iterations during optimization.
-    n_jobs : int, default = -1
-        Number of CPU cores used to fit the models in parallel. When set to -1, all CPU cores are used.
+    n_jobs : int or float, default = 0.5
+        Number of CPU cores used to fit the models in parallel.
+        When set to a float between 0 and 1, that fraction of available CPU cores is used.
+        When set to a positive integer, that many cores are used.
+        When set to -1, all CPU cores are used.
     """
 
     quantile_method_name = "conf_int"
     statsmodels_allowed_init_args = [
         "order",
         "seasonal_order",
-        "seasonal_period",
+        "seasonal_periods",
         "enforce_stationarity",
     ]
     statsmodels_allowed_fit_args = [
         "maxiter",
     ]
 
-    def _fit_local_model(
-        self, timeseries: TimeSeriesDataFrame, default_model_init_args: dict, default_model_fit_args: dict
-    ) -> FittedLocalModel:
+    def _update_model_init_and_fit_args(
+        self, default_model_init_args: dict, default_model_fit_args: dict
+    ) -> Tuple[dict, dict]:
         model_init_args = default_model_init_args.copy()
-        # Set trend to constant if trend = True
         model_init_args.setdefault("enforce_stationarity", True)
-        model_init_args.setdefault("with_intercept", True)
+        model_init_args["trend"] = "c"
+
         # Infer seasonal_periods if seasonal_periods is not given / is set to None
-        seasonal_period = model_init_args.pop("seasonal_period", None)
-        if seasonal_period is None:
-            seasonal_period = get_seasonality(self.freq)
+        seasonal_periods = model_init_args.pop("seasonal_periods", None)
+        if seasonal_periods is None:
+            seasonal_periods = get_seasonality(self.freq)
+
         seasonal_order = model_init_args.pop("seasonal_order", (0, 0, 0))
+        seasonal_order_is_valid = len(seasonal_order) == 3 and all(isinstance(p, int) for p in seasonal_order)
+        if not seasonal_order_is_valid:
+            raise ValueError(
+                f"{self.name} can't interpret received seasonal_order {seasonal_order} as a "
+                "tuple with 3 nonnegative integers (P, D, Q)."
+            )
 
         # Disable seasonality if seasonal_period is too short
-        if seasonal_period <= 1:
+        if seasonal_periods <= 1:
             model_init_args["seasonal_order"] = (0, 0, 0, 0)
         else:
-            model_init_args["seasonal_order"] = tuple(seasonal_order) + (seasonal_period,)
+            model_init_args["seasonal_order"] = tuple(seasonal_order) + (seasonal_periods,)
 
+        model_fit_args = default_model_fit_args.copy()
+        return model_init_args, model_fit_args
+
+    def _fit_local_model(self, timeseries: pd.Series, model_init_args: dict, model_fit_args: dict) -> FittedLocalModel:
         with statsmodels_warning_filter():
-            model = SARIMAX(endog=timeseries, freq=self.freq, **model_init_args)
-            fit_result = model.fit(disp=False, **default_model_fit_args)
+            model = StatsmodelsSARIMAX(endog=timeseries, freq=self.freq, **model_init_args)
+            fit_result = model.fit(disp=False, **model_fit_args)
         # Only save the parameters of the trained model, not the model itself
         parameters = dict(fit_result.params.iteritems())
         return FittedLocalModel(model_name=self.name, model_init_args=model_init_args, parameters=parameters)
@@ -164,7 +200,7 @@ class ARIMAModel(AbstractStatsmodelsModel):
         assert fitted_model.model_name == self.name
         parameters = np.array(list(fitted_model.parameters.values()))
         with statsmodels_warning_filter():
-            base_model = SARIMAX(endog=timeseries, freq=self.freq, **fitted_model.model_init_args)
+            base_model = StatsmodelsSARIMAX(endog=timeseries, freq=self.freq, **fitted_model.model_init_args)
             # This is a hack that allows us to set the parameters to their estimated values & initialize the model
             initialized_model = base_model.fit(start_params=parameters, maxiter=0, disp=False)
         return self._get_predictions_from_initialized_model(

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -69,8 +69,8 @@ class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
         "order",
         "seasonal_order",
         "seasonal_period",
-        "trend",
         "enforce_stationarity",
+        "with_intercept",
     ]
     statsmodels_allowed_fit_args = [
         "maxiter",
@@ -81,10 +81,8 @@ class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
     ) -> ModelFitSummary:
         model_init_args = default_model_init_args.copy()
         # Set trend to constant if trend = True
-        trend = model_init_args.pop("trend", True)
-        if trend:
-            model_init_args["trend"] = "c"
-        model_init_args.setdefault("enforce_stationarity", False)
+        model_init_args.setdefault("enforce_stationarity", True)
+        model_init_args.setdefault("with_intercept", True)
         # Infer seasonal_periods if seasonal_periods is not given / is set to None
         seasonal_period = model_init_args.pop("seasonal_period", None)
         if seasonal_period is None:

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -34,7 +34,7 @@ class StatsmodelsETSModel(AbstractStatsmodelsModel):
         # Infer seasonal_periods if seasonal_periods is not given / is set to None
         seasonal_period = model_init_args.pop("seasonal_period", None)
         if seasonal_period is None:
-            seasonal_period = get_seasonality(timeseries.freq)
+            seasonal_period = get_seasonality(self.freq)
         # Disable seasonality if the model cannot be fit with seasonality
         if len(timeseries) < 2 * seasonal_period or seasonal_period == 1:
             model_init_args["seasonal"] = None
@@ -71,6 +71,7 @@ class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
         "seasonal_order",
         "seasonal_period",
         "trend",
+        "enforce_stationarity",
     ]
     statsmodels_allowed_fit_args = [
         "maxiter",
@@ -80,11 +81,15 @@ class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
         self, timeseries: TimeSeriesDataFrame, default_model_init_args: dict, default_model_fit_args: dict
     ) -> ModelFitSummary:
         model_init_args = default_model_init_args.copy()
-        model_init_args.setdefault("trend", "c")
+        # Set trend to constant if trend = True
+        trend = model_init_args.pop("trend", True)
+        if trend:
+            model_init_args["trend"] = "c"
+        model_init_args.setdefault("enforce_stationarity", False)
         # Infer seasonal_periods if seasonal_periods is not given / is set to None
         seasonal_period = model_init_args.pop("seasonal_period", None)
         if seasonal_period is None:
-            seasonal_period = get_seasonality(timeseries.freq)
+            seasonal_period = get_seasonality(self.freq)
         seasonal_order = model_init_args.pop("seasonal_order", (0, 0, 0))
 
         # Disable seasonality if seasonal_period is too short

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -7,78 +7,136 @@ from statsmodels.tsa.statespace.sarimax import SARIMAX
 
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.utils.seasonality import get_seasonality
+from autogluon.timeseries.utils.warning_filters import statsmodels_warning_filter
 
-from .abstract_statsmodels import AbstractStatsmodelsModel, ModelFitSummary
+from .abstract_statsmodels import AbstractStatsmodelsModel, FittedLocalModel
 
 
 class StatsmodelsETSModel(AbstractStatsmodelsModel):
-    # TODO: Expose more hyperparameters & make them consistent across models
-    # TODO: Check default values of hyperparameters
-    # TODO: Add docstrings
+    """Exponential smoothing with trend and seasonality model.
+
+    Based on `statsmodels.tsa.exponential_smoothing.ets.ETSModel`.
+
+    See `AbstractStatsmodelsModel` for common parameters.
+
+
+    Other Parameters
+    ----------------
+    error : str, default = "add"
+        Error model. Allowed values are "add" and "mul".
+        Note that "mul" is only applicable for time series with positive values.
+    trend : str or None, default = "add"
+        Trend component model. Allowed values are "add", "mul" and None.
+        Note that "mul" is only applicable for time series with positive values.
+    damped_trend : bool, default = False
+        Whether or not the included trend component is damped.
+    seasonal : bool, default = True
+        Whether to enable additive seasonality.
+    seasonal_periods : int or None, default = None
+        Number of time steps in a complete seasonal cycle for seasonal models. For example, 7 for daily data with a
+        weekly cycle or 12 for monthly data with an annual cycle.
+        When set to None, seasonal_periods will be inferred from the frequency of the training data. Can also be
+        specified manually by providing an integer > 1.
+        If seasonal_periods (inferred or provided) is equal to 1, seasonality will be disabled.
+    maxiter : int, default = 1000
+        Number of iterations during optimization.
+    n_jobs : int, default = -1
+        Number of CPU cores used to fit the models in parallel. When set to -1, all CPU cores are used.
+    """
+
     quantile_method_name = "pred_int"
     statsmodels_allowed_init_args = [
         "error",
         "trend",
+        "damped_trend",
         "seasonal",
         "seasonal_period",
     ]
     statsmodels_allowed_fit_args = [
         "maxiter",
+        "n_jobs",
     ]
 
     def _fit_local_model(
-        self, timeseries: TimeSeriesDataFrame, default_model_init_args: dict, default_model_fit_args: dict
-    ) -> ModelFitSummary:
+        self, timeseries: pd.Series, default_model_init_args: dict, default_model_fit_args: dict
+    ) -> FittedLocalModel:
         model_init_args = default_model_init_args.copy()
         # Infer seasonal_periods if seasonal_periods is not given / is set to None
-        seasonal_period = model_init_args.pop("seasonal_period", None)
-        if seasonal_period is None:
-            seasonal_period = get_seasonality(self.freq)
+        seasonal_periods = model_init_args.pop("seasonal_periods", None)
+        if seasonal_periods is None:
+            seasonal_periods = get_seasonality(self.freq)
         # Disable seasonality if the model cannot be fit with seasonality
-        if len(timeseries) < 2 * seasonal_period or seasonal_period == 1:
+        if len(timeseries) < 2 * seasonal_periods or seasonal_periods == 1:
             model_init_args["seasonal"] = None
             model_init_args["seasonal_periods"] = 1
         else:
-            model_init_args["seasonal_periods"] = seasonal_period
+            model_init_args["seasonal_periods"] = seasonal_periods
 
-        model = ETSModel(endog=timeseries.squeeze(1), freq=self.freq, **model_init_args)
-        fit_result = model.fit(full_output=False, disp=False, **default_model_fit_args)
+        with statsmodels_warning_filter():
+            model = ETSModel(endog=timeseries, freq=self.freq, **model_init_args)
+            fit_result = model.fit(full_output=False, disp=False, **default_model_fit_args)
         # Only save the parameters of the trained model, not the model itself
         parameters = dict(zip(fit_result.param_names, fit_result.params))
-        return ModelFitSummary(model_name=self.name, model_init_args=model_init_args, parameters=parameters)
+        return FittedLocalModel(model_name=self.name, model_init_args=model_init_args, parameters=parameters)
 
-    def _predict_using_fit_summary(
-        self, fit_summary: ModelFitSummary, timeseries: TimeSeriesDataFrame, quantile_levels: List[float]
+    def _predict_with_local_model(
+        self, timeseries: pd.Series, fitted_model: FittedLocalModel, quantile_levels: List[float]
     ) -> pd.DataFrame:
-        assert fit_summary.model_name == self.name
-        # Initialize the model with fitted parameters
-        model = ETSModel(endog=timeseries.squeeze(1), freq=self.freq, **fit_summary.model_init_args)
-        parameters = np.array(list(fit_summary.parameters.values()))
-        fitted_model = model.fit(start_params=parameters, maxiter=0, disp=False)
-        return self._get_predictions_from_fitted_model(
-            fitted_model=fitted_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
+        assert fitted_model.model_name == self.name
+        with statsmodels_warning_filter():
+            base_model = ETSModel(endog=timeseries, freq=self.freq, **fitted_model.model_init_args)
+            parameters = np.array(list(fitted_model.parameters.values()))
+            # This is a hack that allows us to set the parameters to their estimated values & initialize the model
+            initialized_model = base_model.fit(start_params=parameters, maxiter=0, disp=False)
+        return self._get_predictions_from_initialized_model(
+            initialized_model=initialized_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
         )
 
 
 class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
-    # TODO: Expose more hyperparameters & make them consistent across models
-    # TODO: Check default values of hyperparameters
-    # TODO: Add docstrings
+    """Autoregressive Integrated Moving Average (ARIMA) model.
+
+    Based on `statsmodels.tsa.statespace.sarimax.SARIMAX`
+
+    See `AbstractStatsmodelsModel` for common parameters.
+
+    Other Parameters
+    ----------------
+    order: Tuple[int, int, int], default = (1, 1, 1)
+        The (p, d, q) order of the model for the number of AR parameters, differences, and MA parameters to use.
+    seasonal_order: Tuple[int, int, int], default = (0, 0, 0)
+        The (P, D, Q) parameters of the seasonal ARIMA model. Setting to (0, 0, 0) disables seasonality.
+    seasonal_periods : int or None, default = None
+        Number of time steps in a complete seasonal cycle for seasonal models. For example, 7 for daily data with a
+        weekly cycle or 12 for monthly data with an annual cycle.
+        When set to None, seasonal_periods will be inferred from the frequency of the training data. Can also be
+        specified manually by providing an integer > 1.
+        If seasonal_periods (inferred or provided) is equal to 1, seasonality will be disabled.
+    enforce_stationarity : bool, default = True
+        Whether to transform the AR parameters to enforce stationarity in the autoregressive component of the model.
+        If ARIMA crashes during fitting with an LU decomposition error, you can either set enforce_stationarity to
+        False or increase the differencing parameter `d` in `order`.
+    maxiter : int, default = 1000
+        Number of iterations during optimization.
+    n_jobs : int, default = -1
+        Number of CPU cores used to fit the models in parallel. When set to -1, all CPU cores are used.
+    """
+
     quantile_method_name = "conf_int"
     statsmodels_allowed_init_args = [
         "order",
         "seasonal_order",
         "seasonal_period",
         "enforce_stationarity",
-        "with_intercept",
     ]
     statsmodels_allowed_fit_args = [
         "maxiter",
+        "n_jobs",
     ]
 
     def _fit_local_model(
         self, timeseries: TimeSeriesDataFrame, default_model_init_args: dict, default_model_fit_args: dict
-    ) -> ModelFitSummary:
+    ) -> FittedLocalModel:
         model_init_args = default_model_init_args.copy()
         # Set trend to constant if trend = True
         model_init_args.setdefault("enforce_stationarity", True)
@@ -95,19 +153,22 @@ class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
         else:
             model_init_args["seasonal_order"] = tuple(seasonal_order) + (seasonal_period,)
 
-        model = SARIMAX(endog=timeseries.squeeze(1), freq=self.freq, **model_init_args)
-        fit_result = model.fit(disp=False, **default_model_fit_args)
+        with statsmodels_warning_filter():
+            model = SARIMAX(endog=timeseries, freq=self.freq, **model_init_args)
+            fit_result = model.fit(disp=False, **default_model_fit_args)
         # Only save the parameters of the trained model, not the model itself
         parameters = dict(fit_result.params.iteritems())
-        return ModelFitSummary(model_name=self.name, model_init_args=model_init_args, parameters=parameters)
+        return FittedLocalModel(model_name=self.name, model_init_args=model_init_args, parameters=parameters)
 
-    def _predict_using_fit_summary(
-        self, fit_summary: ModelFitSummary, timeseries: TimeSeriesDataFrame, quantile_levels: List[float]
+    def _predict_with_local_model(
+        self, timeseries: pd.Series, fitted_model: FittedLocalModel, quantile_levels: List[float]
     ) -> pd.DataFrame:
-        assert fit_summary.model_name == self.name
-        model = SARIMAX(endog=timeseries.squeeze(1), freq=self.freq, **fit_summary.model_init_args)
-        parameters = np.array(list(fit_summary.parameters.values()))
-        fitted_model = model.fit(start_params=parameters, maxiter=0, disp=False)
-        return self._get_predictions_from_fitted_model(
-            fitted_model=fitted_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
+        assert fitted_model.model_name == self.name
+        parameters = np.array(list(fitted_model.parameters.values()))
+        with statsmodels_warning_filter():
+            base_model = SARIMAX(endog=timeseries, freq=self.freq, **fitted_model.model_init_args)
+            # This is a hack that allows us to set the parameters to their estimated values & initialize the model
+            initialized_model = base_model.fit(start_params=parameters, maxiter=0, disp=False)
+        return self._get_predictions_from_initialized_model(
+            initialized_model=initialized_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
         )

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -45,7 +45,7 @@ class ETSModel(AbstractStatsmodelsModel):
         Number of iterations during optimization.
     n_jobs : int or float, default = 0.5
         Number of CPU cores used to fit the models in parallel.
-        When set to a float between 0 and 1, that fraction of available CPU cores is used.
+        When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
     """
@@ -142,7 +142,7 @@ class ARIMAModel(AbstractStatsmodelsModel):
         Number of iterations during optimization.
     n_jobs : int or float, default = 0.5
         Number of CPU cores used to fit the models in parallel.
-        When set to a float between 0 and 1, that fraction of available CPU cores is used.
+        When set to a float between 0.0 and 1.0, that fraction of available CPU cores is used.
         When set to a positive integer, that many cores are used.
         When set to -1, all CPU cores are used.
     """

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -1,0 +1,111 @@
+from typing import List
+
+import numpy as np
+import pandas as pd
+from statsmodels.tools.sm_exceptions import ConvergenceWarning, ValueWarning
+from statsmodels.tsa.exponential_smoothing.ets import ETSModel
+from statsmodels.tsa.statespace.mlemodel import MLEResults
+from statsmodels.tsa.statespace.sarimax import SARIMAX
+
+from ... import TimeSeriesDataFrame
+from ...utils.seasonality import get_seasonality
+from .abstract_statsmodels import AbstractStatsmodelsModel, ModelFitSummary
+
+
+class StatsmodelsETSModel(AbstractStatsmodelsModel):
+    # TODO: Expose more hyperparameters & make them consistent across models
+    # TODO: Check default values of hyperparameters
+    # TODO: Add docstrings
+    quantile_method_name = "pred_int"
+    statsmodels_allowed_init_args = [
+        "error",
+        "trend",
+        "seasonal",
+        "seasonal_period",
+    ]
+    statsmodels_allowed_fit_args = [
+        "maxiter",
+    ]
+
+    def _fit_local_model(
+        self, timeseries: TimeSeriesDataFrame, default_model_init_args: dict, default_model_fit_args: dict
+    ) -> ModelFitSummary:
+        model_init_args = default_model_init_args.copy()
+        # Infer seasonal_periods if seasonal_periods is not given / is set to None
+        seasonal_period = model_init_args.pop("seasonal_period", None)
+        if seasonal_period is None:
+            seasonal_period = get_seasonality(timeseries.freq)
+        # Disable seasonality if the model cannot be fit with seasonality
+        if len(timeseries) < 2 * seasonal_period or seasonal_period == 1:
+            model_init_args["seasonal"] = None
+            model_init_args["seasonal_periods"] = 1
+        else:
+            model_init_args["seasonal_periods"] = seasonal_period
+
+        model = ETSModel(endog=timeseries.squeeze(1), freq=self.freq, **model_init_args)
+        fit_result = model.fit(full_output=False, disp=False, **default_model_fit_args)
+        # Only save the parameters of the trained model, not the model itself
+        parameters = dict(zip(fit_result.param_names, fit_result.params))
+        return ModelFitSummary(model_name=self.name, model_init_args=model_init_args, parameters=parameters)
+
+    def _predict_using_fit_summary(
+        self, fit_summary: ModelFitSummary, timeseries: TimeSeriesDataFrame, quantile_levels: List[float]
+    ) -> pd.DataFrame:
+        assert fit_summary.model_name == self.name
+        # Initialize the model with fitted parameters
+        model = ETSModel(endog=timeseries.squeeze(1), freq=self.freq, **fit_summary.model_init_args)
+        parameters = np.array(list(fit_summary.parameters.values()))
+        fitted_model = model.fit(start_params=parameters, maxiter=0, disp=False)
+        return self._get_predictions_from_fitted_model(
+            fitted_model=fitted_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
+        )
+
+
+class StatsmodelsARIMAModel(AbstractStatsmodelsModel):
+    # TODO: Expose more hyperparameters & make them consistent across models
+    # TODO: Check default values of hyperparameters
+    # TODO: Add docstrings
+    quantile_method_name = "conf_int"
+    statsmodels_allowed_init_args = [
+        "order",
+        "seasonal_order",
+        "seasonal_period",
+        "trend",
+    ]
+    statsmodels_allowed_fit_args = [
+        "maxiter",
+    ]
+
+    def _fit_local_model(
+        self, timeseries: TimeSeriesDataFrame, default_model_init_args: dict, default_model_fit_args: dict
+    ) -> ModelFitSummary:
+        model_init_args = default_model_init_args.copy()
+        model_init_args.setdefault("trend", "c")
+        # Infer seasonal_periods if seasonal_periods is not given / is set to None
+        seasonal_period = model_init_args.pop("seasonal_period", None)
+        if seasonal_period is None:
+            seasonal_period = get_seasonality(timeseries.freq)
+        seasonal_order = model_init_args.pop("seasonal_order", (0, 0, 0))
+
+        # Disable seasonality if seasonal_period is too short
+        if seasonal_period <= 1:
+            model_init_args["seasonal_order"] = (0, 0, 0, 0)
+        else:
+            model_init_args["seasonal_order"] = tuple(seasonal_order) + (seasonal_period,)
+
+        model = SARIMAX(endog=timeseries.squeeze(1), freq=self.freq, **model_init_args)
+        fit_result = model.fit(disp=False, **default_model_fit_args)
+        # Only save the parameters of the trained model, not the model itself
+        parameters = dict(fit_result.params.iteritems())
+        return ModelFitSummary(model_name=self.name, model_init_args=model_init_args, parameters=parameters)
+
+    def _predict_using_fit_summary(
+        self, fit_summary: ModelFitSummary, timeseries: TimeSeriesDataFrame, quantile_levels: List[float]
+    ) -> pd.DataFrame:
+        assert fit_summary.model_name == self.name
+        model = SARIMAX(endog=timeseries.squeeze(1), freq=self.freq, **fit_summary.model_init_args)
+        parameters = np.array(list(fit_summary.parameters.values()))
+        fitted_model = model.fit(start_params=parameters, maxiter=0, disp=False)
+        return self._get_predictions_from_fitted_model(
+            fitted_model=fitted_model, cutoff=timeseries.index.max(), quantile_levels=quantile_levels
+        )

--- a/timeseries/src/autogluon/timeseries/utils/warning_filters.py
+++ b/timeseries/src/autogluon/timeseries/utils/warning_filters.py
@@ -2,8 +2,12 @@ import contextlib
 import functools
 import logging
 import os
+import warnings
 
-__all__ = ["evaluator_warning_filter", "disable_root_logger", "disable_tqdm"]
+from statsmodels.tools.sm_exceptions import ConvergenceWarning, ValueWarning
+
+
+__all__ = ["evaluator_warning_filter", "statsmodels_warning_filter", "disable_root_logger", "disable_tqdm"]
 
 
 @contextlib.contextmanager
@@ -16,6 +20,17 @@ def evaluator_warning_filter():
         yield
     finally:
         os.environ["PYTHONWARNINGS"] = env_py_warnings
+
+
+@contextlib.contextmanager
+def statsmodels_warning_filter():
+    with warnings.catch_warnings():
+        for warning_category in [RuntimeWarning, UserWarning, ConvergenceWarning, ValueWarning]:
+            warnings.simplefilter("ignore", category=warning_category)
+        try:
+            yield
+        finally:
+            pass
 
 
 @contextlib.contextmanager

--- a/timeseries/src/autogluon/timeseries/utils/warning_filters.py
+++ b/timeseries/src/autogluon/timeseries/utils/warning_filters.py
@@ -6,7 +6,6 @@ import warnings
 
 from statsmodels.tools.sm_exceptions import ConvergenceWarning, ValueWarning
 
-
 __all__ = ["evaluator_warning_filter", "statsmodels_warning_filter", "disable_root_logger", "disable_tqdm"]
 
 

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -1,6 +1,6 @@
 """Common utils and data for all model tests"""
 import random
-from typing import List, Union
+from typing import Dict, List, Union
 
 import pandas as pd
 from gluonts.dataset.common import ListDataset
@@ -52,6 +52,28 @@ def get_data_frame_with_item_index(
 
 
 DUMMY_TS_DATAFRAME = get_data_frame_with_item_index(["A", "B", "C", "D"])
+
+
+def get_data_frame_with_variable_lengths(item_id_to_length: Dict[str, int]):
+    tuples = []
+    for item_id, length in item_id_to_length.items():
+        for ts in pd.date_range(pd.Timestamp("2022-01-01"), periods=length, freq="D"):
+            tuples.append((item_id, ts))
+    index = pd.MultiIndex.from_tuples(tuples, names=[ITEMID, TIMESTAMP])
+    df = TimeSeriesDataFrame(
+        pd.DataFrame(
+            index=index,
+            data=[random.random() for _ in index],
+            columns=["target"],
+        )
+    )
+    df.freq  # compute _cached_freq
+    return df
+
+
+DUMMY_VARIABLE_LENGTH_TS_DATAFRAME = get_data_frame_with_variable_lengths(
+    item_id_to_length={"A": 22, "B": 50, "C": 10, "D": 17}
+)
 
 
 def dict_equal_primitive(this, that):

--- a/timeseries/tests/unittests/models/test_ensemble.py
+++ b/timeseries/tests/unittests/models/test_ensemble.py
@@ -1,21 +1,21 @@
 import pytest
 
-from autogluon.timeseries.models import AutoETSModel
+from autogluon.timeseries.models import ETSModel
 from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleWrapper
 
 from ..common import DUMMY_TS_DATAFRAME
 
 
 def test_when_some_base_models_fail_during_prediction_then_ensemble_can_still_predict():
-    ets = AutoETSModel(prediction_length=1)
+    ets = ETSModel(prediction_length=1, freq=DUMMY_TS_DATAFRAME.freq)
     ets.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"maxiter": 1, "seasonal": None})
-    ensemble = TimeSeriesEnsembleWrapper(weights={"ARIMA": 0.5, "AutoETS": 0.5}, name="WeightedEnsemble")
+    ensemble = TimeSeriesEnsembleWrapper(weights={"ARIMA": 0.5, "ETS": 0.5}, name="WeightedEnsemble")
     ets_preds = ets.predict(DUMMY_TS_DATAFRAME)
-    ensemble_preds = ensemble.predict(data={"ARIMA": None, "AutoETS": ets_preds})
+    ensemble_preds = ensemble.predict(data={"ARIMA": None, "ETS": ets_preds})
     assert (ets_preds.values == ensemble_preds.values).all()
 
 
 def test_when_all_base_models_fail_during_prediction_then_ensemble_raises_runtime_error():
-    ensemble = TimeSeriesEnsembleWrapper(weights={"ARIMA": 0.5, "AutoETS": 0.5}, name="WeightedEnsemble")
+    ensemble = TimeSeriesEnsembleWrapper(weights={"ARIMA": 0.5, "ETS": 0.5}, name="WeightedEnsemble")
     with pytest.raises(RuntimeError):
-        ensemble.predict(data={"ARIMA": None, "AutoETS": None})
+        ensemble.predict(data={"ARIMA": None, "ETS": None})

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -13,7 +13,7 @@ from gluonts.model.seq2seq import MQRNNEstimator
 
 import autogluon.core as ag
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
-from autogluon.timeseries.models import AutoETSModel, DeepARModel
+from autogluon.timeseries.models import ETSModel, DeepARModel
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.gluonts import GenericGluonTSModel
 
@@ -203,7 +203,7 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_corr
 
 
 @pytest.mark.parametrize(
-    "model_class", [DeepARModel, AutoETSModel, partial(GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator)]
+    "model_class", [DeepARModel, ETSModel, partial(GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator)]
 )
 @pytest.mark.parametrize("test_data_index", [["A", "B"], ["C", "D"], ["A"]])
 def test_when_fit_called_then_models_train_and_returned_predictor_inference_aligns_with_time(
@@ -230,7 +230,7 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_alig
 
 
 @pytest.mark.parametrize(
-    "model_class", [DeepARModel, AutoETSModel, partial(GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator)]
+    "model_class", [DeepARModel, ETSModel, partial(GenericGluonTSModel, gluonts_estimator_class=MQRNNEstimator)]
 )
 @pytest.mark.parametrize(
     "train_data, test_data",

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -13,7 +13,7 @@ from gluonts.model.seq2seq import MQRNNEstimator
 
 import autogluon.core as ag
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
-from autogluon.timeseries.models import ETSModel, DeepARModel
+from autogluon.timeseries.models import DeepARModel, ETSModel
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.gluonts import GenericGluonTSModel
 

--- a/timeseries/tests/unittests/models/test_sktime.py
+++ b/timeseries/tests/unittests/models/test_sktime.py
@@ -7,24 +7,22 @@ import pytest
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.models.sktime import (  # AutoARIMAModel,; TBATSModel,
     AbstractSktimeModel,
-    ARIMAModel,
-    AutoETSModel,
-    ThetaModel,
+    SktimeARIMAModel,
+    SktimeAutoETSModel,
+    SktimeThetaModel,
 )
 
 from ..common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
 
 TESTABLE_MODELS = [
-    ARIMAModel,
-    # AutoARIMAModel,
-    AutoETSModel,
-    # TBATSModel,
-    ThetaModel,
+    SktimeARIMAModel,
+    SktimeAutoETSModel,
+    SktimeThetaModel,
 ]
 
 
 def test_when_sktime_converts_dataframe_then_data_not_duplicated_and_index_correct():
-    model = AutoETSModel()
+    model = SktimeAutoETSModel()
 
     df = DUMMY_TS_DATAFRAME.copy(deep=True)
     sktime_df = model._to_sktime_data_frame(df)
@@ -47,7 +45,7 @@ def test_when_sktime_converts_dataframe_then_data_not_duplicated_and_index_corre
 
 
 def test_when_sktime_converts_from_dataframe_then_data_not_duplicated_and_index_correct():
-    model = AutoETSModel()
+    model = SktimeAutoETSModel()
 
     sktime_df = model._to_sktime_data_frame(DUMMY_TS_DATAFRAME.copy(deep=True))
     df = model._to_time_series_data_frame(sktime_df)

--- a/timeseries/tests/unittests/models/test_statsmodels.py
+++ b/timeseries/tests/unittests/models/test_statsmodels.py
@@ -126,3 +126,18 @@ def test_when_invalid_model_arguments_provided_then_statsmodels_ignores_them(mod
         assert "ignores following hyperparameters: ['bad_argument']" in caplog.text
         single_fitted_model = next(iter(model._fitted_models.values()))
         assert "bad_argument" not in single_fitted_model.model_init_args
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_train_and_test_data_have_different_freq_then_exception_is_raised(model_class, temp_model_path):
+    model = model_class(
+        path=temp_model_path,
+        prediction_length=3,
+        hyperparameters={"maxiter": 1},
+    )
+    train_data = get_data_frame_with_item_index([1, 2, 3], freq="H")
+    test_data = get_data_frame_with_item_index([1, 2, 3], freq="D")
+
+    model.fit(train_data=train_data)
+    with pytest.raises(RuntimeError, match="must match the frequency"):
+        model.predict(test_data)

--- a/timeseries/tests/unittests/models/test_statsmodels.py
+++ b/timeseries/tests/unittests/models/test_statsmodels.py
@@ -14,7 +14,7 @@ TESTABLE_MODELS = [
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 def test_when_statsmodels_models_saved_then_fitted_models_can_be_loaded(model_class, temp_model_path):
-    model = model_class(freq=DUMMY_TS_DATAFRAME.freq, path=temp_model_path)
+    model = model_class(path=temp_model_path)
     model.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"maxiter": 1})
     model.save()
 
@@ -27,7 +27,7 @@ def test_when_statsmodels_models_saved_then_fitted_models_can_be_loaded(model_cl
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("n_jobs", [0.5, 3])
 def test_when_statsmodels_models_saved_then_n_jobs_is_saved(model_class, n_jobs, temp_model_path):
-    model = model_class(freq=DUMMY_TS_DATAFRAME.freq, path=temp_model_path, hyperparameters={"n_jobs": n_jobs})
+    model = model_class(path=temp_model_path, hyperparameters={"n_jobs": n_jobs})
     model.save()
 
     loaded_model = model.__class__.load(path=model.path)
@@ -42,9 +42,7 @@ def test_when_predict_called_with_test_data_then_predictor_inference_correct(
     train_data = get_data_frame_with_item_index(list(range(train_data_size)))
     test_data = get_data_frame_with_item_index(list(range(test_data_size)))
 
-    model = model_class(
-        path=temp_model_path, prediction_length=3, hyperparameters={"maxiter": 1}, freq=train_data.freq
-    )
+    model = model_class(path=temp_model_path, prediction_length=3, hyperparameters={"maxiter": 1})
     model.fit(train_data=train_data)
 
     with caplog.at_level(logging.INFO):
@@ -79,12 +77,7 @@ def test_when_seasonal_period_is_set_to_none_then_inferred_period_is_used(
     expected_seasonal_period,
 ):
     train_data = get_data_frame_with_item_index(["A", "B", "C"], data_length=ts_length, freq=freqstr)
-    model = model_class(
-        path=temp_model_path,
-        prediction_length=3,
-        hyperparameters=hyperparameters,
-        freq=train_data.freq,
-    )
+    model = model_class(path=temp_model_path, prediction_length=3, hyperparameters=hyperparameters)
 
     model.fit(train_data=train_data)
     single_fitted_model = next(iter(model._fitted_models.values()))
@@ -111,10 +104,7 @@ def test_when_seasonal_period_is_provided_then_inferred_period_is_overriden(
 ):
     train_data = get_data_frame_with_item_index(["A", "B", "C"], data_length=ts_length, freq=freqstr)
     model = model_class(
-        path=temp_model_path,
-        prediction_length=3,
-        hyperparameters={"seasonal_period": provided_seasonal_period},
-        freq=train_data.freq,
+        path=temp_model_path, prediction_length=3, hyperparameters={"seasonal_period": provided_seasonal_period}
     )
 
     model.fit(train_data=train_data)

--- a/timeseries/tests/unittests/models/test_statsmodels.py
+++ b/timeseries/tests/unittests/models/test_statsmodels.py
@@ -1,0 +1,138 @@
+import logging
+
+import pytest
+
+from autogluon.timeseries.models.statsmodels import ARIMAModel, ETSModel
+
+from ..common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
+
+TESTABLE_MODELS = [
+    ARIMAModel,
+    ETSModel,
+]
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_statsmodels_models_saved_then_fitted_models_can_be_loaded(model_class, temp_model_path):
+    model = model_class(freq=DUMMY_TS_DATAFRAME.freq, path=temp_model_path)
+    model.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"maxiter": 1})
+    model.save()
+
+    loaded_model = model.__class__.load(path=model.path)
+    for ts_hash, model in model._fitted_models.items():
+        assert ts_hash in loaded_model._fitted_models
+        assert loaded_model._fitted_models[ts_hash] == model
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("n_jobs", [0.5, 3])
+def test_when_statsmodels_models_saved_then_n_jobs_is_saved(model_class, n_jobs, temp_model_path):
+    model = model_class(freq=DUMMY_TS_DATAFRAME.freq, path=temp_model_path, hyperparameters={"n_jobs": n_jobs})
+    model.save()
+
+    loaded_model = model.__class__.load(path=model.path)
+    assert model.n_jobs == loaded_model.n_jobs
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("train_data_size, test_data_size", [(5, 10), (10, 5), (5, 5)])
+def test_when_predict_called_with_test_data_then_predictor_inference_correct(
+    model_class, temp_model_path, train_data_size, test_data_size, caplog
+):
+    train_data = get_data_frame_with_item_index(list(range(train_data_size)))
+    test_data = get_data_frame_with_item_index(list(range(test_data_size)))
+
+    model = model_class(
+        path=temp_model_path, prediction_length=3, hyperparameters={"maxiter": 1}, freq=train_data.freq
+    )
+    model.fit(train_data=train_data)
+
+    with caplog.at_level(logging.INFO):
+        _ = model.predict(test_data)
+        assert f"received {test_data_size} items not seen during training, re-running fit" in caplog.text
+
+
+def get_seasonal_period_from_fitted_local_model(model, model_name):
+    if model_name == "ARIMA":
+        return model.model_init_args["seasonal_order"][-1]
+    elif model_name == "ETS":
+        return model.model_init_args["seasonal_periods"]
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize("hyperparameters", [{"seasonal_period": None}, {}])
+@pytest.mark.parametrize(
+    "freqstr, ts_length, expected_seasonal_period",
+    [
+        ("H", 100, 24),
+        ("2H", 100, 12),
+        ("B", 100, 5),
+        ("M", 100, 12),
+    ],
+)
+def test_when_seasonal_period_is_set_to_none_then_inferred_period_is_used(
+    model_class,
+    hyperparameters,
+    temp_model_path,
+    freqstr,
+    ts_length,
+    expected_seasonal_period,
+):
+    train_data = get_data_frame_with_item_index(["A", "B", "C"], data_length=ts_length, freq=freqstr)
+    model = model_class(
+        path=temp_model_path,
+        prediction_length=3,
+        hyperparameters=hyperparameters,
+        freq=train_data.freq,
+    )
+
+    model.fit(train_data=train_data)
+    single_fitted_model = next(iter(model._fitted_models.values()))
+    model_seasonal_period = get_seasonal_period_from_fitted_local_model(single_fitted_model, model.name)
+    assert model_seasonal_period == expected_seasonal_period
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+@pytest.mark.parametrize(
+    "freqstr, ts_length, provided_seasonal_period",
+    [
+        ("H", 100, 12),
+        ("2H", 100, 5),
+        ("B", 100, 10),
+        ("M", 100, 24),
+    ],
+)
+def test_when_seasonal_period_is_provided_then_inferred_period_is_overriden(
+    model_class,
+    temp_model_path,
+    freqstr,
+    ts_length,
+    provided_seasonal_period,
+):
+    train_data = get_data_frame_with_item_index(["A", "B", "C"], data_length=ts_length, freq=freqstr)
+    model = model_class(
+        path=temp_model_path,
+        prediction_length=3,
+        hyperparameters={"seasonal_period": provided_seasonal_period},
+        freq=train_data.freq,
+    )
+
+    model.fit(train_data=train_data)
+    # Select one of the fitted models
+    single_fitted_model = next(iter(model._fitted_models.values()))
+    model_seasonal_period = get_seasonal_period_from_fitted_local_model(single_fitted_model, model.name)
+    assert model_seasonal_period == provided_seasonal_period
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_invalid_model_arguments_provided_then_statsmodels_ignores_them(model_class, temp_model_path, caplog):
+    model = model_class(
+        path=temp_model_path,
+        prediction_length=3,
+        hyperparameters={"bad_argument": 33},
+    )
+    with caplog.at_level(logging.WARNING):
+        model.fit(train_data=DUMMY_TS_DATAFRAME)
+        assert "ignores following hyperparameters: ['bad_argument']" in caplog.text
+        single_fitted_model = next(iter(model._fitted_models.values()))
+        assert "bad_argument" not in single_fitted_model.model_init_args

--- a/timeseries/tests/unittests/models/test_statsmodels.py
+++ b/timeseries/tests/unittests/models/test_statsmodels.py
@@ -13,7 +13,7 @@ TESTABLE_MODELS = [
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
-def test_when_statsmodels_models_saved_then_fitted_models_can_be_loaded(model_class, temp_model_path):
+def test_when_statsmodels_model_saved_then_fitted_models_can_be_loaded(model_class, temp_model_path):
     model = model_class(path=temp_model_path)
     model.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"maxiter": 1})
     model.save()
@@ -22,6 +22,15 @@ def test_when_statsmodels_models_saved_then_fitted_models_can_be_loaded(model_cl
     for ts_hash, model in model._fitted_models.items():
         assert ts_hash in loaded_model._fitted_models
         assert loaded_model._fitted_models[ts_hash] == model
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_statsmodels_model_is_saved_and_loaded_then_model_can_predict(model_class, temp_model_path):
+    model = model_class(path=temp_model_path)
+    model.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"maxiter": 1})
+    model.save()
+    loaded_model = model.__class__.load(path=model.path)
+    loaded_model.predict(data=DUMMY_TS_DATAFRAME)
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)

--- a/timeseries/tests/unittests/models/test_statsmodels.py
+++ b/timeseries/tests/unittests/models/test_statsmodels.py
@@ -37,11 +37,19 @@ def test_when_statsmodels_model_is_saved_and_loaded_then_model_can_predict(model
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
 @pytest.mark.parametrize("n_jobs", [0.5, 3])
 def test_when_statsmodels_models_saved_then_n_jobs_is_saved(model_class, n_jobs, temp_model_path):
-    model = model_class(path=temp_model_path, hyperparameters={"n_jobs": n_jobs})
+    model = model_class(path=temp_model_path, hyperparameters={"n_jobs": n_jobs, "maxiter": 1})
     model.save()
 
     loaded_model = model.__class__.load(path=model.path)
     assert model.n_jobs == loaded_model.n_jobs
+
+
+@pytest.mark.parametrize("model_class", TESTABLE_MODELS)
+def test_when_statsmodels_model_fitted_then_freq_is_saved_to_sm_model_init_args(model_class, temp_model_path):
+    model = model_class(path=temp_model_path, hyperparameters={"maxiter": 1})
+    model.fit(train_data=DUMMY_TS_DATAFRAME)
+    single_fitted_model = next(iter(model._fitted_models.values()))
+    assert single_fitted_model.sm_model_init_args["freq"] == DUMMY_TS_DATAFRAME.freq
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -19,7 +19,7 @@ from .common import DUMMY_TS_DATAFRAME
 
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1}},
-    {"DeepAR": {"epochs": 1}, "AutoETS": {}},
+    {"DeepAR": {"epochs": 1}, "ETS": {}},
 ]
 TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS = [1, 2]
 

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -180,8 +180,8 @@ def test_given_hyperparameters_when_predictor_called_and_loaded_back_then_all_mo
 @pytest.mark.parametrize(
     "hyperparameters",
     [
-        {"StatsmodelsETS": {}, "SimpleFeedForward": {"epochs": 1}},
-        {"StatsmodelsETS": {}, "SimpleFeedForward": {"epochs": ag.Int(1, 3)}},
+        {"ETS": {"maxiter": 1}, "SimpleFeedForward": {"epochs": 1}},
+        {"ETS": {"maxiter": 1}, "SimpleFeedForward": {"epochs": ag.Int(1, 3)}},
     ],
 )
 def test_given_hp_spaces_and_custom_target_when_predictor_called_predictor_can_predict(
@@ -453,7 +453,7 @@ def test_given_model_fails_when_predictor_predicts_then_exception_is_caught_by_l
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters={"ARIMA": {"maxiter": 1, "seasonal_period": 1, "seasonal_order": (0, 0, 0)}},
     )
-    with mock.patch("autogluon.timeseries.models.sktime.models.ARIMA.predict") as arima_predict:
+    with mock.patch("autogluon.timeseries.models.statsmodels.models.ARIMAModel.predict") as arima_predict:
         arima_predict.side_effect = RuntimeError("Numerical error")
         with pytest.raises(RuntimeError, match="Prediction failed, please provide a different model to"):
             predictor.predict(DUMMY_TS_DATAFRAME)

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -19,7 +19,7 @@ from .common import DUMMY_TS_DATAFRAME
 
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1}},
-    {"AutoETS": {"maxiter": 1}, "SimpleFeedForward": {"epochs": 1}},
+    {"StatsmodelsETS": {"maxiter": 1}, "SimpleFeedForward": {"epochs": 1}},
 ]
 
 
@@ -180,8 +180,8 @@ def test_given_hyperparameters_when_predictor_called_and_loaded_back_then_all_mo
 @pytest.mark.parametrize(
     "hyperparameters",
     [
-        {"AutoETS": {}, "SimpleFeedForward": {"epochs": 1}},
-        {"AutoETS": {}, "SimpleFeedForward": {"epochs": ag.Int(1, 3)}},
+        {"StatsmodelsETS": {}, "SimpleFeedForward": {"epochs": 1}},
+        {"StatsmodelsETS": {}, "SimpleFeedForward": {"epochs": ag.Int(1, 3)}},
     ],
 )
 def test_given_hp_spaces_and_custom_target_when_predictor_called_predictor_can_predict(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -19,7 +19,7 @@ from .common import DUMMY_TS_DATAFRAME
 
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1}},
-    {"StatsmodelsETS": {"maxiter": 1}, "SimpleFeedForward": {"epochs": 1}},
+    {"ETS": {"maxiter": 1}, "SimpleFeedForward": {"epochs": 1}},
 ]
 
 

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -1,42 +1,18 @@
 import logging
-import random
 from ast import literal_eval
-from typing import Dict
 
-import pandas as pd
 import pytest
 
-from autogluon.timeseries.dataset import TimeSeriesDataFrame
-from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID
 from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter, append_suffix_to_item_id
+
+from .common import DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, get_data_frame_with_variable_lengths
 
 SPLITTERS = [
     LastWindowSplitter(),
     MultiWindowSplitter(num_windows=2, overlap=0),
     MultiWindowSplitter(num_windows=5, overlap=2),
 ]
-
-
-def get_data_frame_with_variable_lengths(item_id_to_length: Dict[str, int]):
-    tuples = []
-    for item_id, length in item_id_to_length.items():
-        for ts in pd.date_range(pd.Timestamp("2022-01-01"), periods=length):
-            tuples.append((item_id, ts))
-    index = pd.MultiIndex.from_tuples(tuples, names=[ITEMID, TIMESTAMP])
-    df = TimeSeriesDataFrame(
-        pd.DataFrame(
-            index=index,
-            data=[random.random() for _ in index],
-            columns=["target"],
-        )
-    )
-    df.freq  # compute _cached_freq
-    return df
-
-
-DUMMY_VARIABLE_LENGTH_TS_DATAFRAME = get_data_frame_with_variable_lengths(
-    item_id_to_length={"A": 22, "B": 50, "C": 10, "D": 17}
-)
 
 
 def get_original_item_id_and_slice(tuning_item_id: str):

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -24,7 +24,7 @@ from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index
 DUMMY_TRAINER_HYPERPARAMETERS = {"SimpleFeedForward": {"epochs": 1}}
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1}},
-    {"DeepAR": {"epochs": 1}, "AutoETS": {}},
+    {"DeepAR": {"epochs": 1}, "ETS": {}},
 ]
 TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS = [1, 2]
 


### PR DESCRIPTION
This PR introduces local models (ETS, ARIMA) from the `statsmodels` package to AutoGluonTS. This takes care of a few problems that we currently have when using `sktime`
- Correctly handles datasets with multiple time series of different lengths (`sktime` used to have problems with estimating `cutoff` for such datasets and sometimes produced wrong results).
- High disk usage - models now take a few KB instead of many MB/GB when saved to disk.

Other changes:
- Training and prediction are parallelized over CPU cores with `joblib`
- `statsmodels` models are used as default local models; `sktime` models received a `Sktime` prefix and were removed from the default presets.

Comparison of `statsmodels` and `sktime` versions of ETS and ARIMA on the `artificial_seasonal` dataset (parallelizing over 16 CPU cores)
```
ETSModel (statsmodels):
 - fit time: 10.6 s
 - predict time: 0.5 s
 - mean_wQuantileLoss: -0.15596
 - pickled size: 64 KB

SktimeAutoETSModel (sktime):
 - fit time: 30.6 s
 - predict time: 8.7 s
 - mean_wQuantileLoss: -0.15596
 - pickled size: 4421 KB

ARIMAModel (statsmodels):
 - fit time: 5.4 s
 - predict time: 0.8 s
 - mean_wQuantileLoss: -0.15570
 - pickled size: 25 KB

SktimeARIMAModel (sktime):
 - fit time: 56.8 s
 - predict time: 15.7 s
 - mean_wQuantileLoss: -0.15600
 - pickled size: 468814 KB
```
Note that the original dataset only takes 228 KB on disk, but the fitted ARIMA model from `sktime`/`pmdarima` takes 468 MB of disk space, fit and predict time are both improved ~10x. We get closer to linear scaling with # of cores when using bigger datasets.

![image](https://user-images.githubusercontent.com/6944857/186441177-0dddda68-b125-437d-bf49-8deba30689cd.png)
![image](https://user-images.githubusercontent.com/6944857/186441226-3fde3cde-bab8-470e-9cba-1796db5bd337.png)

Use attached file [compare_sktime_vs_statsmodels.py.zip](https://github.com/awslabs/autogluon/files/9416815/compare_sktime_vs_statsmodels.py.zip) to reproduce the results.

TODO:
- [x] Add docstrings, make sure hyperparameter names are consistent & defaults are reasonable
- [x] Parallelize training / prediction across cores
- [x] Add tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

