### PR TITLE
Fix realtime inference for mmcv models

### DIFF
--- a/multimodal/src/autogluon/multimodal/constants.py
+++ b/multimodal/src/autogluon/multimodal/constants.py
@@ -152,6 +152,7 @@ MMDET_IMAGE = "mmdet_image"
 MMOCR_TEXT_DET = "mmocr_text_detection"
 MMOCR_TEXT_RECOG = "mmocr_text_recognition"
 HF_MODELS = (HF_TEXT, T_FEW, CLIP)
+MMCV_MODELS = (MMDET_IMAGE, MMOCR_TEXT_DET, MMOCR_TEXT_RECOG)
 
 # metric learning loss type
 CONTRASTIVE_LOSS = "contrastive_loss"

--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -123,7 +123,7 @@ class BaseDataModule(LightningDataModule):
             num_workers=self.num_workers,
             shuffle=True,
             pin_memory=False,
-            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors),
+            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors, per_gpu_batch_size=self.per_gpu_batch_size),
         )
         return loader
 
@@ -142,7 +142,7 @@ class BaseDataModule(LightningDataModule):
             batch_size=self.per_gpu_batch_size,
             num_workers=self.num_workers,
             pin_memory=False,
-            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors),
+            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors, per_gpu_batch_size=self.per_gpu_batch_size),
         )
         return loader
 
@@ -161,7 +161,7 @@ class BaseDataModule(LightningDataModule):
             batch_size=self.per_gpu_batch_size,
             num_workers=self.num_workers,
             pin_memory=False,
-            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors),
+            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors, per_gpu_batch_size=self.per_gpu_batch_size),
         )
         return loader
 
@@ -180,6 +180,6 @@ class BaseDataModule(LightningDataModule):
             batch_size=self.per_gpu_batch_size,
             num_workers=self.num_workers,
             pin_memory=False,
-            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors),
+            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors, per_gpu_batch_size=self.per_gpu_batch_size),
         )
         return loader

--- a/multimodal/src/autogluon/multimodal/data/datamodule.py
+++ b/multimodal/src/autogluon/multimodal/data/datamodule.py
@@ -123,7 +123,11 @@ class BaseDataModule(LightningDataModule):
             num_workers=self.num_workers,
             shuffle=True,
             pin_memory=False,
-            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors, per_gpu_batch_size=self.per_gpu_batch_size),
+            collate_fn=get_collate_fn(
+                df_preprocessor=self.df_preprocessor,
+                data_processors=self.data_processors,
+                per_gpu_batch_size=self.per_gpu_batch_size,
+            ),
         )
         return loader
 
@@ -142,7 +146,11 @@ class BaseDataModule(LightningDataModule):
             batch_size=self.per_gpu_batch_size,
             num_workers=self.num_workers,
             pin_memory=False,
-            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors, per_gpu_batch_size=self.per_gpu_batch_size),
+            collate_fn=get_collate_fn(
+                df_preprocessor=self.df_preprocessor,
+                data_processors=self.data_processors,
+                per_gpu_batch_size=self.per_gpu_batch_size,
+            ),
         )
         return loader
 
@@ -161,7 +169,11 @@ class BaseDataModule(LightningDataModule):
             batch_size=self.per_gpu_batch_size,
             num_workers=self.num_workers,
             pin_memory=False,
-            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors, per_gpu_batch_size=self.per_gpu_batch_size),
+            collate_fn=get_collate_fn(
+                df_preprocessor=self.df_preprocessor,
+                data_processors=self.data_processors,
+                per_gpu_batch_size=self.per_gpu_batch_size,
+            ),
         )
         return loader
 
@@ -180,6 +192,10 @@ class BaseDataModule(LightningDataModule):
             batch_size=self.per_gpu_batch_size,
             num_workers=self.num_workers,
             pin_memory=False,
