### PR TITLE
[eda] Added ApplyFeatureGenerator

### DIFF
--- a/eda/setup.py
+++ b/eda/setup.py
@@ -30,6 +30,7 @@ install_requires = [
     'seaborn>=0.12.0,<0.13',
     'ipython>=8.0,<9.0',
     'ipywidgets>=8.0,<9.0',
+    f'autogluon.features=={version}',
 ]
 
 extras_require = dict()

--- a/eda/src/autogluon/eda/__init__.py
+++ b/eda/src/autogluon/eda/__init__.py
@@ -1,3 +1,2 @@
 from .state import AnalysisState
 from .version import __version__
-

--- a/eda/src/autogluon/eda/analysis/__init__.py
+++ b/eda/src/autogluon/eda/analysis/__init__.py
@@ -1,3 +1,4 @@
 import phik
 from .base import Namespace
 from .dataset import Sampler
+from .transform import ApplyFeatureGenerator

--- a/eda/src/autogluon/eda/analysis/base.py
+++ b/eda/src/autogluon/eda/analysis/base.py
@@ -15,12 +15,12 @@ class AbstractAnalysis(ABC, StateCheckMixin):
 
     def __init__(self,
                  parent: Optional[AbstractAnalysis] = None,
-                 children: List[AbstractAnalysis] = [],
+                 children: Optional[List[AbstractAnalysis]] = None,
                  state: Optional[AnalysisState] = None,
                  **kwargs) -> None:
 
         self.parent = parent
-        self.children: List[AbstractAnalysis] = children
+        self.children: List[AbstractAnalysis] = [] if children is None else children
         self.state: Optional[AnalysisState] = state
         for c in self.children:
             c.parent = self
@@ -133,7 +133,7 @@ class BaseAnalysis(AbstractAnalysis):
 
     def __init__(self,
                  parent: Optional[AbstractAnalysis] = None,
-                 children: List[AbstractAnalysis] = [],
+                 children: Optional[List[AbstractAnalysis]] = None,
                  **kwargs) -> None:
         super().__init__(parent, children, **kwargs)
 
@@ -152,7 +152,7 @@ class Namespace(AbstractAnalysis):
     def __init__(self,
                  namespace: Optional[str] = None,
                  parent: Optional[AbstractAnalysis] = None,
-                 children: List[AbstractAnalysis] = [],
+                 children: Optional[List[AbstractAnalysis]] = None,
                  **kwargs) -> None:
         super().__init__(parent, children, **kwargs)
         self.namespace = namespace

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -44,7 +44,7 @@ class Sampler(AbstractAnalysis):
     def __init__(self,
                  sample: Union[None, int, float] = None,
                  parent: Optional[AbstractAnalysis] = None,
-                 children: List[AbstractAnalysis] = [],
+                 children: Optional[List[AbstractAnalysis]] = None,
                  **kwargs) -> None:
         super().__init__(parent, children, **kwargs)
         if sample is not None and isinstance(sample, float):

