### PR TITLE
Cleanup Temperature Scaling code

### DIFF
--- a/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
+++ b/core/src/autogluon/core/models/ensemble/bagged_ensemble_model.py
@@ -296,7 +296,7 @@ class BaggedEnsembleModel(AbstractModel):
             pred_proba += model.predict_proba(X=X, preprocess_nonadaptive=False, normalize=normalize)
         pred_proba = pred_proba / len(self.models)
 
-        if self.temperature_scalar is not None:
+        if self.params_aux.get("temperature_scalar", None) is not None:
             pred_proba = self._apply_temperature_scaling(pred_proba)
         elif self.conformalize is not None:
             pred_proba = self._apply_conformalization(pred_proba)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -18,19 +18,15 @@ from autogluon.common.utils.file_utils import get_directory_size, get_directory_
 from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.common.utils.pandas_utils import get_approximate_df_mem_usage
 from autogluon.common.utils.utils import setup_outputdir, get_autogluon_metadata, compare_autogluon_metadata
-from autogluon.core.calibrate.temperature_scaling import tune_temperature_scaling
-from autogluon.core.calibrate.conformity_score import compute_conformity_score
 from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE, AUTO_WEIGHT, BALANCE_WEIGHT, PSEUDO_MODEL_SUFFIX, PROBLEM_TYPES_CLASSIFICATION
 from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
 from autogluon.core.dataset import TabularDataset
 from autogluon.core.pseudolabeling.pseudolabeling import filter_pseudo, filter_ensemble_pseudo
 from autogluon.core.scheduler.scheduler_factory import scheduler_factory
 from autogluon.core.trainer import AbstractTrainer
-from autogluon.core.utils import get_pred_from_proba_df, try_import_torch
+from autogluon.core.utils import get_pred_from_proba_df
 from autogluon.core.utils import plot_performance_vs_trials, plot_summary_of_models, plot_tabular_models
 from autogluon.core.utils.decorators import apply_presets
-from autogluon.tabular.models import _IModelsModel
-
 from autogluon.core.utils.loaders import load_pkl, load_str
 from autogluon.core.utils.savers import save_pkl, save_str
 from autogluon.core.utils.utils import default_holdout_frac
@@ -894,9 +890,9 @@ class TabularPredictor:
 
         if calibrate:
             if self.problem_type in PROBLEM_TYPES_CLASSIFICATION:
-                self._calibrate_model()
+                self._trainer.calibrate_model()
             elif self.problem_type == QUANTILE:
-                self._calibrate_model()
+                self._trainer.calibrate_model()
             else:
                 logger.log(30, 'WARNING: `calibrate=True` is only applicable to classification or quantile regression problems. Skipping calibration...')
 
@@ -905,74 +901,6 @@ class TabularPredictor:
 
         if save_space:
             self.save_space()
-
-    def _calibrate_model(self, model_name: str = None, lr: float = 0.01, max_iter: int = 1000, init_val: float = 1.0):
-        """
-        Applies temperature scaling to the AutoGluon model. Applies
-        inverse softmax to predicted probs then trains temperature scalar
-        on validation data to maximize negative log likelihood. Inversed
-        softmaxes are divided by temperature scalar then softmaxed to return
-        predicted probs.
-
-        Parameters:
-        -----------
-        model_name: str: default=None
-            model name to tune temperature scaling on. If set to None
-            then will tune best model only. Best model chosen by validation score
-        lr: float: default=0.01
-            The learning rate for temperature scaling algorithm
-        max_iter: int: default=1000
-            Number of iterations optimizer should take for
-            tuning temperature scaler
-        init_val: float: default=1.0
-            The initial value for temperature scalar term
-        """
-        # TODO: Note that temperature scaling is known to worsen calibration in the face of shifted test data.
-        try:
-            # FIXME: Avoid depending on torch for temp scaling
-            try_import_torch
-        except ImportError:
-            logger.log(30, 'Warning: Torch is not installed, skipping calibration step...')
-            return
-
-        if model_name is None:
-            model_name = self.get_model_best()
-
-        model_full_dict = self._trainer.get_model_full_dict()
-        model_name_og = model_name
-        for m, m_full in model_full_dict.items():
-            if m_full == model_name:
-                model_name_og = m
-                break
-        if self._trainer.bagged_mode:
-            y_val_probs = self.get_oof_pred_proba(model_name_og, transformed=True, internal_oof=True).to_numpy()
-            y_val = self._trainer.load_y().to_numpy()
-        else:
-            X_val = self._trainer.load_X_val()
-            y_val_probs = self._trainer.predict_proba(X_val, model_name_og)
-            y_val = self._trainer.load_y_val().to_numpy()
-
-            if self.problem_type == BINARY:
-                y_val_probs = LabelCleanerMulticlassToBinary.convert_binary_proba_to_multiclass_proba(y_val_probs)
-
-        model = self._trainer.load_model(model_name=model_name)
-        if self.problem_type == QUANTILE:
-            logger.log(15, f'Conformity scores being computed to calibrate model: {model_name}')
-            conformalize = compute_conformity_score(y_val_pred=y_val_probs, y_val=y_val,
-                                                    quantile_levels=self.quantile_levels)
-            model.conformalize = conformalize
-            model.save()
-        else:
-            logger.log(15, f'Temperature scaling term being tuned for model: {model_name}')
-            temp_scalar = tune_temperature_scaling(y_val_probs=y_val_probs, y_val=y_val,
-                                                   init_val=init_val, max_iter=max_iter, lr=lr)
-            if temp_scalar is None:
-                logger.log(15, f'Warning: Infinity found during calibration, skipping calibration on {model.name}! '
-                               f'This can occur when the model is absolutely certain of a validation prediction (1.0 pred_proba).')
-            else:
-                logger.log(15, f'Temperature term found is: {temp_scalar}')
-                model.temperature_scalar = temp_scalar
-                model.save()
 
     # TODO: Consider adding infer_limit to fit_extra
     def fit_extra(self, hyperparameters, time_limit=None, base_model_names=None, **kwargs):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Moved calibration method from predictor to trainer
- Removed temperature_scalar attribute from AbstractModel, moved to params_aux so it can propagate correctly to refit_full models.
- No functional change except that now refit model will inherit the temperature scaling term from the parent (this is good, previously it was not inherited which caused inconsistency between settings which applied calibration prior to refitting and after refitting). No impact to presets, only if user manually called refit_full.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
