### PR TITLE
[EDA] Added Sampler and analyze loop shortcut

### DIFF
--- a/.github/workflow_scripts/env_setup.sh
+++ b/.github/workflow_scripts/env_setup.sh
@@ -47,7 +47,7 @@ function install_features {
 }
 
 function install_eda {
-    python3 -m pip install --upgrade -e eda/
+    python3 -m pip install --upgrade -e eda/[tests]
 }
 
 function install_tabular {

--- a/.github/workflow_scripts/test_eda.sh
+++ b/.github/workflow_scripts/test_eda.sh
@@ -13,4 +13,4 @@ install_features
 install_eda
 
 cd eda/
-python3 -m pytest --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests
+python3 -m pytest --mypy --junitxml=results.xml --runslow "$ADDITIONAL_TEST_ARGS" tests

--- a/eda/setup.py
+++ b/eda/setup.py
@@ -9,9 +9,9 @@ from setuptools import setup
 filepath = os.path.abspath(os.path.dirname(__file__))
 filepath_import = os.path.join(filepath, '..', 'core', 'src', 'autogluon', 'core', '_setup_utils.py')
 spec = importlib.util.spec_from_file_location("ag_min_dependencies", filepath_import)
-ag = importlib.util.module_from_spec(spec)
+ag = importlib.util.module_from_spec(spec)  # type: ignore
 # Identical to `from autogluon.core import _setup_utils as ag`, but works without `autogluon.core` being installed.
-spec.loader.exec_module(ag)
+spec.loader.exec_module(ag)  # type: ignore
 ###########################
 
 version = ag.load_version_file()
@@ -35,7 +35,8 @@ install_requires = [
 extras_require = dict()
 
 test_requirements = [
-    'pytest'
+    'pytest',
+    'pytest-mypy'
 ]
 
 test_requirements = list(set(test_requirements))

--- a/eda/src/autogluon/eda/analysis/__init__.py
+++ b/eda/src/autogluon/eda/analysis/__init__.py
@@ -1,2 +1,3 @@
 import phik
 from .base import Namespace
+from .dataset import Sampler

--- a/eda/src/autogluon/eda/analysis/base.py
+++ b/eda/src/autogluon/eda/analysis/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Union, Tuple
+from typing import List, Tuple, Optional, Generator
 
 from pandas import DataFrame
 
@@ -14,14 +14,14 @@ logger = logging.getLogger(__name__)
 class AbstractAnalysis(ABC, StateCheckMixin):
 
     def __init__(self,
-                 parent: Union[None, AbstractAnalysis] = None,
+                 parent: Optional[AbstractAnalysis] = None,
                  children: List[AbstractAnalysis] = [],
-                 state: AnalysisState = None,
+                 state: Optional[AnalysisState] = None,
                  **kwargs) -> None:
 
         self.parent = parent
         self.children: List[AbstractAnalysis] = children
-        self.state: AnalysisState = state
+        self.state: Optional[AnalysisState] = state
         for c in self.children:
             c.parent = self
             c.state = self.state
@@ -31,12 +31,12 @@ class AbstractAnalysis(ABC, StateCheckMixin):
         chain = [self]
         while chain[0].parent is not None:
             chain.insert(0, chain[0].parent)
-        args = {}
+        args = AnalysisState()
         for node in chain:
             args = AnalysisState({**args, **node.args})
         return args
 
-    def available_datasets(self, args: AnalysisState) -> Tuple[str, DataFrame]:
+    def available_datasets(self, args: AnalysisState) -> Generator[Tuple[str, DataFrame], None, None]:
         """
         Generator which iterates only through the datasets provided in arguments
 
@@ -63,7 +63,7 @@ class AbstractAnalysis(ABC, StateCheckMixin):
                 state = AnalysisState()
             else:
                 state = self.parent.state
-        return state
+        return state  # type: ignore
 
     @abstractmethod
     def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
@@ -132,7 +132,7 @@ class AbstractAnalysis(ABC, StateCheckMixin):
 class BaseAnalysis(AbstractAnalysis):
 
     def __init__(self,
-                 parent: Union[None, AbstractAnalysis] = None,
+                 parent: Optional[AbstractAnalysis] = None,
                  children: List[AbstractAnalysis] = [],
                  **kwargs) -> None:
         super().__init__(parent, children, **kwargs)
@@ -150,8 +150,8 @@ class Namespace(AbstractAnalysis):
         return True
 
     def __init__(self,
-                 namespace: str = None,
-                 parent: Union[None, AbstractAnalysis] = None,
+                 namespace: Optional[str] = None,
+                 parent: Optional[AbstractAnalysis] = None,
                  children: List[AbstractAnalysis] = [],
                  **kwargs) -> None:
         super().__init__(parent, children, **kwargs)

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Union
+from typing import List, Union, Optional
 
 from .base import AbstractAnalysis
 from ..state import AnalysisState
@@ -19,7 +19,7 @@ class Sampler(AbstractAnalysis):
         sample size; if `int`, then row number is used;
         `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
         `None` means no sampling
-    parent: Union[None, AbstractAnalysis], default = None
+    parent: Optional[AbstractAnalysis], default = None
         parent Analysis
     children: List[AbstractAnalysis], default []
         wrapped analyses; these will receive sampled `args` during `fit` call
@@ -43,7 +43,7 @@ class Sampler(AbstractAnalysis):
 
     def __init__(self,
                  sample: Union[None, int, float] = None,
-                 parent: Union[None, AbstractAnalysis] = None,
+                 parent: Optional[AbstractAnalysis] = None,
                  children: List[AbstractAnalysis] = [],
                  **kwargs) -> None:
         super().__init__(parent, children, **kwargs)

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import List, Union
+
+from .base import AbstractAnalysis
+from ..state import AnalysisState
+
+__all__ = ['Sampler']
+
+
+class Sampler(AbstractAnalysis):
+    """
+    Sampler is a wrapper that provides sampling capabilites for the wrapped analyses.
+    The sampling is performed for all datasets in `args` and passed to all `children` during `fit` call.
+
+    Parameters
+    ----------
+    sample: Union[None, int, float], default = None
+        sample size; if `int`, then row number is used;
+        `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
+        `None` means no sampling
+    parent: Union[None, AbstractAnalysis], default = None
+        parent Analysis
+    children: List[AbstractAnalysis], default []
+        wrapped analyses; these will receive sampled `args` during `fit` call
+    kwargs
+
+    Examples
+    --------
+    >>> from autogluon.eda.analysis.base import BaseAnalysis
+    >>> from autogluon.eda.analysis import Sampler
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>>
+    >>> df_train = pd.DataFrame(np.random.randint(0, 100, size=(10, 4)), columns=list('ABCD'))
+    >>> df_test = pd.DataFrame(np.random.randint(0, 100, size=(20, 4)), columns=list('EFGH'))
+    >>> analysis = BaseAnalysis(train_data=df_train, test_data=df_test, children=[
+    >>>     Sampler(sample=5, children=[
+    >>>         # Analysis here will be performed on a sample of 5 for both train_data and test_data
+    >>>     ])
+    >>> ])
+    """
+
+    def __init__(self,
+                 sample: Union[None, int, float] = None,
+                 parent: Union[None, AbstractAnalysis] = None,
+                 children: List[AbstractAnalysis] = [],
+                 **kwargs) -> None:
+        super().__init__(parent, children, **kwargs)
+        if sample is not None and isinstance(sample, float):
+            assert 0.0 < sample < 1.0, 'sample must be within the range (0.0, 1.0)'
+        self.sample = sample
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return True
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs):
+        if self.sample is not None:
+            state.sample_size = self.sample
+            for (ds, df) in self.available_datasets(args):
+                arg = 'n'
+                if self.sample is not None and isinstance(self.sample, float):
+                    arg = 'frac'
+                self.args[ds] = df.sample(**{arg: self.sample}, random_state=0)

--- a/eda/src/autogluon/eda/auto/__init__.py
+++ b/eda/src/autogluon/eda/auto/__init__.py
@@ -1,0 +1,1 @@
+from .simple import analyze

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -1,0 +1,80 @@
+from typing import Union, List
+
+from .. import AnalysisState
+from ..analysis.base import BaseAnalysis, AbstractAnalysis
+from ..analysis.dataset import Sampler
+from ..visualization.base import AbstractVisualization
+from ..visualization.layouts import SimpleVerticalLinearLayout
+
+
+def analyze(train_data=None,
+            test_data=None,
+            val_data=None,
+            model=None,
+            label: str = None,
+            state: Union[None, dict, AnalysisState] = None,
+            sample: Union[None, int, float] = None,
+            anlz_facets: List[AbstractAnalysis] = [],
+            viz_facets: List[AbstractVisualization] = [],
+            return_state: bool = False):
+    """
+    This helper creates `BaseAnalysis` wrapping passed analyses into
+    `Sampler` if needed, then fits and renders produced state with
+    specified visualizations.
+
+    Parameters
+    ----------
+    train_data
+        training dataset
+    test_data
+        test dataset
+    val_data
+        validation dataset
+    model
+        trained `Predictor`
+    label: str
+        target variable
+    state: Union[None, dict, AnalysisState], default = None
+        pass prior state if necessary; the object will be updated during `anlz_facets` `fit` call.
+    sample: Union[None, int, float], default = None
+        sample size; if `int`, then row number is used;
+        `float` must be between 0.0 and 1.0 and represents fraction of dataset to sample;
+        `None` means no sampling
+        See also :func:`autogluon.eda.analysis.dataset.Sampler`
+    anlz_facets: List[AbstractAnalysis]
+        analyses to add to this composite analysis
+    viz_facets: List[AbstractVisualization]
+        visualizations to add to this composite analysis
+    return_state: bool, default = False
+        return state if `True`
+
+    Returns
+    -------
+        state after `fit` call if `return_state` is `True`; `None` otherwise
+
+    """
+
+    assert isinstance(state, (dict, AnalysisState))
+    if not isinstance(state, AnalysisState):
+        state = AnalysisState(state)
+
+    analysis = BaseAnalysis(
+        state=state,
+        train_data=train_data,
+        test_data=test_data,
+        val_data=val_data,
+        model=model,
+        label=label,
+        children=[
+            Sampler(sample=sample, children=anlz_facets),
+        ]
+    )
+
+    state = analysis.fit()
+
+    SimpleVerticalLinearLayout(
+        facets=viz_facets,
+    ).render(state)
+
+    if return_state:
+        return state

--- a/eda/src/autogluon/eda/state.py
+++ b/eda/src/autogluon/eda/state.py
@@ -8,7 +8,7 @@ __all__ = ['AnalysisState', 'StateCheckMixin']
 class AnalysisState(dict):
     """Enabling dot.notation access to dictionary attributes and dynamic code assist in jupyter"""
     __getattr__ = dict.get
-    __delattr__ = dict.__delitem__
+    __delattr__ = dict.__delitem__  # type: ignore
 
     def __init__(self, *args, **kwargs) -> None:
         for arg in args:

--- a/eda/src/autogluon/eda/state.py
+++ b/eda/src/autogluon/eda/state.py
@@ -1,11 +1,12 @@
 import logging
-from typing import List
 
 logger = logging.getLogger(__name__)
 
+__all__ = ['AnalysisState', 'StateCheckMixin']
+
 
 class AnalysisState(dict):
-    """Dictionary wrapper which enables dot.notation access to dictionary attributes and dynamic code assist in jupyter"""
+    """Enabling dot.notation access to dictionary attributes and dynamic code assist in jupyter"""
     __getattr__ = dict.get
     __delattr__ = dict.__delitem__
 
@@ -34,7 +35,7 @@ class AnalysisState(dict):
 
 
 class StateCheckMixin:
-    def at_least_one_key_must_be_present(self, state: AnalysisState, keys: List[str]):
+    def at_least_one_key_must_be_present(self, state: AnalysisState, *keys):
         """
         Checks if at least one key is present in the state
 
@@ -42,7 +43,7 @@ class StateCheckMixin:
         ----------
         state: AnalysisState
             state object to perform check on
-        keys: List[str]
+        keys:
             list of the keys to check
 
         Returns
@@ -55,7 +56,7 @@ class StateCheckMixin:
         logger.warning(f'{self.__class__.__name__}: at least one of the following keys must be present: {keys}')
         return False
 
-    def all_keys_must_be_present(self, state: AnalysisState, keys: List[str]):
+    def all_keys_must_be_present(self, state: AnalysisState, *keys):
         """
         Checks if all the keys are present in the state
 
@@ -63,7 +64,7 @@ class StateCheckMixin:
         ----------
         state: AnalysisState
             state object to perform check on
-        keys: List[str]
+        keys:
             list of the keys to check
 
         Returns

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -1,1 +1,1 @@
-from .layouts import SimpleVerticalLinearLayout, SimpleHorizontalLayout, TabLayout, MarkdownSectionComponent
+from .layouts import MarkdownSectionComponent, SimpleVerticalLinearLayout, SimpleHorizontalLayout, TabLayout

--- a/eda/src/autogluon/eda/visualization/base.py
+++ b/eda/src/autogluon/eda/visualization/base.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
 from ..state import AnalysisState, StateCheckMixin
 
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 class AbstractVisualization(ABC, StateCheckMixin):
 
-    def __init__(self, namespace: str = None, **kwargs) -> None:
+    def __init__(self, namespace: Optional[str] = None, **kwargs) -> None:
         """
         Parameters
         ----------
@@ -18,10 +18,10 @@ class AbstractVisualization(ABC, StateCheckMixin):
         kwargs
         """
         super().__init__()
-        self.namespace = namespace
+        self.namespace: List[str] = []
         self._kwargs = kwargs
-        if self.namespace is not None:
-            self.namespace: List[str] = self.namespace.split('.')
+        if namespace is not None:
+            self.namespace = namespace.split('.')
 
     def _get_namespace_state(self, state):
         if self.namespace is not None:

--- a/eda/src/autogluon/eda/visualization/layouts.py
+++ b/eda/src/autogluon/eda/visualization/layouts.py
@@ -6,6 +6,8 @@ from ipywidgets import HBox, Output, Layout, Tab
 from .base import AbstractVisualization
 from .. import AnalysisState
 
+__all__ = ['MarkdownSectionComponent', 'SimpleVerticalLinearLayout', 'SimpleHorizontalLayout', 'TabLayout']
+
 
 class SimpleVerticalLinearLayout(AbstractVisualization):
     """
@@ -37,12 +39,12 @@ class SimpleHorizontalLayout(SimpleVerticalLinearLayout):
     """
 
     def _render(self, state: AnalysisState) -> None:
-        outs = [Output() for i in range(len(self.facets))]
+        outs = [Output() for _ in range(len(self.facets))]
         for out, facet in zip(outs, self.facets):
             with out:
                 facet.render(state)
 
-        self.display_obj(HBox(outs, layout=Layout(flex='row wrap')))
+        display(HBox(outs, layout=Layout(flex='row wrap')))
 
 
 class TabLayout(SimpleVerticalLinearLayout):
@@ -65,7 +67,7 @@ class TabLayout(SimpleVerticalLinearLayout):
         tab = Tab(children=outs, width=400)
         for i, name in enumerate(self.facet_tab_names):
             tab.set_title(i, name)
-        self.display_obj(tab)
+        display(tab)
         for out, facet in zip(outs, self.facets):
             with out:
                 facet.render(state)

--- a/eda/tests/conftest.py
+++ b/eda/tests/conftest.py
@@ -9,6 +9,8 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    plugin = config.pluginmanager.getplugin("mypy")
+    plugin.mypy_argv.append("--ignore-missing-imports")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/eda/tests/unittests/analysis/test_base.py
+++ b/eda/tests/unittests/analysis/test_base.py
@@ -95,7 +95,7 @@ def test_abstractanalysis_fit_gathers_args():
 
 def test_namespaces():
     def side_effect(state: AnalysisState, args: AnalysisState, **fit_kwargs):
-        state.update = fit_kwargs
+        state.upd = fit_kwargs
 
     inner_analysis: BaseAnalysis = BaseAnalysis(arg=1)
     inner_analysis._fit = MagicMock()
@@ -116,4 +116,4 @@ def test_namespaces():
         Namespace(namespace='ns2', children=[inner_analysis])
     ]).fit(op='fit3')
 
-    assert state == {'ns1': {'update': {'op': 'fit1'}}, 'ns2': {'update': {'op': 'fit3'}}}
+    assert state == {'ns1': {'upd': {'op': 'fit1'}}, 'ns2': {'upd': {'op': 'fit3'}}}

--- a/eda/tests/unittests/analysis/test_dataset.py
+++ b/eda/tests/unittests/analysis/test_dataset.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+
+from autogluon.eda import AnalysisState
+from autogluon.eda.analysis import Sampler, Namespace
+from autogluon.eda.analysis.base import BaseAnalysis
+
+
+class SomeAnalysis(BaseAnalysis):
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        state.args = args.copy()
+
+
+def test_Sampler():
+    df_train = pd.DataFrame(np.random.randint(0, 100, size=(10, 4)), columns=list('ABCD'))
+    df_test = pd.DataFrame(np.random.randint(0, 100, size=(20, 4)), columns=list('EFGH'))
+    assert df_train.shape == (10, 4)
+    assert df_test.shape == (20, 4)
+
+    analysis = BaseAnalysis(train_data=df_train, test_data=df_test, children=[
+        Namespace(namespace='ns_sampler', children=[
+            Sampler(sample=5, children=[
+                SomeAnalysis()
+            ])
+        ]),
+        Namespace(namespace='ns_sampler_none', children=[
+            Sampler(sample=None, children=[
+                SomeAnalysis()
+            ])
+        ]),
+        Namespace(namespace='ns_no_sampler', children=[
+            SomeAnalysis()
+        ])
+    ])
+
+    state = analysis.fit()
+    assert state.ns_sampler.args.train_data.shape == (5, 4)
+    assert state.ns_sampler.args.test_data.shape == (5, 4)
+    assert state.ns_sampler.sample_size == 5
+
+    assert state.ns_sampler_none.args.train_data.shape == (10, 4)
+    assert state.ns_sampler_none.args.test_data.shape == (20, 4)
+    assert state.ns_sampler_none.sample_size is None
+
+    assert state.ns_no_sampler.args.train_data.shape == (10, 4)
+    assert state.ns_no_sampler.args.test_data.shape == (20, 4)
+    assert state.ns_no_sampler.sample_size is None
+
+
+def test_Sampler_frac():
+    df_train = pd.DataFrame(np.random.randint(0, 100, size=(10, 4)), columns=list('ABCD'))
+    df_test = pd.DataFrame(np.random.randint(0, 100, size=(20, 4)), columns=list('EFGH'))
+    assert df_train.shape == (10, 4)
+    assert df_test.shape == (20, 4)
+
+    analysis = BaseAnalysis(train_data=df_train, test_data=df_test, children=[
+        Sampler(sample=0.5, children=[
+            SomeAnalysis()
+        ])
+    ])
+
+    state = analysis.fit()
+    assert state.sample_size == 0.5
+    assert state.args.train_data.shape == (5, 4)
+    assert state.args.test_data.shape == (10, 4)

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+
+from autogluon.eda import AnalysisState
+from autogluon.eda.analysis import Namespace
+from autogluon.eda.analysis.base import BaseAnalysis
+from autogluon.eda.auto import analyze
+from autogluon.eda.visualization.base import AbstractVisualization
+
+
+class SomeAnalysis(BaseAnalysis):
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        state.args = args.copy()
+
+
+class SomeVisualization(AbstractVisualization):
+
+    def can_handle(self, state: AnalysisState) -> bool:
+        return 'required_key' in state
+
+    def _render(self, state: AnalysisState) -> None:
+        pass
+
+
+def test_analyze():
+    df_train = pd.DataFrame(np.random.randint(0, 100, size=(10, 2)), columns=list('AB'))
+    df_test = pd.DataFrame(np.random.randint(0, 100, size=(11, 2)), columns=list('CD'))
+    df_val = pd.DataFrame(np.random.randint(0, 100, size=(12, 2)), columns=list('EF'))
+    state = {'some_previous_state': {'arg': 1}}
+
+    anlz = SomeAnalysis()
+    anlz.can_handle = MagicMock(return_value=True)
+
+    viz = SomeVisualization(namespace='ns1')
+    viz._render = MagicMock()
+    viz.can_handle = MagicMock(wraps=viz.can_handle)
+
+    state = analyze(
+        train_data=df_train, test_data=df_test, val_data=df_val,
+        model='model', label='label',
+        state=state, sample=5,
+        return_state=True,
+        anlz_facets=[
+            Namespace(namespace='ns1', children=[
+                anlz
+            ])
+        ],
+        viz_facets=[
+            viz
+        ],
+    )
+    assert state.sample_size == 5
+    assert state.some_previous_state == {'arg': 1}
+    assert state.ns1.args.train_data.shape == (5, 2)
+    assert state.ns1.args.test_data.shape == (5, 2)
+    assert state.ns1.args.val_data.shape == (5, 2)
+    assert state.ns1.args.model == 'model'
+    assert state.ns1.args.label == 'label'
+
+
+def test_analyze_return_state():
+    state = {'some_previous_state': {'arg': 1}}
+    assert analyze(state=state) is None
+    assert analyze(state=state, return_state=True) == state
+
+
+def test_analyze_state_dict_convert():
+    state = {'some_previous_state': {'arg': 1}}
+    assert not isinstance(state, AnalysisState)
+    _state = analyze(state=state, return_state=True)
+    assert _state == state
+    assert _state is not state
+    assert isinstance(_state, AnalysisState)
+
+
+def test_analyze_state_no_AnalysisState_convert():
+    state = AnalysisState({'some_previous_state': {'arg': 1}})
+    assert isinstance(state, AnalysisState)
+    _state = analyze(state=state, return_state=True)
+    assert _state == state
+    assert _state is state
+    assert isinstance(_state, AnalysisState)

--- a/eda/tests/unittests/test_state.py
+++ b/eda/tests/unittests/test_state.py
@@ -40,16 +40,16 @@ def test_analysis_state_nested_mutation():
 
 
 def test_statecheckmixin_at_least_one_key_must_be_present():
-    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), ['missing']) is False
-    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), ['q']) is True
-    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), ['w']) is True
-    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), ['q', 'w']) is True
-    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), ['q', 'missing']) is True
+    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), 'missing') is False
+    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), 'q') is True
+    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), 'w') is True
+    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), 'q', 'w') is True
+    assert StateCheckMixin().at_least_one_key_must_be_present(AnalysisState(q=42, w=43), 'q', 'missing') is True
 
 
 def test_statecheckmixin_all_keys_must_be_present():
-    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), ['missing']) is False
-    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), ['q']) is True
-    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), ['w']) is True
-    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), ['q', 'w']) is True
-    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), ['q', 'missing']) is False
+    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), 'missing') is False
+    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), 'q') is True
+    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), 'w') is True
+    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), 'q', 'w') is True
+    assert StateCheckMixin().all_keys_must_be_present(AnalysisState(q=42, w=43), 'q', 'missing') is False

--- a/eda/tests/unittests/visualization/test_base.py
+++ b/eda/tests/unittests/visualization/test_base.py
@@ -4,7 +4,7 @@ from autogluon.eda import AnalysisState
 from autogluon.eda.visualization.base import AbstractVisualization
 
 
-class TestVizualization(AbstractVisualization):
+class SomeVisualization(AbstractVisualization):
 
     def can_handle(self, state: AnalysisState) -> bool:
         return 'required_key' in state
@@ -13,8 +13,8 @@ class TestVizualization(AbstractVisualization):
         pass
 
 
-def test_abstractvisualization_cannot_render():
-    viz = TestVizualization()
+def test_AbstractVisualization_cannot_render():
+    viz = SomeVisualization()
     viz._render = MagicMock()
     viz.can_handle = MagicMock(wraps=viz.can_handle)
     viz.render(AnalysisState({'ns1': {'required_key': True, 'data': 1}, 'ns2': {}}))
@@ -22,8 +22,8 @@ def test_abstractvisualization_cannot_render():
     viz._render.assert_not_called()
 
 
-def test_abstractvisualization_can_render():
-    viz = TestVizualization(namespace='ns1')
+def test_AbstractVisualization_can_render():
+    viz = SomeVisualization(namespace='ns1')
     viz._render = MagicMock()
     viz.can_handle = MagicMock(wraps=viz.can_handle)
     viz.render(AnalysisState({'ns1': {'required_key': True, 'data': 1}, 'ns2': {}}))


### PR DESCRIPTION
*Description of changes:*

Added `Sampler` wrapper
```python
from autogluon.eda.analysis import Sampler
from autogluon.eda.analysis.base import BaseAnalysis

analysis = BaseAnalysis(train_data=df_train, test_data=df_test, children=[
    Sampler(sample=5, children=[
        # Analysis here will be performed on a sample of 5 for both train_data and test_data
    ])
])
```

`auto.analyze()` shortcut allows quickly define a fit-render pipeline and add sampling if needed
```python
import autogluon.eda.auto as auto

state = auto.analyze(
    train_data=df_train, label=target_col, return_state=True,
    anlz_facets=[
        eda.dataset.DatasetSummary(),
        eda.dataset.RawTypesAnalysis(),
        eda.dataset.VariableTypeAnalysis(),
        eda.dataset.SpecialTypesAnalysis(),
        eda.missing.MissingValuesAnalysis(),
    ],
    viz_facets=[
        viz.dataset.DatasetStatistics()
    ]
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
