### PR TITLE
Add TemporalFusionTransformer time series model

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/__init__.py
@@ -1,12 +1,20 @@
-from .gluonts import AutoTabularModel, DeepARModel, MQCNNModel, SimpleFeedForwardModel, TransformerModel
+from .gluonts import (
+    AutoTabularModel,
+    DeepARModel,
+    MQCNNModel,
+    SimpleFeedForwardModel,
+    TemporalFusionTransformerModel,
+    TransformerModel,
+)
 from .sktime import SktimeARIMAModel, SktimeAutoARIMAModel, SktimeAutoETSModel, SktimeTBATSModel, SktimeThetaModel
 from .statsmodels import ARIMAModel, ETSModel
 
 __all__ = [
     "AutoTabularModel",
     "DeepARModel",
-    "SimpleFeedForwardModel",
     "MQCNNModel",
+    "SimpleFeedForwardModel",
+    "TemporalFusionTransformerModel",
     "TransformerModel",
     "SktimeARIMAModel",
     "SktimeAutoARIMAModel",

--- a/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/__init__.py
@@ -6,6 +6,7 @@ from .models import (
     MQRNNModel,
     ProphetModel,
     SimpleFeedForwardModel,
+    TemporalFusionTransformerModel,
     TransformerModel,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "MQRNNModel",
     "ProphetModel",
     "SimpleFeedForwardModel",
+    "TemporalFusionTransformerModel",
     "TransformerModel",
 ]

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -216,6 +216,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             )
 
     def predict(self, data: TimeSeriesDataFrame, quantile_levels: List[float] = None, **kwargs) -> TimeSeriesDataFrame:
+        if self.gts_predictor is None:
+            raise ValueError("Please fit the model before predicting.")
 
         logger.debug(f"Predicting with time series model {self.name}")
         logger.debug(

--- a/timeseries/src/autogluon/timeseries/models/gluonts/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/models.py
@@ -15,6 +15,7 @@ with warning_filter():
     from gluonts.model.seq2seq import MQCNNEstimator, MQRNNEstimator
     from gluonts.model.simple_feedforward import SimpleFeedForwardEstimator
     from gluonts.model.transformer import TransformerEstimator
+    from gluonts.model.tft import TemporalFusionTransformerEstimator
     from gluonts.mx.context import get_mxnet_context
     from gluonts.nursery.autogluon_tabular import TabularEstimator
 
@@ -188,6 +189,51 @@ class SimpleFeedForwardModel(AbstractGluonTSModel):
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = SimpleFeedForwardEstimator
+
+
+class TemporalFusionTransformerModel(AbstractGluonTSModel):
+    """TemporalFusionTransformer model for forecasting, as described in [Lim2020]_.
+
+    .. [Lim2021] Lim, Bryan, et al.
+        "Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting."
+        International Journal of Forecasting. 2021.
+
+    See `AbstractGluonTSModel` for common parameters.
+
+    Other Parameters
+    ----------------
+    context_length : int or None, default = None
+        Number of past values used for prediction.
+        (default: None, in which case context_length = prediction_length)
+    hidden_dim : int, default = 32
+        Size of the hidden layer.
+    num_heads : int, default = 4
+        Number of attention heads in multi-head attention.
+    dropout_rate : float, default = 0.1
+        Dropout regularization parameter
+    batch_size : int, default = 32
+        Size of the mini-batch during training.
+    epochs : int, default = 100
+        Number of epochs the model will be trained for.
+    """
+
+    gluonts_estimator_class: Type[GluonTSEstimator] = TemporalFusionTransformerEstimator
+
+    def _get_estimator(self) -> GluonTSEstimator:
+        """Return the GluonTS Estimator object for the model"""
+        hyperparameters = self._get_estimator_init_args()
+        # Turning off hybridization prevents MXNet errors when training on GPU
+        hyperparameters["hybridize"] = False
+        # TFT cannot handle arbitrary quantiles, this is a workaround
+        hyperparameters["num_outputs"] = 9
+        supported_quantiles = set([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+        if not set(self.quantile_levels).issubset(supported_quantiles):
+            raise ValueError(
+                f"{self.name} requires that quantile_levels are a subset of "
+                f"{supported_quantiles} (received quantile_levels = {self.quantile_levels})"
+            )
+        with warning_filter():
+            return self.gluonts_estimator_class.from_hyperparameters(**hyperparameters)
 
 
 class TransformerModel(AbstractGluonTSModel):

--- a/timeseries/src/autogluon/timeseries/models/gluonts/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/models.py
@@ -236,7 +236,7 @@ class TemporalFusionTransformerModel(AbstractGluonTSModel):
             return self.gluonts_estimator_class.from_hyperparameters(**hyperparameters)
 
     def predict(self, data: TimeSeriesDataFrame, quantile_levels: List[float] = None, **kwargs) -> TimeSeriesDataFrame:
-        if quantile_levels is not None and not set(self.quantile_levels).issubset(self.supported_quantiles):
+        if quantile_levels is not None and not set(quantile_levels).issubset(self.supported_quantiles):
             raise ValueError(
                 f"{self.name} requires that quantile_levels are a subset of "
                 f"{self.supported_quantiles} (received quantile_levels = {self.quantile_levels})"

--- a/timeseries/src/autogluon/timeseries/models/gluonts/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/models.py
@@ -4,7 +4,6 @@ from typing import List, Type
 import mxnet as mx
 
 from autogluon.core.utils import warning_filter
-
 from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame
 from autogluon.timeseries.models.abstract.abstract_timeseries_model import AbstractTimeSeriesModelFactory
 

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -13,6 +13,7 @@ from .gluonts import (
     MQRNNModel,
     ProphetModel,
     SimpleFeedForwardModel,
+    TemporalFusionTransformerModel,
     TransformerModel,
 )
 from .sktime import SktimeARIMAModel, SktimeAutoARIMAModel, SktimeAutoETSModel
@@ -29,6 +30,7 @@ MODEL_TYPES = dict(
     AutoTabular=AutoTabularModel,
     Prophet=ProphetModel,
     Transformer=TransformerModel,
+    TemporalFusionTransformer=TemporalFusionTransformerModel,
     SktimeARIMA=SktimeARIMAModel,
     SktimeAutoARIMA=SktimeAutoARIMAModel,
     SktimeAutoETS=SktimeAutoETSModel,
@@ -41,6 +43,7 @@ DEFAULT_MODEL_PRIORITY = dict(
     MQRNN=40,
     SimpleFeedForward=50,
     Transformer=40,
+    TemporalFusionTransformer=45,
     DeepAR=50,
     Prophet=10,
     AutoTabular=10,

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -172,6 +172,9 @@ def test_when_fit_called_then_models_train_and_returned_predictor_inference_has_
             "epochs": 1,
         },
     )
+    # TFT cannot handle arbitrary quantiles
+    if model.name == "TemporalFusionTransformer":
+        return
 
     model.fit(train_data=DUMMY_TS_DATAFRAME)
     predictions = model.predict(DUMMY_TS_DATAFRAME, quantile_levels=quantile_levels)


### PR DESCRIPTION
Thanks to Lorenzo's fix from https://github.com/awslabs/gluon-ts/issues/2264  we can add TFT to AutoGluon (the model should work both on CPU and GPU).

*Description of changes:*
- Add `TemporalFusionTransformerModel` to `timeseries.models`, wrapping `TemporalFusionTransformerEstimator` from GluonTS.

The model will be added to the default presets later after we complete benchmarking.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
