### PR TITLE
Clean up the TimeSeriesDataFrame public API

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -507,29 +507,31 @@ class TimeSeriesDataFrame(pd.DataFrame):
         result._cached_freq = self._cached_freq
         return result
 
-    def subsequence(self, start_time: pd.Timestamp, end_time: pd.Timestamp) -> TimeSeriesDataFrame:
+    def subsequence(self, start: pd.Timestamp, end: pd.Timestamp) -> TimeSeriesDataFrame:
         """Select a subsequence from each time series between start (inclusive) and end (exclusive) timestamps.
+
         Parameters
         ----------
-        start_time: pd.Timestamp
-            Start time (inclusive) of the slice for each time series.
-        end_time: pd.Timestamp
-            End time (exclusive) of the slice for each time series.
+        start: pd.Timestamp
+            The start time (inclusive) of a time range that will be used for subsequence.
+        end: pd.Timestamp
+            The end time (exclusive) of a time range that will be used for subsequence.
+
         Returns
         -------
         ts_df: TimeSeriesDataFrame
-            A new time series dataframe containing entries of the original time series between start and end timestamps.
+            A new data frame in ``TimeSeriesDataFrame`` format contains time-series in a time range
+            defined between start and end time.
         """
-        if end_time < start_time:
-            raise ValueError(f"end_time {end_time} is earlier than start_time {start_time}")
 
