### PR TITLE
Speed up RandomForestQuantileRegressor and ExtraTreesQuantileRegressor

### DIFF
--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -127,10 +127,12 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
         X_leaves = self.apply(X)
         unique_leaves = np.unique(X_leaves)
         for leaf in unique_leaves:
-            quantiles[X_leaves == leaf] = weighted_percentile(self.y_train_[self.y_train_leaves_ == leaf], quantile)
+            quantiles[X_leaves == leaf] = weighted_percentile(
+                self.y_train_[self.y_train_leaves_ == leaf], quantile)
         return quantiles
 
-    def fit(self, X, y, sample_weight=None, check_input=True, X_idx_sorted=None):
+    def fit(self, X, y, sample_weight=None, check_input=True,
+            X_idx_sorted=None):
         """
         Build a decision tree classifier from the training set (X, y).
 

--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -1,5 +1,7 @@
 import logging
+import pandas as pd
 import numpy as np
+from functools import partial
 from sklearn.tree import BaseDecisionTree
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.tree import ExtraTreeRegressor
@@ -11,7 +13,7 @@ from sklearn.utils import check_random_state
 logger = logging.getLogger(__name__)
 
 
-def weighted_percentile(a, q, weights=None, sorter=None):
+def weighted_percentile(a, q, weights=None, sorter=None, is_filtered=False):
     """
     Returns the weighted percentile of a at q given weights.
     Parameters
@@ -19,13 +21,16 @@ def weighted_percentile(a, q, weights=None, sorter=None):
     a: array-like, shape=(n_samples,)
         samples at which the quantile.
     q: int
-        quantile.
+        quantile between 0 and 100.
     weights: array-like, shape=(n_samples,)
         weights[i] is the weight given to point a[i] while computing the
         quantile. If weights[i] is zero, a[i] is simply ignored during the
         percentile computation.
     sorter: array-like, shape=(n_samples,)
         If provided, assume that a[sorter] is sorted.
+    is_filtered: bool
+        If True, weights is assumed to contain only non-zero values.
+
     Returns
     -------
     percentile: float
@@ -44,8 +49,7 @@ def weighted_percentile(a, q, weights=None, sorter=None):
     if weights is None:
         weights = np.ones_like(a)
     if q > 100 or q < 0:
-        raise ValueError("q should be in-between 0 and 100, "
-                         "got %d" % q)
+        raise ValueError("q should be in-between 0 and 100, " "got %d" % q)
 
     a = np.asarray(a, dtype=np.float32)
     weights = np.asarray(weights, dtype=np.float32)
@@ -56,9 +60,10 @@ def weighted_percentile(a, q, weights=None, sorter=None):
         a = a[sorter]
         weights = weights[sorter]
 
-    nz = weights != 0
-    a = a[nz]
-    weights = weights[nz]
+    if not is_filtered:
+        nz = weights != 0
+        a = a[nz]
+        weights = weights[nz]
 
     if sorter is None:
         sorted_indices = np.argsort(a)
@@ -119,12 +124,10 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
         X_leaves = self.apply(X)
         unique_leaves = np.unique(X_leaves)
         for leaf in unique_leaves:
-            quantiles[X_leaves == leaf] = weighted_percentile(
-                self.y_train_[self.y_train_leaves_ == leaf], quantile)
+            quantiles[X_leaves == leaf] = weighted_percentile(self.y_train_[self.y_train_leaves_ == leaf], quantile)
         return quantiles
 
-    def fit(self, X, y, sample_weight=None, check_input=True,
-            X_idx_sorted=None):
+    def fit(self, X, y, sample_weight=None, check_input=True, X_idx_sorted=None):
         """
         Build a decision tree classifier from the training set (X, y).
 
@@ -167,11 +170,10 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
             y = np.ravel(y)
 
         # apply method requires X to be of dtype np.float32
-        X, y = check_X_y(
-            X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
+        X, y = check_X_y(X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
         super(BaseTreeQuantileRegressor, self).fit(
-            X, y, sample_weight=sample_weight, check_input=check_input,
-            X_idx_sorted=X_idx_sorted)
+            X, y, sample_weight=sample_weight, check_input=check_input, X_idx_sorted=X_idx_sorted
+        )
         self.y_train_ = y
 
         # Stores the leaf nodes that the samples lie in.
@@ -280,15 +282,18 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
         Cache the leaf nodes that each training sample falls into.
         y_train_leaves_[i] is the leaf that y_train[i] ends up at.
     """
