### PR TITLE
Fix hyperparameter overloading in HPO for time series models

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1009,7 +1009,7 @@ class AbstractModel:
         time_start = time.time()
         logger.log(15, "Starting generic AbstractModel hyperparameter tuning for %s model..." % self.name)
         search_space = self._get_search_space()
-
+        
         try:
             hpo_executor.validate_search_space(search_space, self.name)
         except EmptySearchSpace:
@@ -1066,7 +1066,7 @@ class AbstractModel:
             model_path_root=self.path_root,
             time_start=time_start,
         )
-
+        
         # cleanup artifacts
         for data_file in [train_path, val_path]:
             try:
@@ -1075,7 +1075,7 @@ class AbstractModel:
                 pass
 
         return hpo_results
-
+    
     def _get_hpo_backend(self):
         """Choose which backend(Ray or Custom) to use for hpo"""
         return CUSTOM_BACKEND
@@ -1351,13 +1351,6 @@ class AbstractModel:
 
     def _more_tags(self):
         return _DEFAULT_TAGS
-
+    
     def _get_model_base(self):
         return self
-
-    def get_user_params(self) -> dict:
-        """Used to access user-specified parameters for the model before initialization."""
-        if self._user_params is None:
-            return {}
-        else:
-            return self._user_params.copy()

--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1009,7 +1009,7 @@ class AbstractModel:
         time_start = time.time()
         logger.log(15, "Starting generic AbstractModel hyperparameter tuning for %s model..." % self.name)
         search_space = self._get_search_space()
-        
+
         try:
             hpo_executor.validate_search_space(search_space, self.name)
         except EmptySearchSpace:
@@ -1066,7 +1066,7 @@ class AbstractModel:
             model_path_root=self.path_root,
             time_start=time_start,
         )
-        
+
         # cleanup artifacts
         for data_file in [train_path, val_path]:
             try:
@@ -1075,7 +1075,7 @@ class AbstractModel:
                 pass
 
         return hpo_results
-    
+
     def _get_hpo_backend(self):
         """Choose which backend(Ray or Custom) to use for hpo"""
         return CUSTOM_BACKEND
@@ -1351,6 +1351,13 @@ class AbstractModel:
 
     def _more_tags(self):
         return _DEFAULT_TAGS
-    
+
     def _get_model_base(self):
         return self
+
+    def get_user_params(self) -> dict:
+        """Used to access user-specified parameters for the model before initialization."""
+        if self._user_params is None:
+            return {}
+        else:
+            return self._user_params.copy()

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -10,9 +10,9 @@ from autogluon.core.hpo.exceptions import EmptySearchSpace
 from autogluon.core.hpo.executors import HpoExecutor
 from autogluon.core.models import AbstractModel
 
-from ... import TimeSeriesEvaluator
-from ...dataset import TimeSeriesDataFrame
-from ...utils.metadata import get_prototype_metadata_dict
+from autogluon.timeseries.evaluator import TimeSeriesEvaluator
+from autogluon.timeseries.dataset import TimeSeriesDataFrame
+from autogluon.timeseries.utils.metadata import get_prototype_metadata_dict
 from .model_trial import model_trial, skip_hpo
 
 logger = logging.getLogger(__name__)
@@ -394,6 +394,13 @@ class AbstractTimeSeriesModel(AbstractModel):
         template = self.__class__(**params)
 
         return template
+
+    def get_user_params(self) -> dict:
+        """Used to access user-specified parameters for the model before initialization."""
+        if self._user_params is None:
+            return {}
+        else:
+            return self._user_params.copy()
 
 
 class AbstractTimeSeriesModelFactory:

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -9,10 +9,10 @@ from autogluon.common.savers import save_pkl
 from autogluon.core.hpo.exceptions import EmptySearchSpace
 from autogluon.core.hpo.executors import HpoExecutor
 from autogluon.core.models import AbstractModel
-
-from autogluon.timeseries.evaluator import TimeSeriesEvaluator
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
+from autogluon.timeseries.evaluator import TimeSeriesEvaluator
 from autogluon.timeseries.utils.metadata import get_prototype_metadata_dict
