### PR TITLE
Add Scorer error calculation plus code cleanup

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -8,7 +8,6 @@ import sklearn.metrics
 
 from . import classification_metrics
 from ..constants import BINARY, MULTICLASS, REGRESSION, QUANTILE, SOFTCLASS
-from ..utils.miscs import warning_filter
 from .classification_metrics import *
 from . import quantile_metrics
 
@@ -16,17 +15,22 @@ from . import quantile_metrics
 class Scorer(object, metaclass=ABCMeta):
     """
     Scorer wraps an external or custom metric function to align it with AutoGluon's metric logic and API.
+    Scorer will alter the returned metric output to ensure higher_is_better and to allow computing metric error. This greatly simplifies downstream logic.
+    All metric logic within AutoGluon should use Scorer to ensure consistency whenever possible.
 
     Parameters
     ----------
     name : str
         Name of the metric. Used in logs and as a key in dictionaries when multiple metric outputs are computed.
-    score_func :
+    score_func : callable
         Scoring metric function that will be called internally to score.
         Required to be a callable with the first two arguments corresponding to y_true, y_pred that returns a float indicating the metric value.
     optimum : float
         The highest/best value the metric can return. For example, optimal=1 for accuracy, optimal=0 for mean_squared_error.
         This is used to calculate regret / error. For example, a score of 1 for accuracy would have an error of 0.
+        NOTE: This value should be for the original score_func prior to changing the sign of the metric output.
+            For example, if score_func is lower_is_better with an optimum of -2 (aka a value of 0.5 has an error of 2.5),
+            then you should specify `optimum=-2, sign=-1`.
     sign : int
         Valid values are 1 and -1.
         The sign of the metric to ensure greater_is_better.
@@ -36,7 +40,7 @@ class Scorer(object, metaclass=ABCMeta):
         kwargs to pass to score_func when called.
         For example, kwargs = {"beta": 2} when using sklearn.metrics.fbeta_score where beta is a required argument.
     """
-    def __init__(self, name: str, score_func, optimum: float, sign: int, kwargs: dict = None):
+    def __init__(self, name: str, score_func: callable, optimum: float, sign: int, kwargs: dict = None):
         self.name = name
         if kwargs is None:
             kwargs = dict()
@@ -48,7 +52,7 @@ class Scorer(object, metaclass=ABCMeta):
         self._sign = sign
         self.alias = set()
 
-    def __call__(self, y_true, y_pred, sample_weight=None, **kwargs):
+    def __call__(self, y_true, y_pred, sample_weight=None, **kwargs) -> float:
         """
         Evaluate predicted target values for X relative to y_true.
 
@@ -83,7 +87,33 @@ class Scorer(object, metaclass=ABCMeta):
 
         return self._score(y_true=y_true, y_pred=y_pred, **k)
 
-    def _score(self, y_true, y_pred, **kwargs):
+    def error(self, *args, **kwargs) -> float:
+        """
+        Returns error in lower_is_better format.
+        An error of 0 indicates a perfect score.
+
+        Equivalent to `scorer.convert_score_to_error(scorer(*args, **kwargs))`
+        """
+        score = self(*args, **kwargs)
+        return self.convert_score_to_error(score)
+
+    def convert_score_to_error(self, score: float) -> float:
+        """
+        Converts score in higher_is_better format to error in lower_is_better format.
+
+        An error of 0 indicates a perfect score.
+        """
+        return self.optimum - score
+
+    @property
+    def optimum(self) -> float:
+        """
+        The highest/best value the metric can return in higher_is_better format. For example, optimal=1 for accuracy, optimal=0 for mean_squared_error.
+        This is used to calculate regret / error. For example, a score of 1 for accuracy would have an error of 0.
+        """
+        return self.convert_score_to_original(self._optimum)
+
+    def _score(self, y_true, y_pred, **kwargs) -> float:
         y_true, y_pred, kwargs = self._preprocess(y_true=y_true, y_pred=y_pred, **kwargs)
         return self._sign * self._score_func(y_true, y_pred, **kwargs)
 
@@ -95,18 +125,33 @@ class Scorer(object, metaclass=ABCMeta):
 
     @property
     def greater_is_better(self) -> bool:
-        """Return whether the score is greater the better.
-
-        We use the stored `sign` object to decide the property.
+        """
+        Return whether the score returned by scorer(...) is in greater_is_better format.
+        By default, all Scorers are in greater_is_better format.
 
         Returns
         -------
-        flag
+        flag :
             The "greater_is_better" flag.
+        """
+        return True
+
+    @property
+    def greater_is_better_internal(self) -> bool:
+        """
+        Return whether the inner self.score_func returns metric values in greater_is_better format.
+
+        We use the stored `sign` variable to decide the property.
+        Users should not need to access this property during normal usage.
+
+        Returns
+        -------
+        flag :
+            The "greater_is_better_internal" flag.
         """
         return self._sign > 0
 