-    def __init__(self,
-                 criterion="squared_error",
-                 splitter="best",
-                 max_depth=None,
-                 min_samples_split=2,
-                 min_samples_leaf=1,
-                 max_features=None,
-                 random_state=None,
-                 max_leaf_nodes=None):
+
+    def __init__(
+        self,
+        criterion="squared_error",
+        splitter="best",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        max_features=None,
+        random_state=None,
+        max_leaf_nodes=None,
+    ):
         super(DecisionTreeQuantileRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -297,19 +302,22 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
             min_samples_leaf=min_samples_leaf,
             max_features=max_features,
             max_leaf_nodes=max_leaf_nodes,
-            random_state=random_state)
+            random_state=random_state,
+        )
 
 
 class ExtraTreeQuantileRegressor(ExtraTreeRegressor, BaseTreeQuantileRegressor):
-    def __init__(self,
-                 criterion='squared_error',
-                 splitter='random',
-                 max_depth=None,
-                 min_samples_split=2,
-                 min_samples_leaf=1,
-                 max_features='auto',
-                 random_state=None,
-                 max_leaf_nodes=None):
+    def __init__(
+        self,
+        criterion="squared_error",
+        splitter="random",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        max_features="auto",
+        random_state=None,
+        max_leaf_nodes=None,
+    ):
         super(ExtraTreeQuantileRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -318,7 +326,8 @@ class ExtraTreeQuantileRegressor(ExtraTreeRegressor, BaseTreeQuantileRegressor):
             min_samples_leaf=min_samples_leaf,
             max_features=max_features,
             max_leaf_nodes=max_leaf_nodes,
-            random_state=random_state)
+            random_state=random_state,
+        )
 
 
 def generate_sample_indices(random_state, n_samples):
@@ -343,10 +352,92 @@ def generate_sample_indices(random_state, n_samples):
     return sample_indices
 
 
+def get_weighted_neighbors_dataframe(X_leaves, y_train_leaves, y_train, y_weights):
+    """For each test sample, get the list of weighted targets that are assigned to the same leaf by at least one estimator.
+
+    Parameters
+    ----------
+    X_leaves : array, shape [n_test, n_estimators]
+        Index of the leave assigned to each test sample by each estimator.
+    y_train_leaves : array, shape [n_estimators, n_train]
+        Index of the leave assigned to each training sample by each estimator.
+    y_train : array, shape [n_train]
+        Values of training samples.
+    y_weights : array, shape [n_estimators, n_train]
+        Weight assigned to each training sample by each estimator.
+
+    Returns
+    -------
+    weighted_neighbors_dataframe : pd.DataFrame
+        Dataframe that contains weighted neighbors of each item in the test set.
+        Columns:
+            item_id: ID of each item in the test set
+            y: Target value encountered in the same leaf as the item
+            weight: Weight assigned to each target value
+    """
+    assert X_leaves.shape[1] == y_train_leaves.shape[0] == y_weights.shape[0]
+    assert y_train_leaves.shape[1] == y_train.shape[0] == y_weights.shape[1]
+
+    num_test, num_trees = X_leaves.shape
+    _, num_train = y_train_leaves.shape
+
+    tree_index_x = np.arange(num_trees)[None].repeat([num_test], axis=0)
+    item_index_x = np.arange(num_test)[:, None].repeat([num_trees], axis=1)
+    df_x = pd.DataFrame(
+        {
+            "item_id": item_index_x.ravel(),
+            "tree_id": tree_index_x.ravel(),
+            "leaf": X_leaves.ravel(),
+        }
+    )
+    tree_index_y = np.arange(num_trees)[:, None].repeat([num_train], axis=1)
+    target_y = y_train[None].repeat([num_trees], axis=0)
+    df_y = pd.DataFrame(
+        {
+            "tree_id": tree_index_y.ravel(),
+            "leaf": y_train_leaves.ravel(),
+            "y": target_y.ravel(),
+            "weight": y_weights.ravel(),
+        }
+    )
+    samples_with_neighbors = pd.merge(df_x, df_y, on=["tree_id", "leaf"])
+    return samples_with_neighbors.groupby(["item_id", "y"]).sum().reset_index()[["item_id", "y", "weight"]]
+
+
+def get_quantiles(neighbors_df, quantile_levels):
+    """Compute predicted quantiles for the given sample.
+
+    Parameters
+    ----------
+    neighbors_df : pd.DataFrame
+        DataFrame with columns y (target values for each sample) and weight (weigth assigned to each sample)
+    quantile_levels : List[float]
+        List of quantiles to predict between 0.0 and 1.0
+
+    Returns
+    -------
+    quantiles : array, shape [len(quantile_levels)]
+        Predicted quantiles.
+    """
+    result = []
+    for q in quantile_levels:
+        result.append(
+            weighted_percentile(
+                neighbors_df.y,
+                int(q * 100),
+                neighbors_df.weight,
+                sorter=slice(None),  # targets are already sorted, so no sorting required
+                is_filtered=True
+            )
+        )
+    return result
+
+
 class BaseForestQuantileRegressor(ForestRegressor):
     def fit(self, X, y, sample_weight=None):
         """
         Build a forest from the training set (X, y).
+
         Parameters
         ----------
         X : array-like or sparse matrix, shape = [n_samples, n_features]
@@ -361,25 +452,23 @@ class BaseForestQuantileRegressor(ForestRegressor):
             ignored while searching for a split in each node. Splits are also
             ignored if they would result in any single class carrying a
             negative weight in either child node.
-        check_input : boolean, (default=True)
-            Allow to bypass several input checking.
-            Don't use this parameter unless you know what you do.
-        X_idx_sorted : array-like, shape = [n_samples, n_features], optional
-            The indexes of the sorted training input samples. If many tree
-            are grown on the same dataset, this allows the ordering to be
-            cached between trees. If None, the data will be sorted here.
-            Don't use this parameter unless you know what to do.
+
         Returns
         -------
         self : object
             Returns self.
         """
