### PR TITLE
[M1] Removing deprecated eval_metric from fit - causing segfaults on M1 w/ xgboost 1.4.2

### DIFF
--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -137,7 +137,6 @@ class XGBoostModel(AbstractModel):
             X=X,
             y=y,
             eval_set=eval_set,
-            eval_metric=eval_metric,
             verbose=False,
             callbacks=callbacks,
             sample_weight=sample_weight


### PR DESCRIPTION
*Description of changes:*
Removing deprecated eval_metric from fit - causing segfaults on M1 w/ xgboost 1.4.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