-            collate_fn=get_collate_fn(df_preprocessor=self.df_preprocessor, data_processors=self.data_processors, per_gpu_batch_size=self.per_gpu_batch_size),
+            collate_fn=get_collate_fn(
+                df_preprocessor=self.df_preprocessor,
+                data_processors=self.data_processors,
+                per_gpu_batch_size=self.per_gpu_batch_size,
+            ),
         )
         return loader

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -55,6 +55,7 @@ from ..constants import (
     MMOCR_TEXT_DET,
     MMOCR_TEXT_RECOG,
     TIMM_IMAGE,
+    MMCV_MODELS,
 )
 from .collator import Pad, Stack
 from .trivial_augmenter import TrivialAugment
@@ -74,7 +75,6 @@ class ImageProcessor:
         model: nn.Module,
         train_transform_types: List[str],
         val_transform_types: List[str],
-        samples_per_gpu: Optional[int] = None,
         norm_type: Optional[str] = None,
         size: Optional[int] = None,
         max_img_num_per_col: Optional[int] = 1,
@@ -90,8 +90,6 @@ class ImageProcessor:
             A list of image transforms used in training. Note that the transform order matters.
         val_transform_types
             A list of image transforms used in validation/test/prediction. Note that the transform order matters.
-        samples_per_gpu
-            Number of samples per gpu, used in MMDET to group data in each batch.
         norm_type
             How to normalize an image. We now support:
             - inception
@@ -158,8 +156,8 @@ class ImageProcessor:
         self.max_img_num_per_col = max_img_num_per_col
         logger.debug(f"max_img_num_per_col: {max_img_num_per_col}")
 
-        if self.prefix == MMDET_IMAGE or self.prefix.lower().startswith(MMOCR):
-            if self.prefix == MMDET_IMAGE:
+        if self.prefix.lower().startswith(MMCV_MODELS):
+            if self.prefix.lower().startswith(MMDET_IMAGE):
                 assert mmdet is not None, "Please install MMDetection by: pip install mmdet."
             else:
                 assert mmocr is not None, "Please install MMOCR by: pip install mmocr."
@@ -167,10 +165,6 @@ class ImageProcessor:
             cfg.data.test.pipeline = replace_ImageToTensor(cfg.data.test.pipeline)
             self.val_processor = Compose(cfg.data.test.pipeline)
             self.train_processor = Compose(cfg.data.test.pipeline)
-            if isinstance(samples_per_gpu, int) and samples_per_gpu > 0:
-                self.samples_per_gpu = samples_per_gpu
-            else:
-                raise ValueError(f"invalid samples_per_gpu value: {samples_per_gpu}")
         else:
             self.train_processor = self.construct_processor(self.train_transform_types)
             self.val_processor = self.construct_processor(self.val_transform_types)
@@ -187,7 +181,7 @@ class ImageProcessor:
     def image_column_prefix(self):
         return f"{self.image_key}_{COLUMN}"
 
