### PR TITLE
Fix error when doing HPO with KNN, RF, or XT

### DIFF
--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -116,5 +116,5 @@ def skip_hpo(model, X, y, X_val, y_val, time_limit=None, **kwargs):
     hpo_results = {'total_time': model.fit_time}
     hpo_model_performances = {model.name: model.val_score}
     hpo_results['hpo_model_performances'] = hpo_model_performances
-    hpo_models = {model.name: model.path}
+    hpo_models = {model.name: {'path': model.path}}
     return hpo_models, hpo_results

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -597,16 +597,7 @@ def test_tabularHPO():
     #### If fast_benchmark = True, can control model training time here. Only used if fast_benchmark=True ####
     if fast_benchmark:
         subsample_size = 100
-        nn_options = {'num_epochs': 2}
-        gbm_options = {'num_boost_round': 20}
-        hyperparameters = {
-            'GBM': gbm_options,
-            'NN_TORCH': nn_options,
-            'RF': {},
-            'XT': {},
-            'KNN': {},
-        }
-        time_limit = 120
+        time_limit = 240
         hyperparameter_tune_kwargs['num_trials'] = 5
 
     fit_args = {'verbosity': verbosity,}

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -599,8 +599,14 @@ def test_tabularHPO():
         subsample_size = 100
         nn_options = {'num_epochs': 2}
         gbm_options = {'num_boost_round': 20}
-        hyperparameters = {'GBM': gbm_options, 'NN_TORCH': nn_options}
-        time_limit = 60
+        hyperparameters = {
+            'GBM': gbm_options,
+            'NN_TORCH': nn_options,
+            'RF': {},
+            'XT': {},
+            'KNN': {},
+        }
+        time_limit = 120
         hyperparameter_tune_kwargs['num_trials'] = 5
 
     fit_args = {'verbosity': verbosity,}


### PR DESCRIPTION
*Issue #, if available:*
Bug introduced in #1954 

*Description of changes:*
- Fix error when doing HPO with KNN, RF, or XT due to type error.
- Ensure RF, XT, and KNN are unit tested when HPO is enabled.

Mainline:

```
Hyperparameter tuning model: KNeighborsUnif ... Tuning model for up to 24.91s of the 359.82s of remaining time.
	No hyperparameter search space specified for KNeighborsUnif. Skipping HPO. Will train one model based on the provided hyperparameters.
Traceback (most recent call last):
  File "/home/ubuntu/.conda/envs/autogluon/lib/python3.8/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "/home/ubuntu/.cache/JetBrains/RemoteDev/dist/3c8721a60180e_pycharm-professional-2021.3.3/plugins/python/helpers/pydev/_pydev_bundle/pydev_umd.py", line 198, in runfile
    pydev_imports.execfile(filename, global_vars, local_vars)  # execute the script
  File "/home/ubuntu/.cache/JetBrains/RemoteDev/dist/3c8721a60180e_pycharm-professional-2021.3.3/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/home/ubuntu/workspace/code/autogluon-benchmark/scratch/run_adult.py", line 32, in <module>
    predictor.fit(**fit_kwargs)
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/utils/decorators.py", line 30, in _call
    return f(*gargs, **gkwargs)
  File "/home/ubuntu/workspace/code/autogluon/tabular/src/autogluon/tabular/predictor/predictor.py", line 834, in fit
    self._learner.fit(X=train_data, X_val=tuning_data, X_unlabeled=unlabeled_data,
  File "/home/ubuntu/workspace/code/autogluon/tabular/src/autogluon/tabular/learner/abstract_learner.py", line 118, in fit
    return self._fit(X=X, X_val=X_val, **kwargs)
  File "/home/ubuntu/workspace/code/autogluon/tabular/src/autogluon/tabular/learner/default_learner.py", line 116, in _fit
    trainer.fit(
  File "/home/ubuntu/workspace/code/autogluon/tabular/src/autogluon/tabular/trainer/auto_trainer.py", line 85, in fit
    self._train_multi_and_ensemble(X=X,
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 1665, in _train_multi_and_ensemble
    model_names_fit = self.train_multi_levels(X, y, hyperparameters=hyperparameters, X_val=X_val, y_val=y_val,
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 296, in train_multi_levels
    base_model_names, aux_models = self.stack_new_level(
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 411, in stack_new_level
    core_models = self.stack_new_level_core(X=X, y=y, X_val=X_val, y_val=y_val, X_unlabeled=X_unlabeled, models=models,
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 502, in stack_new_level_core
    return self._train_multi(X=X_init, y=y, X_val=X_val, y_val=y_val, X_unlabeled=X_unlabeled,
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 1635, in _train_multi
    model_names_trained = self._train_multi_initial(X=X, y=y, models=models, k_fold=k_fold, n_repeats=n_repeats_initial, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 1521, in _train_multi_initial
    models = self._train_multi_fold(models=models, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 1606, in _train_multi_fold
    model_name_trained_lst = self._train_single_full(X, y, model, time_limit=time_left, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs_model, **kwargs)
  File "/home/ubuntu/workspace/code/autogluon/core/src/autogluon/core/trainer/abstract_trainer.py", line 1407, in _train_single_full
    model_hpo = self.load_model(model_hpo_name, path=model_info['path'], model_type=type(model))
TypeError: string indices must be integers
```

This PR:

```
Fitting 13 L1 models ...
Hyperparameter tuning model: KNeighborsUnif ... Tuning model for up to 24.91s of the 359.83s of remaining time.
	No hyperparameter search space specified for KNeighborsUnif. Skipping HPO. Will train one model based on the provided hyperparameters.
Fitted model: KNeighborsUnif ...
	0.6798	 = Validation score   (roc_auc)
	0.05s	 = Training   runtime
	0.2s	 = Validation runtime
Hyperparameter tuning model: KNeighborsDist ... Tuning model for up to 24.91s of the 359.57s of remaining time.
	No hyperparameter search space specified for KNeighborsDist. Skipping HPO. Will train one model based on the provided hyperparameters.
Fitted model: KNeighborsDist ...
	0.6944	 = Validation score   (roc_auc)
	0.05s	 = Training   runtime
	0.2s	 = Validation runtime
Hyperparameter tuning model: LightGBMXT ... Tuning model for up to 24.91s of the 359.31s of remaining time.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
