### PR TITLE
Avoid division by zero errors in TimeSeriesEvaluator

### DIFF
--- a/timeseries/src/autogluon/timeseries/evaluator.py
+++ b/timeseries/src/autogluon/timeseries/evaluator.py
@@ -121,9 +121,12 @@ class TimeSeriesEvaluator:
     def higher_is_better(self) -> bool:
         return self.coefficient > 0
 
+    def _safemean(self, data: pd.Series) -> float:
+        return data.replace([np.inf, -np.inf], np.nan).dropna().mean()
+
     def _mse(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         y_pred = predictions["mean"]
-        return mse_per_item(y_true=y_true, y_pred=y_pred).mean()
+        return self._safemean(mse_per_item(y_true=y_true, y_pred=y_pred))
 
     def _rmse(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         return np.sqrt(self._mse(y_true=y_true, predictions=predictions))
@@ -132,15 +135,15 @@ class TimeSeriesEvaluator:
         y_pred = self._get_median_forecast(predictions)
         mae = mae_per_item(y_true=y_true, y_pred=y_pred)
         naive_1_error = in_sample_naive_1_error(y_history=y_history)
-        return (mae / naive_1_error).mean()
+        return self._safemean(mae / naive_1_error)
 
     def _mape(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         y_pred = self._get_median_forecast(predictions)
-        return mape_per_item(y_true=y_true, y_pred=y_pred).mean()
+        return self._safemean(mape_per_item(y_true=y_true, y_pred=y_pred))
 
     def _smape(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         y_pred = self._get_median_forecast(predictions)
-        return symmetric_mape_per_item(y_true=y_true, y_pred=y_pred).mean()
+        return self._safemean(symmetric_mape_per_item(y_true=y_true, y_pred=y_pred))
 
     def _mean_wquantileloss(self, y_true: pd.Series, predictions: TimeSeriesDataFrame, **kwargs) -> float:
         loss_values = []


### PR DESCRIPTION
*Description of changes:*
- Fixes a minor bug introduced in #2147, where the metrics can become `NaN` if the dataset contains constant time series.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