-    def collate_fn(self, image_column_names: Optional[List] = None) -> Dict:
+    def collate_fn(self, image_column_names: Optional[List] = None, per_gpu_batch_size: Optional[int] = None) -> Dict:
         """
         Collate images into a batch. Here it pads images since the image number may
         vary from sample to sample. Samples with less images will be padded zeros.
@@ -204,11 +198,11 @@ class ImageProcessor:
             for col_name in image_column_names:
                 fn[f"{self.image_column_prefix}_{col_name}"] = Stack()
 
-        if self.prefix == MMDET_IMAGE or self.prefix.lower().startswith(MMOCR):
+        if self.prefix.lower().startswith(MMCV_MODELS):
             assert mmcv is not None, "Please install mmcv-full by: mim install mmcv-full."
             fn.update(
                 {
-                    self.image_key: lambda x: collate(x, samples_per_gpu=self.samples_per_gpu),
+                    self.image_key: lambda x: collate(x, samples_per_gpu=per_gpu_batch_size),
                 }
             )
         else:

--- a/multimodal/src/autogluon/multimodal/data/process_image.py
+++ b/multimodal/src/autogluon/multimodal/data/process_image.py
@@ -50,12 +50,12 @@ from ..constants import (
     COLUMN,
     IMAGE,
     IMAGE_VALID_NUM,
+    MMCV_MODELS,
     MMDET_IMAGE,
     MMOCR,
     MMOCR_TEXT_DET,
     MMOCR_TEXT_RECOG,
     TIMM_IMAGE,
-    MMCV_MODELS,
 )
 from .collator import Pad, Stack
 from .trivial_augmenter import TrivialAugment

--- a/multimodal/src/autogluon/multimodal/data/utils.py
+++ b/multimodal/src/autogluon/multimodal/data/utils.py
@@ -1,15 +1,15 @@
 import codecs
 import random
-from typing import Iterable, List, Tuple, Union, Optional
+from typing import Iterable, List, Optional, Tuple, Union
 
 import pandas as pd
 from nlpaug import Augmenter
 from nlpaug.util import Method
 from text_unidecode import unidecode
 
+from ..constants import MMCV_MODELS
 from .collator import Dict
 from .preprocess_dataframe import MultiModalFeaturePreprocessor
-from ..constants import MMCV_MODELS
 
 
 def extract_value_from_config(
@@ -161,7 +161,11 @@ def get_collate_fn(
             if per_modality_column_names:
                 for per_model_processor in per_data_processors_group[per_modality]:
                     if per_model_processor.prefix.lower().startswith(MMCV_MODELS):
-                        collate_fn.update(per_model_processor.collate_fn(per_modality_column_names, per_gpu_batch_size=per_gpu_batch_size))
+                        collate_fn.update(
+                            per_model_processor.collate_fn(
+                                per_modality_column_names, per_gpu_batch_size=per_gpu_batch_size
+                            )
+                        )
                     else:
                         collate_fn.update(per_model_processor.collate_fn(per_modality_column_names))
     return Dict(collate_fn)

--- a/multimodal/src/autogluon/multimodal/data/utils.py
+++ b/multimodal/src/autogluon/multimodal/data/utils.py
@@ -1,6 +1,6 @@
 import codecs
 import random
-from typing import Iterable, List, Tuple, Union
+from typing import Iterable, List, Tuple, Union, Optional
 
 import pandas as pd
 from nlpaug import Augmenter
@@ -9,6 +9,7 @@ from text_unidecode import unidecode
 
 from .collator import Dict
 from .preprocess_dataframe import MultiModalFeaturePreprocessor
+from ..constants import MMCV_MODELS
 
 
 def extract_value_from_config(
@@ -128,11 +129,21 @@ class InsertPunctuation(Augmenter):
 def get_collate_fn(
     df_preprocessor: Union[MultiModalFeaturePreprocessor, List[MultiModalFeaturePreprocessor]],
     data_processors: Union[dict, List[dict]],
+    per_gpu_batch_size: Optional[int] = None,
 ):
     """
     Collect collator functions for each modality input of every model.
     These collator functions are wrapped by the "Dict" collator function,
     which can then be used by the Pytorch DataLoader.
+
+    Parameters
+    ----------
+    df_preprocessor
+        One or a list of dataframe preprocessors.
+    data_processors
+        One or a list of data processor dicts.
+    per_gpu_batch_size
+        Mini-batch size for each GPU.
 
     Returns
     -------
