### PR TITLE
Speed up TimeSeriesEvaluator

### DIFF
--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -130,8 +130,7 @@ class TimeSeriesEvaluator:
         return mse_per_item(y_true=y_true, y_pred=y_pred).mean()
 
     def _rmse(self, y_true: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, **kwargs) -> float:
-        y_pred = predictions["mean"]
-        return mse_per_item(y_true=y_true, y_pred=y_pred).pow(0.5).mean()
+        return np.sqrt(self._mse(y_true=y_true, predictions=predictions))
 
     def _mase(
         self, y_true: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, y_history: TimeSeriesDataFrame

--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -125,30 +125,30 @@ class TimeSeriesEvaluator:
         data_filled = data.replace([np.inf, -np.inf], np.nan, inplace=True)
         return data_filled.mean()
 
-    def _mse(self, y_true: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, **kwargs) -> float:
+    def _mse(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         y_pred = predictions["mean"]
         return mse_per_item(y_true=y_true, y_pred=y_pred).mean()
 
-    def _rmse(self, y_true: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, **kwargs) -> float:
+    def _rmse(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         return np.sqrt(self._mse(y_true=y_true, predictions=predictions))
 
     def _mase(
-        self, y_true: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, y_history: TimeSeriesDataFrame
+        self, y_true: pd.Series, predictions: TimeSeriesDataFrame, y_history: pd.Series
     ) -> float:
         y_pred = self._get_median_forecast(predictions)
         mae = mae_per_item(y_true=y_true, y_pred=y_pred)
         naive_1_error = in_sample_naive_1_error(y_history=y_history)
         return (mae / naive_1_error).mean()
 
-    def _mape(self, y_true: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, **kwargs) -> float:
+    def _mape(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         y_pred = self._get_median_forecast(predictions)
         return mape_per_item(y_true=y_true, y_pred=y_pred).mean()
 
-    def _smape(self, y_true: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, **kwargs) -> float:
+    def _smape(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         y_pred = self._get_median_forecast(predictions)
         return symmetric_mape_per_item(y_true=y_true, y_pred=y_pred).mean()
 
-    def _mean_wquantileloss(self, y_true: TimeSeriesDataFrame, predictions: TimeSeriesDataFrame, **kwargs) -> float:
+    def _mean_wquantileloss(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         loss_values = []
         abs_target_sum = y_true.abs().sum()
         for col in predictions.columns:

--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -121,10 +121,6 @@ class TimeSeriesEvaluator:
     def higher_is_better(self) -> bool:
         return self.coefficient > 0
 
-    def _safemean(self, data: pd.Series):
-        data_filled = data.replace([np.inf, -np.inf], np.nan, inplace=True)
-        return data_filled.mean()
-
     def _mse(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         y_pred = predictions["mean"]
         return mse_per_item(y_true=y_true, y_pred=y_pred).mean()
@@ -132,9 +128,7 @@ class TimeSeriesEvaluator:
     def _rmse(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         return np.sqrt(self._mse(y_true=y_true, predictions=predictions))
 
-    def _mase(
-        self, y_true: pd.Series, predictions: TimeSeriesDataFrame, y_history: pd.Series
-    ) -> float:
+    def _mase(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, y_history: pd.Series) -> float:
         y_pred = self._get_median_forecast(predictions)
         mae = mae_per_item(y_true=y_true, y_pred=y_pred)
         naive_1_error = in_sample_naive_1_error(y_history=y_history)


### PR DESCRIPTION
The current implementation of TimeSeriesEvaluator is rather slow because of a for loop over individual time series. This was especially damaging for the `WeightedEnsemble`, where we need to re-compute the metrics multiple times each iteration.

*Description of changes:*
- Vectorize all metric computations using `pandas.groupby`.

With this PR, fitting time for `WeightedEnsemble` in the quickstart tutorial went from 207s to 13.5s. There were also minor speedups of `prediction runtime` for all models, as this time includes metric computation. Expand details for full comparison (p3.8xlarge).
<details>

Old version
```
Training timeseries model ETS.
        -0.3132       = Validation score (-MAPE)
        7.82    s     = Training runtime
        1.13    s     = Validation (prediction) runtime
Training timeseries model SimpleFeedForward.
        -0.5856       = Validation score (-MAPE)
        11.04   s     = Training runtime
        1.38    s     = Validation (prediction) runtime
Training timeseries model DeepAR.
        -0.8268       = Validation score (-MAPE)
        14.79   s     = Training runtime
        2.20    s     = Validation (prediction) runtime
Training timeseries model ARIMA.
        -0.4912       = Validation score (-MAPE)
        0.93    s     = Training runtime
        1.38    s     = Validation (prediction) runtime
Training timeseries model Transformer.
        -1.5853       = Validation score (-MAPE)
        11.41   s     = Training runtime
        2.17    s     = Validation (prediction) runtime
Fitting simple weighted ensemble.
        -0.3132       = Validation score (-MAPE)
        207.88  s     = Training runtime
        1.13    s     = Validation (prediction) runtime
Training complete. Models trained: ['ETS', 'SimpleFeedForward', 'DeepAR', 'ARIMA', 'Transformer', 'WeightedEnsemble']
Total runtime: 268.60 s
```

This PR
```
Training timeseries model ETS.
        -0.3502       = Validation score (-MAPE)
        7.94    s     = Training runtime
        0.78    s     = Validation (prediction) runtime
Training timeseries model SimpleFeedForward.
[16:47:39] ../src/base.cc:79: cuDNN lib mismatch: linked-against version 8401 != compiled-against version 8101.  Set MXNET_CUDNN_LIB_CHECKING=0 to quiet this warning.
        -0.6161       = Validation score (-MAPE)
        10.73   s     = Training runtime
        0.89    s     = Validation (prediction) runtime
Training timeseries model DeepAR.
        -1.3063       = Validation score (-MAPE)
        14.34   s     = Training runtime
        1.63    s     = Validation (prediction) runtime
Training timeseries model ARIMA.
        -0.4912       = Validation score (-MAPE)
        0.99    s     = Training runtime
        1.01    s     = Validation (prediction) runtime
Training timeseries model Transformer.
        -1.3490       = Validation score (-MAPE)
        11.17   s     = Training runtime
        1.64    s     = Validation (prediction) runtime
Fitting simple weighted ensemble.
        -0.3075       = Validation score (-MAPE)
        13.50   s     = Training runtime
        3.42    s     = Validation (prediction) runtime
Training complete. Models trained: ['ETS', 'SimpleFeedForward', 'DeepAR', 'ARIMA', 'Transformer', 'WeightedEnsemble']
Total runtime: 70.54 s
```

</details>

Here is the output of a small [sanity check script](https://github.com/awslabs/autogluon/files/9609768/validate_evaluator.py.zip) that compares the old vs. new implementations 

<details>

```
eval_metric: MASE
 - new evaluator score: 0.9743255809274336
 - old evaluator score: 0.9743255809274336
eval_metric: MAPE
 - new evaluator score: 6.957109184139206
 - old evaluator score: 6.957109184139206
eval_metric: sMAPE
 - new evaluator score: 0.9225294838525226
 - old evaluator score: 0.9225294838525226
eval_metric: mean_wQuantileLoss
 - new evaluator score: 0.6128063135705983
 - old evaluator score: 0.6128063135705983
eval_metric: MSE
 - new evaluator score: 0.1056583058392912
 - old evaluator score: 0.10565830583929121
eval_metric: RMSE
 - new evaluator score: 0.32505123571414274
 - old evaluator score: 0.3250512357141428
```

</details>

------

*To discuss:*
New implementation of MAPE sometimes produces results that differ from the old code:
- Old code: 
  - For each time series, if the metric is equal to `NaN` for AT LEAST ONE timestep (e.g., 0/0), the result for this ENTIRE time series is completely removed.
- New code:
  - For each time series: Remove timesteps where the metric is equal to `NaN`, compute average over timesteps where the metric is not undefined.

The new version seems to be more reasonable, but I wonder if we should somehow communicate this change to the users / do additional testing.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.