-    def convert_score_to_sklearn_val(self, score):
+    def convert_score_to_original(self, score: float) -> float:
         """Scores are always greater_is_better, this flips the sign of metrics who were originally lower_is_better."""
         return self._sign * score
 
@@ -114,17 +159,12 @@ class Scorer(object, metaclass=ABCMeta):
     def _preprocess(self, y_true, y_pred, **kwargs):
         raise NotImplementedError
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.name
-
-    def sklearn_scorer(self):
-        with warning_filter():
-            ret = sklearn.metrics.scorer.make_scorer(score_func=self, greater_is_better=True, needs_proba=self.needs_proba, needs_threshold=self.needs_threshold)
-        return ret
 
     @property
     @abstractmethod
-    def needs_pred(self):
+    def needs_pred(self) -> bool:
         raise NotImplementedError
 
     @property
@@ -141,6 +181,8 @@ class Scorer(object, metaclass=ABCMeta):
     @abstractmethod
     def needs_quantile(self) -> bool:
         raise NotImplementedError
+
+    score = __call__
 
 
 class _PredictScorer(Scorer):

--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -542,10 +542,11 @@ log_loss = make_scorer('log_loss',
                        needs_proba=True)
 log_loss.add_alias('nll')
 
-pac_score = make_scorer('pac_score',
-                        classification_metrics.pac_score,
-                        greater_is_better=True,
-                        needs_proba=True)
+pac = make_scorer('pac',
+                  classification_metrics.pac,
+                  greater_is_better=True,
+                  needs_proba=True)
+pac.add_alias('pac_score')
 
 REGRESSION_METRICS = dict()
 for scorer in [
@@ -572,7 +573,7 @@ for scorer in [
     mcc,
     roc_auc_ovo_macro,
     log_loss,
-    pac_score,
+    pac,
     quadratic_kappa,
 ]:
     for metric_dict in [BINARY_METRICS, MULTICLASS_METRICS]:

--- a/core/src/autogluon/core/metrics/classification_metrics.py
+++ b/core/src/autogluon/core/metrics/classification_metrics.py
@@ -75,7 +75,7 @@ def balanced_accuracy(solution, prediction):
     return np.mean(bac)  # average over all classes
 
 
-def pac_score(solution, prediction):
+def pac(solution, prediction):
     """
     Probabilistic Accuracy based on log_loss metric.
     We assume the solution is in {0, 1} and prediction in [0, 1].

--- a/core/src/autogluon/core/trainer/abstract_trainer.py
+++ b/core/src/autogluon/core/trainer/abstract_trainer.py
@@ -63,7 +63,7 @@ class AbstractTrainer:
             self.eval_metric = infer_eval_metric(problem_type=self.problem_type)
 
         logger.log(25, f"AutoGluon will gauge predictive performance using evaluation metric: '{self.eval_metric.name}'")
-        if not self.eval_metric.greater_is_better:
+        if not self.eval_metric.greater_is_better_internal:
             logger.log(25, "\tThis metric's sign has been flipped to adhere to being higher_is_better. The metric score can be multiplied by -1 to get the metric value.")
         if not (self.eval_metric.needs_pred or self.eval_metric.needs_quantile):
             logger.log(25, "\tThis metric expects predicted probabilities rather than predicted class labels, so you'll need to use predict_proba() instead of predict()")
@@ -1510,7 +1510,7 @@ class AbstractTrainer:
         if model.val_score is not None:
             if model.eval_metric.name != self.eval_metric.name:
                 logger.log(20, f'\tNote: model has different eval_metric than default.')
-            if not model.eval_metric.greater_is_better:
+            if not model.eval_metric.greater_is_better_internal:
                 sign_str = '-'
             else:
                 sign_str = ''

--- a/core/tests/unittests/metrics/test_classification_metrics.py
+++ b/core/tests/unittests/metrics/test_classification_metrics.py
@@ -188,7 +188,7 @@ def test_log_loss_with_sklearn(gt, probs):
     # Thus, the true value should be the negation of the real log_loss
     np.testing.assert_allclose(ag_loss, -sklearn_log_loss)
 
-    ag_loss_as_sklearn = log_loss.convert_score_to_sklearn_val(ag_loss)
+    ag_loss_as_sklearn = log_loss.convert_score_to_original(ag_loss)
     np.testing.assert_allclose(ag_loss_as_sklearn, sklearn_log_loss)
 
 

--- a/core/tests/unittests/metrics/test_metric_kwargs.py
+++ b/core/tests/unittests/metrics/test_metric_kwargs.py
@@ -17,6 +17,16 @@ def test_metric_kwargs():
     assert score > score_pos_label_0
     assert score_pos_label_0 == 0.4
 
+    error = f1.error(y_true, y_pred)
+    error_pos_label_1 = f1.error(y_true, y_pred, pos_label=1)
+    error_pos_label_0 = f1.error(y_true, y_pred, pos_label=0)
+
+    assert f1.optimum == 1
+    assert error == (f1.optimum - score)
+    assert error_pos_label_1 == (f1.optimum - score_pos_label_1)
+    assert error_pos_label_0 == (f1.optimum - score_pos_label_0)
+    assert error_pos_label_0 == 0.6
+
 
 def test_metric_kwargs_init():
     y_true = np.array([1, 1, 1, 0, 0, 0])

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -3,7 +3,7 @@ from math import isclose
 import numpy as np
 import pytest
 
-from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
+from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION, QUANTILE
 from autogluon.core.metrics import METRICS, Scorer
 
 
@@ -11,77 +11,98 @@ BINARY_METRICS = list(METRICS[BINARY].keys())
 MULTICLASS_METRICS = list(METRICS[MULTICLASS].keys())
 REGRESSION_METRICS = list(METRICS[REGRESSION].keys())
 
+EXPECTED_BINARY_METRICS = {
+    "acc",
+    "accuracy",
+    "average_precision",
+    "balanced_accuracy",
+    "f1",
+    "f1_macro",
+    "f1_micro",
+    "f1_weighted",
+    "log_loss",
+    "mcc",
+    "nll",
+    "pac",
+    "pac_score",
+    "precision",
+    "precision_macro",
+    "precision_micro",
+    "precision_weighted",
+    "quadratic_kappa",
+    "recall",
+    "recall_macro",
+    "recall_micro",
+    "recall_weighted",
+    "roc_auc",
+    "roc_auc_ovo_macro",
+}
 
-def test_metric_exists():
+EXPECTED_MULTICLASS_METRICS = {
+    "acc",
+    "accuracy",
+    "balanced_accuracy",
+    "f1_macro",
+    "f1_micro",
+    "f1_weighted",
+    "log_loss",
+    "mcc",
+    "nll",
+    "pac",
+    "pac_score",
+    "precision_macro",
+    "precision_micro",
+    "precision_weighted",
+    "quadratic_kappa",
+    "recall_macro",
+    "recall_micro",
+    "recall_weighted",
+    "roc_auc_ovo_macro",
+}
+
+EXPECTED_REGRESSION_METRICS = {
+    "mae",
+    "mape",
+    "mean_absolute_error",
+    "mean_absolute_percentage_error",
+    "mean_squared_error",
+    "median_absolute_error",
+    "mse",
+    "pearsonr",
+    "r2",
+    "rmse",
+    "root_mean_squared_error",
+    "spearmanr",
+}
+
+EXPECTED_QUANTILE_METRICS = {
+    "pinball",
+    "pinball_loss",
+}
+
+
+@pytest.mark.parametrize("metrics,expected_metrics_and_aliases", [
+    [METRICS[BINARY], EXPECTED_BINARY_METRICS],
+    [METRICS[MULTICLASS], EXPECTED_MULTICLASS_METRICS],
+    [METRICS[REGRESSION], EXPECTED_REGRESSION_METRICS],
+    [METRICS[QUANTILE], EXPECTED_QUANTILE_METRICS],
+], ids=[
+    BINARY,
+    MULTICLASS,
+    REGRESSION,
+    QUANTILE,
+])  # noqa
+def test_metric_exists(metrics: dict, expected_metrics_and_aliases: set):
     """
     Ensure all expected metrics are present and no unexpected metrics are present
     """
-    expected_metrics_and_aliases = {
-        "accuracy",
-        "acc",
-        "balanced_accuracy",
-        "mcc",
-        "roc_auc_ovo_macro",
-        "log_loss",
-        "nll",
-        "pac_score",
-        "quadratic_kappa",
-        "roc_auc",
-        "average_precision",
-        "precision",
-        "precision_macro",
-        "precision_micro",
-        "precision_weighted",
-        "recall",
-        "recall_macro",
-        "recall_micro",
-        "recall_weighted",
-        "f1",
-        "f1_macro",
-        "f1_micro",
-        "f1_weighted",
-        "accuracy",
-        "acc",
-        "balanced_accuracy",
-        "mcc",
-        "roc_auc_ovo_macro",
-        "log_loss",
-        "nll",
-        "pac_score",
-        "quadratic_kappa",
-        "precision_macro",
-        "precision_micro",
-        "precision_weighted",
-        "recall_macro",
-        "recall_micro",
-        "recall_weighted",
-        "f1_macro",
-        "f1_micro",
-        "f1_weighted",
-        "r2",
-        "mean_squared_error",
-        "mse",
-        "root_mean_squared_error",
-        "rmse",
-        "mean_absolute_error",
-        "mae",
-        "median_absolute_error",
-        "mean_absolute_percentage_error",
-        "mape",
-        "spearmanr",
-        "pearsonr",
-        "pinball_loss",
-        "pinball",
-    }
-
     seen_metrics = set()
 
-    for problem_type in METRICS.keys():
-        for metric_name, metric_obj in METRICS[problem_type].items():
-            assert (metric_name == metric_obj.name) or (metric_name in metric_obj.alias)
-            assert metric_obj.greater_is_better is True
-            if metric_name not in seen_metrics:
-                seen_metrics.add(metric_name)
+    for metric_name, metric_obj in metrics.items():
+        assert (metric_name == metric_obj.name) or (metric_name in metric_obj.alias)
+        assert metric_obj.greater_is_better is True
+        if metric_name not in seen_metrics:
+            seen_metrics.add(metric_name)
     diff_metrics = seen_metrics.symmetric_difference(expected_metrics_and_aliases)
     if len(diff_metrics) > 0:
         missing_metrics = expected_metrics_and_aliases.difference(seen_metrics)

--- a/core/tests/unittests/metrics/test_metrics.py
+++ b/core/tests/unittests/metrics/test_metrics.py
@@ -1,0 +1,156 @@
+from math import isclose
+
+import numpy as np
+import pytest
+
+from autogluon.core.constants import BINARY, MULTICLASS, REGRESSION
+from autogluon.core.metrics import METRICS, Scorer
+
+
+BINARY_METRICS = list(METRICS[BINARY].keys())
+MULTICLASS_METRICS = list(METRICS[MULTICLASS].keys())
+REGRESSION_METRICS = list(METRICS[REGRESSION].keys())
+
+
+def test_metric_exists():
+    """
+    Ensure all expected metrics are present and no unexpected metrics are present
+    """
+    expected_metrics_and_aliases = {
+        "accuracy",
+        "acc",
+        "balanced_accuracy",
+        "mcc",
+        "roc_auc_ovo_macro",
+        "log_loss",
+        "nll",
+        "pac_score",
+        "quadratic_kappa",
+        "roc_auc",
+        "average_precision",
+        "precision",
+        "precision_macro",
+        "precision_micro",
+        "precision_weighted",
+        "recall",
+        "recall_macro",
+        "recall_micro",
+        "recall_weighted",
+        "f1",
+        "f1_macro",
+        "f1_micro",
+        "f1_weighted",
+        "accuracy",
+        "acc",
+        "balanced_accuracy",
+        "mcc",
+        "roc_auc_ovo_macro",
+        "log_loss",
+        "nll",
+        "pac_score",
+        "quadratic_kappa",
+        "precision_macro",
+        "precision_micro",
+        "precision_weighted",
+        "recall_macro",
+        "recall_micro",
+        "recall_weighted",
+        "f1_macro",
+        "f1_micro",
+        "f1_weighted",
+        "r2",
+        "mean_squared_error",
+        "mse",
+        "root_mean_squared_error",
+        "rmse",
+        "mean_absolute_error",
+        "mae",
+        "median_absolute_error",
+        "mean_absolute_percentage_error",
+        "mape",
+        "spearmanr",
+        "pearsonr",
+        "pinball_loss",
+        "pinball",
+    }
+
+    seen_metrics = set()
+
+    for problem_type in METRICS.keys():
+        for metric_name, metric_obj in METRICS[problem_type].items():
+            assert (metric_name == metric_obj.name) or (metric_name in metric_obj.alias)
+            assert metric_obj.greater_is_better is True
+            if metric_name not in seen_metrics:
+                seen_metrics.add(metric_name)
+    diff_metrics = seen_metrics.symmetric_difference(expected_metrics_and_aliases)
+    if len(diff_metrics) > 0:
+        missing_metrics = expected_metrics_and_aliases.difference(seen_metrics)
+        if len(missing_metrics) > 0:
+            raise AssertionError(f'Missing metrics: {list(missing_metrics)}')
+        else:
+            unknown_metrics = seen_metrics.difference(expected_metrics_and_aliases)
+            raise AssertionError(f'Invalid metrics (If you have added a new metric, '
+                                 f'please include it in the variable `expected_metrics_and_aliases`):'
+                                 f'\n\t{list(unknown_metrics)}')
+
+
+@pytest.mark.parametrize("metric", BINARY_METRICS, ids=BINARY_METRICS)  # noqa
+def test_metrics_perfect_binary(metric: str):
+    _assert_perfect_score(scorer=METRICS[BINARY][metric])
+
+
+@pytest.mark.parametrize("metric", MULTICLASS_METRICS, ids=MULTICLASS_METRICS)  # noqa
+def test_metrics_perfect_multiclass(metric: str):
+    _assert_perfect_score(scorer=METRICS[MULTICLASS][metric])
+
+
+@pytest.mark.parametrize("metric", REGRESSION_METRICS, ids=REGRESSION_METRICS)  # noqa
+def test_metrics_perfect_regression(metric: str):
+    _assert_perfect_score(scorer=METRICS[REGRESSION][metric])
+
+
+@pytest.mark.parametrize("metric", BINARY_METRICS, ids=BINARY_METRICS)  # noqa
+def test_metrics_imperfect_binary(metric: str):
+    _assert_imperfect_score(scorer=METRICS[BINARY][metric])
+
+
+@pytest.mark.parametrize("metric", MULTICLASS_METRICS, ids=MULTICLASS_METRICS)  # noqa
+def test_metrics_imperfect_multiclass(metric: str):
+    _assert_imperfect_score(scorer=METRICS[MULTICLASS][metric])
+
+
+@pytest.mark.parametrize("metric", REGRESSION_METRICS, ids=REGRESSION_METRICS)  # noqa
+def test_metrics_imperfect_regression(metric: str):
+    _assert_imperfect_score(scorer=METRICS[REGRESSION][metric])
+
+
+def _assert_perfect_score(scorer: Scorer, abs_tol=1e-5):
+    """
+    Ensure a perfect prediction has an error of 0
+    and a score equal to scorer's optimum for a given scorer.
+    """
+    y_true = np.array([0, 0, 1])
+    y_pred = np.array([0.0, 0.0, 1.0])
+    score = scorer(y_true, y_pred)
+    assert score == scorer.score(y_true, y_pred)
+    error = scorer.error(y_true, y_pred)
+    assert error == scorer.convert_score_to_error(score)
+    assert isclose(error, 0, abs_tol=abs_tol)
+    assert isclose(score, scorer.optimum, abs_tol=abs_tol)
+
+
+def _assert_imperfect_score(scorer: Scorer, abs_tol=1e-5):
+    """
+    Ensure an imperfect prediction has an error greater than 0
+    and a score less than the scorer's optimum for a given scorer.
+    """
+    y_true = np.array([0, 0, 1])
+    y_pred = np.array([1.0, 1.0, 0.0])
+    score = scorer(y_true, y_pred)
+    assert score == scorer.score(y_true, y_pred)
+    error = scorer.error(y_true, y_pred)
+    assert error == scorer.convert_score_to_error(score)
+    assert error > 0
+    assert score < scorer.optimum
+    assert not isclose(error, 0, abs_tol=abs_tol)
+    assert not isclose(score, scorer.optimum, abs_tol=abs_tol)

--- a/tabular/src/autogluon/tabular/learner/abstract_learner.py
+++ b/tabular/src/autogluon/tabular/learner/abstract_learner.py
@@ -584,19 +584,12 @@ class AbstractTabularLearner(AbstractLearner):
                     )
                 performance_dict[aux_metric.name] = score
 
-        if self.eval_metric.name in performance_dict:
-            score_eval = performance_dict[self.eval_metric.name]
-            score_eval_flipped = self.eval_metric.convert_score_to_sklearn_val(score_eval)  # flip negative once again back to positive (so higher is no longer necessarily better)
-            if score_eval_flipped != score_eval:
-                flipped = True
-            else:
-                flipped = False
-            if not silent:
-                logger.log(20, f"Evaluation: {self.eval_metric.name} on test data: {score_eval}")
-                if flipped:
-                    logger.log(20, f"\tNote: Scores are always higher_is_better. This metric score can be multiplied by -1 to get the metric value.")
-
         if not silent:
+            if self.eval_metric.name in performance_dict:
+                score_eval = performance_dict[self.eval_metric.name]
+                logger.log(20, f"Evaluation: {self.eval_metric.name} on test data: {score_eval}")
+                if not self.eval_metric.greater_is_better_internal:
+                    logger.log(20, f"\tNote: Scores are always higher_is_better. This metric score can be multiplied by -1 to get the metric value.")
             logger.log(20, "Evaluations on test data:")
             logger.log(20, json.dumps(performance_dict, indent=4))
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add scorer error calculation via `Scorer.error`
- Majorly cleaned up scorer API, improved documentation
- Improved custom metric tutorial
- Added unit tests for scorer.optimum, we now confirm via unit tests that the optimum value for all metrics is set correctly, along with the `greater_is_better` flag. (No bugs in metrics found via this PR, so it appears our metrics are correctly implemented already)
- Fixed NeuralNetTorch using incorrect sign in HPO reporter for lower_is_better native metrics like log_loss and RMSE. This caused Bayesian Optimization and Hyperband to search poorly for NeuralNetTorch. Also fixed this issue for MXNet version of autogluon.text and Tabular's NeuralNetMXNet. (Fixed by correcting `Scorer.greater_is_better`)
- Fixed theoretical bug where `optimum` is a negative value and `greater_is_better=False` when calculating `Scorer.error`, now this situation works correctly.
- Removed old unused code such as `Scorer.sklearn_scorer`
- Added alias `Scorer.score` of `Scorer` callable to complement `Scorer.error`.
- Added `Scorer.optimum` property
- Added type hints
- Added unit test to ensure all expected metrics + aliases are available (and no unexpected ones are present)
- Added unit tests to ensure all metrics work without crashing and satisfy sanity checks of correctness regarding score consistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
