### PR TITLE
Add predictor clone support

### DIFF
--- a/common/src/autogluon/common/utils/file_utils.py
+++ b/common/src/autogluon/common/utils/file_utils.py
@@ -1,0 +1,70 @@
+import os
+
+import pandas as pd
+
+
+def get_directory_size(path: str) -> int:
+    """
+    Returns the combined size of all files under the path directory in bytes, excluding symbolic links.
+    """
+    total_size = 0
+    for dir_path, dir_names, file_names in os.walk(path):
+        for file_name in file_names:
+            file_path = os.path.join(dir_path, file_name)
+            if not os.path.islink(file_path):  # skip symbolic links
+                file_size = os.path.getsize(file_path)
+                total_size += file_size
+    return total_size
+
+
+def get_directory_size_per_file(path: str,
+                                *,
+                                sort_by: str = "size",
+                                include_path_in_name: bool = False) -> pd.Series:
+    """
+    Returns the size of each file under the path directory in bytes, excluding symbolic links.
+
+    Parameters
+    ----------
+    path : str
+        The path to a directory on local disk.
+    sort_by : str, default = "size"
+        If None, output files will be ordered based on order of search in os.walk(path).
+        If "size", output files will be ordered in descending order of file size.
+        If "name", output files will be ordered by name in ascending alphabetical order.
+    include_path_in_name : bool, default = False
+        If True, includes the full path of the file including the input `path` as part of the index in the output pd.Series.
+        If False, removes the `path` prefix of the file path in the index of the output pd.Series.
+
+        For example, for a file located at `foo/bar/model.pkl`, with path='foo/'
+            If True, index will be `foo/bar/model.pkl`
+            If False, index will be `bar/model.pkl`
+
+    Returns
+    -------
+    pd.Series with index file path and value file size in bytes.
+    """
+    file_sizes = dict()
+    og_dir_path = None
+    for dir_path, dir_names, file_names in os.walk(path):
+        if og_dir_path is None:
+            og_dir_path = dir_path
+        for file_name in file_names:
+            file_path = os.path.join(dir_path, file_name)
+            if not os.path.islink(file_path):  # skip symbolic links
+                file_size = os.path.getsize(file_path)
+                if include_path_in_name:
+                    file_sizes[file_path] = file_size
+                else:
+                    # remove path from file_path in dictionary
+                    file_sizes[file_path.split(og_dir_path, 1)[-1]] = file_size
+
+    file_size_series = pd.Series(file_sizes, name='size')
+    if sort_by is None:
+        return file_size_series
+    elif sort_by == 'size':
+        return file_size_series.sort_values(ascending=False)
+    elif sort_by == 'name':
+        return file_size_series.sort_index(ascending=True)
+    else:
+        raise AssertionError(f'sort_by={sort_by} is unknown. Supported values: [None, "size", "name"]')

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -20,6 +20,12 @@ Tabular Prediction
       In-depth tutorial on controlling various aspects of model fitting.
 
    .. card::
+      :title: Deployment Optimization
+      :link: tabular_prediction/tabular-deployment.html
+
+      Tutorial on optimizing the predictor artifact for production deployment.
+
+   .. card::
       :title: Kaggle Tutorial
       :link: tabular_prediction/tabular-kaggle.html
 

