### PR TITLE
Modularize realtime inference

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/utils.py
+++ b/multimodal/src/autogluon/multimodal/data/utils.py
@@ -1,6 +1,7 @@
 import random
-from typing import List, Tuple, Union
+from typing import Iterable, List, Tuple, Union
 
+import pandas as pd
 from nlpaug import Augmenter
 from nlpaug.util import Method
 
@@ -148,3 +149,66 @@ def get_collate_fn(
                 for per_model_processor in per_data_processors_group[per_modality]:
                     collate_fn.update(per_model_processor.collate_fn(per_modality_column_names))
     return Dict(collate_fn)
+
+
+def apply_df_preprocessor(data: pd.DataFrame, df_preprocessor: MultiModalFeaturePreprocessor, modalities: Iterable):
+    """
+    Preprocess one dataframe with one df_preprocessor.
+
+    Parameters
+    ----------
+    data
+        A pandas dataframe.
+    df_preprocessor
+        One dataframe preprocessor object.
+    modalities
+        A list of data modalities to preprocess.
+
+    Returns
+    -------
+    modality_features
+        Preprocessed features of given modalities.
+    sample_num
+        Number of samples.
+    """
+    lengths = []
+    modality_features = {}
+    for per_modality in modalities:
+        per_modality_features = getattr(df_preprocessor, f"transform_{per_modality}")(data)
+        modality_features[per_modality] = per_modality_features
+        if per_modality_features:
+            lengths.append(len(per_modality_features[next(iter(per_modality_features))]))
+    assert len(set(lengths)) == 1  # make sure each modality has the same sample num
+    sample_num = lengths[0]
+
+    return modality_features, sample_num
+
+
+def apply_data_processor(modality_features: dict, data_processors: dict, idx: int, is_training: bool):
+    """
+    Process one sample's features.
+
+    Parameters
+    ----------
+    modality_features
+        Features of different modalities got from `apply_df_preprocessor`.
+    data_processors
+        A dict of data processors.
+    idx
+        The sample index.
+    is_training
+        Whether is training.
+
+    Returns
+    -------
+    The processed features of one sample.
+    """
+    sample_features = {}
+    for per_modality, per_modality_processors in data_processors.items():
+        for per_model_processor in per_modality_processors:
+            if modality_features[per_modality]:
+                sample_features.update(
+                    per_model_processor(modality_features[per_modality], idx=idx, is_training=is_training)
+                )
+
+    return sample_features

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1540,6 +1540,7 @@ class MultiModalPredictor:
             batch=batch,
             model=self._model,
             precision=self._config.env.precision,
+            num_gpus=self._config.env.num_gpus,
             loss_func=self._loss_func,
         )
         return [output]

--- a/multimodal/src/autogluon/multimodal/utils.py
+++ b/multimodal/src/autogluon/multimodal/utils.py
@@ -29,6 +29,7 @@ from scipy.special import softmax
 from sklearn.metrics import f1_score
 from sklearn.preprocessing import LabelEncoder
 from torch import nn
+from torch.nn.modules.loss import _Loss
 
 from autogluon.core.metrics import get_metric
 from autogluon.core.utils.loaders import load_pd
@@ -2781,3 +2782,40 @@ def move_to_device(obj: Union[torch.Tensor, nn.Module, Dict, List], device: torc
             f"Make sure the object is one of these: a Pytorch tensor, a Pytorch module, "
             f"a dict or list of tensors or modules."
         )
+
+
+def infer_batch(batch: Dict, model: nn.Module, precision: Union[str, int], loss_func: _Loss):
+    """
+    Perform inference for a batch.
+
+    Parameters
+    ----------
+    batch
+        The batch data.
+    model
+        A Pytorch model.
+    precision
+        The desired precision used in inference.
+    loss_func
+        The loss function used in training the model.
+
+    Returns
+    -------
+    Model output.
+    """
+    precision = infer_precision(num_gpus=1, precision=precision, as_torch=True)
+    device_type = "cuda" if torch.cuda.is_available() else "cpu"
+    device = torch.device(device_type)
+    batch_size = len(batch[next(iter(batch))])
+    if 1 < torch.cuda.device_count() <= batch_size:
+        model = nn.DataParallel(model)
+    model.to(device).eval()
+    batch = move_to_device(batch, device=device)
+    with torch.autocast(device_type=device_type, dtype=precision):
+        with torch.no_grad():
+            output = model(batch)[model.prefix]
+
+    if isinstance(loss_func, nn.BCEWithLogitsLoss):
+        output[LOGITS] = torch.sigmoid(output[LOGITS].float())
+
+    return output


### PR DESCRIPTION
This PR is to modularize some logic shared by the realtime inference and dataloader. This modularization can also benefit the ONNIX export by @FANGAreNotGnu.

1. Add util `apply_df_preprocessor` shared by the realtime inference and dataloader.
2. Add util `apply_data_processor` shared by the realtime inference and dataloader.
3. Add util `infer_batch` for realtime inference.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
