### PR TITLE
Fix regret calculation in TimeSeriesEnsembleSelection

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -49,7 +49,9 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
     def _calculate_regret(self, y_true, y_pred_proba, metric, dummy_pred=None, sample_weight=None):  # noqa
         dummy_pred = copy.deepcopy(self.dummy_pred if dummy_pred is None else dummy_pred)
         dummy_pred[list(dummy_pred.columns)] = y_pred_proba
-        return metric(y_true, dummy_pred) * metric.coefficient
+        score = -metric(y_true, dummy_pred) * metric.coefficient
+        # score: higher is better, regret: lower is better, so we flip the sign
+        return -score
 
 
 class SimpleTimeSeriesWeightedEnsemble(AbstractWeightedEnsemble):

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -49,7 +49,7 @@ class TimeSeriesEnsembleSelection(EnsembleSelection):
     def _calculate_regret(self, y_true, y_pred_proba, metric, dummy_pred=None, sample_weight=None):  # noqa
         dummy_pred = copy.deepcopy(self.dummy_pred if dummy_pred is None else dummy_pred)
         dummy_pred[list(dummy_pred.columns)] = y_pred_proba
-        score = -metric(y_true, dummy_pred) * metric.coefficient
+        score = metric(y_true, dummy_pred) * metric.coefficient
         # score: higher is better, regret: lower is better, so we flip the sign
         return -score
 


### PR DESCRIPTION
*Description of changes:*
- Fix a bug in `TimeSeriesEnsembleSelection._calculate_regret` where the sign of the regret was flipped



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
