### PR TITLE
Make sure that time series splitter doesn't trim training series shorter than prediction_length + 1

### DIFF
--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 import pandas as pd
 
-from .dataset.ts_dataframe import TimeSeriesDataFrame, ITEMID, TIMESTAMP
+from .dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 
 logger = logging.getLogger(__name__)
 

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 import pandas as pd
 
-from .dataset import TimeSeriesDataFrame
+from .dataset.ts_dataframe import TimeSeriesDataFrame, ITEMID, TIMESTAMP
 
 logger = logging.getLogger(__name__)
 
@@ -58,12 +58,9 @@ class AbstractTimeSeriesSplitter:
 def append_suffix_to_item_id(ts_dataframe: TimeSeriesDataFrame, suffix: str) -> TimeSeriesDataFrame:
     """Append a suffix to each item_id in a TimeSeriesDataFrame."""
 
-    def add_suffix(multiindex_element):
-        item_id, timestamp = multiindex_element
-        return (f"{item_id}{suffix}", timestamp)
-
     result = ts_dataframe.copy(deep=False)
-    result.index = result.index.map(add_suffix)
+    new_item_id = result.index.get_level_values(level=ITEMID).astype(str) + suffix
+    result.index = pd.MultiIndex.from_arrays([new_item_id, result.index.get_level_values(TIMESTAMP)])
     return result
 
 

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -67,12 +67,12 @@ def append_suffix_to_item_id(ts_dataframe: TimeSeriesDataFrame, suffix: str) -> 
 class MultiWindowSplitter(AbstractTimeSeriesSplitter):
     """Reserve multiple windows at the end of each time series as the validation set.
 
-    MultiWindowSplitter ensures that each training series doesn't get shorter than ``>= prediction_length + 1``.
-
-    The first valdation series contains the entire series (i.e. the last ``prediction_length`` elements are used for
+    The first validation series contains the entire series (i.e. the last ``prediction_length`` elements are used for
     computing the validation score). For each following validation series we cut off the last ``prediction_length``
     time steps. This process is repeated until ``num_windows`` validation series are generated, or until all training
     series have length less than ``prediction_length + 1``.
+
+    MultiWindowSplitter guarantees that each training series has length of at least ``prediction_length + 1``.
 
     Example:
         input_series = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], prediction_length = 3, num_windows = 2

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -6,12 +6,6 @@ from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitte
 
 from .common import DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, get_data_frame_with_variable_lengths
 
-SPLITTERS = [
-    LastWindowSplitter(),
-    MultiWindowSplitter(num_windows=2),
-    MultiWindowSplitter(num_windows=5),
-]
-
 
 def get_original_item_id_and_slice(tuning_item_id: str):
     """Extract information from tuning set item_id that has format f"{item_id}_[{start}:{end}]"."""
@@ -37,7 +31,7 @@ def test_when_multi_window_splitter_splits_then_train_items_have_correct_length(
 
 
 @pytest.mark.parametrize("item_id_to_length", [{"A": 22, "B": 50, "C": 10}, {"A": 23}])
-@pytest.mark.parametrize("prediction_length, num_windows", [(5, 2), (2, 5), (8, 1)])
+@pytest.mark.parametrize("prediction_length, num_windows", [(5, 2), (2, 5), (8, 1), (10, 2)])
 def test_when_multi_window_splitter_splits_then_val_item_ids_correctly_represent_length(
     item_id_to_length, prediction_length, num_windows
 ):
@@ -52,8 +46,8 @@ def test_when_multi_window_splitter_splits_then_val_item_ids_correctly_represent
         assert expected_length == new_length
 
 
-@pytest.mark.parametrize("splitter", SPLITTERS)
-def test_when_multi_window_splitter_splits_then_cached_freq_is_preserved(splitter):
+def test_when_multi_window_splitter_splits_then_cached_freq_is_preserved():
+    splitter = MultiWindowSplitter()
     prediction_length = 10
     train_data, val_data = splitter.split(
         ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=prediction_length

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -1,17 +1,15 @@
-import logging
 from ast import literal_eval
 
 import pytest
 
-from autogluon.timeseries.dataset.ts_dataframe import ITEMID
 from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter, append_suffix_to_item_id
 
 from .common import DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, get_data_frame_with_variable_lengths
 
 SPLITTERS = [
     LastWindowSplitter(),
-    MultiWindowSplitter(num_windows=2, overlap=0),
-    MultiWindowSplitter(num_windows=5, overlap=2),
+    MultiWindowSplitter(num_windows=2),
+    MultiWindowSplitter(num_windows=5),
 ]
 
 
@@ -22,59 +20,36 @@ def get_original_item_id_and_slice(tuning_item_id: str):
     return item_id, literal_eval(start), literal_eval(end)
 
 
-@pytest.mark.parametrize("item_id_to_length", ({"A": 22, "B": 50, "C": 10}, {"A": 23}))
-@pytest.mark.parametrize("prediction_length, num_windows, overlap", [(5, 2, 0), (2, 5, 1), (8, 1, 0)])
-def test_when_multi_window_splitter_splits_then_train_lengths_are_correct(
-    item_id_to_length, prediction_length, num_windows, overlap
+@pytest.mark.parametrize("item_id_to_length", [{"A": 22, "B": 50, "C": 10}, {"A": 23}])
+@pytest.mark.parametrize("prediction_length, num_windows", [(5, 2), (2, 5), (8, 1)])
+def test_when_multi_window_splitter_splits_then_train_items_have_correct_length(
+    item_id_to_length, prediction_length, num_windows
 ):
-    splitter = MultiWindowSplitter(num_windows=num_windows, overlap=overlap)
+    splitter = MultiWindowSplitter(num_windows=num_windows)
     ts_dataframe = get_data_frame_with_variable_lengths(item_id_to_length=item_id_to_length)
-    original_lengths = ts_dataframe.index.get_level_values(0).value_counts(sort=False)
+    train_data, _ = splitter.split(ts_dataframe=ts_dataframe, prediction_length=prediction_length)
+    original_lengths = ts_dataframe.num_timesteps_per_item()
 
-    train_data, val_data = splitter.split(ts_dataframe=ts_dataframe, prediction_length=prediction_length)
-    num_total_validation_steps = num_windows * (prediction_length - overlap) + overlap
-
-    for item_id in train_data.item_ids:
-        new_length = len(train_data.loc[item_id])
-        expected_length = original_lengths.loc[item_id] - num_total_validation_steps
-        assert expected_length == new_length
+    for item_id, length in original_lengths.iteritems():
+        num_windows_from_this_item = min(num_windows, max((length - 1) // prediction_length - 1, 0))
+        expected_length = length - num_windows_from_this_item * prediction_length
+        assert expected_length == len(train_data.loc[item_id])
 
 
-@pytest.mark.parametrize("item_id_to_length", ({"A": 22, "B": 50, "C": 10}, {"A": 23}))
-@pytest.mark.parametrize("prediction_length, num_windows, overlap", [(5, 2, 0), (2, 5, 1), (8, 1, 0)])
-def test_when_multi_window_splitter_splits_then_val_index_and_lengths_are_correct(
-    item_id_to_length, prediction_length, num_windows, overlap
+@pytest.mark.parametrize("item_id_to_length", [{"A": 22, "B": 50, "C": 10}, {"A": 23}])
+@pytest.mark.parametrize("prediction_length, num_windows", [(5, 2), (2, 5), (8, 1)])
+def test_when_multi_window_splitter_splits_then_val_item_ids_correctly_represent_length(
+    item_id_to_length, prediction_length, num_windows
 ):
-    splitter = MultiWindowSplitter(num_windows=num_windows, overlap=overlap)
+    splitter = MultiWindowSplitter(num_windows=num_windows)
     ts_dataframe = get_data_frame_with_variable_lengths(item_id_to_length=item_id_to_length)
 
-    train_data, val_data = splitter.split(ts_dataframe=ts_dataframe, prediction_length=prediction_length)
-
+    _, val_data = splitter.split(ts_dataframe=ts_dataframe, prediction_length=prediction_length)
     for new_item_id in val_data.item_ids:
         old_item_id, start, end = get_original_item_id_and_slice(new_item_id)
         new_length = len(val_data.loc[new_item_id])
         expected_length = len(ts_dataframe.loc[old_item_id][start:end])
         assert expected_length == new_length
-
-
-@pytest.mark.parametrize("splitter", SPLITTERS)
-def test_when_some_series_too_short_then_they_disappear_from_train_data(splitter):
-    prediction_length = 10
-    train_data, val_data = splitter.split(
-        ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=prediction_length
-    )
-    remaining_items = train_data.index.get_level_values(ITEMID)
-
-    original_lengths = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.index.get_level_values(0).value_counts(sort=False)
-    num_total_validation_steps = splitter.num_windows * (prediction_length - splitter.overlap) + splitter.overlap
-    should_be_missing = original_lengths.index[original_lengths <= num_total_validation_steps]
-
-    for item_id in should_be_missing:
-        assert item_id not in remaining_items
-
-    should_be_present = original_lengths.index[original_lengths > num_total_validation_steps]
-    for item_id in should_be_present:
-        assert item_id in remaining_items
 
 
 @pytest.mark.parametrize("splitter", SPLITTERS)
@@ -86,18 +61,11 @@ def test_when_multi_window_splitter_splits_then_cached_freq_is_preserved(splitte
     assert DUMMY_VARIABLE_LENGTH_TS_DATAFRAME._cached_freq == train_data._cached_freq == val_data._cached_freq
 
 
-@pytest.mark.parametrize("splitter", SPLITTERS)
-def test_when_some_series_too_short_then_warning_is_raised(splitter, caplog):
-    with caplog.at_level(logging.WARNING):
-        splitter.split(ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=10)
-        assert "are too short and won't appear in the training set" in caplog.text
-
-
-def test_when_all_series_too_short_then_sliding_window_splitter_raises_exception():
-    splitter = MultiWindowSplitter(num_windows=5, overlap=0)
-    with pytest.raises(ValueError):
-        splitter.split(ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=10)
-        pytest.fail(f"{splitter.name} should raise ValueError since the training set is empty")
+def test_when_all_series_too_short_then_multi_window_splitter_raises_value_error():
+    splitter = MultiWindowSplitter(num_windows=5)
+    prediction_length = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.num_timesteps_per_item().max() // 2 + 1
+    with pytest.raises(ValueError, match="all training time series are too short"):
+        splitter.split(ts_dataframe=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, prediction_length=prediction_length)
 
 
 def test_when_splitter_adds_suffix_to_index_then_data_is_not_copied():


### PR DESCRIPTION
Some models (e.g. DeepAR) expect training time series to have at least `prediction_length + 1` time steps. This constraint was violated by the old implementation of the `MultiWindowSplitter`, which led to GluonTS models failing. 

*Description of changes:*
- `MultiWindowSplitter` now ensures that no training time series gets cut shorter than `prediction_length + 1` (but if the original series already was shorter, it stays that way).
- Removed the `overlap` parameter from `MultiWindowSplitter` as it wasn't used, but unnecessarily complicates the logic.
- Improved exception message & tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
