### PR TITLE
Enable Default Hyperparamenter with Ray Tune

### DIFF
--- a/core/src/autogluon/core/hpo/ray_hpo.py
+++ b/core/src/autogluon/core/hpo/ray_hpo.py
@@ -231,7 +231,7 @@ def run(
     )
 
     if not ray.is_initialized():
-        ray.init(log_to_driver=True, **total_resources)
+        ray.init(log_to_driver=False, **total_resources)
 
     resources_per_trial = hyperparameter_tune_kwargs.get('resources_per_trial', None)
     resources_per_trial = ray_tune_adapter.get_resources_per_trial(
@@ -360,7 +360,7 @@ def _get_searcher(
             if searcher not in supported_searchers:
                 logger.warning(f'{searcher} is not supported yet. Using it might behave unexpected. Supported options are {supported_searchers}')
         if default_hyperparameters is None:
-            default_hyperparameters = dict()
+            default_hyperparameters = [dict()]
         searcher = SearcherFactory.get_searcher(
             searcher_name=searcher,
             user_init_args=user_init_args,

--- a/core/src/autogluon/core/hpo/ray_tune_searcher_factory.py
+++ b/core/src/autogluon/core/hpo/ray_tune_searcher_factory.py
@@ -11,8 +11,8 @@ class SearcherFactory:
     # These needs to be provided explicitly as searcher init args
     # These should be experiment specified required args
     searcher_required_args = {
-        'random': [],
-        'bayes': ['metric', 'mode'],
+        'random': ['points_to_evaluate'],
+        'bayes': ['metric', 'mode', 'points_to_evaluate'],
     }
     
     # These are the default values if user not specified


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/autogluon/issues/2068

*Description of changes:*
* Added the ability to use default hyperparameter when doing HPO with ray tune.

Example log with `NN_TORCH` and `FASTAI`, which use ray tune as backend. You can see default hyperparameters are correctly used by the single trial. Not shown by the log but same applies to multiple trials, where the first trial would use the default hyperparameters.
```python
Fitting 2 L1 models ...
Hyperparameter tuning model: NeuralNetFastAI ... Tuning model for up to 44.96s of the 99.9s of remaining time.
(model_trial pid=14381) {'layers': None, 'emb_drop': 0.1, 'ps': 0.1, 'bs': 256, 'lr': 0.01, 'epochs': 30, 'early.stopping.min_delta': 0.0001, 'early.stopping.patience': 20, 'smoothing': 0.0}
Fitted model: NeuralNetFastAI/2a4db_00000 ...
        0.898    = Validation score   (roc_auc)
        1.79s    = Training   runtime
        0.02s    = Validation runtime
Hyperparameter tuning model: NeuralNetTorch ... Tuning model for up to 44.96s of the 91.47s of remaining time.
(model_trial pid=14734) {'num_epochs': 500, 'epochs_wo_improve': 20, 'activation': 'relu', 'embedding_size_factor': 1.0, 'embed_exponent': 0.56, 'max_embedding_dim': 100, 'y_range': None, 'y_range_extend': 0.05, 'dropout_prob': 0.1, 'optimizer': 'adam', 'learning_rate': 0.0003, 'weight_decay': 1e-06, 'proc.embed_min_categories': 4, 'proc.impute_strategy': 'median', 'proc.max_category_levels': 100, 'proc.skew_threshold': 0.99, 'use_ngram_features': False, 'num_layers': 2, 'hidden_size': 128, 'max_batch_size': 512, 'use_batchnorm': False, 'loss_function': 'auto'}
Fitted model: NeuralNetTorch/2f278_00000 ...
        0.8924   = Validation score   (roc_auc)
        2.21s    = Training   runtime
        0.02s    = Validation runtime
Fitting model: WeightedEnsemble_L2 ... Training model for up to 99.9s of the 87.22s of remaining time.
        0.9183   = Validation score   (roc_auc)
        0.18s    = Training   runtime
        0.0s     = Validation runtime
AutoGluon training complete, total runtime = 12.97s ... Best model: "WeightedEnsemble_L2"
TabularPredictor saved. To load, use: predictor = TabularPredictor.load("AutogluonModels/ag-20220914_182927/")
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