+
 from .model_trial import model_trial, skip_hpo
 
 logger = logging.getLogger(__name__)

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -151,7 +151,7 @@ def get_preset_models(
     else:
         raise ValueError(
             f"hyperparameters must be a dict, a string or None (received {type(hyperparameters)}). "
-            "Please see the documentation for TimeSeriesPredictor.fit"
+            f"Please see the documentation for TimeSeriesPredictor.fit"
         )
 
     if hyperparameter_tune:

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -135,18 +135,24 @@ def get_preset_models(
     will create models according to presets.
     """
     models = []
-    if isinstance(hyperparameters, str):
+    if hyperparameters is None:
+        hp_string = "default_hpo" if hyperparameter_tune else "default"
+        hyperparameters = copy.deepcopy(get_default_hps(hp_string, prediction_length))
+    elif isinstance(hyperparameters, str):
         hyperparameters = copy.deepcopy(get_default_hps(hyperparameters, prediction_length))
+    elif isinstance(hyperparameters, dict):
+        default_hps = copy.deepcopy(get_default_hps("default", prediction_length))
+        updated_hyperparameters = {}
+        # Only train models from `hyperparameters`, overload default HPs if provided
+        for model, hps in hyperparameters.items():
+            updated_hyperparameters[model] = default_hps.get(model, {})
+            updated_hyperparameters[model].update(hps)
+        hyperparameters = copy.deepcopy(updated_hyperparameters)
     else:
-        hp_str = "default" if not hyperparameter_tune else "default_hpo"
-        default_hps = copy.deepcopy(get_default_hps(hp_str, prediction_length))
-
-        if hyperparameters is not None:
-            # filter only default_hps for models with hyperparameters provided
-            default_hps = {model: default_hps.get(model, {}) for model in hyperparameters}
-            for model in hyperparameters:
-                default_hps[model].update(hyperparameters[model])
-        hyperparameters = copy.deepcopy(default_hps)
+        raise ValueError(
+            f"hyperparameters must be a dict, a string or None (received {type(hyperparameters)}). "
+            "Please see the documentation for TimeSeriesPredictor.fit"
+        )
 
     if hyperparameter_tune:
         verify_contains_searchspace(hyperparameters)

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -214,7 +214,7 @@ def contains_searchspace(model_hyperparameters: Dict[str, Any]) -> bool:
 def verify_contains_at_least_one_searchspace(hyperparameters: Dict[str, Dict[str, Any]]):
     if not any(contains_searchspace(model_hps) for model_hps in hyperparameters.values()):
         raise ValueError(
-            f"Hyperparameter tuning specified, but not a single model contains a hyperparameter search space. "
+            f"Hyperparameter tuning specified, but no model contains a hyperparameter search space. "
             f"Please disable hyperparameter tuning with `hyperparameter_tune_kwargs=None` or provide a search space "
             f"for at least one model."
         )

--- a/timeseries/src/autogluon/timeseries/models/presets.py
+++ b/timeseries/src/autogluon/timeseries/models/presets.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 import autogluon.core as ag
 
@@ -155,9 +155,9 @@ def get_preset_models(
         )
 
     if hyperparameter_tune:
-        verify_contains_searchspace(hyperparameters)
+        verify_contains_at_least_one_searchspace(hyperparameters)
     else:
-        verify_no_searchspace(hyperparameters)
+        verify_contains_no_searchspaces(hyperparameters)
 
     invalid_model_names = set(invalid_model_names)
     all_assigned_names = set(invalid_model_names)
@@ -204,30 +204,26 @@ def get_preset_models(
     return models
 
 
-def verify_contains_searchspace(hyperparameters):
-    for model in hyperparameters:
-        model_contains_searchspace = False
-        model_hps = hyperparameters[model]
-        for hp in model_hps:
-            hp_value = model_hps[hp]
-            if isinstance(hp_value, ag.space.Space):
-                model_contains_searchspace = True
-                break
-        if not model_contains_searchspace:
+def contains_searchspace(model_hyperparameters: Dict[str, Any]) -> bool:
+    for hp_value in model_hyperparameters.values():
+        if isinstance(hp_value, ag.space.Space):
+            return True
+    return False
+
+
+def verify_contains_at_least_one_searchspace(hyperparameters: Dict[str, Dict[str, Any]]):
+    if not any(contains_searchspace(model_hps) for model_hps in hyperparameters.values()):
+        raise ValueError(
+            f"Hyperparameter tuning specified, but not a single model contains a hyperparameter search space. "
+            f"Please disable hyperparameter tuning with `hyperparameter_tune_kwargs=None` or provide a search space "
+            f"for at least one model."
+        )
+
+
+def verify_contains_no_searchspaces(hyperparameters: Dict[str, Dict[str, Any]]):
+    for model, model_hps in hyperparameters.items():
+        if contains_searchspace(model_hps):
             raise ValueError(
-                f"Hyperparameter tuning specified, but no hyperparameter search space provided for {model}. "
-                f"Please convert one of the fixed hyperparameter values of this model to a search space and "
-                f"try again, or do not specify hyperparameter tuning."
+                f"Hyperparameter tuning not specified, so hyperparameters must have fixed values. "
+                f"However, for model {model} hyperparameters {model_hps} contain a search space."
             )
-
-
-def verify_no_searchspace(hyperparameters):
-    for model in hyperparameters:
-        model_hps = hyperparameters[model]
-        for hp in model_hps:
-            hp_value = model_hps[hp]
-            if isinstance(hp_value, ag.space.Space):
-                raise ValueError(
-                    f"Hyperparameter tuning not specified, so hyperparameters must have fixed values. For "
-                    f"{model}, hyperparameter {hp} currently given as search space: {hp_value}."
-                )

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -580,7 +580,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                     )
                 logger.info(fit_log_message)
 
-                if contains_searchspace(model._user_params):
+                if contains_searchspace(model.get_user_params()):
                     with tqdm.external_write_mode():
                         model_names_trained += self.tune_model_hyperparameters(
                             model,

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -18,9 +18,9 @@ from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_json, save_pkl
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
-from autogluon.timeseries.models.presets import contains_searchspace
 from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleSelection, TimeSeriesEnsembleWrapper
 from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
+from autogluon.timeseries.models.presets import contains_searchspace
 from autogluon.timeseries.utils.warning_filters import disable_tqdm
 
 logger = logging.getLogger("autogluon.timeseries.trainer")

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -16,7 +16,6 @@ from autogluon.common.utils.log_utils import set_logger_verbosity
 from autogluon.core.models import AbstractModel
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_json, save_pkl
-
 from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleSelection, TimeSeriesEnsembleWrapper

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -17,11 +17,11 @@ from autogluon.core.models import AbstractModel
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_json, save_pkl
 
-from .. import TimeSeriesDataFrame, TimeSeriesEvaluator
-from ..models.abstract import AbstractTimeSeriesModel
-from ..models.ensemble.greedy_ensemble import TimeSeriesEnsembleSelection, TimeSeriesEnsembleWrapper
-from ..models.gluonts.abstract_gluonts import AbstractGluonTSModel
-from ..utils.warning_filters import disable_tqdm
+from autogluon.timeseries import TimeSeriesDataFrame, TimeSeriesEvaluator
+from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
+from autogluon.timeseries.models.ensemble.greedy_ensemble import TimeSeriesEnsembleSelection, TimeSeriesEnsembleWrapper
+from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTSModel
+from autogluon.timeseries.utils.warning_filters import disable_tqdm
 
 logger = logging.getLogger("autogluon.timeseries.trainer")
 
@@ -568,6 +568,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         if time_limit is not None and len(models) > 0:
             time_limit_model_split /= len(models)
 
+        # TODO: Allow HPO only for some models?
         model_names_trained = []
         for i, model in enumerate(models):
             if hyperparameter_tune_kwargs is not None:

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -179,8 +179,7 @@ def test_given_hyperparameters_when_predictor_called_and_loaded_back_then_all_mo
 @pytest.mark.parametrize(
     "hyperparameters",
     [
-        {"ETS": {"maxiter": 1}, "SimpleFeedForward": {"epochs": 1}},
-        {"ETS": {"maxiter": 1}, "SimpleFeedForward": {"epochs": ag.Int(1, 3)}},
+        {"ETS": {"maxiter": ag.space.Categorical(1)}, "SimpleFeedForward": {"epochs": ag.space.Int(1, 3)}},
     ],
 )
 def test_given_hp_spaces_and_custom_target_when_predictor_called_predictor_can_predict(

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -462,7 +462,7 @@ def test_given_no_searchspace_and_hyperparameter_tune_kwargs_when_predictor_fits
     temp_model_path,
 ):
     predictor = TimeSeriesPredictor(path=temp_model_path, enable_ensemble=False)
-    with pytest.raises(ValueError, match="not a single model contains a hyperparameter search space"):
+    with pytest.raises(ValueError, match="no model contains a hyperparameter search space"):
         predictor.fit(
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters={"SimpleFeedForward": {"epochs": 1}},

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -474,7 +474,9 @@ def test_given_searchspace_and_no_hyperparameter_tune_kwargs_when_predictor_fits
     temp_model_path,
 ):
     predictor = TimeSeriesPredictor(path=temp_model_path, enable_ensemble=False)
-    with pytest.raises(ValueError, match="Hyperparameter tuning not specified, so hyperparameters must have fixed values"):
+    with pytest.raises(
+        ValueError, match="Hyperparameter tuning not specified, so hyperparameters must have fixed values"
+    ):
         predictor.fit(
             train_data=DUMMY_TS_DATAFRAME,
             hyperparameters={"SimpleFeedForward": {"epochs": ag.space.Categorical(1, 2)}},


### PR DESCRIPTION
*Description of changes:*
- Simplifies the logic for constructing the hyperparameter dict
- Fixes a bug where the HPO space was incorrectly bigger than the user-specified HPO space
- Enable training with fixed configs (some models have HP search spaces while others have fixed HPs)

For example the code below now only does HPO on the `num_cells` parameters.
```python
import autogluon.core as ag

TimeSeriesPredictor().fit(
    data,
    hyperparameters={
        "DeepAR": {"num_cells": ag.space.Categorical(10, 20)},
    },
    hyperparameter_tune_kwargs="random",
```
Before the same code used to do HPO on all hyperparameters of DeepAR specified in the `default_hpo` dict.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
