### PR TITLE
Fix timeseries daily frequency inferred period

### DIFF
--- a/timeseries/src/autogluon/timeseries/utils/seasonality.py
+++ b/timeseries/src/autogluon/timeseries/utils/seasonality.py
@@ -5,7 +5,7 @@ import pandas as pd
 DEFAULT_SEASONALITIES = {
     "T": 60 * 24,
     "H": 24,
-    "D": 1,
+    "D": 7,
     "W": 1,
     "M": 12,
     "B": 5,

--- a/timeseries/tests/unittests/models/test_statsmodels.py
+++ b/timeseries/tests/unittests/models/test_statsmodels.py
@@ -97,6 +97,7 @@ def get_seasonal_period_from_fitted_local_model(model, model_name):
         ("H", 100, 24),
         ("2H", 100, 12),
         ("B", 100, 5),
+        ("D", 100, 7),
         ("M", 100, 12),
     ],
 )
@@ -124,6 +125,7 @@ def test_when_seasonal_period_is_set_to_none_then_inferred_period_is_used(
         ("H", 100, 12),
         ("2H", 100, 5),
         ("B", 100, 10),
+        ("D", 100, 8),
         ("M", 100, 24),
     ],
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Set the period of daily time series to 7, replacing the original default 1 inherited from GluonTS.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