@@ -149,7 +160,10 @@ def get_collate_fn(
             per_modality_column_names = per_preprocessor.get_column_names(modality=per_modality)
             if per_modality_column_names:
                 for per_model_processor in per_data_processors_group[per_modality]:
-                    collate_fn.update(per_model_processor.collate_fn(per_modality_column_names))
+                    if per_model_processor.prefix.lower().startswith(MMCV_MODELS):
+                        collate_fn.update(per_model_processor.collate_fn(per_modality_column_names, per_gpu_batch_size=per_gpu_batch_size))
+                    else:
+                        collate_fn.update(per_model_processor.collate_fn(per_modality_column_names))
     return Dict(collate_fn)
 
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -89,6 +89,7 @@ from .utils import (
     assign_feature_column_names,
     average_checkpoints,
     bbox_xyxy_to_xywh,
+    compute_inference_batch_size,
     compute_num_gpus,
     compute_score,
     create_fusion_data_processors,
@@ -121,7 +122,6 @@ from .utils import (
     turn_on_off_feature_column_info,
     update_config_by_rules,
     use_realtime,
-    compute_inference_batch_size,
 )
 
 logger = logging.getLogger(AUTOMM)
@@ -1527,7 +1527,9 @@ class MultiModalPredictor:
             )
             processed_features.append(per_sample_features)
 
-        collate_fn = get_collate_fn(df_preprocessor=df_preprocessor, data_processors=data_processors, per_gpu_batch_size=sample_num)
+        collate_fn = get_collate_fn(
+            df_preprocessor=df_preprocessor, data_processors=data_processors, per_gpu_batch_size=sample_num
+        )
         batch = collate_fn(processed_features)
         output = infer_batch(
             batch=batch,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1527,7 +1527,7 @@ class MultiModalPredictor:
             )
             processed_features.append(per_sample_features)
 
-        collate_fn = get_collate_fn(df_preprocessor=df_preprocessor, data_processors=data_processors)
+        collate_fn = get_collate_fn(df_preprocessor=df_preprocessor, data_processors=data_processors, per_gpu_batch_size=sample_num)
         batch = collate_fn(processed_features)
         output = infer_batch(
             batch=batch,

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -1564,7 +1564,7 @@ class MultiModalPredictor:
         if not realtime:
             batch_size = compute_inference_batch_size(
                 per_gpu_batch_size=self._config.env.per_gpu_batch_size,
-                eval_batch_size_ratio=self._config.env.eval_batch_size_ratio,
+                eval_batch_size_ratio=OmegaConf.select(self._config, "env.eval_batch_size_ratio"),
                 per_gpu_batch_size_evaluation=self._config.env.per_gpu_batch_size_evaluation,  # backward compatibility.
                 num_gpus=num_gpus,
                 strategy=strategy,

--- a/multimodal/src/autogluon/multimodal/utils/__init__.py
+++ b/multimodal/src/autogluon/multimodal/utils/__init__.py
@@ -21,7 +21,7 @@ from .data import (
     turn_on_off_feature_column_info,
 )
 from .download import download, is_url
-from .environment import compute_num_gpus, infer_precision, is_interactive, move_to_device
+from .environment import compute_num_gpus, infer_precision, is_interactive, move_to_device, compute_inference_batch_size
 from .inference import extract_from_output, infer_batch, use_realtime
 from .load import CustomUnpickler, load_text_tokenizers
 from .log import LogFilter, apply_log_filter

--- a/multimodal/src/autogluon/multimodal/utils/__init__.py
+++ b/multimodal/src/autogluon/multimodal/utils/__init__.py
@@ -21,7 +21,13 @@ from .data import (
     turn_on_off_feature_column_info,
 )
 from .download import download, is_url
-from .environment import compute_num_gpus, infer_precision, is_interactive, move_to_device, compute_inference_batch_size
+from .environment import (
+    compute_inference_batch_size,
+    compute_num_gpus,
+    infer_precision,
+    is_interactive,
+    move_to_device,
+)
 from .inference import extract_from_output, infer_batch, use_realtime
 from .load import CustomUnpickler, load_text_tokenizers
 from .log import LogFilter, apply_log_filter

--- a/multimodal/src/autogluon/multimodal/utils/data.py
+++ b/multimodal/src/autogluon/multimodal/utils/data.py
@@ -96,7 +96,6 @@ def create_data_processor(
             model=model,
             train_transform_types=model_config.train_transform_types,
             val_transform_types=model_config.val_transform_types,
-            samples_per_gpu=config.env.per_gpu_batch_size,  # TODO: should be different in MMDET eval, now we force eval_batch_size_ratio in MMDET to be 1
             norm_type=model_config.image_norm,
             size=model_config.image_size,
             max_img_num_per_col=model_config.max_img_num_per_col,

--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -1,12 +1,13 @@
+import contextlib
 import logging
 import math
 import sys
 import warnings
 from typing import Dict, List, Optional, Tuple, Union
-import contextlib
 
 import torch
 from torch import nn
+
 try:
     from mmcv.parallel import DataContainer
 except:
@@ -159,7 +160,13 @@ def move_to_device(obj: Union[torch.Tensor, nn.Module, Dict, List], device: torc
         )
 
 
-def compute_inference_batch_size(per_gpu_batch_size: int, eval_batch_size_ratio: Union[int, float], per_gpu_batch_size_evaluation: int, num_gpus: int, strategy: str):
+def compute_inference_batch_size(
+    per_gpu_batch_size: int,
+    eval_batch_size_ratio: Union[int, float],
+    per_gpu_batch_size_evaluation: int,
+    num_gpus: int,
+    strategy: str,
+):
     if per_gpu_batch_size_evaluation:
         batch_size = per_gpu_batch_size_evaluation
     else:
@@ -181,12 +188,12 @@ def double_precision_context():
     torch.set_default_dtype(default_dtype)
 
 
-def get_precision_context(precision: Union[int, str], device: Optional[torch.device] = None):
+def get_precision_context(precision: Union[int, str], device_type: Optional[str] = None):
     if precision == 32:
         assert torch.get_default_dtype() == torch.float32
         return contextlib.nullcontext()
     elif precision in [16, "bf16"]:
-        return torch.autocast(device, dtype=torch.bfloat16 if precision == "bf16" else torch.half)
+        return torch.autocast(device_type=device_type, dtype=torch.bfloat16 if precision == "bf16" else torch.half)
     elif precision == 64:
         return double_precision_context()
     else:

--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -167,6 +167,26 @@ def compute_inference_batch_size(
     num_gpus: int,
     strategy: str,
 ):
+    """
+    Compute the batch size for inference.
+
+    Parameters
+    ----------
+    per_gpu_batch_size
+        Per gpu batch size from the config.
+    eval_batch_size_ratio
+        per_gpu_batch_size_evaluation = per_gpu_batch_size * eval_batch_size_ratio.
+    per_gpu_batch_size_evaluation
+        Per gpu evaluation batch size from the config.
+    num_gpus
+        Number of GPUs.
+    strategy
+        A pytorch lightning strategy.
+
+    Returns
+    -------
+    Batch size for inference.
+    """
     if per_gpu_batch_size_evaluation:
         batch_size = per_gpu_batch_size_evaluation
     else:
@@ -182,6 +202,9 @@ def compute_inference_batch_size(
 
 @contextlib.contextmanager
 def double_precision_context():
+    """
+    Double precision context manager.
+    """
     default_dtype = torch.get_default_dtype()
     torch.set_default_dtype(torch.float64)
     yield
@@ -189,6 +212,20 @@ def double_precision_context():
 
 
 def get_precision_context(precision: Union[int, str], device_type: Optional[str] = None):
+    """
+    Choose the proper context manager based on the precision.
+
+    Parameters
+    ----------
+    precision
+        The precision.
+    device_type
+        gpu or cpu.
+
+    Returns
+    -------
+    A precision context manager.
+    """
     if precision == 32:
         assert torch.get_default_dtype() == torch.float32
         return contextlib.nullcontext()

--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -150,3 +150,17 @@ def move_to_device(obj: Union[torch.Tensor, nn.Module, Dict, List], device: torc
             f"Make sure the object is one of these: a Pytorch tensor, a Pytorch module, "
             f"a dict or list of tensors or modules."
         )
+
+
+def compute_inference_batch_size(per_gpu_batch_size: int, eval_batch_size_ratio: Union[int, float], per_gpu_batch_size_evaluation: int, num_gpus: int, strategy: str):
+    if per_gpu_batch_size_evaluation:
+        batch_size = per_gpu_batch_size_evaluation
+    else:
+        batch_size = per_gpu_batch_size * eval_batch_size_ratio
+
+    if num_gpus > 1 and strategy == "dp":
+        # If using 'dp', the per_gpu_batch_size would be split by all GPUs.
+        # So, we need to use the GPU number as a multiplier to compute the batch size.
+        batch_size = batch_size * num_gpus
+
+    return batch_size

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 
 from ..constants import AUTOMM, BBOX, COLUMN_FEATURES, FEATURES, IMAGE, LOGITS, MASKS, PROBABILITY, SCORE, TEXT
-from .environment import move_to_device, get_precision_context
+from .environment import get_precision_context, move_to_device
 from .misc import tensor_to_ndarray
 
 logger = logging.getLogger(AUTOMM)
@@ -102,7 +102,7 @@ def infer_batch(
         model = nn.DataParallel(model)
     model.to(device).eval()
     batch = move_to_device(batch, device=device)
-    precision_context = get_precision_context(precision=precision, device=device)
+    precision_context = get_precision_context(precision=precision, device_type=device_type)
     with precision_context, torch.no_grad():
         output = model(batch)
         if model_postprocess_fn:

--- a/multimodal/tests/unittests/test_object_detection.py
+++ b/multimodal/tests/unittests/test_object_detection.py
@@ -35,7 +35,7 @@ def test_mmdet_object_detection_inference(checkpoint_name):
         pipeline="object_detection",
     )
 
-    pred = predictor.predict({"image": [mmdet_image_name] * 10}, realtime=False)  # test batch inference
+    pred = predictor.predict({"image": [mmdet_image_name] * 10})  # test batch inference
     assert len(pred) == 10  # test data size is 100
     assert len(pred[0]) == 80  # COCO has 80 classes
     assert pred[0][0].ndim == 2  # two dimensions, (# of proposals, 5)

--- a/multimodal/tests/unittests/test_text_detection.py
+++ b/multimodal/tests/unittests/test_text_detection.py
@@ -32,7 +32,7 @@ def test_mmocr_text_detection_inference(checkpoint_name):
     )
 
     # two dimensions, (num of text lines, 2 * num of coordinate points)
-    pred = predictor.predict({"image": [mmocr_image_name]}, realtime=False)
+    pred = predictor.predict({"image": [mmocr_image_name]})
 
     # original MMOCR model's output
     checkpoints = download(package="mmocr", configs=[checkpoint_name], dest_root=".")

--- a/multimodal/tests/unittests/test_text_recognition.py
+++ b/multimodal/tests/unittests/test_text_recognition.py
@@ -37,7 +37,7 @@ def test_mmocr_text_recognition_inference(checkpoint_name):
         pipeline="ocr_text_recognition",
     )
 
-    pred = predictor.predict({"image": [mmocr_image_name]}, realtime=False)
+    pred = predictor.predict({"image": [mmocr_image_name]})
 
     # original MMOCR model's output
     checkpoints = download(package="mmocr", configs=[checkpoint_name], dest_root=".")


### PR DESCRIPTION
1. Move the `per_gpu_batch_size ` from image processor initialization to `get_collate_fn()`. In this way, batch size no longer needs to bound with image processor, which allows dynamic batch size in inference. 
2. Add `MMCV_MODELS` constant. We could put all the mmcv models here.
3. Improve the precision context manager.
4. Consider batch size in determining whether to use the realtime inference.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