--- a/docs/tutorials/tabular_prediction/index.rst
+++ b/docs/tutorials/tabular_prediction/index.rst
@@ -19,6 +19,12 @@ For standard datasets that are represented as tables (stored as CSV file, parque
       In-depth tutorial on controlling various aspects of model fitting.
 
    .. card::
+      :title: Deployment Optimization
+      :link: tabular-deployment.html
+
+      Tutorial on optimizing the predictor artifact for production deployment.
+
+   .. card::
       :title: Kaggle Tutorial
       :link: tabular-kaggle.html
 
@@ -90,6 +96,7 @@ For standard datasets that are represented as tables (stored as CSV file, parque
 
    tabular-quickstart
    tabular-indepth
+   tabular-deployment
    tabular-kaggle
    tabular-multimodal
    tabular-multimodal-text-others

--- a/docs/tutorials/tabular_prediction/tabular-deployment.md
+++ b/docs/tutorials/tabular_prediction/tabular-deployment.md
@@ -1,0 +1,164 @@
+# Predicting Columns in a Table - Deployment Optimization
+:label:`sec_tabulardeployment`
+
+This tutorial will cover how to perform the end-to-end AutoML process to create an optimized and deployable
+AutoGluon artifact for production usage.
+
+This tutorial assumes you have already read :ref:`sec_tabularquick` and :ref:`sec_tabularadvanced`.
+
+## Fitting a TabularPredictor
+
+We will again use the AdultIncome dataset as in the previous tutorials and train a predictor
+to predict whether the person's income exceeds $50,000 or not, which is recorded in the `class` column of this table.
+
+```{.python .input}
+from autogluon.tabular import TabularDataset, TabularPredictor
+train_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv')
+label = 'class'
+subsample_size = 500  # subsample subset of data for faster demo, try setting this to much larger values
+train_data = train_data.sample(n=subsample_size, random_state=0)
+train_data.head()
+```
+
+```{.python .input}
+save_path = 'agModels-predictClass-deployment'  # specifies folder to store trained models
+predictor = TabularPredictor(label=label, path=save_path).fit(train_data)
+```
+
+Next, load separate test data to demonstrate how to make predictions on new examples at inference time:
+
+```{.python .input}
+test_data = TabularDataset('https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv')
+y_test = test_data[label]  # values to predict
+test_data.head()
+```
+
+We use our trained models to make predictions on the new data:
+
+```{.python .input}
+predictor = TabularPredictor.load(save_path)  # unnecessary, just demonstrates how to load previously-trained predictor from file
+
+y_pred = predictor.predict(test_data)
+y_pred
+```
+
+We can use leaderboard to evaluate the performance of each individual trained model on our labeled test data:
+
+```{.python .input}
+predictor.leaderboard(test_data, silent=True)
+```
+
+## Snapshot a Predictor with .clone()
+
+Now that we have a working predictor artifact, we may want to alter it in a variety of ways to better suite our needs.
+For example, we may want to delete certain models to reduce disk usage via `.delete_models()`,
+or train additional models on top of the ones we already have via `.fit_extra()`.
+
+While you can do all of these operations on your predictor,
+you may want to be able to be able to revert to a prior state of the predictor in case something goes wrong.
+This is where `predictor.clone()` comes in.
+
+`predictor.clone()` allows you to create a snapshot of the given predictor,
+cloning the artifacts of the predictor to a new location.
+You can then freely play around with the predictor and always load 
+the earlier snapshot in case you want to undo your actions.
+
+All you need to do to clone a predictor is specify a new directory path to clone to:
+
+```{.python .input}
+save_path_clone = save_path + '-clone'
+# will return the path to the cloned predictor, identical to save_path_clone
+path_clone = predictor.clone(path=save_path_clone)
+```
+
+Note that this logic doubles disk usage, as it completely clones
+every predictor artifact on disk to make an exact replica.
+
+Now we can load the cloned predictor:
+
+```{.python .input}
+predictor_clone = TabularPredictor.load(path=path_clone)
+# You can alternatively load the cloned TabularPredictor at the time of cloning:
+# predictor_clone = predictor.clone(path=save_path_clone, return_clone=True)
+```
+
+We can see that the cloned predictor has the same leaderboard and functionality as the original:
+
+```{.python .input}
+y_pred_clone = predictor.predict(test_data)
+y_pred_clone
+```
+
+```{.python .input}
+y_pred.equals(y_pred_clone)
+```
+
+```{.python .input}
+predictor_clone.leaderboard(test_data, silent=True)
+```
+
+Now let's do some extra logic with the clone, such as calling refit_full:
+
+```{.python .input}
+predictor_clone.refit_full()
+
+predictor_clone.leaderboard(test_data, silent=True)
+```
+
+We can see that we were able to fit additional models, but for whatever reason we may want to undo this operation.
+
+Luckily, our original predictor is untouched!
+
+```{.python .input}
+predictor.leaderboard(test_data, silent=True)
+```
+
+We can simply clone a new predictor from our original, and we will no longer be impacted
+by the call to refit_full on the prior clone.
+
+## Snapshot a deployment optimized Predictor via .clone_for_deployment()
+
+Instead of cloning an exact copy, we can instead clone a copy
+which has the minimal set of artifacts needed to do prediction.
+
+Note that this optimized clone will have very limited functionality outside of calling predict and predict_proba.
+For example, it will be unable to train more models.
+
+```{.python .input}
+save_path_clone_opt = save_path + '-clone-opt'
+# will return the path to the cloned predictor, identical to save_path_clone_opt
+path_clone_opt = predictor.clone_for_deployment(path=save_path_clone_opt)
+```
+
+```{.python .input}
+predictor_clone_opt = TabularPredictor.load(path=path_clone_opt)
+```
+
+We can see that the optimized clone still makes the same predictions:
+
+```{.python .input}
+y_pred_clone_opt = predictor_clone_opt.predict(test_data)
+y_pred_clone_opt
+```
+
+```{.python .input}
+y_pred.equals(y_pred_clone_opt)
+```
+
+```{.python .input}
+predictor_clone_opt.leaderboard(test_data, silent=True)
+```
+
+We can check the disk usage of the optimized clone compared to the original:
+
+```{.python .input}
+size_original = predictor.get_size_disk()
+size_opt = predictor_clone_opt.get_size_disk()
+print(f'Size Original:  {size_original} bytes')
+print(f'Size Optimized: {size_opt} bytes')
+```
+
+Now all that is left is to upload the optimized predictor to a centralized storage location such as S3.
+To use this predictor in a new machine / system, simply download the artifact to local disk and load the predictor.
+Ensure that when loading a predictor you use the same Python version
+and AutoGluon version used during training to avoid instability.

--- a/docs/tutorials/tabular_prediction/tabular-deployment.md
+++ b/docs/tutorials/tabular_prediction/tabular-deployment.md
@@ -156,6 +156,21 @@ size_original = predictor.get_size_disk()
 size_opt = predictor_clone_opt.get_size_disk()
 print(f'Size Original:  {size_original} bytes')
 print(f'Size Optimized: {size_opt} bytes')
+print(f'Optimized predictor achieved a {round((1 - (size_opt/size_original)) * 100, 1)}% reduction in disk usage.')
+```
+
+We can also investigate the difference in the files that exist in the original and optimized predictor.
+
+Original:
+
+```{.python .input}
+predictor.get_size_disk_per_file()
+```
+
+Optimized:
+
+```{.python .input}
+predictor_clone_opt.get_size_disk_per_file()
 ```
 
 Now all that is left is to upload the optimized predictor to a centralized storage location such as S3.

--- a/docs/tutorials/tabular_prediction/tabular-indepth.md
+++ b/docs/tutorials/tabular_prediction/tabular-indepth.md
@@ -229,7 +229,10 @@ To better understand our trained predictor, we can estimate the overall importan
 predictor.feature_importance(test_data)
 ```
 
-Computed via [permutation-shuffling](https://explained.ai/rf-importance/), these feature importance scores quantify the drop in predictive performance (of the already trained predictor) when one column's values are randomly shuffled across rows. The top features in this list contribute most to AutoGluon's accuracy (for predicting when/if a patient will be readmitted to the hospital). Features with non-positive importance score hardly contribute to the predictor's accuracy, or may even be actively harmful to include in the data (consider removing these features from your data and calling `fit` again). These scores facilitate interpretability of the predictor's global behavior (which features it relies on for *all* predictions). To get [local explanations](https://christophm.github.io/interpretable-ml-book/taxonomy-of-interpretability-methods.html) regarding which features influence a *particular* prediction, check out the [example notebooks](https://github.com/awslabs/autogluon/tree/master/examples/tabular/interpret) for explaining particular AutoGluon predictions using [Shapely values](https://github.com/slundberg/shap/).
+Computed via [permutation-shuffling](https://explained.ai/rf-importance/), these feature importance scores quantify the drop in predictive performance (of the already trained predictor) when one column's values are randomly shuffled across rows. The top features in this list contribute most to AutoGluon's accuracy (for predicting when/if a patient will be readmitted to the hospital). Features with non-positive importance score hardly contribute to the predictor's accuracy, or may even be actively harmful to include in the data (consider removing these features from your data and calling `fit` again). These scores facilitate interpretability of the predictor's global behavior (which features it relies on for *all* predictions).
+To get [local explanations](https://christophm.github.io/interpretable-ml-book/taxonomy-of-interpretability-methods.html) regarding which features influence a *particular* prediction, check out the [example notebooks](https://github.com/awslabs/autogluon/tree/master/examples/tabular/interpret) for explaining particular AutoGluon predictions using [Shapely values](https://github.com/slundberg/shap/).
+
+Before making judgement on if AutoGluon is more or less interpretable than another solution, we recommend reading [The Mythos of Model Interpretability](https://dl.acm.org/doi/pdf/10.1145/3236386.3241340) by Zachary Lipton, which covers why often-claimed interpretable models such as trees and linear models are rarely meaningfully more interpretable than more advanced models.
 
 ## Accelerating inference
 
@@ -494,3 +497,7 @@ To reduce disk usage, you may try each of the following strategies individually 
 The following paper describes how AutoGluon internally operates on tabular data:
 
 Erickson et al. [AutoGluon-Tabular: Robust and Accurate AutoML for Structured Data](https://arxiv.org/abs/2003.06505). *Arxiv*, 2020.
+
+## Next Steps
+
+If you are interested in deployment optimization, refer to the :ref:`sec_tabulardeployment` tutorial.

--- a/docs/tutorials/tabular_prediction/tabular-quickstart.md
+++ b/docs/tutorials/tabular_prediction/tabular-quickstart.md
@@ -192,3 +192,5 @@ Refer to the [TabularPredictor documentation](../../api/autogluon.predictor.html
 ## Advanced Usage
 
 For more advanced usage examples of AutoGluon, refer to :ref:`sec_tabularadvanced`
+
+If you are interested in deployment optimization, refer to the :ref:`sec_tabulardeployment` tutorial.

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3388,6 +3388,9 @@ class TabularPredictor:
         This is ideal for use-cases where saving a snapshot of the predictor is desired before performing
         more advanced operations (such as fit_extra and refit_full).
 
+        Note that the clone can no longer fit new models,
+        and most functionality except for predict and predict_proba will no longer work.
+
         Identical to performing the following operations in order:
 
         predictor_clone = predictor.clone(path=path, return_clone=True, dirs_exist_ok=dirs_exist_ok)

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -87,7 +87,7 @@ def test_advanced_functionality():
     savedir = directory + 'AutogluonOutput/'
     shutil.rmtree(savedir, ignore_errors=True)  # Delete AutoGluon output directory to ensure previous runs' information has been removed.
     savedir_predictor_original = savedir + 'predictor/'
-    predictor = TabularPredictor(label=label, path=savedir_predictor_original).fit(train_data)
+    predictor: TabularPredictor = TabularPredictor(label=label, path=savedir_predictor_original).fit(train_data)
     leaderboard = predictor.leaderboard(data=test_data)
     extra_metrics = ['accuracy', 'roc_auc', 'log_loss']
     leaderboard_extra = predictor.leaderboard(data=test_data, extra_info=True, extra_metrics=extra_metrics)
@@ -139,7 +139,7 @@ def test_advanced_functionality():
     assert len(leaderboard) == len(leaderboard_loaded)
     assert predictor_loaded.get_model_names_persisted() == []  # Assert that models were not still persisted after loading predictor
 
-    assert predictor.get_size_disk() > 0  # Assert that .get_size_disk() produces a >0 result and doesn't crash
+    _assert_predictor_size(predictor=predictor)
     # Test cloning logic
     with pytest.raises(AssertionError):
         # Ensure don't overwrite existing predictor
@@ -197,6 +197,14 @@ def test_advanced_functionality():
     y_pred_proba_clone_2 = predictor_clone.predict_proba(data=test_data)
     assert y_pred_proba.equals(y_pred_proba_clone_2)
     print('Tabular Advanced Functionality Test Succeeded.')
+
+
+def _assert_predictor_size(predictor: TabularPredictor):
+    predictor_size_disk = predictor.get_size_disk()
+    predictor_size_disk_per_file = predictor.get_size_disk_per_file()
+    assert predictor_size_disk > 0  # Assert that .get_size_disk() produces a >0 result and doesn't crash
+    assert len(predictor_size_disk_per_file) > 0
+    assert predictor_size_disk == predictor_size_disk_per_file.sum()
 
 
 def test_advanced_functionality_bagging():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add predictor clone support to make a perfect replica of a predictor in a new location on disk
- Add predictor optimized clone support to make an optimized version of the original predictor in a new location on disk
- Add tutorial on deployment optimization + usage of clone
- Add unit tests for clone
- Add get_size_disk method
- Add get_size_disk_per_file method

Refer to tutorial for example usage: http://autogluon-staging.s3-website-us-west-2.amazonaws.com/PR-2071/0daed4a/tutorials/tabular_prediction/tabular-deployment.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
