### PR TITLE
Added additive attention (linear complexity) to transformer models.

### DIFF
--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -22,6 +22,8 @@ model:
     head_activation: relu
     data_types:
     - categorical
+    additive_attention: False
+    share_qv_weights: False
   numerical_mlp:
     hidden_size: 128
     activation: "leaky_relu"
@@ -51,6 +53,8 @@ model:
       - 'linear'
       - 'relu'
     merge: "concat"
+    additive_attention: False
+    share_qv_weights: False
   hf_text:
     checkpoint_name: "google/electra-base-discriminator"
     gradient_checkpointing: False
@@ -194,3 +198,5 @@ model:
     ffn_activation: "geglu"
     head_activation: "relu"
     data_types:
+    additive_attention: False
+    share_qv_weights: False

--- a/multimodal/src/autogluon/multimodal/models/categorical_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/categorical_transformer.py
@@ -108,6 +108,8 @@ class CategoricalTransformer(nn.Module):
         kv_compression_sharing: Optional[str] = None,
         head_activation: Optional[str] = "relu",
         head_normalization: Optional[str] = "layer_norm",
+        additive_attention: Optional[bool] = False,
+        share_qv_weights: Optional[bool] = False,
     ) -> None:
         """
         Parameters
@@ -197,7 +199,11 @@ class CategoricalTransformer(nn.Module):
         )
 
         if kv_compression_ratio is not None:
-            n_tokens = self.categorical_feature_tokenizer.n_tokens + 1
+            # number of tokens depends on whether the CLS token is included or not.
+            if self.cls_token:
+                n_tokens = self.categorical_feature_tokenizer.n_tokens + 1
+            else:
+                n_tokens = self.categorical_feature_tokenizer.n_tokens
         else:
             n_tokens = None
 
@@ -222,6 +228,8 @@ class CategoricalTransformer(nn.Module):
             head_activation=head_activation,
             head_normalization=head_normalization,
             d_out=out_features,
+            additive_attention=additive_attention,
+            share_qv_weights=share_qv_weights,
         )
 
         self.head = FT_Transformer.Head(

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -403,11 +403,11 @@ class AdditiveAttention(nn.Module):
         v = self.qv_proj(x_kv) if self.share_qv_weights else self.v_proj(x_kv)
         k = self.k_proj(x_kv)
 
-        alphas = (self.W_q(q) / math.sqrt(self.head_dim)).softmax(dim=-1)
+        alphas = (self.W_q(q) / math.sqrt(self.head_dim)).softmax(dim=1)
         q_r = (
             q.reshape(batch_size, n_q_tokens, self.n_heads, self.head_dim)
         )
-        global_query = torch.einsum(" b s h, b s h d -> b h d", alphas, q_r) / math.sqrt(n_k_tokens)
+        global_query = torch.einsum(" b s h, b s h d -> b h d", alphas, q_r)
         global_query = (
             global_query.reshape(batch_size, self.n_heads * self.head_dim)
             .unsqueeze(1)
@@ -415,11 +415,11 @@ class AdditiveAttention(nn.Module):
 
         p = k * global_query
 
-        betas = (self.W_k(p) / math.sqrt(self.head_dim)).softmax(dim=-1)
+        betas = (self.W_k(p) / math.sqrt(self.head_dim)).softmax(dim=1)
         p_r = (
             p.reshape(batch_size, n_k_tokens, self.n_heads, self.head_dim)
         )
-        global_key = torch.einsum(" b s h, b s h d -> b h d", betas, p_r) / math.sqrt(n_k_tokens)
+        global_key = torch.einsum(" b s h, b s h d -> b h d", betas, p_r)
         global_key = (
             global_key.reshape(batch_size, self.n_heads * self.head_dim)
             .unsqueeze(1)

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -518,7 +518,7 @@ class FT_Transformer(nn.Module):
         head_normalization: ModuleType,
         d_out: int,
         projection: Optional[bool] = False,
-        additive_attention: Optional[bool] = True,
+        additive_attention: Optional[bool] = False,
         share_qv_weights: Optional[bool] = False,
     ) -> None:
         super().__init__()

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -311,6 +311,128 @@ class MultiheadAttention(nn.Module):
         }
 
 
+class AdditiveAttention(nn.Module):
+    """Additive Attention with linear complexity to input sequence length.
+
+    Additive attention was proposed and use in FastFormer.
+    See Ref. [1] for details.
+    This implementation is motivated by: https://github.com/jrzaurin/pytorch-widedeep.git
+
+    References:
+    ----------
+    [1] Wu, Chuhan, et al. "Fastformer: Additive attention can be all you need." arXiv preprint arXiv:2108.09084 (2021).
+    """
+    def __init__(
+        self,
+        *,
+        d_token: int,
+        n_heads: int,
+        dropout: float,
+        bias: bool,
+        share_qv_weights: bool,
+        initialization: str,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        d_token:
+            the token size. Must be a multiple of :code:`n_heads`.
+        n_heads:
+            the number of heads. If greater than 1, then the module will have
+            an addition output layer (so called "mixing" layer).
+        bias:
+            if `True`, then input (and output, if presented) layers also have bias.
+            `True` is a reasonable default choice.
+        dropout:
+            dropout rate for the attention map. The dropout is applied to
+            *probabilities* and do not affect logits.
+        share_qv_weights:
+            if 'True', then value and query transformation parameters are shared.
+        initialization:
+            initialization for input projection layers. Must be one of
+            :code:`['kaiming', 'xavier']`. `kaiming` is a reasonable default choice.
+        """
+        super().__init__()
+
+        assert d_token % n_heads == 0, "d_token must be a multiple of n_heads"
+        assert initialization in ["kaiming", "xavier"]
+
+        self.head_dim = d_token // n_heads
+        self.n_heads = n_heads
+        self.share_qv_weights = share_qv_weights
+        self.dropout = nn.Dropout(dropout)
+
+        trainable = []
+        if share_qv_weights:
+            self.qv_proj = nn.Linear(d_token, d_token, bias=bias)
+            trainable.extend([self.qv_proj])
+        else:
+            self.q_proj = nn.Linear(d_token, d_token, bias=bias)
+            self.v_proj = nn.Linear(d_token, d_token, bias=bias)
+            trainable.extend([self.q_proj, self.v_proj])
+
+        self.k_proj = nn.Linear(d_token, d_token, bias=bias)
+        self.W_q = nn.Linear(d_token, n_heads)
+        self.W_k = nn.Linear(d_token, n_heads)
+        self.r_out = nn.Linear(d_token, d_token)
+        trainable.extend([self.k_proj, self.W_q, self.W_k, self.r_out])
+
+        for m in trainable:
+            # the "xavier" branch tries to follow torch.nn.MultiheadAttention;
+            # the second condition checks if W_v plays the role of W_out; the latter one
+            # is initialized with Kaiming in torch
+            if initialization == "xavier":
+                # gain is needed since W_qkv is represented with 3 separate layers (it
+                # implies different fan_out)
+                nn.init.xavier_uniform_(m.weight, gain=1 / math.sqrt(2))
+            if m.bias is not None:
+                nn.init.zeros_(m.bias)
+
+
+    def forward(
+            self,
+            x_q: Tensor,
+            x_kv: Tensor,
+            *args,  # Not used. just to make the input consistent with MultiheadAttention.
+        ) -> Tuple[Tensor, Dict[str, Tensor]]:
+
+        batch_size, n_q_tokens, d_token = x_q.shape
+        batch_size, n_k_tokens, d_token = x_kv.shape
+
+        q = self.qv_proj(x_q) if self.share_qv_weights else self.q_proj(x_q)
+        v = self.qv_proj(x_kv) if self.share_qv_weights else self.v_proj(x_kv)
+        k = self.k_proj(x_kv)
+
+        alphas = (self.W_q(q) / math.sqrt(self.head_dim)).softmax(dim=-1)
+        q_r = (
+            q.reshape(batch_size, n_q_tokens, self.n_heads, self.head_dim)
+        )
+        global_query = torch.einsum(" b s h, b s h d -> b h d", alphas, q_r)
+        global_query = (
+            global_query.reshape(batch_size, self.n_heads * self.head_dim)
+            .unsqueeze(1)
+        )
+
+        p = k * global_query
+
+        betas = (self.W_k(p) / math.sqrt(self.head_dim)).softmax(dim=-1)
+        p_r = (
+            p.reshape(batch_size, n_k_tokens, self.n_heads, self.head_dim)
+        )
+        global_key = torch.einsum(" b s h, b s h d -> b h d", betas, p_r)
+        global_key = (
+            global_key.reshape(batch_size, self.n_heads * self.head_dim)
+            .unsqueeze(1)
+        )
+
+        u = v * global_key
+        output = q + self.dropout(self.r_out(u))
+
+        return output, {
+            "query_weight": alphas,
+            "key_weight": betas,
+        }
+
 class FT_Transformer(nn.Module):
     """Transformer with extra features.
 
@@ -396,6 +518,8 @@ class FT_Transformer(nn.Module):
         head_normalization: ModuleType,
         d_out: int,
         projection: Optional[bool] = False,
+        additive_attention: Optional[bool] = True,
+        share_qv_weights: Optional[bool] = False,
     ) -> None:
         super().__init__()
         if isinstance(last_layer_query_idx, int):
@@ -411,6 +535,9 @@ class FT_Transformer(nn.Module):
             "If any of the following arguments is (not) None, then all of them must (not) be None: "
             "n_tokens, kv_compression_ratio, kv_compression_sharing"
         )
+        assert (
+            additive_attention or not share_qv_weights
+        ), "If `share_qv_weights` is True, then `additive_attention` must be True"
         assert kv_compression_sharing in [None, "headwise", "key-value", "layerwise"]
         if not prenormalization:
             if self.WARNINGS["prenormalization"]:
@@ -450,7 +577,14 @@ class FT_Transformer(nn.Module):
         for layer_idx in range(n_blocks):
             layer = nn.ModuleDict(
                 {
-                    "attention": MultiheadAttention(
+                    "attention": AdditiveAttention(
+                        d_token=d_token,
+                        n_heads=attention_n_heads,
+                        dropout=attention_dropout,
+                        bias=True,
+                        share_qv_weights=share_qv_weights,
+                        initialization=attention_initialization,
+                    ) if additive_attention else MultiheadAttention(
                         d_token=d_token,
                         n_heads=attention_n_heads,
                         dropout=attention_dropout,

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -407,7 +407,7 @@ class AdditiveAttention(nn.Module):
         q_r = (
             q.reshape(batch_size, n_q_tokens, self.n_heads, self.head_dim)
         )
-        global_query = torch.einsum(" b s h, b s h d -> b h d", alphas, q_r)
+        global_query = torch.einsum(" b s h, b s h d -> b h d", alphas, q_r) / math.sqrt(n_k_tokens)
         global_query = (
             global_query.reshape(batch_size, self.n_heads * self.head_dim)
             .unsqueeze(1)
@@ -419,7 +419,7 @@ class AdditiveAttention(nn.Module):
         p_r = (
             p.reshape(batch_size, n_k_tokens, self.n_heads, self.head_dim)
         )
-        global_key = torch.einsum(" b s h, b s h d -> b h d", betas, p_r)
+        global_key = torch.einsum(" b s h, b s h d -> b h d", betas, p_r) / math.sqrt(n_k_tokens)
         global_key = (
             global_key.reshape(batch_size, self.n_heads * self.head_dim)
             .unsqueeze(1)

--- a/multimodal/src/autogluon/multimodal/models/fusion.py
+++ b/multimodal/src/autogluon/multimodal/models/fusion.py
@@ -243,6 +243,8 @@ class MultimodalFusionTransformer(nn.Module):
         head_normalization: Optional[str] = "layer_norm",
         adapt_in_features: Optional[str] = None,
         loss_weight: Optional[float] = None,
+        additive_attention: Optional[bool] = False,
+        share_qv_weights: Optional[bool] = False,
     ):
         super().__init__()
         logger.debug("initializing MultimodalFusionTransformer")
@@ -289,6 +291,8 @@ class MultimodalFusionTransformer(nn.Module):
             head_normalization=head_normalization,
             d_out=hidden_features,
             projection=False,
+            additive_attention=additive_attention,
+            share_qv_weights=share_qv_weights,
         )
 
         self.head = FT_Transformer.Head(

--- a/multimodal/src/autogluon/multimodal/models/numerical_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/numerical_transformer.py
@@ -382,6 +382,8 @@ class NumericalTransformer(nn.Module):
         head_activation: Optional[str] = "relu",
         head_normalization: Optional[str] = "layer_norm",
         embedding_arch: Optional[List[str]] = ["linear"],
+        additive_attention: Optional[bool] = False,
+        share_qv_weights: Optional[bool] = False,
     ):
         """
         Parameters
