### PR TITLE
Deprecate high, good and low quality presets for time series

### DIFF
--- a/docs/tutorials/timeseries/forecasting-indepth.md
+++ b/docs/tutorials/timeseries/forecasting-indepth.md
@@ -178,7 +178,7 @@ The following presets are available:
 
 <!-- **TODO: These will be significantly changed by 0.6.0** -->
 
-- `"local_models"`: train simple statistical models (`"ETS"`, `"ARIMA"`, `"Theta"`). These model are fast to train but can be slow at prediction time for unseen data.
+- `"fast_training"`: train simple statistical models (`"ETS"`, `"ARIMA"`, `"Theta"`). These model are fast to train but can be slow at prediction time for unseen data.
 - `"medium_quality"`: train several selected models (`"ETS"`, `"ARIMA"`, `"DeepAR"`, `"SimpleFeedForward"`, `"TemporalFusionTransformer"`) without hyperparameter optimization. A good baseline setting.
 - `"best_quality"`: Train all available models with hyperparameter optimization.
 

--- a/docs/tutorials/timeseries/forecasting-indepth.md
+++ b/docs/tutorials/timeseries/forecasting-indepth.md
@@ -60,6 +60,7 @@ Available local models include:
 
 - `ETS`
 - `ARIMA`
+- `Theta`
 
 If the dataset consists of multiple time series, we fit a separate local model to each time series — hence the name "local".
 This means, if we want to make a forecast for a new time series that wasn't part of the training set, all local models will be fit from scratch for the new time series.
@@ -177,7 +178,7 @@ The following presets are available:
 
 <!-- **TODO: These will be significantly changed by 0.6.0** -->
 
-- `"low_quality"`: quickly train a few toy models. This setting should only be used as a sanity check.
+- `"local_models"`: train simple statistical models (`"ETS"`, `"ARIMA"`, `"Theta"`). These model are fast to train but can be slow at prediction time for unseen data.
 - `"medium_quality"`: train several selected models (`"ETS"`, `"ARIMA"`, `"DeepAR"`, `"SimpleFeedForward"`, `"TemporalFusionTransformer"`) without hyperparameter optimization. A good baseline setting.
 - `"best_quality"`: Train all available models with hyperparameter optimization.
 

--- a/docs/tutorials/timeseries/forecasting-quickstart.md
+++ b/docs/tutorials/timeseries/forecasting-quickstart.md
@@ -154,15 +154,14 @@ predictor = TimeSeriesPredictor(
 
 predictor.fit(
     train_data=train_data,
-    presets="low_quality",
+    presets="local_models",
 )
 ```
-In a short amount of time AutoGluon fits five time series forecasting models on the training data.
-These models are three neural network forecasters: DeepAR, Transformer, a feedforward neural network; and two simple statistical models: ARIMA and ETS.
-AutoGluon also constructs a weighted ensemble on top of these models capable of quantile forecasting.
+Here we used the `"local_models"` presets to quickly obtain the results.
+In a short amount of time AutoGluon fits three statistical models (ARIMA, ETS, Theta), and a weighted ensemble on top of these models.
 
-Here we used the `"low_quality"` presets to quickly obtain the results.
 In realistic scenarios, we can set `presets` to be one of `"medium_quality"` or `"best_quality"`.
+These presets additionally include powerful deep learning models (such as DeepAR, Temporal Fusion Transformer).
 Higher quality presets will usually produce more accurate forecasts but take longer to train and may produce less efficient models.
 
 Note that inside `fit()` the last `prediction_length` steps of each time series in `train_data` were automatically used as a tuning (validation) set.
@@ -248,7 +247,7 @@ predictor = TimeSeriesPredictor(
 )
 predictor.fit(
     train_data=ts_dataframe,
-    presets="low_quality",  # other options: "medium_quality", "best_quality"
+    presets="local_models",  # other options: "medium_quality", "best_quality"
 )
 
 # Generate the forecasts

--- a/docs/tutorials/timeseries/forecasting-quickstart.md
+++ b/docs/tutorials/timeseries/forecasting-quickstart.md
@@ -154,13 +154,15 @@ predictor = TimeSeriesPredictor(
 
 predictor.fit(
     train_data=train_data,
-    presets="local_models",
+    presets="fast_training",
 )
 ```
-Here we used the `"local_models"` presets to quickly obtain the results.
-In a short amount of time AutoGluon fits three statistical models (ARIMA, ETS, Theta), and a weighted ensemble on top of these models.
+Here we used the `"fast_training"` presets to quickly obtain the results.
+Under this setting, AutoGluon fits several local statistical models for forecasting (ARIMA, ETS, Theta).
+Moreover, AutoGluon fits a weighted ensemble on top of these models that is capable of predicting the quantiles.
 
-In realistic scenarios, we can set `presets` to be one of `"medium_quality"` or `"best_quality"`.
+The local models used under the `"fast_training"` presets are quick to train, but may be slow when making predictions for new unseen data.
+In practical scenarios, we can set `presets` to be one of `"medium_quality"` or `"best_quality"`.
 These presets additionally include powerful deep learning models (such as DeepAR, Temporal Fusion Transformer).
 Higher quality presets will usually produce more accurate forecasts but take longer to train and may produce less efficient models.
 
@@ -247,7 +249,7 @@ predictor = TimeSeriesPredictor(
 )
 predictor.fit(
     train_data=ts_dataframe,
-    presets="local_models",  # other options: "medium_quality", "best_quality"
+    presets="fast_training",  # other options: "medium_quality", "best_quality"
 )
 
 # Generate the forecasts

--- a/timeseries/src/autogluon/timeseries/configs/presets_configs.py
+++ b/timeseries/src/autogluon/timeseries/configs/presets_configs.py
@@ -13,9 +13,9 @@ TIMESERIES_PRESETS_CONFIGS = dict(
         },
     },
     medium_quality={"hyperparameters": "default"},
