### PR TITLE
Enable Ray Tune backend for time series models

### DIFF
--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -158,6 +158,7 @@ class RayHpoExecutor(HpoExecutor):
     custom_to_ray_searcher_preset_map = {
         'local_random': 'random',
         'random': 'random',
+        # TODO: Should this be changed to 'auto': 'bayes'?
         'auto': 'random',
     }
     

--- a/core/src/autogluon/core/hpo/executors.py
+++ b/core/src/autogluon/core/hpo/executors.py
@@ -158,8 +158,7 @@ class RayHpoExecutor(HpoExecutor):
     custom_to_ray_searcher_preset_map = {
         'local_random': 'random',
         'random': 'random',
-        # TODO: Should this be changed to 'auto': 'bayes'?
-        'auto': 'random',
+        'auto': 'bayes',
     }
     
     def __init__(self):

--- a/core/src/autogluon/core/searcher/searcher_factory.py
+++ b/core/src/autogluon/core/searcher/searcher_factory.py
@@ -10,6 +10,10 @@ SEARCHER_CONFIGS = dict(
     local_grid=dict(
         searcher_cls=LocalGridSearcher,
     ),
+    # Fall back to random search since Bayes searcher is not supported
+    bayes=dict(
+        searcher_cls=LocalRandomSearcher
+    ),
 )
 
 

--- a/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/model_trial.py
@@ -20,7 +20,6 @@ def model_trial(
     reporter=None,  # reporter only used by custom strategy, hence optional
     time_limit=None,
     fit_kwargs=None,
-    checkpoint_dir=None,  # Timeseries doesn't support checkpoint in the middle yet. This is here to disable warning from ray tune
 ):
     """Runs a single trial of a hyperparameter tuning. Replaces
     `core.models.abstract.model_trial.model_trial` for timeseries models.

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -2,7 +2,6 @@ import logging
 import re
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Type
-from autogluon.core.hpo.constants import RAY_BACKEND
 
 import gluonts
 import numpy as np
@@ -14,6 +13,7 @@ from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
 from gluonts.model.predictor import Predictor as GluonTSPredictor
 
 from autogluon.common.utils.log_utils import set_logger_verbosity
+from autogluon.core.hpo.constants import RAY_BACKEND
 from autogluon.core.utils import warning_filter
 from autogluon.core.utils.savers import save_pkl
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -2,6 +2,7 @@ import logging
 import re
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Type
+from autogluon.core.hpo.constants import RAY_BACKEND
 
 import gluonts
 import numpy as np
@@ -309,3 +310,6 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             result_dfs.append(df)
 
         return TimeSeriesDataFrame.from_data_frame(pd.concat(result_dfs))
+
+    def _get_hpo_backend(self):
+        return RAY_BACKEND

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -105,6 +105,7 @@ class TimeSeriesPredictor:
     quantiles : List[float]
         Alias for :attr:`quantile_levels`.
     """
+
     # TODO: Update description of presets after the presets are finalized
     # TODO: Update docstring for predict
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -347,7 +347,7 @@ class TimeSeriesPredictor:
         self.save()
         return self
 
-    # TODO: to be changed after ray tune integration
+    # TODO: Is this method safe to delete?
     def _get_scheduler_options(
         self,
         hyperparameter_tune_kwargs: Optional[Union[str, Dict]],

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -568,6 +568,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         if time_limit is not None and len(models) > 0:
             time_limit_model_split /= len(models)
 
+        # TODO: Allow HPO only for some models?
         model_names_trained = []
         for i, model in enumerate(models):
             if hyperparameter_tune_kwargs is not None:

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -572,7 +572,6 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         if time_limit is not None and len(models) > 0:
             time_limit_model_split /= len(models)
 
-        # TODO: Allow HPO only for some models?
         model_names_trained = []
         for i, model in enumerate(models):
             if hyperparameter_tune_kwargs is not None:

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -10,6 +10,7 @@ from warnings import warn
 
 import networkx as nx
 import pandas as pd
+from ray.tune import ExperimentAnalysis
 from tqdm import tqdm
 
 from autogluon.common.utils.log_utils import set_logger_verbosity
@@ -427,6 +428,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         ):
             default_num_trials = 10
 
+        tuning_start_time = time.time()
         with disable_tqdm():
             hpo_models, hpo_results = model.hyperparameter_tune(
                 train_data=train_data,
@@ -435,6 +437,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                 time_limit=time_limit,
                 default_num_trials=default_num_trials,
             )
+        total_tuning_time = time.time() - tuning_start_time
 
         self.hpo_results[model.name] = hpo_results
         model_names_trained = []
@@ -450,18 +453,21 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         logger.info(f"\tTrained {len(model_names_trained)} models while tuning {model.name}.")
 
-        # TODO: log result for ray backend
-        if hpo_results and isinstance(hpo_results, dict):
+        if hpo_results and isinstance(hpo_results, (ExperimentAnalysis, dict)):
+            if isinstance(hpo_results, ExperimentAnalysis):
+                best_val_score = hpo_results.best_result["validation_performance"]
+                best_config = hpo_results.get_best_config()
+            else:
+                best_val_score = hpo_results.get("best_reward")
+                best_config = hpo_results.get("best_config")
+
             if TimeSeriesEvaluator.METRIC_COEFFICIENTS[self.eval_metric] == -1:
                 sign_str = "-"
             else:
                 sign_str = ""