@@ -500,6 +502,8 @@ class NumericalTransformer(nn.Module):
             head_activation=head_activation,
             head_normalization=head_normalization,
             d_out=out_features,
+            additive_attention=additive_attention,
+            share_qv_weights=share_qv_weights,
         )
 
         self.head = FT_Transformer.Head(

--- a/multimodal/src/autogluon/multimodal/utils/environment.py
+++ b/multimodal/src/autogluon/multimodal/utils/environment.py
@@ -120,7 +120,7 @@ def infer_precision(num_gpus: int, precision: Union[int, str], as_torch: Optiona
     return precision
 
 
-def move_to_device(obj: Union[torch.Tensor, nn.Module, Dict, List], device: torch.device):
+def move_to_device(obj: Union[torch.Tensor, nn.Module, Dict, List, Tuple], device: torch.device):
     """
     Move an object to the given device.
 
@@ -145,7 +145,7 @@ def move_to_device(obj: Union[torch.Tensor, nn.Module, Dict, List], device: torc
         for k, v in obj.items():
             res[k] = move_to_device(v, device)
         return res
-    elif isinstance(obj, list):
+    elif isinstance(obj, list) or isinstance(obj, tuple):
         res = []
         for v in obj:
             res.append(move_to_device(v, device))

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -101,7 +101,6 @@ def infer_batch(
     if 1 < num_gpus <= batch_size:
         model = nn.DataParallel(model)
     model.to(device).eval()
-    print("guaguagua----------", batch)
     batch = move_to_device(batch, device=device)
     precision_context = get_precision_context(precision=precision, device_type=device_type)
     with precision_context, torch.no_grad():

--- a/multimodal/src/autogluon/multimodal/utils/inference.py
+++ b/multimodal/src/autogluon/multimodal/utils/inference.py
@@ -101,6 +101,7 @@ def infer_batch(
     if 1 < num_gpus <= batch_size:
         model = nn.DataParallel(model)
     model.to(device).eval()
+    print("guaguagua----------", batch)
     batch = move_to_device(batch, device=device)
     precision_context = get_precision_context(precision=precision, device_type=device_type)
     with precision_context, torch.no_grad():

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -223,6 +223,8 @@ def create_model(
             embedding_arch=model_config.embedding_arch,
             num_classes=num_classes,
             ffn_d_hidden=OmegaConf.select(model_config, "ffn_d_hidden", default=192),
+            additive_attention=model_config.additive_attention,
+            share_qv_weights=model_config.share_qv_weights,
         )
     elif model_name.lower().startswith(CATEGORICAL_MLP):
         model = CategoricalMLP(
@@ -254,6 +256,8 @@ def create_model(
             ffn_d_hidden=OmegaConf.select(model_config, "ffn_d_hidden", default=192),
             num_classes=num_classes,
             cls_token=False,
+            additive_attention=model_config.additive_attention,
+            share_qv_weights=model_config.share_qv_weights,
         )
     elif model_name.lower().startswith(MMDET_IMAGE):
         model = MMDetAutoModelForObjectDetection(
@@ -301,6 +305,8 @@ def create_model(
             head_activation=model_config.head_activation,
             adapt_in_features=model_config.adapt_in_features,
             loss_weight=model_config.weight if hasattr(model_config, "weight") else None,
+            additive_attention=model_config.additive_attention,
+            share_qv_weights=model_config.share_qv_weights,
         )
     else:
         raise ValueError(f"unknown model name: {model_name}")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Added additive attention as an option for transformer-based models. To replace the MutiHeadAttention with AdditiveAttention, simply pass the following to TabularPredictor().

```
hyperparameters['FT_TRANSFORMER'] = {
    "model.fusion_transformer.additive_attention": True,
    "model.fusion_transformer.share_qv_weights": False,
}
```
Results using additive attention and its comparison to MultiHeadAttention can be found [here](https://quip-amazon.com/9ixBA110jgY6/Progress-Pre-training-on-Tabular-DL?range_cols=5&range_rows=1#temp:s:temp:C:MVY9817779fa3774e1caae594d75;temp:C:MVY519fd4e2f7184d409214df2af).

2. Since Categorical features are stored as Tuples. Added "tuple" to realtime_predict to fix errors with Categorical features.

3. I believe there is a issue when calculating the n_tokens for CategoricalTransformer. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