-    local_models={"hyperparameters": "local_models"},
+    fast_training={"hyperparameters": "local_only"},
     # TODO: Remove deprecated presets below
     high_quality={"hyperparameters": "default"},
     good_quality={"hyperparameters": "default"},
-    low_quality={"hyperparameters": "local_models"},
+    low_quality={"hyperparameters": "local_only"},
 )

--- a/timeseries/src/autogluon/timeseries/configs/presets_configs.py
+++ b/timeseries/src/autogluon/timeseries/configs/presets_configs.py
@@ -12,8 +12,10 @@ TIMESERIES_PRESETS_CONFIGS = dict(
             "num_trials": 20,
         },
     },
+    medium_quality={"hyperparameters": "default"},
+    local_models={"hyperparameters": "local_models"},
+    # TODO: Remove deprecated presets below
     high_quality={"hyperparameters": "default"},
     good_quality={"hyperparameters": "default"},
-    medium_quality={"hyperparameters": "default"},
-    low_quality={"hyperparameters": "toy"},
+    low_quality={"hyperparameters": "local_models"},
 )

--- a/timeseries/src/autogluon/timeseries/configs/presets_configs.py
+++ b/timeseries/src/autogluon/timeseries/configs/presets_configs.py
@@ -12,22 +12,8 @@ TIMESERIES_PRESETS_CONFIGS = dict(
             "num_trials": 20,
         },
     },
