### PR TITLE
Fix ray tune layer warning

### DIFF
--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -162,6 +162,7 @@ class RayHpoExecutor(HpoExecutor):
     }
     
     def __init__(self):
+        super().__init__()
         self.resources = None
         self.hyperparameter_tune_kwargs = None
         self.analysis = None
@@ -239,6 +240,9 @@ class RayHpoExecutor(HpoExecutor):
             run,
             RayTuneAdapterFactory
         )
+        # Disable tensorboard logging to avoid layer warning
+        # TODO: remove this when ray tune fix ray tune pass tuple to hyperopt issue
+        os.environ['TUNE_DISABLE_AUTO_CALLBACK_LOGGERS'] = '1'
         analysis = run(
             trainable=model_trial,
             trainable_args=train_fn_kwargs,
@@ -255,6 +259,7 @@ class RayHpoExecutor(HpoExecutor):
             time_budget_s=self.time_limit,
             verbose=0,
         )
+        os.environ.pop('TUNE_DISABLE_AUTO_CALLBACK_LOGGERS', None)
         self.analysis = analysis
         
     def report(self, reporter, **kwargs):
@@ -291,6 +296,7 @@ class CustomHpoExecutor(HpoExecutor):
     """Implementation of HpoExecutor Interface, where our custom logic is used as the backend"""
     
     def __init__(self):
+        super().__init__()
         self.scheduler_options = None
         self.scheduler = None
         

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -177,6 +177,7 @@ class NNFastAiTabularModel(AbstractModel):
 
         import torch
         torch.set_num_threads(num_cpus)
+
         start_time = time.time()
         if sample_weight is not None:  # TODO: support
             logger.log(15, "sample_weight not yet supported for NNFastAiTabularModel, this model will ignore them in training.")
@@ -216,6 +217,10 @@ class NNFastAiTabularModel(AbstractModel):
         if params.get('layers', None) is not None:
             layers = params['layers']
             if isinstance(layers, tuple):
+            if isinstance(layers, tuple):
+            if isinstance(layers, tuple):
+                layers = list(layers)
+                layers = list(layers)
                 layers = list(layers)
         elif self.problem_type in [REGRESSION, BINARY]:
             layers = [200, 100]

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -217,10 +217,6 @@ class NNFastAiTabularModel(AbstractModel):
         if params.get('layers', None) is not None:
             layers = params['layers']
             if isinstance(layers, tuple):
-            if isinstance(layers, tuple):
-            if isinstance(layers, tuple):
-                layers = list(layers)
-                layers = list(layers)
                 layers = list(layers)
         elif self.problem_type in [REGRESSION, BINARY]:
             layers = [200, 100]

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -177,7 +177,6 @@ class NNFastAiTabularModel(AbstractModel):
 
         import torch
         torch.set_num_threads(num_cpus)
-
         start_time = time.time()
         if sample_weight is not None:  # TODO: support
             logger.log(15, "sample_weight not yet supported for NNFastAiTabularModel, this model will ignore them in training.")
@@ -216,6 +215,8 @@ class NNFastAiTabularModel(AbstractModel):
         # TODO: calculate max emb concat layer size and use 1st layer as that value and 2nd in between number of classes and the value
         if params.get('layers', None) is not None:
             layers = params['layers']
+            if isinstance(layers, tuple):
+                layers = list(layers)
         elif self.problem_type in [REGRESSION, BINARY]:
             layers = [200, 100]
         elif self.problem_type == QUANTILE:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/issues/2069

*Description of changes:*
This PR addresses point 4 in the above issue. To be notice, I cannot reproduce point 3 now for some reason even though I was able to last week.
* Handle layer as tuple passed to fastai. `nn_torch` doesn't have layers as as nested list so it doesn't have this issue
* Disable tensorboard logging for tabular hpo tune until ray tune handles hyperopt tune issue correctly
* Added `super().__init__()`, which was missing previously

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
