### PR TITLE
[Cloud] Cloud Batch Inference Optimization

### DIFF
--- a/cloud/src/autogluon/cloud/job/sagemaker_job.py
+++ b/cloud/src/autogluon/cloud/job/sagemaker_job.py
@@ -1,10 +1,13 @@
 import logging
+import os
 import sagemaker
 
 from abc import ABC, abstractmethod
 from ..utils.ag_sagemaker import (
     AutoGluonSagemakerEstimator,
     AutoGluonSagemakerInferenceModel,
+    AutoGluonRepackInferenceModel,
+    AutoGluonNonRepackInferenceModel,
 )
 
 logger = logging.getLogger(__name__)
@@ -104,6 +107,7 @@ class SageMakerFitJob(SageMakerJob):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self._estimator = None
         self._framework_version = None
 
     @classmethod
@@ -182,9 +186,18 @@ class SageMakerFitJob(SageMakerJob):
             )
             self._job_name = job_name
             self._framework_version = framework_version
+            self._estimator = sagemaker_estimator
         except Exception as e:
             logger.error(f'Training failed. Please check sagemaker console training jobs {job_name} for details.')
             raise e
+
+    def __getstate__(self):
+        self._estimator = None
+        state = self.__dict__.copy()
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
 
 class SageMakerBatchTransformationJob(SageMakerJob):
@@ -230,10 +243,66 @@ class SageMakerBatchTransformationJob(SageMakerJob):
         wait,
         autogluon_sagemaker_inference_model_kwargs,
         transformer_kwargs,
+        repack_model=False,
         **kwargs
     ):
-        logger.log(20, 'Creating inference model...')
-        model = AutoGluonSagemakerInferenceModel(
+        if repack_model:
+            model_cls = AutoGluonRepackInferenceModel
+            # model = AutoGluonNonRepackInferenceModel(
+            #     model_data=model_data,
+            #     role=role,
+            #     region=region,
+            #     framework_version=framework_version,
+            #     py_version=py_version,
+            #     instance_type=instance_type,
+            #     entry_point=entry_point,
+            #     predictor_cls=predictor_cls,
+            #     **autogluon_sagemaker_inference_model_kwargs
+            # )
+            # print('creating model')
+            # model = fitted_estimator.create_model(
+            #     region=region,
+            #     instance_type=instance_type,
+            #     framework_version=framework_version,
+            #     py_version=py_version,
+            #     entry_point=entry_point,
+            #     **autogluon_sagemaker_inference_model_kwargs,
+            # )
+            # print('model created')
+            # model.create()
+            # model_name = model.name
+            # from sagemaker.transformer import Transformer
+            # print('creating transformer')
+            # transformer = Transformer(
+            #     model_name=model_name,
+            #     instance_count=instance_count,
+            #     instance_type=instance_type,
+            #     strategy='MultiRecord',
+            #     max_payload=6,  # Maximum size of the payload in a single HTTP request to the container in MB. Will split into multiple batches if a request is more than max_payload
+            #     max_concurrent_transforms=1,  # The maximum number of HTTP requests to be made to each individual transform container at one time.
+            #     accept='application/json',
+            #     assemble_with='Line',
+            #     **transformer_kwargs,
+            # )
+            # print('transformer created')
+            # print('transforming')
+        else:
+            logger.log(20, 'Creating inference model...')
+            model_cls = AutoGluonNonRepackInferenceModel
+            # model = AutoGluonRepackInferenceModel(
+            #     model_data=model_data,
+            #     role=role,
+            #     region=region,
+            #     framework_version=framework_version,
+            #     py_version=py_version,
+            #     instance_type=instance_type,
+            #     entry_point=entry_point,
+            #     predictor_cls=predictor_cls,
+            #     **autogluon_sagemaker_inference_model_kwargs
+            # )
+            logger.log(20, 'Inference model created successfully')
+        print('creating model')
+        model = model_cls(
             model_data=model_data,
             role=role,
             region=region,
@@ -244,8 +313,7 @@ class SageMakerBatchTransformationJob(SageMakerJob):
             predictor_cls=predictor_cls,
             **autogluon_sagemaker_inference_model_kwargs
         )
-        logger.log(20, 'Inference model created successfully')
-
+        print('model created successfully')
         logger.log(20, 'Creating transformer...')
         transformer = model.transformer(
             instance_count=instance_count,
@@ -256,6 +324,7 @@ class SageMakerBatchTransformationJob(SageMakerJob):
         logger.log(20, 'Transformer created successfully')
 
         try:
+            print('transforming')
             transformer.transform(
                 test_input,
                 job_name=job_name,
@@ -265,6 +334,7 @@ class SageMakerBatchTransformationJob(SageMakerJob):
                 **kwargs
             )
             self._job_name = job_name
+            print('transform done')
         except Exception as e:
             transformer.delete_model()
             raise e
@@ -272,7 +342,7 @@ class SageMakerBatchTransformationJob(SageMakerJob):
         self._output_filename = test_input.split('/')[-1] + '.out'
 
         if wait:
-            transformer.delete_model()
+            # transformer.delete_model()
             logger.log(20, f'Predict results have been saved to {self.get_output_path()}')
         else:
             logger.log(20, 'Predict asynchronously. You can use `info()` or `get_job_status()` to check the status.')

--- a/cloud/src/autogluon/cloud/job/sagemaker_job.py
+++ b/cloud/src/autogluon/cloud/job/sagemaker_job.py
@@ -105,7 +105,6 @@ class SageMakerFitJob(SageMakerJob):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._estimator = None
         self._framework_version = None
 
     @classmethod
@@ -184,18 +183,9 @@ class SageMakerFitJob(SageMakerJob):
             )
             self._job_name = job_name
             self._framework_version = framework_version
-            self._estimator = sagemaker_estimator
         except Exception as e:
             logger.error(f'Training failed. Please check sagemaker console training jobs {job_name} for details.')
             raise e
-
-    def __getstate__(self):
-        self._estimator = None
-        state = self.__dict__.copy()
-        return state
-
-    def __setstate__(self, state):
-        self.__dict__.update(state)
 
 
 class SageMakerBatchTransformationJob(SageMakerJob):

--- a/cloud/src/autogluon/cloud/scripts/train.py
+++ b/cloud/src/autogluon/cloud/scripts/train.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
         "--images_dir", type=str, required=False, default=get_env_if_present("SM_CHANNEL_IMAGES")
     )
     parser.add_argument("--ag_config", type=str, default=get_env_if_present("SM_CHANNEL_CONFIG"))
