### PR TITLE
Handle timeseries model failures during the prediction phase

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -109,10 +109,13 @@ class TimeSeriesLearner(AbstractLearner):
     def predict(
         self,
         data: TimeSeriesDataFrame,
-        model: Optional[AbstractTimeSeriesModel] = None,
+        model: Optional[Union[str, AbstractTimeSeriesModel]] = None,
         **kwargs,
     ) -> TimeSeriesDataFrame:
-        return self.load_trainer().predict(data=data, model=model, **kwargs)
+        prediction = self.load_trainer().predict(data=data, model=model, **kwargs)
+        if prediction is None:
+            raise RuntimeError("Prediction failed, please provide a different model to the `predict` method.")
+        return prediction
 
     def score(
         self, data: TimeSeriesDataFrame, model: AbstractTimeSeriesModel = None, metric: Optional[str] = None

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -805,9 +805,16 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         data: TimeSeriesDataFrame,
         model: Optional[AbstractTimeSeriesModel] = None,
         **kwargs,
-    ) -> TimeSeriesDataFrame:
+    ) -> Union[TimeSeriesDataFrame, None]:
         model = self._get_model_for_prediction(model)
-        return self._predict_model(data, model, **kwargs)
+        try:
+            return self._predict_model(data, model, **kwargs)
+        except Exception as err:
+            logger.error(f"\tWarning: Model {model.name} failed during prediction with exception: {err}")
+            other_models = [m for m in self.get_model_names() if m != model.name]
+            if len(other_models) > 0:
+                logger.info(f"\tYou can call predict(data, model) with one of other available models: {other_models}")
+            return None
 
     def score(
         self,

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -803,16 +803,17 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
     def predict(
         self,
         data: TimeSeriesDataFrame,
-        model: Optional[AbstractTimeSeriesModel] = None,
+        model: Optional[Union[str, AbstractTimeSeriesModel]] = None,
         **kwargs,
     ) -> Union[TimeSeriesDataFrame, None]:
+        model_was_selected_automatically = model is None
         model = self._get_model_for_prediction(model)
         try:
             return self._predict_model(data, model, **kwargs)
         except Exception as err:
             logger.error(f"\tWarning: Model {model.name} failed during prediction with exception: {err}")
             other_models = [m for m in self.get_model_names() if m != model.name]
-            if len(other_models) > 0:
+            if len(other_models) > 0 and model_was_selected_automatically:
                 logger.info(f"\tYou can call predict(data, model) with one of other available models: {other_models}")
             return None
 

--- a/timeseries/tests/unittests/models/test_ensemble.py
+++ b/timeseries/tests/unittests/models/test_ensemble.py
@@ -1,0 +1,21 @@
+import pytest
+
+from autogluon.timeseries.models import AutoETSModel
+from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleWrapper
+
+from ..common import DUMMY_TS_DATAFRAME
+
+
+def test_when_some_base_models_fail_during_prediction_then_ensemble_can_still_predict():
+    ets = AutoETSModel(prediction_length=1)
+    ets.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"maxiter": 1, "seasonal": None})
+    ensemble = TimeSeriesEnsembleWrapper(weights={"ARIMA": 0.5, "AutoETS": 0.5}, name="WeightedEnsemble")
+    ets_preds = ets.predict(DUMMY_TS_DATAFRAME)
+    ensemble_preds = ensemble.predict(data={"ARIMA": None, "AutoETS": ets_preds})
+    assert (ets_preds.values == ensemble_preds.values).all()
+
+
+def test_when_all_base_models_fail_during_prediction_then_ensemble_raises_runtime_error():
+    ensemble = TimeSeriesEnsembleWrapper(weights={"ARIMA": 0.5, "AutoETS": 0.5}, name="WeightedEnsemble")
+    with pytest.raises(RuntimeError):
+        ensemble.predict(data={"ARIMA": None, "AutoETS": None})

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -1,11 +1,11 @@
 """Unit tests for predictors"""
 import copy
 import logging
+from unittest import mock
 
 import numpy as np
 import pandas as pd
 import pytest
-from unittest import mock
 
 import autogluon.core as ag
 from autogluon.timeseries.dataset import TimeSeriesDataFrame

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -443,7 +443,7 @@ def test_given_enable_ensemble_false_when_predictor_called_then_ensemble_is_not_
     assert not any("ensemble" in n.lower() for n in predictor.get_model_names())
 
 
-def test_given_model_fails_when_predictor_predicts_then_error_is_logged(temp_model_path, caplog):
+def test_given_model_fails_when_predictor_predicts_then_exception_is_caught_by_learner(temp_model_path):
     predictor = TimeSeriesPredictor(
         path=temp_model_path,
         eval_metric="MAPE",
@@ -455,6 +455,5 @@ def test_given_model_fails_when_predictor_predicts_then_error_is_logged(temp_mod
     )
     with mock.patch("autogluon.timeseries.models.sktime.models.ARIMA.predict") as arima_predict:
         arima_predict.side_effect = RuntimeError("Numerical error")
-        with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="Prediction failed, please provide a different model to"):
             predictor.predict(DUMMY_TS_DATAFRAME)
-            assert "Model ARIMA failed during prediction with exception: Numerical error" in caplog.text


### PR DESCRIPTION
Currently, if some model raises an exception during prediction (inside `AbstractTimeSeriesTrainer.predict`) the whole program crashes. This PR allows us to handle such model failures gracefully.

Changes:
- Add try/catch block in `AbstractTimeSeriesTrainer.predict` + instructions about what other models are available to the user if the best model failed.
- Re-normalize the weights in `SimpleTimeSeriesWeightedEnsemble.weight_pred_proba` in case some input models failed during prediction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
