### PR TITLE
[CI] Add Path Check for Docs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -26,15 +26,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Lint Check on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU
@@ -46,15 +46,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Common on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU
@@ -66,15 +66,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Core on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU
@@ -86,15 +86,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Features on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU
@@ -106,15 +106,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Tabular on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -126,15 +126,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Text on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -146,15 +146,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Multimodal on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -166,15 +166,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Vision on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -186,15 +186,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Timeseries on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -206,15 +206,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Check if doc changes only
+      - name: Check if changes beside docs
         uses: dorny/paths-filter@v2
         id: changes
         with:
           filters: |
-            docs:
-              - 'docs/**'
+            other_than_docs:
+              - '!(docs/**)**'
       - name: Test Install on AWS Batch
-        if: steps.changes.outputs.docs == 'false'
+        if: steps.changes.outputs.other_than_docs == 'true'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -26,7 +26,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Lint Check on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU
@@ -38,7 +46,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Common on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU
@@ -50,7 +66,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Core on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU
@@ -62,7 +86,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Features on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU
@@ -74,7 +106,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Tabular on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -86,7 +126,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Text on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -98,7 +146,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Multimodal on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -110,7 +166,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Vision on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -122,7 +186,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Timeseries on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-GPU
@@ -134,7 +206,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: Check if doc changes only
+        uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
       - name: Test Install on AWS Batch
+        if: steps.changes.outputs.docs == 'false'
         uses: ./.github/actions/submit-job
         with:
           job-type: CI-CPU


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Added the ability to detect if changes are only made to files under `docs/`. If so, we'll skip unit test and build website directly. This should make doc site only changes to iterate much quicker.
* Changes won't take effect until merging in and cannot be tested within this PR because this PR involves changes outside `docs/`. Tried it on my fork with minimized examples, where **lint check** should not build on aws if there are only doc changes and **temp** should always be executed(like build docs): 
1. changes outside doc: https://github.com/yinweisu/autogluon/actions/runs/3101782203. Lint check build on aws and temp triggered
2. changes under doc only: https://github.com/yinweisu/autogluon/actions/runs/3101784234. Lint check skipped build on aws but temp executed.
3. changes under both: https://github.com/yinweisu/autogluon/actions/runs/3101786829. Lint check build on aws and temp triggered

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
