### PR TITLE
Fix timeseries warnings and tqdm output

### DIFF
--- a/timeseries/src/autogluon/timeseries/__init__.py
+++ b/timeseries/src/autogluon/timeseries/__init__.py
@@ -13,8 +13,8 @@ try:
     assert parse("2.0") > parse(mxnet_version) >= parse("1.9")
 except (ImportError, AssertionError):
     raise ImportError(
-        "autogluon.forecasting depends on Apache MXNet v1.9 or greater (below v2.0). "
-        "Please install a suitable version of MXNet in order to use autogluon.forecasting using "
+        "autogluon.timeseries depends on Apache MXNet v1.9 or greater (below v2.0). "
+        "Please install a suitable version of MXNet in order to use autogluon.timeseries using "
         "`pip install mxnet==1.9` or a matching MXNet package for your CUDA driver if you are using "
         "a GPU. See the MXNet documentation for more info."
     )

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, Iterator, List, Optional, Type
 import gluonts
 import numpy as np
 import pandas as pd
-from gluonts.dataset.common import Dataset as GluonTSDataset
 from gluonts.core.settings import let
+from gluonts.dataset.common import Dataset as GluonTSDataset
 from gluonts.model.estimator import Estimator as GluonTSEstimator
 from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
 from gluonts.model.predictor import Predictor as GluonTSPredictor

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -7,7 +7,7 @@ import gluonts
 import numpy as np
 import pandas as pd
 from gluonts.dataset.common import Dataset as GluonTSDataset
-from gluonts.env import env as gluonts_env
+from gluonts.core.settings import let
 from gluonts.model.estimator import Estimator as GluonTSEstimator
 from gluonts.model.forecast import Forecast, QuantileForecast, SampleForecast
 from gluonts.model.predictor import Predictor as GluonTSPredictor
@@ -25,7 +25,6 @@ from .callback import GluonTSEarlyStoppingCallback, TimeLimitCallback
 
 logger = logging.getLogger(__name__)
 gts_logger = logging.getLogger(gluonts.__name__)
-gluonts_env.use_tqdm = False
 
 
 class SimpleGluonTSDataset(GluonTSDataset):
@@ -209,7 +208,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         self._deferred_init_params_aux(dataset=train_data, callbacks=callbacks, **kwargs)
 
         estimator = self._get_estimator()
-        with warning_filter(), disable_root_logger():
+        with warning_filter(), disable_root_logger(), let(gluonts.env.env, use_tqdm=False):
             self.gts_predictor = estimator.train(
                 self._to_gluonts_dataset(train_data),
                 validation_data=self._to_gluonts_dataset(val_data),
@@ -226,7 +225,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         )
         input_index_type = type(data.index.levels[0][0])
 
-        with warning_filter():
+        with warning_filter(), let(gluonts.env.env, use_tqdm=False):
             quantiles = quantile_levels or self.quantile_levels
             if not all(0 < q < 1 for q in quantiles):
                 raise ValueError("Invalid quantile value specified. Quantiles must be between 0 and 1 (exclusive).")

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/__init__.py
@@ -1,8 +1,8 @@
 import warnings
+
 import statsmodels.tools.sm_exceptions
 
 from .models import ARIMAModel, ETSModel, ThetaModel
-
 
 warnings.simplefilter("ignore", statsmodels.tools.sm_exceptions.ModelWarning)
 warnings.simplefilter("ignore", statsmodels.tools.sm_exceptions.ConvergenceWarning)

--- a/timeseries/src/autogluon/timeseries/models/statsmodels/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/statsmodels/__init__.py
@@ -1,5 +1,12 @@
-from .abstract_statsmodels import AbstractStatsmodelsModel
+import warnings
+import statsmodels.tools.sm_exceptions
+
 from .models import ARIMAModel, ETSModel, ThetaModel
+
+
+warnings.simplefilter("ignore", statsmodels.tools.sm_exceptions.ModelWarning)
+warnings.simplefilter("ignore", statsmodels.tools.sm_exceptions.ConvergenceWarning)
+
 
 __all__ = [
     "ETSModel",

--- a/timeseries/src/autogluon/timeseries/utils/warning_filters.py
+++ b/timeseries/src/autogluon/timeseries/utils/warning_filters.py
@@ -33,6 +33,18 @@ def statsmodels_warning_filter():
 
 
 @contextlib.contextmanager
+def statsmodels_joblib_warning_filter():
+    env_py_warnings = os.environ.get("PYTHONWARNINGS", "")
+    warning_categories = [RuntimeWarning, UserWarning, FutureWarning, ConvergenceWarning, ValueWarning]  # ignore these
+    try:
+        # required to suppress gluonts evaluation warnings as the module uses multiprocessing
+        os.environ["PYTHONWARNINGS"] = ",".join([f"ignore::{c.__name__}" for c in warning_categories])
+        yield
+    finally:
+        os.environ["PYTHONWARNINGS"] = env_py_warnings
+
+
+@contextlib.contextmanager
 def disable_root_logger():
     try:
         logging.getLogger().setLevel(logging.ERROR)


### PR DESCRIPTION
*Issue #, if available:*

- Fix statsmodels warning output, which made the logs/stdout unusable
- Fix gluonts tqdm, where our monkeypatch stopped working after the bump (?)
- Fix mxnet warning text

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
