### PR TITLE
Fix timm

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -24,7 +24,6 @@ DEPENDENT_PACKAGES = {
     'gluoncv': '>=0.10.5,<0.10.6',
     'tqdm': '>=4.38.0',
     'Pillow': '>=9.0.1,<9.1.0',
-    'timm': '>=0.5.4,<0.6.0',
 }
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES

--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -24,6 +24,7 @@ DEPENDENT_PACKAGES = {
     'gluoncv': '>=0.10.5,<0.10.6',
     'tqdm': '>=4.38.0',
     'Pillow': '>=9.0.1,<9.1.0',
+    'timm': '>=0.5.4,<0.7.0',
 }
 DEPENDENT_PACKAGES = {package: package + version for package, version in DEPENDENT_PACKAGES.items()}
 # TODO: Use DOCS_PACKAGES and TEST_PACKAGES

--- a/multimodal/src/autogluon/multimodal/models/timm_image.py
+++ b/multimodal/src/autogluon/multimodal/models/timm_image.py
@@ -21,7 +21,7 @@ class TimmAutoModelForImagePrediction(nn.Module):
         self,
         prefix: str,
         checkpoint_name: str,
-        num_classes: Optional[int] = None,
+        num_classes: Optional[int] = 0,
         mix_choice: Optional[str] = "all_logits",
         pretrained: Optional[bool] = True,
     ):

--- a/multimodal/src/autogluon/multimodal/models/timm_image.py
+++ b/multimodal/src/autogluon/multimodal/models/timm_image.py
@@ -108,16 +108,17 @@ class TimmAutoModelForImagePrediction(nn.Module):
                 images.sum(dim=1) / torch.clamp(image_valid_num, min=1e-6)[:, None, None, None]
             )  # mixed shape: (b, 3, h, w)
             features = self.model(mixed_images)
-            logits = self.head(features)
+            if self.num_classes > 0:
+                logits = self.head(features)
 
         elif self.mix_choice == "all_logits":  # mix outputs
             b, n, c, h, w = images.shape
             features = self.model(images.reshape((b * n, c, h, w)))  # (b*n, num_features)
-            logits = self.head(features)
+            if self.num_classes > 0:
+                logits = self.head(features)
             steps = torch.arange(0, n).type_as(image_valid_num)
-            image_masks = (steps.reshape((1, -1)) < image_valid_num.reshape((-1, 1))).type_as(logits)  # (b, n)
+            image_masks = (steps.reshape((1, -1)) < image_valid_num.reshape((-1, 1))).type_as(features)  # (b, n)
             features = features.reshape((b, n, -1)) * image_masks[:, :, None]  # (b, n, num_features)
-            logits = logits.reshape((b, n, -1)) * image_masks[:, :, None]  # (b, n, num_classes)
 
             # collect features by image column names
             column_features, column_feature_masks = get_column_features(
@@ -130,7 +131,9 @@ class TimmAutoModelForImagePrediction(nn.Module):
             ret[COLUMN_FEATURES][MASKS].update(column_feature_masks)
 
             features = features.sum(dim=1) / torch.clamp(image_valid_num, min=1e-6)[:, None]  # (b, num_features)
-            logits = logits.sum(dim=1) / torch.clamp(image_valid_num, min=1e-6)[:, None]  # (b, num_classes)
+            if self.num_classes > 0:
+                logits = logits.reshape((b, n, -1)) * image_masks[:, :, None]  # (b, n, num_classes)
+                logits = logits.sum(dim=1) / torch.clamp(image_valid_num, min=1e-6)[:, None]  # (b, num_classes)
 
         else:
             raise ValueError(f"unknown mix_choice: {self.mix_choice}")

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -129,7 +129,7 @@ def select_model(
 def create_model(
     model_name: str,
     model_config: DictConfig,
-    num_classes: Optional[int] = None,
+    num_classes: Optional[int] = 0,
     num_numerical_columns: Optional[int] = None,
     num_categories: Optional[List[int]] = None,
     pretrained: Optional[bool] = True,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Make timm caps consistent between core and multimodal. Temporarily keep the timm cap in core since the vision module also needs to install timm. We can remove it after refactoring the vision module.
2. Set the default num_classes=0 and compute logits only when `num_classes>0`. This is to handle some special heads in timm, e.g., https://github.com/rwightman/pytorch-image-models/blob/8a1ba67a5019cac4e0e6c430a846e5653f636c3f/timm/models/layers/classifier.py#L38

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
