### PR TITLE
[Multimodal] Fix presets by constraining modal.names

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -1,11 +1,10 @@
 model:
   names:
-    # Can attach the list of models to use, e.g.
-    # - "categorical_mlp"
-    # - "numerical_mlp"
-    # - "hf_text"
-    # - "timm_image"
-    # - "fusion_mlp"
+    - "categorical_mlp"
+    - "numerical_mlp"
+    - "hf_text"
+    - "timm_image"
+    - "fusion_mlp"
   categorical_mlp:
     hidden_size: 64
     activation: "leaky_relu"

--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -4,9 +4,7 @@ model:
     - "numerical_mlp"
     - "hf_text"
     - "timm_image"
-    - "clip"
     - "fusion_mlp"
-    - "t_few"
   categorical_mlp:
     hidden_size: 64
     activation: "leaky_relu"

--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -1,10 +1,11 @@
 model:
   names:
-    - "categorical_mlp"
-    - "numerical_mlp"
-    - "hf_text"
-    - "timm_image"
-    - "fusion_mlp"
+    # Can attach the list of models to use, e.g.
+    # - "categorical_mlp"
+    # - "numerical_mlp"
+    # - "hf_text"
+    # - "timm_image"
+    # - "fusion_mlp"
   categorical_mlp:
     hidden_size: 64
     activation: "leaky_relu"

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -9,6 +9,7 @@ automm_presets = Registry("automm_presets")
 @automm_presets.register()
 def default():
     return {
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
     }
@@ -17,6 +18,7 @@ def default():
 @automm_presets.register()
 def medium_quality_faster_train():
     return {
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
         "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
         "optimization.learning_rate": 4e-4,
@@ -26,6 +28,7 @@ def medium_quality_faster_train():
 @automm_presets.register()
 def high_quality():
     return {
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
     }
@@ -34,6 +37,7 @@ def high_quality():
 @automm_presets.register()
 def best_quality():
     return {
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "microsoft/deberta-v3-base",
         "model.timm_image.checkpoint_name": "swin_large_patch4_window7_224",
         "env.per_gpu_batch_size": 1,
@@ -43,6 +47,7 @@ def best_quality():
 @automm_presets.register()
 def multilingual():
     return {
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "microsoft/mdeberta-v3-base",
         "optimization.top_k": 1,
         "env.precision": "bf16",

--- a/multimodal/src/autogluon/multimodal/presets.py
+++ b/multimodal/src/autogluon/multimodal/presets.py
@@ -9,7 +9,7 @@ automm_presets = Registry("automm_presets")
 @automm_presets.register()
 def default():
     return {
-        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "clip", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
     }
@@ -18,7 +18,7 @@ def default():
 @automm_presets.register()
 def medium_quality_faster_train():
     return {
-        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "clip", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "google/electra-small-discriminator",
         "model.timm_image.checkpoint_name": "swin_small_patch4_window7_224",
         "optimization.learning_rate": 4e-4,
@@ -28,7 +28,7 @@ def medium_quality_faster_train():
 @automm_presets.register()
 def high_quality():
     return {
-        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "clip", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "google/electra-base-discriminator",
         "model.timm_image.checkpoint_name": "swin_base_patch4_window7_224",
     }
@@ -37,7 +37,7 @@ def high_quality():
 @automm_presets.register()
 def best_quality():
     return {
-        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "clip", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "microsoft/deberta-v3-base",
         "model.timm_image.checkpoint_name": "swin_large_patch4_window7_224",
         "env.per_gpu_batch_size": 1,
@@ -47,7 +47,7 @@ def best_quality():
 @automm_presets.register()
 def multilingual():
     return {
-        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "fusion_mlp"],
+        "model.names": ["categorical_mlp", "numerical_mlp", "timm_image", "hf_text", "clip", "fusion_mlp"],
         "model.hf_text.checkpoint_name": "microsoft/mdeberta-v3-base",
         "optimization.top_k": 1,
         "env.precision": "bf16",


### PR DESCRIPTION
*Description of changes:*

Follow-up revision PR of https://github.com/awslabs/autogluon/pull/2032 . Now "t-few" is enabled in the default config

https://github.com/awslabs/autogluon/blob/e3fda1fc9d84ded0c612bc13c7472194503089f0/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml#L2-L9

We need to explicitly set "model.names" in the presets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