-        nanosecond_before_end_time = end_time - pd.Timedelta(nanoseconds=1)
-        result = TimeSeriesDataFrame(
-            self.loc[(slice(None), slice(start_time, nanosecond_before_end_time)), :],
+        if end < start:
+            raise ValueError(f"end time {end} is earlier than stat time {start}")
+
+        nanosecond_before_end = end - pd.Timedelta(nanoseconds=1)
+        return TimeSeriesDataFrame(
+            self.loc[(slice(None), slice(start, nanosecond_before_end)), :],
             static_features=self.static_features,
         )
-        result._cached_freq = self._cached_freq
-        return result
 
     @classmethod
     def from_pickle(cls, filepath_or_buffer: Any) -> "TimeSeriesDataFrame":

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import itertools
 from collections.abc import Iterable
-from typing import Any, Optional, Tuple, Type
+from typing import Any, Optional, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -181,7 +181,8 @@ class TimeSeriesDataFrame(pd.DataFrame):
     def num_items(self):
         return len(self.item_ids)
 
-    def num_timesteps_per_item(self) -> pd.Series:
+    def length_per_item(self) -> pd.Series:
+        """Length of each time series in the dataframe."""
         return self.groupby(level=ITEMID, sort=False).size()
 
     @classmethod
@@ -373,8 +374,7 @@ class TimeSeriesDataFrame(pd.DataFrame):
         return self
 
     def split_by_time(self, cutoff_time: pd.Timestamp) -> Tuple[TimeSeriesDataFrame, TimeSeriesDataFrame]:
-        """Split dataframe to two different ``TimeSeriesDataFrame`` s before and after a certain
-        ``cutoff_time``.
+        """Split dataframe into two separate ``TimeSeriesDataFrame``s before and after a certain ``cutoff_time``.
 
         Parameters
         ----------
@@ -384,9 +384,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
         Returns
         -------
         data_before: TimeSeriesDataFrame
-            Data frame containing time series before the ``cutoff_time`` (exclude ``cutoff_time``).
+            Data frame containing all rows of the original data frame before the ``cutoff_time`` (excluding ``cutoff_time``).
         data_after: TimeSeriesDataFrame
-            Data frame containing time series after the ``cutoff_time`` (include ``cutoff_time``).
+            Data frame containing all rows of the original data frame after the ``cutoff_time`` (including ``cutoff_time``).
         """
 
         nanosecond_before_cutoff = cutoff_time - pd.Timedelta(nanoseconds=1)
@@ -399,6 +399,123 @@ class TimeSeriesDataFrame(pd.DataFrame):
         after._cached_freq = self._cached_freq
         return before, after
 
+    def slice_items_by_index(self, start_index: Union[int, None], end_index: Union[int, None]) -> TimeSeriesDataFrame:
+        """Select a subsequence from each time series between start (inclusive) and end (exclusive) indices.
+
+        This operation is equivalent to selecting a slice ``[start_index : end_index]`` from each time series, and then
+        combining these slices into a new ``TimeSeriesDataFrame``. See examples below.
+
+        Returns a copy of the original data. This is useful for constructing holdout sets for validation.
+
+        Parameters
+        ----------
+        start_index : int or None, default = None
+            Start index (inclusive) of the slice for each time series.
+            Negative values are counted from the end of each time series.
+            When set to None, the slice starts from the beginning of each time series.
+        end_index : int or None, default = None
+            End index (exclusive) of the slice for each time series.
+            Negative values are counted from the end of each time series.
+            When set to None, the slice includes the end of each time series.
+
+        Returns
+        -------
+        ts_df : TimeSeriesDataFrame
+            A new time series dataframe containing entries of the original time series between start and end indices.
+
+        Example
+        -------
+        .. code-block:: python
+
+            >>> print(ts_dataframe)
+            item_id  timestamp  target
+                  0 2019-01-01       0
+                  0 2019-01-02       1
+                  0 2019-01-03       2
+                  1 2019-01-02       3
+                  1 2019-01-03       4
+                  1 2019-01-04       5
+                  2 2019-01-03       6
+                  2 2019-01-04       7
+                  2 2019-01-05       8
+
+            >>> df.slice_items_by_index(0, 1)  # select the first entry of each time series
+            item_id  timestamp  target
+                  0 2019-01-01       0
+                  1 2019-01-02       3
+                  2 2019-01-03       6
+
+            >>> df.slice_items_by_index(-2, None)  # select the last 2 entries of each time series
+            item_id  timestamp  target
+                  0 2019-01-02       1
+                  0 2019-01-03       2
+                  1 2019-01-03       4
+                  1 2019-01-04       5
+                  2 2019-01-04       7
+                  2 2019-01-05       8
+
+            >>> df.slice_items_by_index(None, -1)  # select all except the last entry of each time series
+            item_id  timestamp  target
+                  0 2019-01-01       0
+                  0 2019-01-02       1
+                  1 2019-01-02       3
+                  1 2019-01-03       4
+                  2 2019-01-03       6
+                  2 2019-01-04       7
+
+            >>> df.slice_items_by_index(None, None)  # copy the entire dataframe
+            item_id  timestamp  target
+                  0 2019-01-01       0
+                  0 2019-01-02       1
+                  0 2019-01-03       2
+                  1 2019-01-02       3
+                  1 2019-01-03       4
+                  1 2019-01-04       5
+                  2 2019-01-03       6
+                  2 2019-01-04       7
+                  2 2019-01-05       8
+
+        """
+        num_timesteps_per_item = self.num_timesteps_per_item()
+        # Create a boolean index that selects the correct slice in each timeseries
+        boolean_indicators = []
+        for length in num_timesteps_per_item:
+            indicator = np.zeros(length, dtype=bool)
+            indicator[start_index:end_index] = True
+            boolean_indicators.append(indicator)
+        index = np.concatenate(boolean_indicators)
+        result = TimeSeriesDataFrame(self[index].copy(), static_features=self.static_features)
+        result._cached_freq = self._cached_freq
+        return result
+
+    def slice_items_by_time(self, start_time: pd.Timestamp, end_time: pd.Timestamp) -> TimeSeriesDataFrame:
+        """Select a subsequence from each time series between start (inclusive) and end (exclusive) timestamps.
+
+        Parameters
+        ----------
+        start_time: pd.Timestamp
+            Start time (inclusive) of the slice for each time series.
+        end_time: pd.Timestamp
+            End time (exclusive) of the slice for each time series.
+
+        Returns
+        -------
+        ts_df: TimeSeriesDataFrame
+            A new time series dataframe containing entries of the original time series between start and end timestamps.
+
+        """
+        if end_time < start_time:
+            raise ValueError(f"end_time {end_time} is earlier than start_time {start_time}")
+
+        nanosecond_before_end_time = end_time - pd.Timedelta(nanoseconds=1)
+        result = TimeSeriesDataFrame(
+            self.loc[(slice(None), slice(start_time, nanosecond_before_end_time)), :],
+            static_features=self.static_features,
+        )
+        result._cached_freq = self._cached_freq
+        return result
+
+    @deprecated("Please use `TimeSeriesDataFrame.slice_items_by_index` instead.", version_removed="0.7")
     def slice_by_timestep(self, time_step_slice: slice) -> TimeSeriesDataFrame:
         """Return a slice of time steps (with no regards to the actual timestamp) from within
         each item in a time series data frame. For example, if a data frame is constructed as::
@@ -441,19 +558,9 @@ class TimeSeriesDataFrame(pd.DataFrame):
         """
         if time_step_slice.step is not None and time_step_slice != 1:
             raise ValueError("Upsampling via slicing with step sizes is not supported with `slice_by_timestep`.")
+        return self.slice_items_by_index(start_index=time_step_slice.start, end_index=time_step_slice.stop)
 
-        num_timesteps_per_item = self.num_timesteps_per_item()
-        # Create a boolean index that selects the correct slice in each timeseries
-        boolean_indicators = []
-        for length in num_timesteps_per_item:
-            indicator = np.zeros(length, dtype=bool)
-            indicator[time_step_slice] = True
-            boolean_indicators.append(indicator)
-        index = np.concatenate(boolean_indicators)
-        slice_df = self.__class__(self[index].copy(), static_features=self.static_features)
-        slice_df._cached_freq = self._cached_freq
-        return slice_df
-
+    @deprecated("Please use `TimeSeriesDataFrame.slice_items_by_time` instead.", version_removed="0.7")
     def subsequence(self, start: pd.Timestamp, end: pd.Timestamp) -> TimeSeriesDataFrame:
         """Extract time-series between start (inclusive) and end (exclusive) time.
 
@@ -463,22 +570,13 @@ class TimeSeriesDataFrame(pd.DataFrame):
             The start time (inclusive) of a time range that will be used for subsequence.
         end: pd.Timestamp
             The end time (exclusive) of a time range that will be used for subsequence.
-
         Returns
         -------
         ts_df: TimeSeriesDataFrame
             A new data frame in ``TimeSeriesDataFrame`` format contains time-series in a time range
             defined between start and end time.
         """
-
-        if end < start:
-            raise ValueError(f"end time {end} is earlier than stat time {start}")
-
-        nanosecond_before_end = end - pd.Timedelta(nanoseconds=1)
-        return TimeSeriesDataFrame(
-            self.loc[(slice(None), slice(start, nanosecond_before_end)), :],
-            static_features=self.static_features,
-        )
+        return self.slice_items_by_time(start_time=start, end_time=end)
 
     @classmethod
     def from_pickle(cls, filepath_or_buffer: Any) -> "TimeSeriesDataFrame":

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -495,10 +495,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
             start_index = time_step_slice.start
             end_index = time_step_slice.stop
 
-        length_per_item = self.num_timesteps_per_item()
+        num_timesteps_per_item = self.num_timesteps_per_item()
         # Create a boolean index that selects the correct slice in each timeseries
         boolean_indicators = []
-        for length in length_per_item:
+        for length in num_timesteps_per_item:
             indicator = np.zeros(length, dtype=bool)
             indicator[start_index:end_index] = True
             boolean_indicators.append(indicator)

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -410,11 +410,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
 
         Parameters
         ----------
-        start_index : int or None, default = None
+        start_index : int or None
             Start index (inclusive) of the slice for each time series.
             Negative values are counted from the end of each time series.
             When set to None, the slice starts from the beginning of each time series.
-        end_index : int or None, default = None
+        end_index : int or None
             End index (exclusive) of the slice for each time series.
             Negative values are counted from the end of each time series.
             When set to None, the slice includes the end of each time series.

--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -384,9 +384,11 @@ class TimeSeriesDataFrame(pd.DataFrame):
         Returns
         -------
         data_before: TimeSeriesDataFrame
-            Data frame containing all rows of the original data frame before the ``cutoff_time`` (excluding ``cutoff_time``).
+            A new time series dataframe containing entries of the original time series before the ``cutoff_time``
+            (excluding ``cutoff_time``).
         data_after: TimeSeriesDataFrame
-            Data frame containing all rows of the original data frame after the ``cutoff_time`` (including ``cutoff_time``).
+            A new time series dataframe containing entries of the original time series after the ``cutoff_time``
+            (including ``cutoff_time``).
         """
 
         nanosecond_before_cutoff = cutoff_time - pd.Timedelta(nanoseconds=1)
@@ -476,10 +478,10 @@ class TimeSeriesDataFrame(pd.DataFrame):
                   2 2019-01-05       8
 
         """
-        num_timesteps_per_item = self.num_timesteps_per_item()
+        length_per_item = self.length_per_item()
         # Create a boolean index that selects the correct slice in each timeseries
         boolean_indicators = []
-        for length in num_timesteps_per_item:
+        for length in length_per_item:
             indicator = np.zeros(length, dtype=bool)
             indicator[start_index:end_index] = True
             boolean_indicators.append(indicator)

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -281,7 +281,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             data is given as a separate forecast item in the dictionary, keyed by the `item_id`s
             of input items.
         """
-        return self.predict(data.slice_by_timestep(slice(None, -self.prediction_length)), **kwargs)
+        return self.predict(data.slice_by_timestep(None, -self.prediction_length), **kwargs)
 
     def score(self, data: TimeSeriesDataFrame, metric: str = None, **kwargs) -> float:
         """Return the evaluation scores for given metric and dataset. The last

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -175,12 +175,12 @@ class MultiWindowSplitter(AbstractTimeSeriesSplitter):
         validation_dataframes = [append_suffix_to_item_id(ts_dataframe, "_[None:None]")]
 
         for window_idx in range(1, self.num_windows):
-            ts_dataframe = ts_dataframe.slice_by_timestep(slice(None, -step_size))
+            ts_dataframe = ts_dataframe.slice_by_timestep(None, -step_size)
             total_offset = step_size * window_idx
             next_val_dataframe = append_suffix_to_item_id(ts_dataframe, f"_[None:{-total_offset}]")
             validation_dataframes.append(next_val_dataframe)
 
-        train_data = ts_dataframe.slice_by_timestep(slice(None, -prediction_length))
+        train_data = ts_dataframe.slice_by_timestep(None, -prediction_length)
         val_data = pd.concat(validation_dataframes)
         val_data._cached_freq = train_data._cached_freq
 


### PR DESCRIPTION
*Description of changes:*

- `TimeSeriesDataFrame.slice_by_timestep` now accepts `(start_index: Optional[int] = None, end_index: Optional[int] = None)` as input instead of a `slice` object.  
  - Passing a `slice` object is still supported; a deprecation warning is made in this case.
- `TimeSeriesDataFrame.subsequence` is renamed to `TimeSeriesDataFrame.slice_by_time`, old method is deprecated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