+    parser.add_argument("--serving_script", type=str, default=get_env_if_present("SM_CHANNEL_SERVING"))
 
     args, _ = parser.parse_known_args()
 
@@ -132,3 +133,9 @@ if __name__ == "__main__":
         if config.get("leaderboard", False):
             lb = predictor.leaderboard(silent=False)
             lb.to_csv(f"{args.output_data_dir}/leaderboard.csv")
+
+    print('Saving serving script')
+    serving_script_saving_path = os.path.join(save_path, 'code')
+    os.mkdir(serving_script_saving_path)
+    serving_script_path = get_input_path(args.serving_script)
+    shutil.move(serving_script_path, os.path.join(serving_script_saving_path, os.path.basename(serving_script_path)))

--- a/cloud/src/autogluon/cloud/utils/ag_sagemaker.py
+++ b/cloud/src/autogluon/cloud/utils/ag_sagemaker.py
@@ -12,7 +12,7 @@ from .deserializers import PandasDeserializer
 from .sagemaker_utils import retrieve_latest_framework_version
 
 
-# Framework documentation: https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.Framework
+# Estimator documentation: https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#estimators
 class AutoGluonSagemakerEstimator(Estimator):
     def __init__(
         self,

--- a/cloud/src/autogluon/cloud/utils/ag_sagemaker.py
+++ b/cloud/src/autogluon/cloud/utils/ag_sagemaker.py
@@ -1,7 +1,11 @@
+import copy
+import os
 import sagemaker
-from sagemaker.estimator import Framework
-from sagemaker import image_uris
-from sagemaker.model import FrameworkModel
+from sagemaker import fw_utils
+from sagemaker.estimator import Framework, Estimator
+from sagemaker.mxnet.estimator import MXNet
+from sagemaker import image_uris, vpc_utils
+from sagemaker.model import FrameworkModel, Model, DIR_PARAM_NAME, SCRIPT_PARAM_NAME
 from sagemaker.predictor import Predictor
 from sagemaker.mxnet import MXNetModel
 from sagemaker.serializers import CSVSerializer, NumpySerializer
@@ -14,7 +18,7 @@ from .sagemaker_utils import retrieve_latest_framework_version
 
 
 # Framework documentation: https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.Framework
-class AutoGluonSagemakerEstimator(Framework):
+class AutoGluonSagemakerEstimator(Estimator):
     def __init__(
         self,
         entry_point,
@@ -37,9 +41,9 @@ class AutoGluonSagemakerEstimator(Framework):
             instance_type=instance_type,
         )
         super().__init__(
-            entry_point,
-            source_dir,
-            hyperparameters,
+            entry_point=entry_point,
+            source_dir=source_dir,
+            hyperparameters=hyperparameters,
             instance_type=instance_type,
             image_uri=self.image_uri,
             **kwargs,
@@ -50,16 +54,55 @@ class AutoGluonSagemakerEstimator(Framework):
 
     def create_model(
         self,
-        model_server_workers=None,
-        role=None,
-        vpc_config_override=None,
-        entry_point=None,
+        region,
+        framework_version,
+        py_version,
+        instance_type,
         source_dir=None,
-        dependencies=None,
-        image_name=None,
+        entry_point=None,
+        role=None,
+        image_uri=None,
+        predictor_cls=None,
+        vpc_config_override=vpc_utils.VPC_CONFIG_DEFAULT,
         **kwargs,
     ):
-        return None
+        image_uri = image_uris.retrieve(
+            "autogluon",
+            region=region,
+            version=framework_version,
+            py_version=py_version,
+            image_scope="inference",
+            instance_type=instance_type,
+        )
+        if predictor_cls is None:
+
+            def predict_wrapper(endpoint, session):
+                return Predictor(endpoint, session)
+
+            predictor_cls = predict_wrapper
+
+        role = role or self.role
+
+        if "enable_network_isolation" not in kwargs:
+            kwargs["enable_network_isolation"] = self.enable_network_isolation()
+
+        return AutoGluonNonRepackModel(
+            image_uri=image_uri,
+            source_dir=source_dir,
+            entry_point=entry_point,
+            model_data=self.model_data,
+            role=role,
+            vpc_config=self.get_vpc_config(vpc_config_override),
+            sagemaker_session=self.sagemaker_session,
+            predictor_cls=predictor_cls,
+            **kwargs,
+        )
+        # return super().create_model(
+        #     image_uri=image_uri,
+        #     source_dir=source_dir,
+        #     entry_point=entry_point,
+        #     **kwargs
+        # )
 
     @classmethod
     def _prepare_init_params_from_job_description(cls, job_details, model_channel_name=None):
@@ -68,6 +111,156 @@ class AutoGluonSagemakerEstimator(Framework):
         init_params['region'] = 'us-east-1'
         init_params['framework_version'] = retrieve_latest_framework_version()
         return init_params
+
+
+# Documentation for FrameworkModel: https://sagemaker.readthedocs.io/en/stable/api/inference/model.html#sagemaker.model.FrameworkModel
+class AutoGluonSagemakerInferenceModel(Model):
+    def __init__(
+        self,
+        model_data,
+        role,
+        entry_point,
+        region,
+        framework_version,
+        py_version,
+        instance_type,
+        **kwargs
+    ):
+        image_uri = image_uris.retrieve(
+            "autogluon",
+            region=region,
+            version=framework_version,
+            py_version=py_version,
+            image_scope="inference",
+            instance_type=instance_type,
+        )
+        super().__init__(
+            model_data=model_data,
+            role=role,
+            entry_point=entry_point,
+            image_uri=image_uri,
+            **kwargs
+        )
+
+    def transformer(
+        self,
+        instance_count,
+        instance_type,
+        strategy='MultiRecord',
+        max_payload=6,  # Maximum size of the payload in a single HTTP request to the container in MB. Will split into multiple batches if a request is more than max_payload
+        max_concurrent_transforms=1,  # The maximum number of HTTP requests to be made to each individual transform container at one time.
+        accept='application/json',
+        assemble_with='Line',
+        **kwargs
+    ):
+        return super().transformer(
+            instance_count=instance_count,
+            instance_type=instance_type,
+            strategy=strategy,
+            max_payload=max_payload,
+            max_concurrent_transforms=max_concurrent_transforms,
+            accept=accept,
+            assemble_with=assemble_with,
+            **kwargs
+        )
+
+
+class AutoGluonRepackInferenceModel(AutoGluonSagemakerInferenceModel):
+
+    def prepare_container_def(
+        self,
+        instance_type=None,
+        accelerator_type=None,
+        serverless_inference_config=None,
+    ):  # pylint: disable=unused-argument
+        """Return a dict created by ``sagemaker.container_def()``.
+
+        It is used for deploying this model to a specified instance type.
+
+        Subclasses can override this to provide custom container definitions
+        for deployment to a specific instance type. Called by ``deploy()``.
+
+        Args:
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'.
+            serverless_inference_config (sagemaker.serverless.ServerlessInferenceConfig):
+                Specifies configuration related to serverless endpoint. Instance type is
+                not provided in serverless inference. So this is used to find image URIs.
+
+        Returns:
+            dict: A container definition object usable with the CreateModel API.
+        """
+        deploy_key_prefix = fw_utils.model_code_key_prefix(
+            self.key_prefix, self.name, self.image_uri
+        )
+        deploy_env = copy.deepcopy(self.env)
+        self._upload_code(deploy_key_prefix, repack=True)
+        deploy_env.update(self._script_mode_env_vars())
+        return sagemaker.container_def(
+            self.image_uri,
+            self.repacked_model_data or self.model_data,
+            deploy_env,
+            image_config=self.image_config,
+        )
+
+
+class AutoGluonNonRepackInferenceModel(AutoGluonSagemakerInferenceModel):
+
+    def prepare_container_def(
+        self,
+        instance_type=None,
+        accelerator_type=None,
+        serverless_inference_config=None,
+    ):  # pylint: disable=unused-argument
+        """Return a dict created by ``sagemaker.container_def()``.
+
+        It is used for deploying this model to a specified instance type.
+
+        Subclasses can override this to provide custom container definitions
+        for deployment to a specific instance type. Called by ``deploy()``.
+
+        Args:
+            instance_type (str): The EC2 instance type to deploy this Model to.
+                For example, 'ml.p2.xlarge'.
+            accelerator_type (str): The Elastic Inference accelerator type to
+                deploy to the instance for loading and making inferences to the
+                model. For example, 'ml.eia1.medium'.
+            serverless_inference_config (sagemaker.serverless.ServerlessInferenceConfig):
+                Specifies configuration related to serverless endpoint. Instance type is
+                not provided in serverless inference. So this is used to find image URIs.
+
+        Returns:
+            dict: A container definition object usable with the CreateModel API.
+        """
+        # c_def = super().prepare_container_def(
+        #     instance_type=instance_type,
+        #     accelerator_type=accelerator_type,
+        #     serverless_inference_config=serverless_inference_config
+        # ).copy()
+        deploy_env = copy.deepcopy(self.env)
+        deploy_env.update(self._script_mode_env_vars())
+        deploy_env[SCRIPT_PARAM_NAME.upper()] = os.path.basename(deploy_env[SCRIPT_PARAM_NAME.upper()])
+        deploy_env[DIR_PARAM_NAME.upper()] = '/opt/ml/model/code'
+
+        return sagemaker.container_def(
+            self.image_uri,
+            self.model_data,
+            deploy_env,
+            image_config=self.image_config,
+        )
+
+        # if 'Environment' in c_def and DIR_PARAM_NAME in c_def['Environment']:
+        #     c_def['Environment'][DIR_PARAM_NAME] = '/opt/ml/model/code'
+        # return sagemaker.container_def(
+        #     image_uri=c_def.get('Image', None),
+        #     model_data_url=c_def.get('ModelDataUrl', None),
+        #     env=c_def.get('Environment', None),
+        #     container_mode=c_def.get('Mode', None),
+        #     image_config=c_def.get('ImageConfig', None)
+        # )
 
 
 # Predictor documentation: https://sagemaker.readthedocs.io/en/stable/api/inference/predictors.html
@@ -112,54 +305,4 @@ class AutoGluonBatchPredictor(Predictor):
         )
 
 
-# Documentation for FrameworkModel: https://sagemaker.readthedocs.io/en/stable/api/inference/model.html#sagemaker.model.FrameworkModel
-class AutoGluonSagemakerInferenceModel(MXNetModel):
-    def __init__(
-        self,
-        model_data,
-        role,
-        entry_point,
-        region,
-        framework_version,
-        py_version,
-        instance_type,
-        **kwargs
-    ):
-        image_uri = image_uris.retrieve(
-            "autogluon",
-            region=region,
-            version=framework_version,
-            py_version=py_version,
-            image_scope="inference",
-            instance_type=instance_type,
-        )
-        super().__init__(
-            model_data,
-            role,
-            entry_point,
-            image_uri=image_uri,
-            framework_version="1.8.0",
-            **kwargs
-        )
 
-    def transformer(
-        self,
-        instance_count,
-        instance_type,
-        strategy='MultiRecord',
-        max_payload=6,  # Maximum size of the payload in a single HTTP request to the container in MB. Will split into multiple batches if a request is more than max_payload
-        max_concurrent_transforms=1,  # The maximum number of HTTP requests to be made to each individual transform container at one time.
-        accept='application/json',
-        assemble_with='Line',
-        **kwargs
-    ):
-        return super().transformer(
-            instance_count=instance_count,
-            instance_type=instance_type,
-            strategy=strategy,
-            max_payload=max_payload,
-            max_concurrent_transforms=max_concurrent_transforms,
-            accept=accept,
-            assemble_with=assemble_with,
-            **kwargs
-        )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR enable CloudPredictor to skip repacking step when doing batch inference and deployment. This could save a lot of time when the model artifact is large and the network speed is slow
* Adding inference script into model artifacts to avoid repack it with model afterwards.
* Instead of using `MxnetModel` implementation, now we inherit from `Model`. Also updated estimator to inherit from base `Estimator` instead of `Framework`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
