### PR TITLE
Fix data shuffling for 1-gpu training

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -121,6 +121,7 @@ class BaseDataModule(LightningDataModule):
             self.train_dataset,
             batch_size=self.per_gpu_batch_size,
             num_workers=self.num_workers,
+            shuffle=True,
             pin_memory=False,
             collate_fn=self.get_collate_fn(),
         )

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1175,6 +1175,7 @@ class MultiModalPredictor:
                 check_val_every_n_epoch=config.optimization.check_val_every_n_epoch
                 if hasattr(config.optimization, "check_val_every_n_epoch")
                 else 1,
+                reload_dataloaders_every_n_epochs=1,
             )
 
         with warnings.catch_warnings():


### PR DESCRIPTION
Make sure data is shuffled automatically in the single-gpu training.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