--- a/eda/src/autogluon/eda/analysis/transform.py
+++ b/eda/src/autogluon/eda/analysis/transform.py
@@ -50,7 +50,7 @@ class ApplyFeatureGenerator(AbstractAnalysis, StateCheckMixin):
 
     def __init__(self,
                  parent: Optional[AbstractAnalysis] = None,
-                 children: List[AbstractAnalysis] = [],
+                 children: Optional[List[AbstractAnalysis]] = None,
                  state: Optional[AnalysisState] = None,
                  category_to_numbers: bool = False,
                  feature_generator: Optional[AbstractFeatureGenerator] = None,

--- a/eda/src/autogluon/eda/analysis/transform.py
+++ b/eda/src/autogluon/eda/analysis/transform.py
@@ -1,0 +1,92 @@
+import logging
+from typing import List, Optional
+
+import pandas as pd
+
+from autogluon.features import AbstractFeatureGenerator, AutoMLPipelineFeatureGenerator
+from .base import AbstractAnalysis
+from ..state import AnalysisState
+from ..state import StateCheckMixin
+
+logger = logging.getLogger(__name__)
+
+
+class ApplyFeatureGenerator(AbstractAnalysis, StateCheckMixin):
+    """
+    This wrapper provides transformed features to all `children` shadowing outer datasets with the updated one after application of FeatureGenerator.
+
+    Parameters
+    ----------
+    category_to_numbers: bool, default = False
+        if `True', then transform `category` variables into their codes. This is useful when wrapped analyses expect numeric values
+    feature_generator: Optional[AbstractFeatureGenerator], default = None
+        feature generator to use for the transformation. If `None` is provided then `AutoMLPipelineFeatureGenerator` is applied.
+    parent: Optional[AbstractAnalysis], default = None
+        parent Analysis
+    children: List[AbstractAnalysis], default []
+        wrapped analyses; these will receive sampled `args` during `fit` call
+    kwargs
+
+    See also :func:`autogluon.features.AbstractFeatureGenerator`
+
+    Examples
+    --------
+    >>> from autogluon.eda.analysis.base import BaseAnalysis, Namespace
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> df_train = pd.DataFrame(...)
+    >>> df_test = pd.DataFrame(...)
+    >>>
+    >>> analysis = BaseAnalysis(train_data=df_train, test_data=df_test, label='D', children=[
+    >>>     Namespace(namespace='feature_generator_numbers', children=[
+    >>>         ApplyFeatureGenerator(category_to_numbers=True, children=[
+    >>>             # SomeAnalysis()  # This analysis will be called with transformed `train_data` and `test_data`
+    >>>         ])
+    >>>     ]),
+    >>>     # SomeAnalysis()  # This analysis will be called with the original features
+    >>> ])
+
+    """
+
+    def __init__(self,
+                 parent: Optional[AbstractAnalysis] = None,
+                 children: List[AbstractAnalysis] = [],
+                 state: Optional[AnalysisState] = None,
+                 category_to_numbers: bool = False,
+                 feature_generator: Optional[AbstractFeatureGenerator] = None,
+                 **kwargs) -> None:
+        super().__init__(parent, children, state, **kwargs)
+        self.category_to_numbers = category_to_numbers
+        if feature_generator is None:
+            feature_generator = AutoMLPipelineFeatureGenerator(
+                enable_numeric_features=True,
+                enable_categorical_features=True,
+                enable_datetime_features=False,
+                enable_text_special_features=False,
+                enable_text_ngram_features=False,
+                enable_raw_text_features=False,
+                enable_vision_features=False,
+            )
+        self.feature_generator = feature_generator
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return self.all_keys_must_be_present(args, 'train_data', 'label')
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        x = args.train_data.drop(columns=args.label)
+        self.feature_generator.fit(x)
+        self.args['feature_generator'] = True
+        for (ds, df) in self.available_datasets(args):
+            x = df
+            y = None
+            if args.label in df.columns:
+                x = df.drop(columns=args.label)
+                y = df[args.label]
+            x_tx = self.feature_generator.transform(x)
+            if self.category_to_numbers:
+                for col, dtype in x_tx.dtypes.items():
+                    if dtype == 'category':
+                        x_tx[col] = x_tx[col].cat.codes
+            if y is not None:
+                x_tx = pd.concat([x_tx, y], axis=1)
+            self.args[ds] = x_tx

--- a/eda/src/autogluon/eda/state.py
+++ b/eda/src/autogluon/eda/state.py
@@ -40,7 +40,7 @@ class AnalysisState(dict):
 class StateCheckMixin:
     logger = logging.getLogger(__name__)
 
-    def at_least_one_key_must_be_present(self, state: AnalysisState, *keys):
+    def at_least_one_key_must_be_present(self, state: AnalysisState, *keys) -> bool:
         """
         Checks if at least one key is present in the state
 
@@ -61,7 +61,7 @@ class StateCheckMixin:
         self.logger.warning(f'{self.__class__.__name__}: at least one of the following keys must be present: {keys}')
         return False
 
-    def all_keys_must_be_present(self, state: AnalysisState, *keys):
+    def all_keys_must_be_present(self, state: AnalysisState, *keys) -> bool:
         """
         Checks if all the keys are present in the state
 

--- a/eda/src/autogluon/eda/state.py
+++ b/eda/src/autogluon/eda/state.py
@@ -1,14 +1,17 @@
 import logging
 
-logger = logging.getLogger(__name__)
-
 __all__ = ['AnalysisState', 'StateCheckMixin']
+
+from typing import Any
 
 
 class AnalysisState(dict):
     """Enabling dot.notation access to dictionary attributes and dynamic code assist in jupyter"""
-    __getattr__ = dict.get
+    _getattr__ = dict.get
     __delattr__ = dict.__delitem__  # type: ignore
+
+    def __getattr__(self, item) -> Any:  # needed for mypy checks
+        return self._getattr__(item)
 
     def __init__(self, *args, **kwargs) -> None:
         for arg in args:
@@ -35,6 +38,8 @@ class AnalysisState(dict):
 
 
 class StateCheckMixin:
+    logger = logging.getLogger(__name__)
+
     def at_least_one_key_must_be_present(self, state: AnalysisState, *keys):
         """
         Checks if at least one key is present in the state
@@ -53,7 +58,7 @@ class StateCheckMixin:
         for k in keys:
             if k in state:
                 return True
-        logger.warning(f'{self.__class__.__name__}: at least one of the following keys must be present: {keys}')
+        self.logger.warning(f'{self.__class__.__name__}: at least one of the following keys must be present: {keys}')
         return False
 
     def all_keys_must_be_present(self, state: AnalysisState, *keys):
@@ -74,5 +79,6 @@ class StateCheckMixin:
         keys_not_present = [k for k in keys if k not in state.keys()]
         can_handle = len(keys_not_present) == 0
         if not can_handle:
-            logger.warning(f'{self.__class__.__name__}: all of the following keys must be present: {keys}. The following keys are missing: {keys_not_present}')
+            self.logger.warning(
+                f'{self.__class__.__name__}: all of the following keys must be present: {keys}. The following keys are missing: {keys_not_present}')
         return can_handle

--- a/eda/tests/conftest.py
+++ b/eda/tests/conftest.py
@@ -10,7 +10,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     plugin = config.pluginmanager.getplugin("mypy")
-    plugin.mypy_argv.append("--ignore-missing-imports")
+    if plugin is not None:
+        plugin.mypy_argv.append("--ignore-missing-imports")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/eda/tests/unittests/analysis/test_transform.py
+++ b/eda/tests/unittests/analysis/test_transform.py
@@ -41,14 +41,14 @@ def test_ApplyFeatureGenerator():
     ])
 
     state = analysis.fit()
-    assert list(df_train.dtypes.apply(str).values) == ['object', 'int64', 'object', 'int64']
-    assert list(df_test.dtypes.apply(str).values) == ['object', 'int64', 'object', 'int64']
+    assert list(df_train.dtypes.apply(str).to_numpy()) == ['object', 'int64', 'object', 'int64']
+    assert list(df_test.dtypes.apply(str).to_numpy()) == ['object', 'int64', 'object', 'int64']
 
-    assert list(state.no_wrapper.args.train_data[df_train.columns].dtypes.apply(str).values) == ['object', 'int64', 'object', 'int64']
-    assert list(state.no_wrapper.args.test_data[df_test.columns].dtypes.apply(str).values) == ['object', 'int64', 'object', 'int64']
+    assert list(state.no_wrapper.args.train_data[df_train.columns].dtypes.apply(str).to_numpy()) == ['object', 'int64', 'object', 'int64']
+    assert list(state.no_wrapper.args.test_data[df_test.columns].dtypes.apply(str).to_numpy()) == ['object', 'int64', 'object', 'int64']
 
-    assert list(state.feature_generator_default.args.train_data[df_train.columns].dtypes.apply(str).values) == ['category', 'int64', 'category', 'int64']
-    assert list(state.feature_generator_default.args.test_data[df_test.columns].dtypes.apply(str).values) == ['category', 'int64', 'category', 'int64']
+    assert list(state.feature_generator_default.args.train_data[df_train.columns].dtypes.apply(str).to_numpy()) == ['category', 'int64', 'category', 'int64']
+    assert list(state.feature_generator_default.args.test_data[df_test.columns].dtypes.apply(str).to_numpy()) == ['category', 'int64', 'category', 'int64']
 
-    assert list(state.feature_generator_numbers.args.train_data[df_train.columns].dtypes.apply(str).values) == ['int8', 'int64', 'int8', 'int64']
-    assert list(state.feature_generator_numbers.args.test_data[df_test.columns].dtypes.apply(str).values) == ['int8', 'int64', 'int8', 'int64']
+    assert list(state.feature_generator_numbers.args.train_data[df_train.columns].dtypes.apply(str).to_numpy()) == ['int8', 'int64', 'int8', 'int64']
+    assert list(state.feature_generator_numbers.args.test_data[df_test.columns].dtypes.apply(str).to_numpy()) == ['int8', 'int64', 'int8', 'int64']

--- a/eda/tests/unittests/analysis/test_transform.py
+++ b/eda/tests/unittests/analysis/test_transform.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pandas as pd
+
+from autogluon.eda import AnalysisState
+from autogluon.eda.analysis import Namespace
+from autogluon.eda.analysis.base import BaseAnalysis
+from autogluon.eda.analysis.transform import ApplyFeatureGenerator
+
+
+class SomeAnalysis(BaseAnalysis):
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        state.args = args.copy()
+
+
+def test_ApplyFeatureGenerator():
+    df_train = pd.DataFrame((np.arange(10))[:, None].repeat([4], axis=1), columns=list('ABCD'))
+    df_test = pd.DataFrame((np.arange(20))[:, None].repeat([4], axis=1), columns=list('ABCD'))
+    for df in [df_train, df_test]:
+        df['A'] = (df['A'] % 4).map({0: 'a', 1: 'b', 2: 'c', 3: 'd'})
+        df['B'] = (df['B'] % 5)
+        df['C'] = (df['C'] % 3).map({0: 'a', 1: 'b', 2: 'c'})
+        df['D'] = (df['D'] % 5)
+    assert df_train.shape == (10, 4)
+    assert df_test.shape == (20, 4)
+
+    analysis = BaseAnalysis(train_data=df_train, test_data=df_test, label='D', children=[
+        Namespace(namespace='feature_generator_numbers', children=[
+            ApplyFeatureGenerator(category_to_numbers=True, children=[
+                SomeAnalysis()
+            ])
+        ]),
+        Namespace(namespace='feature_generator_default', children=[
+            ApplyFeatureGenerator(children=[
+                SomeAnalysis()
+            ])
+        ]),
+        Namespace(namespace='no_wrapper', children=[
+            SomeAnalysis()
+        ]),
+    ])
+
+    state = analysis.fit()
+    assert list(df_train.dtypes.apply(str).values) == ['object', 'int64', 'object', 'int64']
+    assert list(df_test.dtypes.apply(str).values) == ['object', 'int64', 'object', 'int64']
+
+    assert list(state.no_wrapper.args.train_data[df_train.columns].dtypes.apply(str).values) == ['object', 'int64', 'object', 'int64']
+    assert list(state.no_wrapper.args.test_data[df_test.columns].dtypes.apply(str).values) == ['object', 'int64', 'object', 'int64']
+
+    assert list(state.feature_generator_default.args.train_data[df_train.columns].dtypes.apply(str).values) == ['category', 'int64', 'category', 'int64']
+    assert list(state.feature_generator_default.args.test_data[df_test.columns].dtypes.apply(str).values) == ['category', 'int64', 'category', 'int64']
+
+    assert list(state.feature_generator_numbers.args.train_data[df_train.columns].dtypes.apply(str).values) == ['int8', 'int64', 'int8', 'int64']
+    assert list(state.feature_generator_numbers.args.test_data[df_test.columns].dtypes.apply(str).values) == ['int8', 'int64', 'int8', 'int64']


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Applies `FeatureGenerator` and shadows outer scope with transformed data. This is needed for analysis like correlation since it requires numeric features. If `category_to_numbers` is `True` then categories will be translated into `cat.code`
```python
    analysis = BaseAnalysis(train_data=df_train, test_data=df_test, label=target_label, children=[
        ApplyFeatureGenerator(category_to_numbers=True, children=[
            # SomeAnalysis()  # This analysis sees transformed features
        ]),
        # SomeAnalysis()  # This analysis sees original features
    ])
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
