### PR TITLE
always init bias with zeros and free tokens from weight decay

### DIFF
--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -367,7 +367,7 @@ class AdditiveAttention(nn.Module):
         trainable = []
         if share_qv_weights:
             self.qv_proj = nn.Linear(d_token, d_token, bias=bias)
-            trainable.extend([self.share_qv_weights])
+            trainable.extend([self.qv_proj])
         else:
             self.q_proj = nn.Linear(d_token, d_token, bias=bias)
             self.v_proj = nn.Linear(d_token, d_token, bias=bias)

--- a/multimodal/src/autogluon/multimodal/models/ft_transformer.py
+++ b/multimodal/src/autogluon/multimodal/models/ft_transformer.py
@@ -364,18 +364,27 @@ class AdditiveAttention(nn.Module):
         self.n_heads = n_heads
         self.share_qv_weights = share_qv_weights
         self.dropout = nn.Dropout(dropout)
+        trainable = []
         if share_qv_weights:
             self.qv_proj = nn.Linear(d_token, d_token, bias=bias)
+            trainable.extend([self.share_qv_weights])
         else:
             self.q_proj = nn.Linear(d_token, d_token, bias=bias)
             self.v_proj = nn.Linear(d_token, d_token, bias=bias)
+            trainable.extend([self.q_proj, self.v_proj])
+
         self.k_proj = nn.Linear(d_token, d_token, bias=bias)
         self.W_q = nn.Linear(d_token, n_heads)
         self.W_k = nn.Linear(d_token, n_heads)
         self.r_out = nn.Linear(d_token, d_token)
+        trainable.extend([self.k_proj, self.W_q, self.W_k, self.r_out])
 
         if initialization == "xavier":
             self.apply(init_weights)
+        else:
+            for m in trainable:
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
 
     def forward(
         self,

--- a/multimodal/src/autogluon/multimodal/optimization/utils.py
+++ b/multimodal/src/autogluon/multimodal/optimization/utils.py
@@ -350,10 +350,10 @@ def get_weight_decay_param_names(model: nn.Module):
         name
         for name in decay_param_names
         if (
-                "bias" not in name
-                and "cls_token" not in name
-                and "categorical_feature_tokenizer" not in name
-                and "numerical_feature_tokenizer" not in name
+            "bias" not in name
+            and "cls_token" not in name
+            and "categorical_feature_tokenizer" not in name
+            and "numerical_feature_tokenizer" not in name
         )
     ]
     return decay_param_names

--- a/multimodal/src/autogluon/multimodal/optimization/utils.py
+++ b/multimodal/src/autogluon/multimodal/optimization/utils.py
@@ -346,7 +346,16 @@ def get_weight_decay_param_names(model: nn.Module):
         model,
         [nn.LayerNorm, nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.GroupNorm],
     )
-    decay_param_names = [name for name in decay_param_names if "bias" not in name]
+    decay_param_names = [
+        name
+        for name in decay_param_names
+        if (
+                "bias" not in name
+                and "cls_token" not in name
+                and "categorical_feature_tokenizer" not in name
+                and "numerical_feature_tokenizer" not in name
+        )
+    ]
     return decay_param_names
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. According to the code from [FT_Transformer authors](https://github.com/puhsu/tabular-dl-pretrain-objectives/blob/master/lib/deep.py#:~:text=def%20default_zero_weight_decay_condition(module_name%2C%20module%2C%20parameter_name%2C%20parameter)%3A), tokenizers should be free from weight decay.  Worked slightly better on classification tasks (57% win rate).

2. Additive attention always init bias with zeros.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
