### PR TITLE
Simplify XGBoost HPO search space to be stronger with fewer trials

### DIFF
--- a/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/searchspaces.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/searchspaces.py
@@ -25,6 +25,7 @@ def get_base_searchspace():
         'max_depth': Int(lower=3, upper=10, default=6),
         'min_child_weight': Int(lower=1, upper=5, default=1),
         'colsample_bytree': Real(lower=0.5, upper=1.0, default=1.0),
+        # Below lines are commented out as they made search worse. Refine ranges before considering reintroducing these hyperparameters.
         # 'gamma': Real(lower=0, upper=5, default=0),
         # 'subsample': Real(lower=0.5, upper=1.0, default=1.0),
         # 'reg_alpha': Real(lower=0.0, upper=10.0, default=0.0),

--- a/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/searchspaces.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/searchspaces.py
@@ -24,11 +24,11 @@ def get_base_searchspace():
         'learning_rate': Real(lower=5e-3, upper=0.2, default=0.1, log=True),
         'max_depth': Int(lower=3, upper=10, default=6),
         'min_child_weight': Int(lower=1, upper=5, default=1),
-        'gamma': Real(lower=0, upper=5, default=0.01),
-        'subsample': Real(lower=0.5, upper=1.0, default=1.0),
         'colsample_bytree': Real(lower=0.5, upper=1.0, default=1.0),
-        'reg_alpha': Real(lower=0.0, upper=10.0, default=0.0),
-        'reg_lambda': Real(lower=0.0, upper=10.0, default=1.0),
+        # 'gamma': Real(lower=0, upper=5, default=0),
+        # 'subsample': Real(lower=0.5, upper=1.0, default=1.0),
+        # 'reg_alpha': Real(lower=0.0, upper=10.0, default=0.0),
+        # 'reg_lambda': Real(lower=0.0, upper=10.0, default=1.0),
     }
     return base_params
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tested on adult dataset and saw that 50 trials with old config 0/50 were able to get better test score than default. 10/50 trials were able to beat default with new config. Until we do more testing with HPO, it is better to have simple search spaces as it avoids wasting most trials due to a poor hyperparameter value being present in a trial. This change aligns XGBoost search space with LightGBM search space in terms of complexity.

(Side note: @yinweisu this old search space is maybe why you saw parallel HPO was worse for trees, because it didn't use the default config during HPO and that was stronger than the vast majority of random configs.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