-    high_quality={
-        "hyperparameters": "default_hpo",
-        "hyperparameter_tune_kwargs": {
-            "scheduler": "local",
-            "searcher": "random",
-            "num_trials": 10,
-        },
-    },
-    good_quality={
-        "hyperparameters": "default_hpo",
-        "hyperparameter_tune_kwargs": {
-            "scheduler": "local",
-            "searcher": "random",
-            "num_trials": 2,
-        },
-    },
+    high_quality={"hyperparameters": "default"},
+    good_quality={"hyperparameters": "default"},
     medium_quality={"hyperparameters": "default"},
     low_quality={"hyperparameters": "toy"},
 )

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -82,13 +82,17 @@ def get_default_hps(key, prediction_length):
             },
         },
         "default_hpo": {
+            "ARIMA": {
+                "order": ag.Categorical((2, 0, 1), (2, 1, 0), (2, 1, 1), (1, 1, 1)),
+                "seasonal_order": ag.Categorical((0, 0, 0), (1, 0, 0)),
+            },
             "ETS": {
                 "trend": ag.Categorical("add", None),
                 "seasonal": ag.Categorical("add", None),
             },
-            "ARIMA": {
-                "order": ag.Categorical((2, 0, 1), (2, 1, 0), (2, 1, 1), (1, 1, 1)),
-                "seasonal_order": ag.Categorical((0, 0, 0), (1, 0, 0)),
+            "Theta": {
+                "deseasonalize": ag.Categorical(True, False),
+                "method": ag.Categorical("auto", "additive"),
             },
             "DeepAR": {
                 "cell_type": ag.Categorical("gru", "lstm"),
@@ -110,10 +114,6 @@ def get_default_hps(key, prediction_length):
                 "hidden_dim": ag.Categorical(32, 64),
                 "batch_size": 64,
                 "context_length": context_length,
-            },
-            "Theta": {
-                "deseasonalize": ag.Categorical(True, False),
-                "method": ag.Categorical("auto", "additive"),
             },
         },
     }

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -62,7 +62,7 @@ MINIMUM_CONTEXT_LENGTH = 10
 def get_default_hps(key, prediction_length):
     context_length = max(prediction_length * 2, MINIMUM_CONTEXT_LENGTH)
     default_model_hps = {
-        "local_models": {
+        "local_only": {
             "ARIMA": {},
             "ETS": {},
             "Theta": {},

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -163,8 +163,9 @@ def get_preset_models(
         hyperparameters = copy.deepcopy(get_default_hps(hyperparameters, prediction_length))
     elif isinstance(hyperparameters, dict):
         default_hps = copy.deepcopy(get_default_hps("default", prediction_length))
-        updated_hyperparameters = {model: default_hps.get(model, {}) for model in hyperparameters}
+        updated_hyperparameters = {}
         for model, hps in hyperparameters.items():
+            updated_hyperparameters[model] = default_hps.get(model, {})
             updated_hyperparameters[model].update(hps)
         hyperparameters = copy.deepcopy(updated_hyperparameters)
     else:

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -64,68 +64,73 @@ def get_default_hps(key, prediction_length):
     context_length = max(prediction_length * 2, MINIMUM_CONTEXT_LENGTH)
     default_model_hps = {
         "toy": {
+            "ETS": {
+                "maxiter": 20,
+                "seasonal": None,
+            },
+            "ARIMA": {
+                "maxiter": 10,
+                "order": (1, 0, 0),
+            },
+            "DeepAR": {
+                "epochs": 10,
+                "num_batches_per_epoch": 10,
+                "context_length": 5,
+            },
             "SimpleFeedForward": {
                 "epochs": 10,
                 "num_batches_per_epoch": 10,
                 "context_length": 5,
             },
-            "Transformer": {"epochs": 10, "num_batches_per_epoch": 10, "context_length": 5},
-            "DeepAR": {"epochs": 10, "num_batches_per_epoch": 10, "context_length": 5},
-            "ETS": {"maxiter": 20, "seasonal": None},
-            "ARIMA": {
-                "maxiter": 10,
-                "order": (1, 0, 0),
-                "seasonal_order": (0, 0, 0),
+            "Transformer": {
+                "epochs": 10,
+                "num_batches_per_epoch": 10,
+                "context_length": 5,
             },
             "Theta": {},
         },
         "default": {
-            "ETS": {
-                "maxiter": 200,
-                "trend": "add",
-                "seasonal": "add",
-            },
-            "ARIMA": {
-                "maxiter": 50,
-                "order": (1, 1, 1),
-                "seasonal_order": (0, 0, 0),
-            },
-            "Theta": {},
+            "ETS": {},
+            "ARIMA": {},
             "SimpleFeedForward": {
                 "context_length": context_length,
             },
-            "Transformer": {
+            "DeepAR": {
                 "context_length": context_length,
             },
-            "DeepAR": {
+            "TemporalFusionTransformer": {
                 "context_length": context_length,
             },
         },
         "default_hpo": {
-            "DeepAR": {
-                "cell_type": ag.Categorical("gru", "lstm"),
-                "num_layers": ag.Int(1, 4),
-                "num_cells": ag.Categorical(20, 30, 40, 50),
-                "context_length": context_length,
-            },
-            "SimpleFeedForward": {
-                "batch_normalization": ag.Categorical(True, False),
-                "context_length": context_length,
-            },
-            "Transformer": {
-                "model_dim": ag.Categorical(8, 16, 32),
-                "context_length": context_length,
-            },
             "ETS": {
-                "maxiter": 200,
-                "error": ag.Categorical("add", "mul"),
-                "trend": ag.Categorical("add", "mul", None),
+                "trend": ag.Categorical("add", None),
                 "seasonal": ag.Categorical("add", None),
             },
             "ARIMA": {
-                "maxiter": 50,
-                "order": ag.Categorical((2, 0, 1), (2, 1, 1), (1, 1, 1)),
-                "seasonal_order": ag.Categorical((0, 0, 0), (1, 0, 1)),
+                "order": ag.Categorical((2, 0, 1), (2, 1, 0), (2, 1, 1), (1, 1, 1)),
+                "seasonal_order": ag.Categorical((0, 0, 0), (1, 0, 0)),
+            },
+            "DeepAR": {
+                "cell_type": ag.Categorical("gru", "lstm"),
+                "num_layers": ag.Int(1, 3),
+                "num_cells": ag.Categorical(40, 80),
+                "context_length": context_length,
+            },
+            "SimpleFeedForward": {
+                "num_hidden_dimensions": ag.Categorical([40], [40, 40], [120]),
+                "batch_size": 64,
+                "context_length": context_length,
+            },
+            "Transformer": {
+                "model_dim": ag.Categorical(32, 64),
+                "batch_size": 64,
+                "context_length": context_length,
+            },
+            "TemporalFusionTransformer": {
+                "hidden_dim": ag.Categorical(32, 64),
+                "batch_size": 64,
+                "context_length": context_length,
             },
             "Theta": {
                 "deseasonalize": ag.Categorical(True, False),

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -163,9 +163,10 @@ def get_preset_models(
         hyperparameters = copy.deepcopy(get_default_hps(hyperparameters, prediction_length))
     elif isinstance(hyperparameters, dict):
         default_hps = copy.deepcopy(get_default_hps("default", prediction_length))
+        updated_hyperparameters = {model: default_hps.get(model, {}) for model in hyperparameters}
         for model, hps in hyperparameters.items():
-            default_hps[model].update(hps)
-        hyperparameters = copy.deepcopy(default_hps)
+            updated_hyperparameters[model].update(hps)
+        hyperparameters = copy.deepcopy(updated_hyperparameters)
     else:
         raise ValueError(
             f"hyperparameters must be a dict, a string or None (received {type(hyperparameters)}). "

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/models.py
@@ -174,6 +174,8 @@ class ARIMAModel(AbstractStatsmodelsModel):
         sm_model_init_args["freq"] = data.freq
         sm_model_init_args["trend"] = "c"
         sm_model_init_args.setdefault("enforce_stationarity", True)
+        sm_model_init_args.setdefault("order", (1, 1, 1))
+        sm_model_init_args.setdefault("maxiter", 50)
 
         # Infer seasonal_period if seasonal_period is not given / is set to None
         seasonal_period = sm_model_init_args.pop("seasonal_period", None)

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -22,7 +22,11 @@ from .trainer import AbstractTimeSeriesTrainer
 
 logger = logging.getLogger(__name__)
 
-DEPRECATED_PRESETS = ["high_quality", "good_quality"]
+DEPRECATED_PRESETS_TO_FALLBACK = {
+    "low_quality": "local_models",
+    "high_quality": "medium_quality",
+    "good_quality": "medium_quality",
+}
 
 
 class TimeSeriesPredictor:
@@ -225,12 +229,12 @@ class TimeSeriesPredictor:
             and various other properties of the returned predictor. It is recommended to specify presets and avoid
             specifying most other :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` arguments or model
             hyperparameters prior to becoming familiar with AutoGluon. For example, set ``presets="best_quality"``
-            to get a high-accuracy predictor, or set ``presets="low_quality"`` to get a toy predictor that
-            trains quickly but lacks accuracy.
+            to get a high-accuracy predictor, or set ``presets="local_models"`` to quickly fit multiple simple
+            statistical models.
             Any user-specified arguments in :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` will
             override the values used by presets.
 
-            Available presets are "best_quality", "medium_quality", and "low_quality".
+            Available presets are "best_quality", "medium_quality", and "local_models".
             Details for these presets can be found in ``autogluon/timeseries/configs/presets_configs.py``. If not
             provided, user-provided values for other arguments (specifically, ``hyperparameters`` and
             ``hyperparameter_tune_kwargs`` will be used (defaulting to their default values specified below).
@@ -292,13 +296,14 @@ class TimeSeriesPredictor:
         logger.info("================ TimeSeriesPredictor ================")
         logger.info("TimeSeriesPredictor.fit() called")
         if presets is not None:
-            if presets in DEPRECATED_PRESETS:
+            if presets in DEPRECATED_PRESETS_TO_FALLBACK:
+                new_presets = DEPRECATED_PRESETS_TO_FALLBACK[presets]
                 warnings.warn(
                     f"Presets {presets} are deprecated as of version 0.6.0. Please see the documentation for "
-                    "TimeSeriesPredictor.fit for the list of available presets. "
-                    "Falling back to presets='medium_quality'."
+                    f"TimeSeriesPredictor.fit for the list of available presets. "
+                    f"Falling back to presets='{new_presets}'."
                 )
-                presets = "medium_quality"
+                presets = new_presets
             logger.info(f"Setting presets to: {presets}")
         logger.info("Fitting with arguments:")
         logger.info(f"{pprint.pformat(fit_args)}")

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -23,7 +23,7 @@ from .trainer import AbstractTimeSeriesTrainer
 logger = logging.getLogger(__name__)
 
 DEPRECATED_PRESETS_TO_FALLBACK = {
-    "low_quality": "local_models",
+    "low_quality": "fast_training",
     "high_quality": "medium_quality",
     "good_quality": "medium_quality",
 }
@@ -229,12 +229,12 @@ class TimeSeriesPredictor:
             and various other properties of the returned predictor. It is recommended to specify presets and avoid
             specifying most other :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` arguments or model
             hyperparameters prior to becoming familiar with AutoGluon. For example, set ``presets="best_quality"``
-            to get a high-accuracy predictor, or set ``presets="local_models"`` to quickly fit multiple simple
+            to get a high-accuracy predictor, or set ``presets="fast_training"`` to quickly fit multiple simple
             statistical models.
             Any user-specified arguments in :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` will
             override the values used by presets.
 
-            Available presets are "best_quality", "medium_quality", and "local_models".
+            Available presets are "best_quality", "medium_quality", and "fast_training".
             Details for these presets can be found in ``autogluon/timeseries/configs/presets_configs.py``. If not
             provided, user-provided values for other arguments (specifically, ``hyperparameters`` and
             ``hyperparameter_tune_kwargs`` will be used (defaulting to their default values specified below).

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -242,7 +242,7 @@ class TimeSeriesPredictor:
             Determines the hyperparameters used by each model.
 
             If str is passed, will use a preset hyperparameter configuration, can be one of "default", "default_hpo",
-            or "toy". The "toy" setting is only intended for prototyping.
+            or "local_only".
 
             If dict is provided, the keys are strings or Types that indicate which model types to train. In this case,
             the predictor will only train the given model types. Stable model options include: "DeepAR", "MQCNN", and

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1,6 +1,7 @@
 import logging
 import pprint
 import time
+import warnings
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
@@ -20,6 +21,8 @@ from .splitter import AbstractTimeSeriesSplitter, LastWindowSplitter, MultiWindo
 from .trainer import AbstractTimeSeriesTrainer
 
 logger = logging.getLogger(__name__)
+
+DEPRECATED_PRESETS = ["high_quality", "good_quality"]
 
 
 class TimeSeriesPredictor:
@@ -275,8 +278,6 @@ class TimeSeriesPredictor:
 
         verbosity = kwargs.get("verbosity", self.verbosity)
         set_logger_verbosity(verbosity, logger=logger)
-        if presets is not None:
-            logger.info(f"presets is set to {presets}")
 
         fit_args = dict(
             prediction_length=self.prediction_length,
@@ -291,6 +292,13 @@ class TimeSeriesPredictor:
         logger.info("================ TimeSeriesPredictor ================")
         logger.info("TimeSeriesPredictor.fit() called")
         if presets is not None:
+            if presets in DEPRECATED_PRESETS:
+                warnings.warn(
+                    f"Presets {presets} are deprecated as of version 0.6.0. Please see the documentation for "
+                    "TimeSeriesPredictor.fit for the list of available presets. "
+                    "Falling back to presets='medium_quality'."
+                )
+                presets = "medium_quality"
             logger.info(f"Setting presets to: {presets}")
         logger.info("Fitting with arguments:")
         logger.info(f"{pprint.pformat(fit_args)}")

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -230,7 +230,7 @@ class TimeSeriesPredictor:
             Any user-specified arguments in :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` will
             override the values used by presets.
 
-            Available presets are "best_quality", "high_quality", "good_quality", "medium_quality", and "low_quality".
+            Available presets are "best_quality", "medium_quality", and "low_quality".
             Details for these presets can be found in ``autogluon/timeseries/configs/presets_configs.py``. If not
             provided, user-provided values for other arguments (specifically, ``hyperparameters`` and
             ``hyperparameter_tune_kwargs`` will be used (defaulting to their default values specified below).
@@ -238,7 +238,7 @@ class TimeSeriesPredictor:
             Determines the hyperparameters used by each model.
 
             If str is passed, will use a preset hyperparameter configuration, can be one of "default", "default_hpo",
-            "toy", or "toy_hpo", where "toy" settings correspond to models only intended for prototyping.
+            or "toy". The "toy" setting is only intended for prototyping.
 
             If dict is provided, the keys are strings or Types that indicate which model types to train. In this case,
             the predictor will only train the given model types. Stable model options include: "DeepAR", "MQCNN", and

--- a/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/auto_trainer.py
@@ -46,8 +46,7 @@ class AutoTimeSeriesTrainer(AbstractTimeSeriesTrainer):
         hyperparameters: str or Dict
             A dictionary mapping selected model names, model classes or model factory to hyperparameter
             settings. Model names should be present in `trainer.presets.DEFAULT_MODEL_NAMES`. Optionally,
-            the user may provide one of "toy", "toy_hpo", "default", "default_hpo" to specify
-            presets.
+            the user may provide one of "local_only", "default", "default_hpo" to specify presets.
         val_data: TimeSeriesDataFrame
             Optional validation data set to report validation scores on.
         hyperparameter_tune_kwargs

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -194,7 +194,7 @@ def test_given_random_seed_when_learner_called_then_random_seed_set_correctly(te
     learner = TimeSeriesLearner(**init_kwargs)
     learner.fit(
         train_data=DUMMY_TS_DATAFRAME,
-        hyperparameters="toy",
+        hyperparameters="local_only",
         val_data=DUMMY_TS_DATAFRAME,
         time_limit=2,
     )

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -38,7 +38,7 @@ def test_when_predictor_called_then_training_is_performed(temp_model_path):
     assert "SimpleFeedForward" in predictor.get_model_names()
 
 
-@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])  # noqa
+@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["local_only"])  # noqa
 def test_given_hyperparameters_when_predictor_called_then_model_can_predict(temp_model_path, hyperparameters):
     predictor = TimeSeriesPredictor(path=temp_model_path, eval_metric="MAPE", prediction_length=3)
     predictor.fit(
@@ -56,7 +56,7 @@ def test_given_hyperparameters_when_predictor_called_then_model_can_predict(temp
     assert not np.any(np.isnan(predictions))
 
 
-@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["toy"])  # noqa
+@pytest.mark.parametrize("hyperparameters", TEST_HYPERPARAMETER_SETTINGS + ["local_only"])  # noqa
 def test_given_different_target_name_when_predictor_called_then_model_can_predict(temp_model_path, hyperparameters):
     df = TimeSeriesDataFrame(copy.copy(DUMMY_TS_DATAFRAME))
     df.rename(columns={"target": "mytarget"}, inplace=True)


### PR DESCRIPTION
*Description of changes:*
- Update `default` and `default_hpo` hyperparameter configurations
- Remove `high_quality` and `good_quality` presets for time series (these were rather meaningless, only changing the # of random search runs in HPO)
- Rename `low_quality` -> `fast_training` that now only contains local models

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
