### PR TITLE
Tabular Bagging HPO Logic Update

### DIFF
--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -8,8 +8,6 @@ import time
 from abc import ABC, abstractmethod
 from typing import Optional, List, Dict, Union, Callable
 
-from autogluon.core.space import Bool
-
 from .constants import RAY_BACKEND, CUSTOM_BACKEND
 from .exceptions import EmptySearchSpace
 from .. import Space
@@ -81,15 +79,15 @@ class HpoExecutor(ABC):
         """
         user_cpu_count = initialized_model._get_child_aux_val(key='num_cpus', default=None)
         user_gpu_count = initialized_model._get_child_aux_val(key='num_gpus', default=None)
-        model_default_num_cpus, model_default_num_gpus = initialized_model._get_default_resources()
+        resource_kwargs = initialized_model._preprocess_fit_resources()
 
-        num_cpus = ResourceCalculator.get_total_cpu_count(
-            user_specified_num_cpus=user_cpu_count,
-            model_default_num_cpus=model_default_num_cpus,
-        )
         num_gpus = ResourceCalculator.get_total_gpu_count(
             user_specified_num_gpus=user_gpu_count,
-            model_default_num_gpus=model_default_num_gpus,
+            model_default_num_gpus=resource_kwargs.get('num_gpus', 0),
+        )
+        num_cpus = ResourceCalculator.get_total_cpu_count(
+            user_specified_num_cpus=user_cpu_count,
+            model_default_num_cpus=resource_kwargs.get('num_cpus', 0),
         )
 
         self.resources = dict(num_gpus=num_gpus, num_cpus=num_cpus)

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -387,7 +387,8 @@ class CustomHpoExecutor(HpoExecutor):
             trial_model_name = model_name + os.path.sep + file_id
             trial_model_path = model_path_root + trial_model_name + os.path.sep
             trial_reward = self.scheduler.searcher.get_reward(hpo_results['config_history'][trial])
-
+            if trial_reward is None or trial_reward == float('-inf'):
+                continue
             hpo_models[trial_model_name] = dict(
                 path=trial_model_path,
                 val_score=trial_reward,

--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -147,6 +147,7 @@ def run(
     mode: str,
     save_dir: str,
     ray_tune_adapter: RayTuneAdapter,
+    trainable_is_parallel: bool = False,
     total_resources: Optional[dict] = dict(),
     minimum_cpu_per_trial: int = 1,
     minimum_gpu_per_trial: float = 0.0,
@@ -186,6 +187,8 @@ def run(
         For example of creating the custom function, refer to `_trial_dirname_creator`.
     ray_tune_adapter
         Adapter to provide necessary custom info to ray tune.
+    trainable_is_parallel
+        Whether the trainable itself will use ray to run parallel job or not.
     total_resources
         Total resources can be used for HPO.
         If not specified, will use all the resources by default.
@@ -218,7 +221,7 @@ def run(
     search_space = _convert_search_space(search_space)
 
     if not ray.is_initialized():
-        ray.init(log_to_driver=False, **total_resources)
+        ray.init(log_to_driver=True, **total_resources)
 
     resources_per_trial = hyperparameter_tune_kwargs.get('resources_per_trial', None)
     resources_per_trial = ray_tune_adapter.get_resources_per_trial(
@@ -227,7 +230,8 @@ def run(
         resources_per_trial=resources_per_trial,
         minimum_gpu_per_trial=minimum_gpu_per_trial,
         minimum_cpu_per_trial=minimum_cpu_per_trial,
-        model_estimate_memory_usage=model_estimate_memory_usage
+        model_estimate_memory_usage=model_estimate_memory_usage,
+        wrap_resources_per_job_into_placement_group=trainable_is_parallel,
     )
     resources_per_trial = _validate_resources_per_trial(resources_per_trial)
     ray_tune_adapter.resources_per_trial = resources_per_trial
@@ -392,8 +396,13 @@ class TabularRayTuneAdapter(RayTuneAdapter):
         return ResourceCalculatorFactory.get_resource_calculator(calculator_type='cpu' if num_gpus == 0 else 'gpu')
     
     def trainable_args_update_method(self, trainable_args: dict) -> dict:
-        trainable_args['fit_kwargs']['num_cpus'] = self.resources_per_trial.get('cpu', 1)
-        trainable_args['fit_kwargs']['num_gpus'] = self.resources_per_trial.get('gpu', 0)
+        if isinstance(self.resources_per_trial, dict):
+            trainable_args['fit_kwargs']['num_cpus'] = self.resources_per_trial.get('cpu', 1)
+            trainable_args['fit_kwargs']['num_gpus'] = self.resources_per_trial.get('gpu', 0)
+        elif isinstance(self.resources_per_trial, tune.PlacementGroupFactory):
+            required_resources = self.resources_per_trial.required_resources
+            trainable_args['fit_kwargs']['num_cpus'] = required_resources.get('CPU', 1)
+            trainable_args['fit_kwargs']['num_gpus'] = required_resources.get('GPU', 0)
         return trainable_args
     
     

--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -221,7 +221,7 @@ def run(
     search_space = _convert_search_space(search_space)
 
     if not ray.is_initialized():
-        ray.init(log_to_driver=True, **total_resources)
+        ray.init(log_to_driver=False, **total_resources)
 
     resources_per_trial = hyperparameter_tune_kwargs.get('resources_per_trial', None)
     resources_per_trial = ray_tune_adapter.get_resources_per_trial(

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1030,6 +1030,8 @@ class AbstractModel:
 
         model_cls = self.__class__
         init_params = self.get_params()
+        # We set soft time limit to avoid trials being terminated directly by ray tune
+        trial_soft_time_limit = max(hpo_executor.time_limit * 0.9, hpo_executor.time_limit - 5)  # 5 seconds max for buffer
 
         fit_kwargs = dict()
         fit_kwargs['feature_metadata'] = self.feature_metadata
@@ -1040,7 +1042,7 @@ class AbstractModel:
             model_cls=model_cls,
             init_params=init_params,
             time_start=time_start,
-            time_limit=hpo_executor.time_limit,
+            time_limit=trial_soft_time_limit,
             fit_kwargs=fit_kwargs,
             train_path=train_path,
             val_path=val_path,

--- a/core/src/autogluon/core/models/abstract/model_trial.py
+++ b/core/src/autogluon/core/models/abstract/model_trial.py
@@ -70,10 +70,18 @@ def init_model(args, model_cls, init_params, backend, is_bagged_model=False):
         from ray import tune
         task_id = tune.get_trial_id()
         file_prefix = task_id
+    else:
+        raise ValueError(f"Invalid backend: {backend}. Valid options are [{CUSTOM_BACKEND}, {RAY_BACKEND}]")
 
     if is_bagged_model:
+        if 'model_base_kwargs' not in init_params:
+            init_params['model_base_kwargs'] = {}
+        if 'hyperparameters' not in init_params['model_base_kwargs']:
+            init_params['model_base_kwargs']['hyperparameters'] = {}
         init_params['model_base_kwargs']['hyperparameters'].update(args)
     else:
+        if 'hyperparameters' not in init_params:
+            init_params['hyperparameters'] = {}
         init_params['hyperparameters'].update(args)
     init_params['name'] = init_params['name'] + os.path.sep + file_prefix
 

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1026,10 +1026,6 @@ class BaggedEnsembleModel(AbstractModel):
         oof_pred_model_repeats = np.zeros(shape=len(X), dtype=np.uint8)
         return oof_pred_proba, oof_pred_model_repeats
 
-    # def _preprocess_fit_resources(self, silent=False, **kwargs):
-    #     """Pass along to child models to avoid altering up-front"""
-    #     return kwargs
-
     def _hyperparameter_tune(
         self,
         X,
@@ -1042,7 +1038,7 @@ class BaggedEnsembleModel(AbstractModel):
     ):
         time_start = time.time()
         logger.log(15, "Starting generic AbstractModel hyperparameter tuning for %s model..." % self.name)
-        # initialize the model base to get necessary info for estimating memory usage
+        # initialize the model base to get necessary info for search space and estimating memory usage
         initialized_model_base = copy.deepcopy(self.model_base)
         initialized_model_base.initialize(X=X, y=y, **self.model_base.get_params())
         search_space = initialized_model_base._get_search_space()
@@ -1113,123 +1109,6 @@ class BaggedEnsembleModel(AbstractModel):
         )
 
         return hpo_results
-
-    # TODO: Currently double disk usage, saving model in HPO and also saving model in bag
-    # FIXME: with use_bag_holdout=True, the fold-1 scores that are logged are of the inner validation score, not the holdout score.
-    #  Fix this by passing X_val, y_val into this method
-    # def _hyperparameter_tune(self, X, y, k_fold, hpo_executor, preprocess_kwargs=None, groups=None, **kwargs):
-    #     if len(self.models) != 0:
-    #         raise ValueError('self.models must be empty to call hyperparameter_tune, value: %s' % self.models)
-
-    #     kwargs['feature_metadata'] = self.feature_metadata
-    #     kwargs['num_classes'] = self.num_classes  # TODO: maybe don't pass num_classes to children
-    #     model_base = self._get_model_base()
-    #     hpo_context = self.path + 'hpo' + os.path.sep
-    #     model_base.set_contexts(hpo_context)
-
-    #     # TODO: Preprocess data here instead of repeatedly
-    #     if preprocess_kwargs is None:
-    #         preprocess_kwargs = dict()
-    #     use_child_oof = self.params.get('use_child_oof', False)
-    #     X = self.preprocess(X=X, preprocess=False, fit=True, **preprocess_kwargs)
-
-    #     if use_child_oof:
-    #         k_fold = 1
-    #         X_fold = X
-    #         y_fold = y
-    #         X_val_fold = None
-    #         y_val_fold = None
-    #         train_index = list(range(len(X)))
-    #         test_index = train_index
-    #         cv_splitter = None
-    #     else:
-    #         cv_splitter = self._get_cv_splitter(n_splits=k_fold, n_repeats=1, groups=groups)
-    #         if k_fold != cv_splitter.n_splits:
-    #             k_fold = cv_splitter.n_splits
-
-    #         kfolds = cv_splitter.split(X=X, y=y)
-
-    #         train_index, test_index = kfolds[0]
-    #         X_fold, X_val_fold = X.iloc[train_index, :], X.iloc[test_index, :]
-    #         y_fold, y_val_fold = y.iloc[train_index], y.iloc[test_index]
-    #     orig_time = hpo_executor.time_limit
-    #     if orig_time:
-    #         hpo_executor.time_limit = orig_time * 0.8  # TODO: Scheduler doesn't early stop on final model, this is a safety net. Scheduler should be updated to early stop
-    #     hpo_models, hpo_results = model_base.hyperparameter_tune(
-    #         X=X_fold,
-    #         y=y_fold,
-    #         X_val=X_val_fold,
-    #         y_val=y_val_fold,
-    #         hyperparameter_tune_kwargs=None,
-    #         hpo_executor=hpo_executor,
-    #         **kwargs)
-    #     hpo_executor.time_limit = orig_time
-
-    #     bags = {}
-    #     for i, (model_name, model_info) in enumerate(hpo_models.items()):
-    #         model_path = model_info['path']
-    #         child: AbstractModel = self._child_type.load(path=model_path)
-
-    #         # TODO: Create new Ensemble Here
-    #         bag = copy.deepcopy(self)
-    #         bag.rename(f"{bag.name}{os.path.sep}T{i+1}")
-    #         bag.set_contexts(self.path_root + bag.name + os.path.sep)
-
-    #         oof_pred_proba, oof_pred_model_repeats = self._construct_empty_oof(X=X, y=y)
-
-    #         if child._get_tags().get('valid_oof', False):
-    #             y_pred_proba = child.get_oof_pred_proba(X=X, y=y)
-    #             bag._n_repeats_finished = 1
-    #             bag._k_per_n_repeat = [1]
-    #             bag._bagged_mode = False
-    #             bag._child_oof = True  # TODO: Consider a separate tag for refit_folds vs efficient OOF
-    #         else:
-    #             y_pred_proba = child.predict_proba(X_val_fold)
-
-    #         oof_pred_proba[test_index] += y_pred_proba
-    #         oof_pred_model_repeats[test_index] += 1
-
-    #         bag.model_base = None
-    #         child.rename('')
-    #         child.set_contexts(bag.path + child.name + os.path.sep)
-    #         bag.save_model_base(child.convert_to_template())
-
-    #         bag._k = k_fold
-    #         bag._k_fold_end = 1
-    #         bag._n_repeats = 1
-    #         bag._oof_pred_proba = oof_pred_proba
-    #         bag._oof_pred_model_repeats = oof_pred_model_repeats
-    #         child.rename('S1F1')
-    #         child.set_contexts(bag.path + child.name + os.path.sep)
-    #         if not self.params.get('save_bag_folds', True):
-    #             child.model = None
-    #         if bag.low_memory:
-    #             bag.save_child(child, verbose=False)
-    #             bag.models.append(child.name)
-    #         else:
-    #             bag.models.append(child)
-    #         bag.val_score = child.val_score
-    #         bag._add_child_times_to_bag(model=child)
-    #         if cv_splitter is not None:
-    #             bag._cv_splitters = [cv_splitter]
-
-    #         bag.save()
-    #         bags[bag.name] = dict(**model_info)
-    #         bags[bag.name]['path'] = bag.path
-
-    #         # delete original child from its disk location since it is being saved to a new location in the bag
-    #         child: AbstractModel = self._child_type.load(path=model_path)
-    #         child.delete_from_disk(silent=True)
-
-    #     # cleanup artifacts
-    #     for artifact_dir in [model_base._path_v2, model_base.path_root]:
-    #         try:
-    #             os.rmdir(artifact_dir)
-    #         except OSError:
-    #             pass
-
-    #     # TODO: hpo_results likely not correct because no renames
-    #     return bags, hpo_results
 
     def _more_tags(self):
         return {

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1075,6 +1075,8 @@ class BaggedEnsembleModel(AbstractModel):
         # Here the hyperparameters are unprocessed search space.
         # HPO Executor will handle passing in the correct parameters.
         init_params['model_base_kwargs'].pop('hyperparameters', None)
+        # We set soft time limit to avoid trials being terminated directly by ray tune
+        trial_soft_time_limit = max(hpo_executor.time_limit * 0.9, hpo_executor.time_limit - 5)  # 5 seconds max for buffer
 
         fit_kwargs = copy.deepcopy(kwargs)
         fit_kwargs['k_fold'] = k_fold
@@ -1087,7 +1089,7 @@ class BaggedEnsembleModel(AbstractModel):
             model_cls=model_cls,
             init_params=init_params,
             time_start=time_start,
-            time_limit=hpo_executor.time_limit * 0.9,  # Some buffer time for the folds to finish
+            time_limit=trial_soft_time_limit,
             fit_kwargs=fit_kwargs,
             train_path=train_path,
             val_path=val_path,

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1040,7 +1040,10 @@ class BaggedEnsembleModel(AbstractModel):
         logger.log(15, "Starting generic AbstractModel hyperparameter tuning for %s model..." % self.name)
         # initialize the model base to get necessary info for search space and estimating memory usage
         initialized_model_base = copy.deepcopy(self.model_base)
-        initialized_model_base.initialize(X=X, y=y, **self.model_base.get_params())
+        model_init_args = self.model_base.get_params()
+        model_init_args['features'] = self.feature_metadata
+        model_init_args['num_classes'] = self.num_classes
+        initialized_model_base.initialize(X=X, y=y, **model_init_args)
         search_space = initialized_model_base._get_search_space()
 
         try:
@@ -1062,7 +1065,7 @@ class BaggedEnsembleModel(AbstractModel):
 
         model_cls = self.__class__
         init_params = copy.deepcopy(self.get_params())
-        model_base = init_params['model_base']
+        model_base = self._get_model_base()
 
         if not inspect.isclass(model_base):
             init_params['model_base'] = init_params['model_base'].__class__
@@ -1074,7 +1077,7 @@ class BaggedEnsembleModel(AbstractModel):
         fit_kwargs['num_classes'] = self.num_classes
         fit_kwargs['sample_weight'] = kwargs.get('sample_weight', None)
         fit_kwargs['sample_weight_val'] = kwargs.get('sample_weight_val', None)
-        fit_kwargs.pop('time_limit', None)
+        fit_kwargs.pop('time_limit', None)  # time_limit already set in hpo_executor
         train_fn_kwargs = dict(
             model_cls=model_cls,
             init_params=init_params,

--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -1070,6 +1070,9 @@ class BaggedEnsembleModel(AbstractModel):
         if not inspect.isclass(model_base):
             init_params['model_base'] = init_params['model_base'].__class__
             init_params['model_base_kwargs'] = model_base.get_params()
+        # Here the hyperparameters are unprocessed search space.
+        # HPO Executor will handle passing in the correct parameters.
+        init_params['model_base_kwargs'].pop('hyperparameters', None)
 
         fit_kwargs = copy.deepcopy(kwargs)
         fit_kwargs['k_fold'] = k_fold

--- a/core/src/autogluon/core/ray/resources_calculator.py
+++ b/core/src/autogluon/core/ray/resources_calculator.py
@@ -21,10 +21,10 @@ class ResourceCalculator(ABC):
     @staticmethod
     def get_total_gpu_count(user_specified_num_gpus: int, model_default_num_gpus: int, num_gpus_available: Optional[float] = None):
         if user_specified_num_gpus is not None:
-            total_gpu = get_gpu_count_all() if num_gpus_available is None else num_gpus_available
+            total_gpu = get_gpu_count_all() if num_gpus_available is None else min(get_gpu_count_all(), num_gpus_available)
             num_gpus = min(user_specified_num_gpus, total_gpu)
         elif model_default_num_gpus > 0:
-            num_gpus = get_gpu_count_all()
+            num_gpus = get_gpu_count_all() if num_gpus_available is None else min(get_gpu_count_all(), num_gpus_available)
         else:
             num_gpus = 0
         return num_gpus

--- a/core/src/autogluon/core/ray/resources_calculator.py
+++ b/core/src/autogluon/core/ray/resources_calculator.py
@@ -3,6 +3,7 @@ import math
 import psutil
 
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from ..utils import get_cpu_count, get_gpu_count_all
 
@@ -10,17 +11,18 @@ logger = logging.getLogger(__name__)
 
 
 class ResourceCalculator(ABC):
-    
+
     @property
     @abstractmethod
     def calc_type(self):
         """Type of the resource calculator"""
         raise NotImplementedError
-    
+
     @staticmethod
-    def get_total_gpu_count(user_specified_num_gpus: int, model_default_num_gpus: int):
+    def get_total_gpu_count(user_specified_num_gpus: int, model_default_num_gpus: int, num_gpus_available: Optional[float] = None):
         if user_specified_num_gpus is not None:
-            num_gpus = min(user_specified_num_gpus, get_gpu_count_all())
+            total_gpu = get_gpu_count_all() if num_gpus_available is None else num_gpus_available
+            num_gpus = min(user_specified_num_gpus, total_gpu)
         elif model_default_num_gpus > 0:
             num_gpus = get_gpu_count_all()
         else:
@@ -28,33 +30,47 @@ class ResourceCalculator(ABC):
         return num_gpus
 
     @staticmethod
-    def get_total_cpu_count(user_specified_num_cpus: int, model_default_num_cpus: int):
+    def get_total_cpu_count(user_specified_num_cpus: int, model_default_num_cpus: int, num_cpus_available: Optional[int] = None):
+        if num_cpus_available is not None:
+            assert num_cpus_available > 0
         if user_specified_num_cpus is not None:
-            num_cpus = min(user_specified_num_cpus, get_cpu_count())
+            total_cpu = get_cpu_count() if num_cpus_available is None else min(get_cpu_count(), num_cpus_available)
+            num_cpus = min(user_specified_num_cpus, total_cpu)
         elif model_default_num_cpus > 0:
-            num_cpus = get_cpu_count()
+            num_cpus = get_cpu_count() if num_cpus_available is None else min(get_cpu_count(), num_cpus_available)
         else:
             num_cpus = 0
         return num_cpus
-    
+
     @abstractmethod
     def get_resources_per_job(self, **kwargs) -> dict:
         """Calculate resources per trial and return additional info"""
         raise NotImplementedError
-    
+
+    def wrap_resources_per_job_into_placement_group(self, resources_per_job):
+        """
+        When doing parallel training inside parallel trials, Ray requires to provide placement group for resource scheduling
+        We wrap a group where the resource requirement is 0 because the trial only spread the task and doesn't require too much resources.
+        """
+        from ray import tune
+        num_cpus = resources_per_job.get('cpu', 0)
+        num_gpus = resources_per_job.get('gpu', 0)
+        return tune.PlacementGroupFactory([{'CPU': 0.0}] + [{'CPU': num_cpus, 'GPU': num_gpus}])
+
 
 class CpuResourceCalculator(ResourceCalculator):
-    
+
     @property
     def calc_type(self):
         return 'cpu'
-    
+
     def get_resources_per_job(
         self,
         total_num_cpus,
         num_jobs,
         minimum_cpu_per_job,
         model_estimate_memory_usage=None,
+        wrap_resources_per_job_into_placement_group=False,
         **kwargs,
     ):
         cpu_per_job = max(minimum_cpu_per_job, int(total_num_cpus // num_jobs))
@@ -78,6 +94,8 @@ class CpuResourceCalculator(ResourceCalculator):
         cpu_per_job = int(total_num_cpus // num_parallel_jobs)  # update cpu_per_job in case memory is not enough and can use more cores for each job
 
         resources_per_job = dict(cpu=cpu_per_job)
+        if wrap_resources_per_job_into_placement_group:
+            resources_per_job = self.wrap_resources_per_job_into_placement_group(resources_per_job)
         batches = math.ceil(num_jobs / num_parallel_jobs)
 
         resources_info = dict(
@@ -87,16 +105,16 @@ class CpuResourceCalculator(ResourceCalculator):
             cpu_per_job=cpu_per_job
         )
         logger.log(10, f'Resources info for {self.__class__.__name__}: {resources_info}')
-        
+
         return resources_info
-    
-    
+
+
 class GpuResourceCalculator(ResourceCalculator):
-    
+
     @property
     def calc_type(self):
         return 'gpu'
-    
+
     def get_resources_per_job(
         self,
         total_num_cpus,
@@ -104,6 +122,7 @@ class GpuResourceCalculator(ResourceCalculator):
         num_jobs,
         minimum_cpu_per_job,
         minimum_gpu_per_job,
+        wrap_resources_per_job_into_placement_group=False,
         **kwargs,
     ):
         cpu_per_job = max(minimum_cpu_per_job, int(total_num_cpus // num_jobs))
@@ -121,8 +140,10 @@ class GpuResourceCalculator(ResourceCalculator):
         gpu_per_job = total_num_gpus / num_parallel_jobs
 
         resources_per_job = dict(cpu=cpu_per_job, gpu=gpu_per_job)
+        if wrap_resources_per_job_into_placement_group:
+            resources_per_job = self.wrap_resources_per_job_into_placement_group(resources_per_job)
         batches = math.ceil(num_jobs / num_parallel_jobs)
-        
+
         resources_info = dict(
             resources_per_job=resources_per_job,
             num_parallel_jobs=num_parallel_jobs,
@@ -133,17 +154,17 @@ class GpuResourceCalculator(ResourceCalculator):
         logger.log(10, f'Resources info for {self.__class__.__name__}: {resources_info}')
 
         return resources_info
-    
-    
+
+
 class NonParallelGpuResourceCalculator(ResourceCalculator):
     """
     This calculator will only assign < 1 gpu to each job because some job cannot be parallelized
     """
-    
+
     @property
     def calc_type(self):
         return 'non_parallel_gpu'
-    
+
     def get_resources_per_job(
         self,
         total_num_cpus,
@@ -151,6 +172,7 @@ class NonParallelGpuResourceCalculator(ResourceCalculator):
         num_jobs,
         minimum_cpu_per_job,
         minimum_gpu_per_job,
+        wrap_resources_per_job_into_placement_group=False,
         **kwargs,
     ):
         assert 0 < minimum_gpu_per_job <= 1, f'{self.__class__.__name__} only supports assigning < 1 gpu to each job' 
@@ -169,6 +191,8 @@ class NonParallelGpuResourceCalculator(ResourceCalculator):
         gpu_per_job = min(1, total_num_gpus / num_parallel_jobs)
 
         resources_per_job = dict(cpu=cpu_per_job, gpu=gpu_per_job)
+        if wrap_resources_per_job_into_placement_group:
+            resources_per_job = self.wrap_resources_per_job_into_placement_group(resources_per_job)
         batches = math.ceil(num_jobs / num_parallel_jobs)
 
         resources_info = dict(
@@ -181,14 +205,14 @@ class NonParallelGpuResourceCalculator(ResourceCalculator):
         logger.log(10, f'Resources info for {self.__class__.__name__}: {resources_info}')
 
         return resources_info
-    
-    
+
+
 class RayLightningCpuResourceCalculator(ResourceCalculator):
-    
+
     @property
     def calc_type(self):
         return 'ray_lightning_cpu'
-    
+
     def get_resources_per_job(
         self,
         total_num_cpus,
@@ -235,14 +259,14 @@ class RayLightningCpuResourceCalculator(ResourceCalculator):
         logger.log(10, f'Resources info for {self.__class__.__name__}: {resources_info}')
 
         return resources_info
-        
-        
+
+
 class RayLightningGpuResourceCalculator(ResourceCalculator):
-    
+
     @property
     def calc_type(self):
         return 'ray_lightning_gpu'
-    
+
     def get_resources_per_job(
         self,
         total_num_cpus,
@@ -291,7 +315,7 @@ class RayLightningGpuResourceCalculator(ResourceCalculator):
 
 
 class ResourceCalculatorFactory:
-    
+
     __supported_calculators = [
         CpuResourceCalculator,
         GpuResourceCalculator,

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1392,13 +1392,6 @@ class AbstractTrainer:
                         hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
                         **model_fit_kwargs
                     )
-                    # hpo_models, hpo_results = model.hyperparameter_tune(
-                    #     X=X,
-                    #     y=y,
-                    #     k_fold=k_fold,
-                    #     hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
-                    #     **model_fit_kwargs
-                    # )
                 else:
                     hpo_models, hpo_results = model.hyperparameter_tune(
                         X=X,

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1377,13 +1377,28 @@ class AbstractTrainer:
             logger.log(20, fit_log_message)
             try:
                 if isinstance(model, BaggedEnsembleModel):
+                    bagged_model_fit_kwargs = self._get_bagged_model_fit_kwargs(k_fold=k_fold, k_fold_start=k_fold_start, k_fold_end=k_fold_end, n_repeats=n_repeats, n_repeat_start=n_repeat_start)
+                    model_fit_kwargs.update(bagged_model_fit_kwargs)
                     hpo_models, hpo_results = model.hyperparameter_tune(
                         X=X,
                         y=y,
-                        k_fold=k_fold,
+                        model=model,
+                        X_val=X_val,
+                        y_val=y_val,
+                        X_unlabeled=X_unlabeled,
+                        stack_name=stack_name,
+                        level=level,
+                        compute_score=compute_score,
                         hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
                         **model_fit_kwargs
                     )
+                    # hpo_models, hpo_results = model.hyperparameter_tune(
+                    #     X=X,
+                    #     y=y,
+                    #     k_fold=k_fold,
+                    #     hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+                    #     **model_fit_kwargs
+                    # )
                 else:
                     hpo_models, hpo_results = model.hyperparameter_tune(
                         X=X,
@@ -1521,16 +1536,10 @@ class AbstractTrainer:
             models = self._train_multi_fold(models=models, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
                                             time_limit=time_limit, time_split=time_split, time_ratio=time_ratio, **fit_args)
         else:
-            bagged_time_start = time.time()
-            if hpo_enabled:
-                time_ratio = (1 / k_fold) * hpo_time_ratio
-                models = self._train_multi_fold(models=models, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
-                                                k_fold_start=0, k_fold_end=1, n_repeats=n_repeats, n_repeat_start=0, time_limit=time_limit,
-                                                time_split=time_split, time_ratio=time_ratio, **fit_args)
-                k_fold_start = 1
-            bagged_time_limit = time_limit - (time.time() - bagged_time_start) if time_limit is not None else None
-            models = self._train_multi_fold(models=models, hyperparameter_tune_kwargs=None, k_fold_start=k_fold_start,
-                                            k_fold_end=k_fold, n_repeats=n_repeats, n_repeat_start=0, time_limit=bagged_time_limit, **fit_args)
+            time_ratio = hpo_time_ratio if hpo_enabled else 1
+            models = self._train_multi_fold(models=models, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs, k_fold_start=0,
+                                            k_fold_end=k_fold, n_repeats=n_repeats, n_repeat_start=0, time_limit=time_limit, time_ratio=time_ratio,
+                                            **fit_args)
 
         multi_fold_time_elapsed = time.time() - multi_fold_time_start
         if time_limit is not None:

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1402,7 +1402,7 @@ class AbstractTrainer:
                         **model_fit_kwargs
                     )
                 if len(hpo_models) == 0:
-                    logger.warning(f'No model was trained while hyperparameter tuning {model.name}... Skipping this model.')
+                    logger.warning(f'No model was trained during hyperparameter tuning {model.name}... Skipping this model.')
             except Exception as err:
                 logger.exception(f'Warning: Exception caused {model.name} to fail during hyperparameter tuning... Skipping this model.')
                 logger.warning(err)

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -1401,6 +1401,8 @@ class AbstractTrainer:
                         hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
                         **model_fit_kwargs
                     )
+                if len(hpo_models) == 0:
+                    logger.warning(f'No model was trained while hyperparameter tuning {model.name}... Skipping this model.')
             except Exception as err:
                 logger.exception(f'Warning: Exception caused {model.name} to fail during hyperparameter tuning... Skipping this model.')
                 logger.warning(err)
@@ -1531,8 +1533,8 @@ class AbstractTrainer:
         else:
             time_ratio = hpo_time_ratio if hpo_enabled else 1
             models = self._train_multi_fold(models=models, hyperparameter_tune_kwargs=hyperparameter_tune_kwargs, k_fold_start=0,
-                                            k_fold_end=k_fold, n_repeats=n_repeats, n_repeat_start=0, time_limit=time_limit, time_ratio=time_ratio,
-                                            **fit_args)
+                                            k_fold_end=k_fold, n_repeats=n_repeats, n_repeat_start=0, time_limit=time_limit,
+                                            time_split=time_split, time_ratio=time_ratio, **fit_args)
 
         multi_fold_time_elapsed = time.time() - multi_fold_time_start
         if time_limit is not None:

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -177,7 +177,7 @@ class NNFastAiTabularModel(AbstractModel):
 
         import torch
         torch.set_num_threads(num_cpus)
-
+        print('fitting')
         start_time = time.time()
         if sample_weight is not None:  # TODO: support
             logger.log(15, "sample_weight not yet supported for NNFastAiTabularModel, this model will ignore them in training.")

--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -177,7 +177,6 @@ class NNFastAiTabularModel(AbstractModel):
 
         import torch
         torch.set_num_threads(num_cpus)
-        print('fitting')
         start_time = time.time()
         if sample_weight is not None:  # TODO: support
             logger.log(15, "sample_weight not yet supported for NNFastAiTabularModel, this model will ignore them in training.")

--- a/tabular/tests/unittests/test_tabular.py
+++ b/tabular/tests/unittests/test_tabular.py
@@ -603,8 +603,7 @@ def test_tabularHPObagstack():
         nn_options = {'num_epochs': 2, 'learning_rate': ag.Real(0.001, 0.01)}
         gbm_options = {'num_boost_round': 20, 'learning_rate': ag.Real(0.01, 0.1)}
         hyperparameters = {'GBM': gbm_options, 'NN_TORCH': nn_options}
-        time_limit = 150
-        hyperparameter_tune_kwargs['num_trials'] = 3
+        time_limit = 50
 
     fit_args = {
         'num_bag_folds': num_bag_folds,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update bagging hpo logic to be training each bag as a trial, and the underneath trial will then train folds in parallel.
* With the above setting, models using ray tune can do parallel folds within parallel trials.
* Example of new logic output:
```bash
Fitting 3 L1 models ...
Hyperparameter tuning model: LightGBM_BAG_L1 ... Tuning model for up to 44.96s of the 49.95s of remaining time.
  0%|                                                                                                                | 0/4 [00:00<?, ?it/s]Fitting 2 child models (S1F1 - S1F2) | Fitting with ParallelLocalFoldFittingStrategy
 25%|██████████████████████████                                                                              | 1/4 [00:03<00:11,  3.83s/it]Fitting 2 child models (S1F1 - S1F2) | Fitting with ParallelLocalFoldFittingStrategy
 50%|████████████████████████████████████████████████████                                                    | 2/4 [00:04<00:04,  2.20s/it]Fitting 2 child models (S1F1 - S1F2) | Fitting with ParallelLocalFoldFittingStrategy
 75%|██████████████████████████████████████████████████████████████████████████████                          | 3/4 [00:05<00:01,  1.68s/it]Fitting 2 child models (S1F1 - S1F2) | Fitting with ParallelLocalFoldFittingStrategy
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:06<00:00,  1.75s/it]
Fitted model: LightGBM_BAG_L1/T1 ...
        0.851    = Validation score   (roc_auc)
        3.83s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: LightGBM_BAG_L1/T2 ...
        0.851    = Validation score   (roc_auc)
        1.04s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: LightGBM_BAG_L1/T3 ...
        0.851    = Validation score   (roc_auc)
        1.05s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: LightGBM_BAG_L1/T4 ...
        0.851    = Validation score   (roc_auc)
        1.05s    = Training   runtime
        0.0s     = Validation runtime
Hyperparameter tuning model: NeuralNetFastAI_BAG_L1 ... Tuning model for up to 37.95s of the 42.94s of remaining time.
Fitted model: NeuralNetFastAI_BAG_L1/36ed0_00000 ...
        0.8474   = Validation score   (roc_auc)
        4.04s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/36ed0_00001 ...
        0.8474   = Validation score   (roc_auc)
        4.12s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/36ed0_00002 ...
        0.8474   = Validation score   (roc_auc)
        3.95s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetFastAI_BAG_L1/36ed0_00003 ...
        0.8474   = Validation score   (roc_auc)
        3.97s    = Training   runtime
        0.0s     = Validation runtime
Hyperparameter tuning model: NeuralNetTorch_BAG_L1 ... Tuning model for up to 28.18s of the 33.17s of remaining time.
Fitted model: NeuralNetTorch_BAG_L1/3cb8f_00000 ...
        0.8518   = Validation score   (roc_auc)
        2.94s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetTorch_BAG_L1/3cb8f_00001 ...
        0.8518   = Validation score   (roc_auc)
        2.91s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetTorch_BAG_L1/3cb8f_00002 ...
        0.8518   = Validation score   (roc_auc)
        2.74s    = Training   runtime
        0.0s     = Validation runtime
Fitted model: NeuralNetTorch_BAG_L1/3cb8f_00003 ...
        0.8518   = Validation score   (roc_auc)
        2.76s    = Training   runtime
        0.0s     = Validation runtime
Fitting model: WeightedEnsemble_L2 ... Training model for up to 49.95s of the 25.83s of remaining time.
        0.8735   = Validation score   (roc_auc)
        0.78s    = Training   runtime
        0.0s     = Validation runtime
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
