### PR TITLE
Improve averaging checkpoints and creating model

### DIFF
--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -86,7 +86,7 @@ from .utils import (
     compute_num_gpus,
     compute_score,
     create_fusion_data_processors,
-    create_model,
+    create_fusion_model,
     data_to_df,
     extract_from_output,
     filter_search_space,
@@ -614,7 +614,7 @@ class MultiModalPredictor:
             # reload the predictor metadata
             predictor = MultiModalPredictor._load_metadata(predictor=self, path=best_trial_path)
             # construct the model
-            model = create_model(
+            model = create_fusion_model(
                 config=predictor._config,
                 num_classes=predictor._output_shape,
                 num_numerical_columns=len(predictor._df_preprocessor.numerical_feature_names),
@@ -861,7 +861,7 @@ class MultiModalPredictor:
         config = select_model(config=config, df_preprocessor=df_preprocessor)
 
         if self._model is None:
-            model = create_model(
+            model = create_fusion_model(
                 config=config,
                 num_classes=self._output_shape,
                 num_numerical_columns=len(df_preprocessor.numerical_feature_names),
@@ -1960,7 +1960,7 @@ class MultiModalPredictor:
         predictor = cls(label="dummy_label")
         predictor = cls._load_metadata(predictor=predictor, path=path, resume=resume, verbosity=verbosity)
 
-        model = create_model(
+        model = create_fusion_model(
             config=predictor._config,
             num_classes=predictor._output_shape,
             num_numerical_columns=len(predictor._df_preprocessor.numerical_feature_names),

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -944,17 +944,16 @@ def create_fusion_model(
             pretrained=pretrained,
         )
 
-        if OmegaConf.select(config, "optimization.efficient_finetune"):
-            model = apply_model_adaptation(model, config)
-
-        if isinstance(model, functools.partial):
+        if isinstance(model, functools.partial):  # fusion model
             if fusion_model is None:
                 fusion_model = model
             else:
                 raise ValueError(
                     f"More than one fusion models are detected in {names}. Only one fusion model is allowed."
                 )
-        else:
+        else:  # single model
+            if OmegaConf.select(config, "optimization.efficient_finetune"):
+                model = apply_model_adaptation(model, config)
             single_models.append(model)
 
     if len(single_models) > 1:

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -1807,7 +1807,7 @@ def init_pretrained(
     assert (
         len(config.model.names) == 1
     ), f"Zero shot mode only supports using one model, but detects multiple models {config.model.names}"
-    model = create_model(config=config, pretrained=True)
+    model = create_fusion_model(config=config, pretrained=True)
 
     data_processors = create_fusion_data_processors(
         config=config,

--- a/multimodal/tests/unittests/test_predictor_advanced.py
+++ b/multimodal/tests/unittests/test_predictor_advanced.py
@@ -43,6 +43,8 @@ def test_predictor_gradient_checkpointing(backbone, efficient_finetuning, poolin
     train_data = dataset.train_df.sample(200)
     test_data = dataset.test_df.sample(50)
     save_path = f"gradient_checkpointing_{backbone}_{efficient_finetuning}_{pooling_mode}_{precision}"
+    if os.path.isdir(save_path):
+        shutil.rmtree(save_path)
     predictor = MultiModalPredictor(label=dataset.label_columns[0], path=save_path)
     predictor.fit(
         train_data,
@@ -64,9 +66,10 @@ def test_predictor_gradient_checkpointing(backbone, efficient_finetuning, poolin
     predictions = predictor.predict(test_data, as_pandas=False)
     tunable_ratio = trainable_parameters(predictor._model) / total_parameters(predictor._model)
     npt.assert_allclose(tunable_ratio, expected_ratio, 2e-05, 2e-05)
-    predictor.save(save_path + "_new")
-    new_predictor = MultiModalPredictor.load(save_path + "_new")
+    save_path = save_path + "_new"
+    if os.path.isdir(save_path):
+        shutil.rmtree(save_path)
+    predictor.save(save_path)
+    new_predictor = MultiModalPredictor.load(save_path)
     new_predictions = new_predictor.predict(test_data, as_pandas=False)
     npt.assert_allclose(new_predictions, predictions)
-    shutil.rmtree(save_path)
-    shutil.rmtree(save_path + "_new")


### PR DESCRIPTION
1. Decouple weight sharing in checkpoint averaging. Convert weights to float64 to improve averaging robustness.
2. Refactor previous `create_model` into `create_model` and `create_fusion_model` to improve modularization. `create_model` is only in charge of creating a single model, which will be used in creating models in the siamese matcher.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