-        logger.warning(f'\tWARNING: {self.__class__.__name__} are experimental for quantile regression. '
-                       f'They may change or be removed without warning in future releases.')
+        logger.warning(
+            f"\tWARNING: {self.__class__.__name__} are experimental for quantile regression. "
+            f"They may change or be removed without warning in future releases."
+        )
+        if sample_weight is not None:
+            logger.warning(
+                f"\tWARNING: {self.__class__.__name__} ignores sample_weight."
+            )
 
         # apply method requires X to be of dtype np.float32
-        X, y = check_X_y(
-            X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
+        X, y = check_X_y(X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
         super(BaseForestQuantileRegressor, self).fit(X, y)
 
         self.y_train_ = y
@@ -388,17 +477,17 @@ class BaseForestQuantileRegressor(ForestRegressor):
 
         for i, est in enumerate(self.estimators_):
             if self.bootstrap:
-                bootstrap_indices = generate_sample_indices(
-                    est.random_state, len(y))
+                bootstrap_indices = generate_sample_indices(est.random_state, len(y))
             else:
                 bootstrap_indices = np.arange(len(y))
 
             est_weights = np.bincount(bootstrap_indices, minlength=len(y))
             y_train_leaves = est.y_train_leaves_
-            for curr_leaf in np.unique(y_train_leaves):
-                y_ind = y_train_leaves == curr_leaf
-                self.y_weights_[i, y_ind] = (
-                    est_weights[y_ind] / np.sum(est_weights[y_ind]))
+            # Normalize the bootstrap weights such that the total weight of each leaf sums up to 1
+            # Relabel leaves starting from zero in order to efficiently count the total sum per leaf with bincount
+            leaves_starting_from_zero = np.unique(y_train_leaves, return_inverse=True)[1]
+            weight_per_leaf = np.bincount(leaves_starting_from_zero, weights=est_weights)
+            self.y_weights_[i] = est_weights / weight_per_leaf[leaves_starting_from_zero]
 
             self.y_train_leaves_[i, bootstrap_indices] = y_train_leaves[bootstrap_indices]
         return self
@@ -406,22 +495,21 @@ class BaseForestQuantileRegressor(ForestRegressor):
     def predict(self, X, quantile_levels=None):
         """
         Predict regression value for X.
+
         Parameters
         ----------
         X : array-like or sparse matrix of shape = [n_samples, n_features]
             The input samples. Internally, it will be converted to
             ``dtype=np.float32`` and if a sparse matrix is provided
             to a sparse ``csr_matrix``.
-        quantile_levels : int, optional
-            Value ranging from 0 to 100. By default, the mean is returned.
-        check_input : boolean, (default=True)
-            Allow to bypass several input checking.
-            Don't use this parameter unless you know what you do.
+        quantile_levels : List[float], optional
+            List of quantiles (between 0.0 and 1.0) to predict. If not provided, mean is returned.
+
         Returns
         -------
-        y : array of shape = [n_samples]
-            If quantile is set to None, then return E(Y | X). Else return
-            y such that F(Y=y | x) = quantile.
+        y : array
+            If quantile_levels is None, then y contains E(Y | X) and has shape [n_samples].
+            Otherwise, y contains the predicted quantiles and has shape [n_samples, len(quantile_levels)]
         """
         # apply method requires X to be of dtype np.float32
         X = check_array(X, dtype=np.float32, accept_sparse="csc")
@@ -430,18 +518,15 @@ class BaseForestQuantileRegressor(ForestRegressor):
         elif isinstance(quantile_levels, float):
             quantile_levels = [quantile_levels]
 
-        sorter = np.argsort(self.y_train_)
         X_leaves = self.apply(X)
 
-        num_quantiles = len(quantile_levels)
-        quantile_preds = np.zeros((X.shape[0], num_quantiles))
-        for i, x_leaf in enumerate(X_leaves):
-            mask = self.y_train_leaves_ != np.expand_dims(x_leaf, 1)
-            x_weights = np.ma.masked_array(self.y_weights_, mask)
-            weights = x_weights.sum(axis=0)
-            for j, quantile in enumerate(quantile_levels):
-                quantile_preds[i][j] = weighted_percentile(self.y_train_, int(quantile * 100), weights, sorter)
-        return quantile_preds
+        samples_with_weighted_neighbors = get_weighted_neighbors_dataframe(
+            X_leaves=X_leaves, y_train_leaves=self.y_train_leaves_, y_train=self.y_train_, y_weights=self.y_weights_
+        )
+        quantile_preds = samples_with_weighted_neighbors.groupby("item_id").apply(
+            partial(get_quantiles, quantile_levels=quantile_levels)
+        )
+        return np.stack(quantile_preds.values.tolist())
 
 
 class RandomForestQuantileRegressor(BaseForestQuantileRegressor):
@@ -549,38 +634,44 @@ class RandomForestQuantileRegressor(BaseForestQuantileRegressor):
     .. [1] Nicolai Meinshausen, Quantile Regression Forests
         http://www.jmlr.org/papers/volume7/meinshausen06a/meinshausen06a.pdf
     """
-    def __init__(self,
-                 n_estimators=10,
-                 criterion='squared_error',
-                 max_depth=None,
-                 min_samples_split=2,
-                 min_samples_leaf=1,
-                 max_features='auto',
-                 max_leaf_nodes=None,
-                 bootstrap=True,
-                 oob_score=False,
-                 n_jobs=1,
-                 random_state=None,
-                 verbose=0,
-                 warm_start=False,
-                 max_samples=None):
+
+    def __init__(
+        self,
+        n_estimators=10,
+        criterion="squared_error",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        max_features="auto",
+        max_leaf_nodes=None,
+        bootstrap=True,
+        oob_score=False,
+        n_jobs=1,
+        random_state=None,
+        verbose=0,
+        warm_start=False,
+        max_samples=None,
+    ):
         super(RandomForestQuantileRegressor, self).__init__(
             base_estimator=DecisionTreeQuantileRegressor(),
             n_estimators=n_estimators,
-            estimator_params=("criterion",
-                              "max_depth",
-                              "min_samples_split",
-                              "min_samples_leaf",
-                              "max_features",
-                              "max_leaf_nodes",
-                              "random_state"),
+            estimator_params=(
+                "criterion",
+                "max_depth",
+                "min_samples_split",
+                "min_samples_leaf",
+                "max_features",
+                "max_leaf_nodes",
+                "random_state",
+            ),
             bootstrap=bootstrap,
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
             warm_start=warm_start,
-            max_samples=max_samples)
+            max_samples=max_samples,
+        )
 
         self.criterion = criterion
         self.max_depth = max_depth
@@ -692,36 +783,44 @@ class ExtraTreesQuantileRegressor(BaseForestQuantileRegressor):
     .. [1] Nicolai Meinshausen, Quantile Regression Forests
         http://www.jmlr.org/papers/volume7/meinshausen06a/meinshausen06a.pdf
     """
-    def __init__(self,
-                 n_estimators=10,
-                 criterion='squared_error',
-                 max_depth=None,
-                 min_samples_split=2,
-                 min_samples_leaf=1,
-                 max_features='auto',
-                 max_leaf_nodes=None,
-                 bootstrap=True,
-                 oob_score=False,
-                 n_jobs=1,
-                 random_state=None,
-                 verbose=0,
-                 warm_start=False,
-                 max_samples=None):
+
+    def __init__(
+        self,
+        n_estimators=10,
+        criterion="squared_error",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        max_features="auto",
+        max_leaf_nodes=None,
+        bootstrap=True,
+        oob_score=False,
+        n_jobs=1,
+        random_state=None,
+        verbose=0,
+        warm_start=False,
+        max_samples=None,
+    ):
         super(ExtraTreesQuantileRegressor, self).__init__(
             base_estimator=ExtraTreeQuantileRegressor(),
             n_estimators=n_estimators,
-            estimator_params=("criterion", "max_depth", "min_samples_split",
-                              "min_samples_leaf",
-                              "max_features",
-                              "max_leaf_nodes",
-                              "random_state"),
+            estimator_params=(
+                "criterion",
+                "max_depth",
+                "min_samples_split",
+                "min_samples_leaf",
+                "max_features",
+                "max_leaf_nodes",
+                "random_state",
+            ),
             bootstrap=bootstrap,
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
             warm_start=warm_start,
-            max_samples=max_samples)
+            max_samples=max_samples,
+        )
 
         self.criterion = criterion
         self.max_depth = max_depth

--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -173,10 +173,11 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
             y = np.ravel(y)
 
         # apply method requires X to be of dtype np.float32
-        X, y = check_X_y(X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
+        X, y = check_X_y(
+            X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
         super(BaseTreeQuantileRegressor, self).fit(
-            X, y, sample_weight=sample_weight, check_input=check_input, X_idx_sorted=X_idx_sorted
-        )
+            X, y, sample_weight=sample_weight, check_input=check_input,
+            X_idx_sorted=X_idx_sorted)
         self.y_train_ = y
 
         # Stores the leaf nodes that the samples lie in.
@@ -286,17 +287,15 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
         y_train_leaves_[i] is the leaf that y_train[i] ends up at.
     """
 
-    def __init__(
-        self,
-        criterion="squared_error",
-        splitter="best",
-        max_depth=None,
-        min_samples_split=2,
-        min_samples_leaf=1,
-        max_features=None,
-        random_state=None,
-        max_leaf_nodes=None,
-    ):
+    def __init__(self,
+                 criterion="squared_error",
+                 splitter="best",
+                 max_depth=None,
+                 min_samples_split=2,
+                 min_samples_leaf=1,
+                 max_features=None,
+                 random_state=None,
+                 max_leaf_nodes=None):
         super(DecisionTreeQuantileRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -305,22 +304,19 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
             min_samples_leaf=min_samples_leaf,
             max_features=max_features,
             max_leaf_nodes=max_leaf_nodes,
-            random_state=random_state,
-        )
+            random_state=random_state)
 
 
 class ExtraTreeQuantileRegressor(ExtraTreeRegressor, BaseTreeQuantileRegressor):
-    def __init__(
-        self,
-        criterion="squared_error",
-        splitter="random",
-        max_depth=None,
-        min_samples_split=2,
-        min_samples_leaf=1,
-        max_features="auto",
-        random_state=None,
-        max_leaf_nodes=None,
-    ):
+    def __init__(self,
+                 criterion='squared_error',
+                 splitter='random',
+                 max_depth=None,
+                 min_samples_split=2,
+                 min_samples_leaf=1,
+                 max_features='auto',
+                 random_state=None,
+                 max_leaf_nodes=None):
         super(ExtraTreeQuantileRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -329,8 +325,8 @@ class ExtraTreeQuantileRegressor(ExtraTreeRegressor, BaseTreeQuantileRegressor):
             min_samples_leaf=min_samples_leaf,
             max_features=max_features,
             max_leaf_nodes=max_leaf_nodes,
-            random_state=random_state,
-        )
+            random_state=random_state)
+
 
 
 def generate_sample_indices(random_state, n_samples):
@@ -642,43 +638,38 @@ class RandomForestQuantileRegressor(BaseForestQuantileRegressor):
         http://www.jmlr.org/papers/volume7/meinshausen06a/meinshausen06a.pdf
     """
 
-    def __init__(
-        self,
-        n_estimators=10,
-        criterion="squared_error",
-        max_depth=None,
-        min_samples_split=2,
-        min_samples_leaf=1,
-        max_features="auto",
-        max_leaf_nodes=None,
-        bootstrap=True,
-        oob_score=False,
-        n_jobs=1,
-        random_state=None,
-        verbose=0,
-        warm_start=False,
-        max_samples=None,
-    ):
+    def __init__(self,
+                 n_estimators=10,
+                 criterion='squared_error',
+                 max_depth=None,
+                 min_samples_split=2,
+                 min_samples_leaf=1,
+                 max_features='auto',
+                 max_leaf_nodes=None,
+                 bootstrap=True,
+                 oob_score=False,
+                 n_jobs=1,
+                 random_state=None,
+                 verbose=0,
+                 warm_start=False,
+                 max_samples=None):
         super(RandomForestQuantileRegressor, self).__init__(
             base_estimator=DecisionTreeQuantileRegressor(),
             n_estimators=n_estimators,
-            estimator_params=(
-                "criterion",
-                "max_depth",
-                "min_samples_split",
-                "min_samples_leaf",
-                "max_features",
-                "max_leaf_nodes",
-                "random_state",
-            ),
+            estimator_params=("criterion",
+                              "max_depth",
+                              "min_samples_split",
+                              "min_samples_leaf",
+                              "max_features",
+                              "max_leaf_nodes",
+                              "random_state"),
             bootstrap=bootstrap,
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
             warm_start=warm_start,
-            max_samples=max_samples,
-        )
+            max_samples=max_samples)
 
         self.criterion = criterion
         self.max_depth = max_depth
@@ -794,43 +785,36 @@ class ExtraTreesQuantileRegressor(BaseForestQuantileRegressor):
         http://www.jmlr.org/papers/volume7/meinshausen06a/meinshausen06a.pdf
     """
 
-    def __init__(
-        self,
-        n_estimators=10,
-        criterion="squared_error",
-        max_depth=None,
-        min_samples_split=2,
-        min_samples_leaf=1,
-        max_features="auto",
-        max_leaf_nodes=None,
-        bootstrap=True,
-        oob_score=False,
-        n_jobs=1,
-        random_state=None,
-        verbose=0,
-        warm_start=False,
-        max_samples=None,
-    ):
+    def __init__(self,
+                 n_estimators=10,
+                 criterion='squared_error',
+                 max_depth=None,
+                 min_samples_split=2,
+                 min_samples_leaf=1,
+                 max_features='auto',
+                 max_leaf_nodes=None,
+                 bootstrap=True,
+                 oob_score=False,
+                 n_jobs=1,
+                 random_state=None,
+                 verbose=0,
+                 warm_start=False,
+                 max_samples=None):
         super(ExtraTreesQuantileRegressor, self).__init__(
             base_estimator=ExtraTreeQuantileRegressor(),
             n_estimators=n_estimators,
-            estimator_params=(
-                "criterion",
-                "max_depth",
-                "min_samples_split",
-                "min_samples_leaf",
-                "max_features",
-                "max_leaf_nodes",
-                "random_state",
-            ),
+            estimator_params=("criterion", "max_depth", "min_samples_split",
+                              "min_samples_leaf",
+                              "max_features",
+                              "max_leaf_nodes",
+                              "random_state"),
             bootstrap=bootstrap,
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
             warm_start=warm_start,
-            max_samples=max_samples,
-        )
+            max_samples=max_samples)
 
         self.criterion = criterion
         self.max_depth = max_depth

--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -1,3 +1,39 @@
+# The original implementation in this file was based on scikit-garden that comes under the following license.
+# The current version of the code has been modified beyond its original version.
+
+# New BSD License
+
+# Copyright (c) 2016 - scikit-garden developers.
+
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+#   a. Redistributions of source code must retain the above copyright notice,
+#      this list of conditions and the following disclaimer.
+
+#   b. Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+
+#   c. Neither the name of the scikit-garden developers nor the names of
+#      its contributors may be used to endorse or promote products
+#      derived from this software without specific prior written
+#      permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+# DAMAGE.
+
 import logging
 import pandas as pd
 import numpy as np
@@ -127,12 +163,10 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
         X_leaves = self.apply(X)
         unique_leaves = np.unique(X_leaves)
         for leaf in unique_leaves:
-            quantiles[X_leaves == leaf] = weighted_percentile(
-                self.y_train_[self.y_train_leaves_ == leaf], quantile)
+            quantiles[X_leaves == leaf] = weighted_percentile(self.y_train_[self.y_train_leaves_ == leaf], quantile)
         return quantiles
 
-    def fit(self, X, y, sample_weight=None, check_input=True,
-            X_idx_sorted=None):
+    def fit(self, X, y, sample_weight=None, check_input=True, X_idx_sorted=None):
         """
         Build a decision tree classifier from the training set (X, y).
 
@@ -175,11 +209,10 @@ class BaseTreeQuantileRegressor(BaseDecisionTree):
             y = np.ravel(y)
 
         # apply method requires X to be of dtype np.float32
-        X, y = check_X_y(
-            X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
+        X, y = check_X_y(X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
         super(BaseTreeQuantileRegressor, self).fit(
-            X, y, sample_weight=sample_weight, check_input=check_input,
-            X_idx_sorted=X_idx_sorted)
+            X, y, sample_weight=sample_weight, check_input=check_input, X_idx_sorted=X_idx_sorted
+        )
         self.y_train_ = y
 
         # Stores the leaf nodes that the samples lie in.
@@ -289,15 +322,17 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
         y_train_leaves_[i] is the leaf that y_train[i] ends up at.
     """
 
-    def __init__(self,
-                 criterion="squared_error",
-                 splitter="best",
-                 max_depth=None,
-                 min_samples_split=2,
-                 min_samples_leaf=1,
-                 max_features=None,
-                 random_state=None,
-                 max_leaf_nodes=None):
+    def __init__(
+        self,
+        criterion="squared_error",
+        splitter="best",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        max_features=None,
+        random_state=None,
+        max_leaf_nodes=None,
+    ):
         super(DecisionTreeQuantileRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -306,19 +341,22 @@ class DecisionTreeQuantileRegressor(DecisionTreeRegressor, BaseTreeQuantileRegre
             min_samples_leaf=min_samples_leaf,
             max_features=max_features,
             max_leaf_nodes=max_leaf_nodes,
-            random_state=random_state)
+            random_state=random_state,
+        )
 
 
 class ExtraTreeQuantileRegressor(ExtraTreeRegressor, BaseTreeQuantileRegressor):
-    def __init__(self,
-                 criterion='squared_error',
-                 splitter='random',
-                 max_depth=None,
-                 min_samples_split=2,
-                 min_samples_leaf=1,
-                 max_features='auto',
-                 random_state=None,
-                 max_leaf_nodes=None):
+    def __init__(
+        self,
+        criterion="squared_error",
+        splitter="random",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        max_features="auto",
+        random_state=None,
+        max_leaf_nodes=None,
+    ):
         super(ExtraTreeQuantileRegressor, self).__init__(
             criterion=criterion,
             splitter=splitter,
@@ -327,8 +365,8 @@ class ExtraTreeQuantileRegressor(ExtraTreeRegressor, BaseTreeQuantileRegressor):
             min_samples_leaf=min_samples_leaf,
             max_features=max_features,
             max_leaf_nodes=max_leaf_nodes,
-            random_state=random_state)
-
+            random_state=random_state,
+        )
 
 
 def generate_sample_indices(random_state, n_samples):
@@ -430,7 +468,7 @@ def get_quantiles(neighbors_df, quantile_levels):
                 int(q * 100),
                 neighbors_df.weight,
                 sorter=slice(None),  # targets are already sorted, so no sorting required
-                is_filtered=True
+                is_filtered=True,
             )
         )
     return result
@@ -466,9 +504,7 @@ class BaseForestQuantileRegressor(ForestRegressor):
             f"They may change or be removed without warning in future releases."
         )
         if sample_weight is not None:
-            logger.warning(
-                f"\tWARNING: {self.__class__.__name__} ignores sample_weight."
-            )
+            logger.warning(f"\tWARNING: {self.__class__.__name__} ignores sample_weight.")
 
         # apply method requires X to be of dtype np.float32
         X, y = check_X_y(X, y, accept_sparse="csc", dtype=np.float32, multi_output=False)
@@ -640,38 +676,43 @@ class RandomForestQuantileRegressor(BaseForestQuantileRegressor):
         http://www.jmlr.org/papers/volume7/meinshausen06a/meinshausen06a.pdf
     """
 
-    def __init__(self,
-                 n_estimators=10,
-                 criterion='squared_error',
-                 max_depth=None,
-                 min_samples_split=2,
-                 min_samples_leaf=1,
-                 max_features='auto',
-                 max_leaf_nodes=None,
-                 bootstrap=True,
-                 oob_score=False,
-                 n_jobs=1,
-                 random_state=None,
-                 verbose=0,
-                 warm_start=False,
-                 max_samples=None):
+    def __init__(
+        self,
+        n_estimators=10,
+        criterion="squared_error",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        max_features="auto",
+        max_leaf_nodes=None,
+        bootstrap=True,
+        oob_score=False,
+        n_jobs=1,
+        random_state=None,
+        verbose=0,
+        warm_start=False,
+        max_samples=None,
+    ):
         super(RandomForestQuantileRegressor, self).__init__(
             base_estimator=DecisionTreeQuantileRegressor(),
             n_estimators=n_estimators,
-            estimator_params=("criterion",
-                              "max_depth",
-                              "min_samples_split",
-                              "min_samples_leaf",
-                              "max_features",
-                              "max_leaf_nodes",
-                              "random_state"),
+            estimator_params=(
+                "criterion",
+                "max_depth",
+                "min_samples_split",
+                "min_samples_leaf",
+                "max_features",
+                "max_leaf_nodes",
+                "random_state",
+            ),
             bootstrap=bootstrap,
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
             warm_start=warm_start,
-            max_samples=max_samples)
+            max_samples=max_samples,
+        )
 
         self.criterion = criterion
         self.max_depth = max_depth
@@ -787,36 +828,43 @@ class ExtraTreesQuantileRegressor(BaseForestQuantileRegressor):
         http://www.jmlr.org/papers/volume7/meinshausen06a/meinshausen06a.pdf
     """
 
-    def __init__(self,
-                 n_estimators=10,
-                 criterion='squared_error',
-                 max_depth=None,
-                 min_samples_split=2,
-                 min_samples_leaf=1,
-                 max_features='auto',
-                 max_leaf_nodes=None,
-                 bootstrap=True,
-                 oob_score=False,
-                 n_jobs=1,
-                 random_state=None,
-                 verbose=0,
-                 warm_start=False,
-                 max_samples=None):
+    def __init__(
+        self,
+        n_estimators=10,
+        criterion="squared_error",
+        max_depth=None,
+        min_samples_split=2,
+        min_samples_leaf=1,
+        max_features="auto",
+        max_leaf_nodes=None,
+        bootstrap=True,
+        oob_score=False,
+        n_jobs=1,
+        random_state=None,
+        verbose=0,
+        warm_start=False,
+        max_samples=None,
+    ):
         super(ExtraTreesQuantileRegressor, self).__init__(
             base_estimator=ExtraTreeQuantileRegressor(),
             n_estimators=n_estimators,
-            estimator_params=("criterion", "max_depth", "min_samples_split",
-                              "min_samples_leaf",
-                              "max_features",
-                              "max_leaf_nodes",
-                              "random_state"),
+            estimator_params=(
+                "criterion",
+                "max_depth",
+                "min_samples_split",
+                "min_samples_leaf",
+                "max_features",
+                "max_leaf_nodes",
+                "random_state",
+            ),
             bootstrap=bootstrap,
             oob_score=oob_score,
             n_jobs=n_jobs,
             random_state=random_state,
             verbose=verbose,
             warm_start=warm_start,
-            max_samples=max_samples)
+            max_samples=max_samples,
+        )
 
         self.criterion = criterion
         self.max_depth = max_depth

--- a/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
+++ b/tabular/src/autogluon/tabular/models/rf/rf_quantile.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 def weighted_percentile(a, q, weights=None, sorter=None, is_filtered=False):
     """
     Returns the weighted percentile of a at q given weights.
+
     Parameters
     ----------
     a: array-like, shape=(n_samples,)
@@ -35,9 +36,11 @@ def weighted_percentile(a, q, weights=None, sorter=None, is_filtered=False):
     -------
     percentile: float
         Weighted percentile of a at q.
+
     References
     ----------
     1. https://en.wikipedia.org/wiki/Percentile#The_Weighted_Percentile_method
+
     Notes
     -----
     Note that weighted_percentile(a, q) is not equivalent to
@@ -333,6 +336,7 @@ class ExtraTreeQuantileRegressor(ExtraTreeRegressor, BaseTreeQuantileRegressor):
 def generate_sample_indices(random_state, n_samples):
     """
     Generates bootstrap indices for each tree fit.
+
     Parameters
     ----------
     random_state: int, RandomState instance or None
@@ -342,6 +346,7 @@ def generate_sample_indices(random_state, n_samples):
         by np.random.
     n_samples: int
         Number of samples to generate from each tree.
+
     Returns
     -------
     sample_indices: array-like, shape=(n_samples), dtype=np.int32
@@ -538,6 +543,7 @@ class RandomForestQuantileRegressor(BaseForestQuantileRegressor):
     The sub-sample size is always the same as the original
     input sample size but the samples are drawn with replacement if
     `bootstrap=True` (default).
+
     Parameters
     ----------
     n_estimators : integer, optional (default=10)
@@ -629,6 +635,7 @@ class RandomForestQuantileRegressor(BaseForestQuantileRegressor):
         y_train_leaves_[i, j] provides the leaf node that y_train_[i]
         ends up when estimator j is fit. If y_train_[i] is given
         a weight of zero when estimator j is fit, then the value is -1.
+
     References
     ----------
     .. [1] Nicolai Meinshausen, Quantile Regression Forests
@@ -688,6 +695,7 @@ class ExtraTreesQuantileRegressor(BaseForestQuantileRegressor):
     randomized decision trees (a.k.a. extra-trees) on various sub-samples
     of the dataset and use averaging to improve the predictive accuracy
     and control over-fitting.
+
     Parameters
     ----------
     n_estimators : integer, optional (default=10)
@@ -754,6 +762,7 @@ class ExtraTreesQuantileRegressor(BaseForestQuantileRegressor):
         When set to ``True``, reuse the solution of the previous call to fit
         and add more estimators to the ensemble, otherwise, just fit a whole
         new forest.
+
     Attributes
     ----------
     estimators_ : list of ExtraTreeQuantileRegressor
@@ -778,6 +787,7 @@ class ExtraTreesQuantileRegressor(BaseForestQuantileRegressor):
         y_train_leaves_[i, j] provides the leaf node that y_train_[i]
         ends up when estimator j is fit. If y_train_[i] is given
         a weight of zero when estimator j is fit, then the value is -1.
+
     References
     ----------
     .. [1] Nicolai Meinshausen, Quantile Regression Forests


### PR DESCRIPTION
*Description of changes:*
- Replace for loops over samples with vectorized code / pandas operations to speed up training and prediction time.
- Minor fixes to `tabular/models/rf/rf_quantile.py` (e.g., remove unused parameters from docstrings)

Runtime comparison:
![extra_trees](https://user-images.githubusercontent.com/6944857/195329794-2ee4e304-752b-43b3-889b-e2f6ac73b272.jpg)
![rf](https://user-images.githubusercontent.com/6944857/195329800-4b4f6a20-6e01-4335-bbf7-f35c3f0a6d0b.jpg)

Attached is a Jupyter notebook that runs a sanity check ensuring that both old and new versions produce identical results & generates runtime plots. [compare_rf_quantile.zip](https://github.com/awslabs/autogluon/files/9764286/compare_rf_quantile.zip)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
