### PR TITLE
Fixed bug in imodels when no categorical features

### DIFF
--- a/docs/install-include.rst
+++ b/docs/install-include.rst
@@ -137,22 +137,30 @@ Select your preferences below and run the corresponding install commands:
               .. include:: install-gpu-source-windows.rst
 
 
-AutoGluon is modularized into `sub-modules <https://packaging.python.org/guides/packaging-namespace-packages/>`_ specialized for tabular, text, or image data. You can reduce the number of dependencies required by solely installing a specific sub-module via:  `python3 -m pip install <submodule>`, where `<submodule>` may be one of the following options:
+AutoGluon is modularized into `sub-modules <https://packaging.python.org/guides/packaging-namespace-packages/>`_ specialized for tabular, text, image, or time series data. You can reduce the number of dependencies required by solely installing a specific sub-module via:  `python3 -m pip install <submodule>`, where `<submodule>` may be one of the following options:
 
 - `autogluon.tabular` - functionality for tabular data (TabularPredictor)
     - The default installation of `autogluon.tabular` standalone is a skeleton installation.
     - Install via `pip install autogluon.tabular[all]` to get the same installation of tabular as via `pip install autogluon`
     - Available optional dependencies: `lightgbm,catboost,xgboost,fastai`. These are included in `all`.
-    - Optional dependencies not included in `all`: `vowpalwabbit`.
+    - Optional dependencies not included in `all`: `vowpalwabbit,imodels,skex`.
     - To run `autogluon.tabular` with only the optional LightGBM and CatBoost models for example, you can do: `pip install autogluon.tabular[lightgbm,catboost]`
 
     - Experimental optional dependency: `skex`. This will speedup KNN models by 25x in training and inference on CPU. Use `pip install autogluon.tabular[all,skex]` to enable, or `pip install "scikit-learn-intelex<2021.5"` after a standard installation of AutoGluon.
+    - Optional Dependency: `vowpalwabbit`. This will install the VowpalWabbit package and allow you to fit VowpalWabbit in TabularPredictor.
+    - Optional Dependency: `imodels`. This will install the imodels package and allow you to fit interpretable models in TabularPredictor.
 - `autogluon.multimodal` - functionality for image, text, and multimodal problems. Focus on deep learning models.
 - `autogluon.vision` - only functionality for computer vision (ImagePredictor, ObjectDetector)
 - `autogluon.text` - only functionality for natural language processing (TextPredictor)
+- `autogluon.timeseries` - only functionality for time series data (TimeSeriesPredictor)
+- `autogluon.common` - helper functionality. Not useful standalone.
 - `autogluon.core` - only core functionality (Searcher/Scheduler) useful for hyperparameter tuning of arbitrary code/models.
 - `autogluon.features` - only functionality for feature generation / feature preprocessing pipelines (primarily related to Tabular data).
 
 To install a submodule from source, follow the instructions for installing the entire package from source but replace the line `cd autogluon && ./full_install.sh` with `cd autogluon && python3 -m pip install -e {SUBMODULE_NAME}/{OPTIONAL_DEPENDENCIES}`
 
 - For example, to install `autogluon.tabular[lightgbm,catboost]` from source, the command would be: `cd autogluon && python3 -m pip install -e tabular/[lightgbm,catboost]`
+
+To install all AutoGluon optional dependencies:
+
+`pip install autogluon && pip install autogluon.tabular[vowpalwabbit,imodels,skex]`

--- a/docs/tutorials/tabular_prediction/tabular-interpretability.md
+++ b/docs/tutorials/tabular_prediction/tabular-interpretability.md
@@ -7,6 +7,8 @@
 
 In this tutorial, we will explain how to automatically use interpretable models powered by integration with [🔍 the imodels package](https://github.com/csinva/imodels). This allows for automatically learning models based on rules which are extremely concise and can be useful for (1) understanding data or (2) building a transparent predictive model.
 
+*Note*: `imodels` must be installed for this tutorial. You can ensure `imodels` is installed via `pip install autogluon.tabular[imodels]`. `imodels` is not installed by default.
+
 Begin by loading in data to predict. Note: interpretable rule-based modeling is currently only supported for binary classification.
 
 ```{.python .input}

--- a/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
+++ b/tabular/src/autogluon/tabular/models/imodels/imodels_models.py
@@ -12,6 +12,10 @@ class _IModelsModel(AbstractModel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._feature_generator = None
+        self._ohe = None
+        self._ohe_columns = None
+        self._categorical_featnames = None
+        self._other_featnames = None
 
     @abstractmethod
     def get_model(self):
@@ -32,7 +36,7 @@ class _IModelsModel(AbstractModel):
                 self._ohe.fit(X=X[self._categorical_featnames])
                 self._ohe_columns = self._ohe.get_feature_names_out()
             else:
-                self._ohe=None # otherwise no model is fitted when there are not self._categorical_featnames
+                self._ohe = None  # otherwise no model is fitted when there are not self._categorical_featnames
 
         if self._ohe is not None:
             X_index = X.index


### PR DESCRIPTION
*Issue #, if available:*
#2107 

*Description of changes:*
- Fixed missing init of `self._ohe`.
- Improved documentation clarity on how to install and use imodels.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
