### PR TITLE
Add the model post-processing function

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -547,7 +547,7 @@ def get_hf_config_and_model(checkpoint_name: str, pretrained: Optional[bool] = T
     return config, model
 
 
-def custom_sigmoid(output: Dict):
+def apply_sigmoid(output: Dict):
     """
     Apply the sigmoid to logits.
 
@@ -583,6 +583,6 @@ def get_model_postprocess_fn(problem_type: str, loss_func: _Loss):
     postprocess_func = None
     if problem_type == REGRESSION:
         if isinstance(loss_func, nn.BCEWithLogitsLoss):
-            postprocess_func = custom_sigmoid
+            postprocess_func = apply_sigmoid
 
     return postprocess_func

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -72,6 +72,7 @@ from .data.infer_types import (
     infer_problem_type_output_shape,
 )
 from .data.utils import apply_data_processor, apply_df_preprocessor, get_collate_fn
+from .models.utils import get_model_postprocess_fn
 from .optimization.lit_distiller import DistillerLitModule
 from .optimization.lit_matcher import MatcherLitModule
 from .optimization.lit_module import LitModule
@@ -228,6 +229,7 @@ class MultiModalPredictor:
         self._df_preprocessor = None
         self._column_types = None
         self._data_processors = None
+        self._model_postprocess_fn = None
         self._model = None
         self._resume = False
         self._continuous_training = False
@@ -917,11 +919,16 @@ class MultiModalPredictor:
             loss_func_name=OmegaConf.select(config, "optimization.loss_function"),
         )
 
+        model_postprocess_fn = get_model_postprocess_fn(
+            problem_type=self._problem_type,
+            loss_func=loss_func,
+        )
+
         self._config = config
         self._df_preprocessor = df_preprocessor
         self._data_processors = data_processors
         self._model = model
-        self._loss_func = loss_func
+        self._model_postprocess_fn = model_postprocess_fn
 
         if hasattr(config, MATCHER):
             warnings.warn("Matching is experimental. We may change its behaviors in future.", UserWarning)
@@ -1052,6 +1059,7 @@ class MultiModalPredictor:
                 mixup_fn=mixup_fn,
                 mixup_off_epoch=OmegaConf.select(config, "data.mixup.turn_off_epoch"),
                 trainable_param_names=OmegaConf.select(config, "optimization.trainable_param_names", default=None),
+                model_postprocess_fn=model_postprocess_fn,
                 **metrics_kwargs,
                 **optimization_kwargs,
             )
@@ -1372,7 +1380,7 @@ class MultiModalPredictor:
         else:
             task = LitModule(
                 model=self._model,
-                loss_func=self._loss_func if hasattr(self, "_loss_func") else None,
+                model_postprocess_fn=self._model_postprocess_fn,
             )
 
         blacklist_msgs = []
@@ -1541,7 +1549,7 @@ class MultiModalPredictor:
             model=self._model,
             precision=self._config.env.precision,
             num_gpus=self._config.env.num_gpus,
-            loss_func=self._loss_func,
+            model_postprocess_fn=self._model_postprocess_fn,
         )
         return [output]
 
@@ -2141,7 +2149,12 @@ class MultiModalPredictor:
             mixup_active=False,
             loss_func_name=OmegaConf.select(predictor._config, "optimization.loss_function"),
         )
-        predictor._loss_func = loss_func
+
+        model_postprocess_fn = get_model_postprocess_fn(
+            problem_type=predictor._problem_type,
+            loss_func=loss_func,
+        )
+        predictor._model_postprocess_fn = model_postprocess_fn
 
         return predictor
 


### PR DESCRIPTION
Add `model_postprocess_fn` to process the model output for inference. This is to handle the cases where the training loss function includes some operations that are also required to transform predictions in inference. For example, if we use the `nn.BCEWithLogitsLoss` on a regression task, we need to use sigmoid to transform the logits in inference.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