-            logger.info(
-                f"\t{hpo_results.get('best_reward'):<7.4f}".ljust(15)
-                + f"= Validation score ({sign_str}{self.eval_metric})"
-            )
-            logger.info(f"\t{hpo_results.get('total_time'):<7.2f} s".ljust(15) + "= Total tuning time")
-            logger.debug(f"\tBest hyperparameter configuration: {hpo_results.get('best_config')}")
+            logger.info(f"\t{best_val_score:<7.4f}".ljust(15) + f"= Validation score ({sign_str}{self.eval_metric})")
+            logger.info(f"\t{total_tuning_time:<7.2f} s".ljust(15) + "= Total tuning time")
+            logger.debug(f"\tBest hyperparameter configuration: {best_config}")
 
         return model_names_trained
 

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -429,7 +429,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
 
         tuning_start_time = time.time()
         with disable_tqdm():
-            hpo_models, hpo_results = model.hyperparameter_tune(
+            hpo_models, _ = model.hyperparameter_tune(
                 train_data=train_data,
                 val_data=val_data,
                 hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
@@ -438,9 +438,8 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
             )
         total_tuning_time = time.time() - tuning_start_time
 
-        self.hpo_results[model.name] = hpo_results
+        self.hpo_results[model.name] = hpo_models
         model_names_trained = []
-        # TODO: Does this code still work if all model configurations failed?
         # add each of the trained HPO configurations to the trained models
         for model_hpo_name, model_info in hpo_models.items():
             model_path = model_info["path"]

--- a/timeseries/tests/unittests/models/test_models.py
+++ b/timeseries/tests/unittests/models/test_models.py
@@ -110,22 +110,20 @@ def test_given_hyperparameter_spaces_when_tune_called_then_tuning_output_correct
         freq="H",
         quantile_levels=[0.1, 0.9],
         hyperparameters={
-            "epochs": ag.Int(3, 4),
+            "epochs": ag.Int(1, 3),
         },
     )
+    num_trials = 2
 
-    hyperparameter_tune_kwargs = "auto"
-
-    models, results = model.hyperparameter_tune(
-        hyperparameter_tune_kwargs=hyperparameter_tune_kwargs,
+    hpo_results, _ = model.hyperparameter_tune(
+        hyperparameter_tune_kwargs={"num_trials": num_trials, "scheduler": "local", "searcher": "random"},
         time_limit=100,
         train_data=DUMMY_TS_DATAFRAME,
         val_data=DUMMY_TS_DATAFRAME,
     )
-
-    assert len(results["config_history"]) == 2
-    assert results["config_history"][0]["epochs"] == 3
-    assert results["config_history"][1]["epochs"] == 4
+    assert len(hpo_results) == num_trials
+    for result in hpo_results.values():
+        assert 1 <= result["hyperparameters"]["epochs"] <= 3
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -193,9 +193,10 @@ def test_given_hyperparameters_with_spaces_when_trainer_called_then_hpo_is_perfo
 
     assert len(leaderboard) == 2 + 1  # include ensemble
 
-    config_history = next(iter(trainer.hpo_results.values()))["config_history"]
+    hpo_results_first_model = next(iter(trainer.hpo_results.values()))
+    config_history = [result["hyperparameters"] for result in hpo_results_first_model.values()]
     assert len(config_history) == 2
-    assert all(1 <= model["epochs"] <= 4 for model in config_history.values())
+    assert all(1 <= config["epochs"] <= 4 for config in config_history)
 
 
 @pytest.mark.skipif(not PROPHET_IS_INSTALLED, reason="Prophet is not installed.")
@@ -256,7 +257,7 @@ def test_given_hyperparameters_with_spaces_to_prophet_when_trainer_called_then_h
             hyperparameters=hyperparameters,
             val_data=DUMMY_TS_DATAFRAME,
             hyperparameter_tune_kwargs={
-                "num_samples": 2,
+                "num_trials": 2,
                 "searcher": "random",
                 "scheduler": "local",
             },
@@ -489,9 +490,10 @@ def test_given_hyperparameters_with_spaces_and_custom_model_when_trainer_called_
         leaderboard = trainer.leaderboard()
 
     assert len(leaderboard) == 2 + 1  # include ensemble
-    config_history = next(iter(trainer.hpo_results.values()))["config_history"]
+    hpo_results_first_model = next(iter(trainer.hpo_results.values()))
+    config_history = [result["hyperparameters"] for result in hpo_results_first_model.values()]
     assert len(config_history) == 2
-    assert all(1 <= model["epochs"] <= 4 for model in config_history.values())
+    assert all(1 <= config["epochs"] <= 4 for config in config_history)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Description of changes:*
- Use Ray Tune as default HPO backend for GluonTS models. We don't use Ray for other models (e.g., local models from Statsmodels) since 
    1. their searchspace is just a grid
    2. they don't benefit from being trained in parallel
    3. they are deterministic, so always training `num_trials` models with repeated hyperparameters (as done by Ray) doesn't make sense.
- Update HPO results reporting logic in `abstract_trainer.py`
- Update `searcher` mapping in `autogluon.core`

*To do:*
- [x] Discuss TODOs marked in code
- [x] Add documentation for `hyperparameter_tune_kwargs` in `TimeSeriesPredictor`
- [x] Add more tests?
- [x] Fix Ray warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
