### PR TITLE
Added platform machine and version logging

### DIFF
--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -63,6 +63,8 @@ class DefaultLearner(AbstractTabularLearner):
         logger.log(20, f'AutoGluon Version:  {self.version}')
         logger.log(20, f'Python Version:     {self._python_version}')
         logger.log(20, f'Operating System:   {platform.system()}')
+        logger.log(20, f'Platform Machine:   {platform.machine()}')
+        logger.log(20, f'Platform Version:   {platform.version()}')
         logger.log(20, f'Train Data Rows:    {len(X)}')
         logger.log(20, f'Train Data Columns: {len([column for column in X.columns if column != self.label])}')
         if X_val is not None:


### PR DESCRIPTION
*Description of changes:*
Added `Platform Machine` and `Platform Version` logging for initial autogluon debug info logging (see last 2 lines below).

```
Beginning AutoGluon training ...
AutoGluon will save models to "agModels-predictClass/"
AutoGluon Version:  0.5.3b20221020
Python Version:     3.9.13
Operating System:   Darwin
Platform Machine:   arm64
Platform Version:   Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
