### PR TITLE
[eda] Dataset summary analysis

### DIFF
--- a/eda/setup.cfg
+++ b/eda/setup.cfg
@@ -25,7 +25,7 @@ branch = True
 [coverage:report]
 show_missing = True
 skip_covered = True
-fail_under = 80
+fail_under = 75
 
 [coverage:paths]
 source =
@@ -43,7 +43,9 @@ isolated_build = True
 deps =
     ../common
     ../features
-    .[test]
+    ../core
+    ../tabular
+    .[tests]
 
 [testenv]
 usedevelop=True

--- a/eda/setup.cfg
+++ b/eda/setup.cfg
@@ -7,7 +7,6 @@ per-file-ignores =
     */__init__.py: F401
 
 [mypy]
-python_version = 3.9
 warn_unused_configs = True
 show_error_context = True
 pretty = True
@@ -26,7 +25,7 @@ branch = True
 [coverage:report]
 show_missing = True
 skip_covered = True
-fail_under = 85
+fail_under = 80
 
 [coverage:paths]
 source =
@@ -50,12 +49,14 @@ deps =
 usedevelop=True
 deps =
     pytest
+    flake8
     pytest-cov
     {[pkg-imports]deps}
 commands =
     pytest {posargs}
 
 [testenv:typecheck]
+basepython = python3.8
 deps =
     pytest
     pytest-mypy

--- a/eda/setup.cfg
+++ b/eda/setup.cfg
@@ -25,7 +25,7 @@ branch = True
 [coverage:report]
 show_missing = True
 skip_covered = True
-fail_under = 75
+fail_under = 80
 
 [coverage:paths]
 source =

--- a/eda/setup.py
+++ b/eda/setup.py
@@ -31,6 +31,7 @@ install_requires = [
     'ipython>=7.34,<9.0',
     'ipywidgets>=8.0,<9.0',
     f'autogluon.core=={version}',
+    f'autogluon.common=={version}',
     f'autogluon.features=={version}',
     f'autogluon.tabular=={version}',
 ]

--- a/eda/src/autogluon/eda/analysis/base.py
+++ b/eda/src/autogluon/eda/analysis/base.py
@@ -36,7 +36,8 @@ class AbstractAnalysis(ABC, StateCheckMixin):
             args = AnalysisState({**args, **node.args})
         return args
 
-    def available_datasets(self, args: AnalysisState) -> Generator[Tuple[str, DataFrame], None, None]:
+    @staticmethod
+    def available_datasets(args: AnalysisState) -> Generator[Tuple[str, DataFrame], None, None]:
         """
         Generator which iterates only through the datasets provided in arguments
 

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Dict, Set
 
 import pandas as pd
 
@@ -241,12 +241,13 @@ class SpecialTypesAnalysis(AbstractAnalysis):
 
     @staticmethod
     def infer_special_types(ds):
-        special_types = {}
+        special_types: Dict[str, Set[str]] = {}
         for t, cols in get_type_group_map_special(ds).items():
             for col in cols:
                 if col not in special_types:
                     special_types[col] = set()
                 special_types[col].add(t)
+        result: Dict[str, str] = {}
         for col, types in special_types.items():
-            special_types[col] = ', '.join(sorted(types))
-        return special_types
+            result[col] = ', '.join(sorted(types))
+        return result

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -27,7 +27,6 @@ class Sampler(AbstractAnalysis):
         parent Analysis
     children: List[AbstractAnalysis], default []
         wrapped analyses; these will receive sampled `args` during `fit` call
-    kwargs
 
     Examples
     --------
@@ -145,6 +144,15 @@ class VariableTypeAnalysis(AbstractAnalysis):
     Infers variable types for the column: numeric vs category.
 
     This analysis depends on :func:`RawTypesAnalysis`.
+
+    Parameters
+    ----------
+    numeric_as_categorical_threshold: int, default = 20
+        if numeric column has less than this value, then the variable should be considered as categorical
+    parent: Optional[AbstractAnalysis], default = None
+        parent Analysis
+    children: List[AbstractAnalysis], default []
+        wrapped analyses; these will receive sampled `args` during `fit` call
 
     Examples
     --------

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -89,7 +89,7 @@ class DatasetSummary(AbstractAnalysis):
 
     See Also
     --------
-    :class:`autogluon.eda.visualization.dataset.DatasetStatistics`
+    :py:class:`~autogluon.eda.visualization.dataset.DatasetStatistics`
     """
 
     def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
@@ -128,7 +128,7 @@ class RawTypesAnalysis(AbstractAnalysis):
 
     See Also
     --------
-    :class:`autogluon.eda.visualization.dataset.DatasetStatistics`
+    :py:class:`~autogluon.eda.visualization.dataset.DatasetStatistics`
     """
 
     def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
@@ -164,8 +164,8 @@ class VariableTypeAnalysis(AbstractAnalysis):
 
     See Also
     --------
-    :class:`autogluon.eda.analysis.dataset.RawTypesAnalysis`
-    :class:`autogluon.eda.visualization.dataset.DatasetStatistics`
+    :py:class:`~autogluon.eda.analysis.dataset.RawTypesAnalysis`
+    :py:class:`~autogluon.eda.visualization.dataset.DatasetStatistics`
     """
 
     def __init__(self,
@@ -220,7 +220,7 @@ class SpecialTypesAnalysis(AbstractAnalysis):
 
     See Also
     --------
-    :class:`autogluon.eda.visualization.dataset.DatasetStatistics`
+    :py:class:`~autogluon.eda.visualization.dataset.DatasetStatistics`
     """
 
     def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:

--- a/eda/src/autogluon/eda/analysis/dataset.py
+++ b/eda/src/autogluon/eda/analysis/dataset.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from typing import List, Union, Optional
 
+import pandas as pd
+
+from autogluon.common.features.infer_types import get_type_group_map_special, get_type_map_raw
+from autogluon.common.features.types import R_INT, R_FLOAT, R_OBJECT, R_CATEGORY, R_BOOL
 from .base import AbstractAnalysis
 from ..state import AnalysisState
 
-__all__ = ['Sampler']
+__all__ = ['DatasetSummary', 'RawTypesAnalysis', 'Sampler', 'SpecialTypesAnalysis', 'VariableTypeAnalysis']
 
 
 class Sampler(AbstractAnalysis):
@@ -62,3 +66,179 @@ class Sampler(AbstractAnalysis):
                 if self.sample is not None and isinstance(self.sample, float):
                     arg = 'frac'
                 self.args[ds] = df.sample(**{arg: self.sample}, random_state=0)
+
+
+class DatasetSummary(AbstractAnalysis):
+    """
+    Generates dataset summary including counts, number of unique elements, most frequent, dtypes and 7-figure summary (std/mean/min/max/quartiles)
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> state = auto.analyze(
+    >>>     train_data=..., label=..., return_state=True,
+    >>>     anlz_facets=[
+    >>>         eda.dataset.DatasetSummary(),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         viz.dataset.DatasetStatistics()
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :class:`autogluon.eda.visualization.dataset.DatasetStatistics`
+    """
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return True
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs):
+        s = {}
+        for (ds, df) in self.available_datasets(args):
+            summary = df.describe(include='all').T
+            summary = summary.join(pd.DataFrame({'dtypes': df.dtypes}))
+            summary['unique'] = args[ds].nunique()
+            summary['count'] = summary['count'].astype(int)
+            summary = summary.sort_index()
+            s[ds] = summary.to_dict()
+        state.dataset_stats = s
+
+
+class RawTypesAnalysis(AbstractAnalysis):
+    """
+    Infers autogluon raw types for the column.
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> state = auto.analyze(
+    >>>     train_data=..., label=..., return_state=True,
+    >>>     anlz_facets=[
+    >>>         eda.dataset.RawTypesAnalysis(),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         viz.dataset.DatasetStatistics()
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :class:`autogluon.eda.visualization.dataset.DatasetStatistics`
+    """
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return True
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs):
+        state.raw_type = {}
+        for (ds, df) in self.available_datasets(args):
+            state.raw_type[ds] = get_type_map_raw(df)
+
+
+class VariableTypeAnalysis(AbstractAnalysis):
+    """
+    Infers variable types for the column: numeric vs category.
+
+    This analysis depends on :func:`RawTypesAnalysis`.
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> state = auto.analyze(
+    >>>     train_data=..., label=..., return_state=True,
+    >>>     anlz_facets=[
+    >>>         eda.dataset.RawTypesAnalysis(),
+    >>>         eda.dataset.VariableTypeAnalysis(),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         viz.dataset.DatasetStatistics()
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :class:`autogluon.eda.analysis.dataset.RawTypesAnalysis`
+    :class:`autogluon.eda.visualization.dataset.DatasetStatistics`
+    """
+
+    def __init__(self,
+                 parent: Union[None, AbstractAnalysis] = None,
+                 children: Optional[List[AbstractAnalysis]] = None,
+                 numeric_as_categorical_threshold: int = 20,
+                 **kwargs) -> None:
+        super().__init__(parent, children, **kwargs)
+        self.numeric_as_categorical_threshold = numeric_as_categorical_threshold
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return self.all_keys_must_be_present(state, 'raw_type')
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs) -> None:
+        state.variable_type = {}
+        for (ds, df) in self.available_datasets(args):
+            state.variable_type[ds] = {c: self.map_raw_type_to_feature_type(c, t, df, self.numeric_as_categorical_threshold)
+                                       for c, t in state.raw_type[ds].items()}
+
+    @staticmethod
+    def map_raw_type_to_feature_type(col: Optional[str], raw_type: str, df: pd.DataFrame, numeric_as_categorical_threshold: int = 20) -> Union[None, str]:
+        if col is None:
+            return None
+        elif df[col].nunique() <= numeric_as_categorical_threshold:
+            return 'category'
+        elif raw_type in [R_INT, R_FLOAT]:
+            return 'numeric'
+        elif raw_type in [R_OBJECT, R_CATEGORY, R_BOOL]:
+            return 'category'
+        else:
+            return None
+
+
+class SpecialTypesAnalysis(AbstractAnalysis):
+    """
+    Infers autogluon special types for the column (i.e. text).
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> state = auto.analyze(
+    >>>     train_data=..., label=..., return_state=True,
+    >>>     anlz_facets=[
+    >>>         eda.dataset.SpecialTypesAnalysis(),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         viz.dataset.DatasetStatistics()
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :class:`autogluon.eda.visualization.dataset.DatasetStatistics`
+    """
+
+    def can_handle(self, state: AnalysisState, args: AnalysisState) -> bool:
+        return True
+
+    def _fit(self, state: AnalysisState, args: AnalysisState, **fit_kwargs):
+        state.special_types = {}
+        for (ds, df) in self.available_datasets(args):
+            state.special_types[ds] = self.infer_special_types(df)
+
+    @staticmethod
+    def infer_special_types(ds):
+        special_types = {}
+        for t, cols in get_type_group_map_special(ds).items():
+            for col in cols:
+                if col not in special_types:
+                    special_types[col] = set()
+                special_types[col].add(t)
+        for col, types in special_types.items():
+            special_types[col] = ', '.join(sorted(types))
+        return special_types

--- a/eda/src/autogluon/eda/auto/simple.py
+++ b/eda/src/autogluon/eda/auto/simple.py
@@ -60,7 +60,9 @@ def analyze(train_data=None,
     if anlz_facets is None:
         anlz_facets = []
 
-    assert isinstance(state, (dict, AnalysisState))
+    if state is not None:
+        assert isinstance(state, (dict, AnalysisState))
+
     if not isinstance(state, AnalysisState):
         state = AnalysisState(state)
 

--- a/eda/src/autogluon/eda/state.py
+++ b/eda/src/autogluon/eda/state.py
@@ -80,5 +80,6 @@ class StateCheckMixin:
         can_handle = len(keys_not_present) == 0
         if not can_handle:
             self.logger.warning(
-                f'{self.__class__.__name__}: all of the following keys must be present: {keys}. The following keys are missing: {keys_not_present}')
+                f'{self.__class__.__name__}: all of the following keys must be present: [{", ".join(keys)}]. '
+                f'The following keys are missing: [{", ".join(keys_not_present)}]')
         return can_handle

--- a/eda/src/autogluon/eda/visualization/__init__.py
+++ b/eda/src/autogluon/eda/visualization/__init__.py
@@ -1,2 +1,3 @@
 from .layouts import MarkdownSectionComponent, SimpleVerticalLinearLayout, SimpleHorizontalLayout, TabLayout
+from .dataset import DatasetStatistics, DatasetTypeMismatch
 from .shift import XShiftSummary

--- a/eda/src/autogluon/eda/visualization/dataset.py
+++ b/eda/src/autogluon/eda/visualization/dataset.py
@@ -19,7 +19,7 @@ class DatasetStatistics(AbstractVisualization, JupyterMixin):
     :py:class:`~autogluon.eda.analysis.dataset.SpecialTypesAnalysis`.
     The components can be present in any combination (assuming their dependencies are satisfied).
 
-    The report requires at lest one of the analyses present to be rendered.
+    The report requires at least one of the analyses present to be rendered.
 
     Parameters
     ----------

--- a/eda/src/autogluon/eda/visualization/dataset.py
+++ b/eda/src/autogluon/eda/visualization/dataset.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 import pandas as pd
 from pandas import DataFrame
@@ -20,6 +20,17 @@ class DatasetStatistics(AbstractVisualization, JupyterMixin):
     The components can be present in any combination (assuming their dependencies are satisfied).
 
     The report requires at lest one of the analyses present to be rendered.
+
+    Parameters
+    ----------
+    headers: bool, default = False
+        if `True` then render headers
+    namespace: str, default = None
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
+     sort_by: Optional[str], default = None
+        column to sort the resulting table
+     sort_asc: bool, default = True
+        if `sort_by` provided, then if sorting should ascending or descending
 
     Examples
     --------
@@ -50,7 +61,7 @@ class DatasetStatistics(AbstractVisualization, JupyterMixin):
     def __init__(self,
                  headers: bool = False,
                  namespace: str = None,
-                 sort_by: Union[None, str] = None,
+                 sort_by: Optional[str] = None,
                  sort_asc: bool = True,
                  **kwargs) -> None:
         super().__init__(namespace, **kwargs)
@@ -112,6 +123,13 @@ class DatasetTypeMismatch(AbstractVisualization, JupyterMixin, StateCheckMixin):
     Display mismatch between raw types between datasets provided. In case if mismatch found, mark the row with a warning.
 
     The report requires :py:class:`~autogluon.eda.analysis.dataset.RawTypesAnalysis` analysis present.
+
+    Parameters
+    ----------
+    headers: bool, default = False
+        if `True` then render headers
+    namespace: str, default = None
+        namespace to use; can be nested like `ns_a.ns_b.ns_c`
 
     Examples
     --------

--- a/eda/src/autogluon/eda/visualization/dataset.py
+++ b/eda/src/autogluon/eda/visualization/dataset.py
@@ -1,0 +1,143 @@
+from typing import Union, List, Dict, Any
+
+import pandas as pd
+from pandas import DataFrame
+
+from .base import AbstractVisualization
+from .jupyter import JupyterMixin
+from ..state import AnalysisState, StateCheckMixin
+
+__all__ = ['DatasetStatistics', 'DatasetTypeMismatch']
+
+
+class DatasetStatistics(AbstractVisualization, JupyterMixin):
+    """
+    Display aggregate dataset statistics and dataset-level information.
+
+    The report is a composite view of combination of performed analyses: DatasetSummary, RawTypesAnalysis, VariableTypeAnalysis, SpecialTypesAnalysis.
+    The components can be present in any combination (assuming their dependencies are satisfied).
+
+    The report requires at lest one of the analyses present to be rendered.
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> state = auto.analyze(
+    >>>     train_data=..., label=..., return_state=True,
+    >>>     anlz_facets=[
+    >>>         eda.dataset.DatasetSummary(),
+    >>>         eda.dataset.RawTypesAnalysis(),
+    >>>         eda.dataset.VariableTypeAnalysis(),
+    >>>         eda.dataset.SpecialTypesAnalysis(),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         viz.dataset.DatasetStatistics()
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :class:`autogluon.eda.analysis.dataset.DatasetSummary`
+    :class:`autogluon.eda.analysis.dataset.RawTypesAnalysis`
+    :class:`autogluon.eda.analysis.dataset.VariableTypeAnalysis`
+    :class:`autogluon.eda.analysis.dataset.SpecialTypesAnalysis`
+    """
+
+    def __init__(self,
+                 headers: bool = False,
+                 namespace: str = None,
+                 sort_by: Union[None, str] = None,
+                 sort_asc: bool = True,
+                 **kwargs) -> None:
+        super().__init__(namespace, **kwargs)
+        self.headers = headers
+        self.sort_by = sort_by
+        self.sort_asc = sort_asc
+
+    def can_handle(self, state: AnalysisState) -> bool:
+        return self.at_least_one_key_must_be_present(state, 'dataset_stats', 'missing_statistics', 'raw_type', 'special_types')
+
+    def _render(self, state: AnalysisState) -> None:
+        datasets = []
+        for k in ['dataset_stats', 'missing_statistics', 'raw_type', 'variable_type', 'special_types']:
+            if k in state:
+                datasets = state[k].keys()
+
+        for ds in datasets:
+            # Merge different metrics
+            stats: Dict[str, Any] = {}
+            if 'dataset_stats' in state:
+                stats = {**stats, **state.dataset_stats[ds]}
+            if 'missing_statistics' in state:
+                stats = {**stats, **{f'missing_{k}': v for k, v in state.missing_statistics[ds].items() if k in ['count', 'ratio']}}
+            if 'raw_type' in state:
+                stats['raw_type'] = state.raw_type[ds]
+            if 'variable_type' in state:
+                stats['variable_type'] = state.variable_type[ds]
+            if 'special_types' in state:
+                stats['special_types'] = state.special_types[ds]
+            # Fix counts
+            df = pd.DataFrame(stats)
+            if 'dataset_stats' in state:
+                df = self.__fix_counts(df, ['unique', 'freq'])
+            if 'missing_statistics' in state:
+                df = self.__fix_counts(df, ['missing_count'])
+
+            df = df.fillna('')
+
+            self.render_header_if_needed(state, f'{ds} dataset summary')
+            if self.sort_by in df.columns:
+                df = df.sort_values(by=self.sort_by, ascending=self.sort_asc)
+            self.display_obj(df)
+
+    @staticmethod
+    def __fix_counts(df: DataFrame, cols: List[str]) -> DataFrame:
+        for k in cols:
+            if k in df.columns:
+                df[k] = df[k].fillna(-1).astype(int).replace({-1: ''})
+        return df
+
+
+class DatasetTypeMismatch(AbstractVisualization, JupyterMixin, StateCheckMixin):
+    """
+    Display mismatch between raw types between datasets provided. In case if mismatch found, mark the row with a warning.
+
+    The report requires RawTypesAnalysis analysis present.
+
+    Examples
+    --------
+    >>> import autogluon.eda.analysis as eda
+    >>> import autogluon.eda.visualization as viz
+    >>> import autogluon.eda.auto as auto
+    >>> auto.analyze(
+    >>>     train_data=..., test_data=...,
+    >>>     anlz_facets=[
+    >>>         eda.dataset.RawTypesAnalysis(),
+    >>>     ],
+    >>>     viz_facets=[
+    >>>         viz.dataset.DatasetTypeMismatch()
+    >>>     ]
+    >>> )
+
+    See Also
+    --------
+    :class:`autogluon.eda.analysis.dataset.RawTypesAnalysis`
+    """
+
+    def __init__(self, headers: bool = False, namespace: str = None, **kwargs) -> None:
+        super().__init__(namespace, **kwargs)
+        self.headers = headers
+
+    def can_handle(self, state: AnalysisState) -> bool:
+        return self.all_keys_must_be_present(state, 'raw_type')
+
+    def _render(self, state: AnalysisState) -> None:
+        df = pd.DataFrame(state.raw_type).sort_index()
+        warnings = df.eq(df.iloc[:, 0], axis=0)
+        df['warnings'] = warnings.all(axis=1).map({True: '', False: 'warning'})
+        df.fillna('--', inplace=True)
+
+        self.render_header_if_needed(state, 'Types warnings summary')
+        self.display_obj(df)

--- a/eda/src/autogluon/eda/visualization/jupyter.py
+++ b/eda/src/autogluon/eda/visualization/jupyter.py
@@ -1,6 +1,31 @@
 from IPython.display import display, HTML, Markdown
 
 
+class JupyterMixin:
+
+    @staticmethod
+    def display_obj(obj):
+        display(obj)
+
+    @staticmethod
+    def render_text(text, text_type=None):
+        if text_type in [f'h{r}' for r in range(1, 7)]:
+            display(HTML(f"<{text_type}>{text}</{text_type}>"))
+        else:
+            print(text)
+
+    def render_header_if_needed(self, state, header_text):
+        sample_size = state.get('sample_size', None)
+        if self.headers:
+            sample_info = '' if sample_size is None else f' (sample size: {sample_size})'
+            header = f'{header_text}{sample_info}'
+            self.render_text(header, text_type='h3')
+
+    @staticmethod
+    def render_markdown(md):
+        display(Markdown(md))
+
+
 class JupyterTools:
 
     def fix_tabs_scrolling(self):
@@ -22,25 +47,3 @@ class JupyterTools:
             </style>
             """
         display(HTML(style))
-
-
-class JupyterMixin:
-
-    def display_obj(self, obj):
-        display(obj)
-
-    def render_text(self, text, text_type=None):
-        if text_type in [f'h{r}' for r in range(1, 7)]:
-            display(HTML(f"<{text_type}>{text}</{text_type}>"))
-        else:
-            print(text)
-
-    def render_header_if_needed(self, state, header_text):
-        sample_size = state.get('sample_size', None)
-        if self.headers:
-            sample_info = '' if sample_size is None else f' (sample size: {sample_size})'
-            header = f'{header_text}{sample_info}'
-            self.render_text(header, text_type='h3')
-
-    def render_markdown(self, md):
-        display(Markdown(md))

--- a/eda/src/autogluon/eda/visualization/jupyter.py
+++ b/eda/src/autogluon/eda/visualization/jupyter.py
@@ -3,6 +3,9 @@ from IPython.display import display, HTML, Markdown
 
 class JupyterMixin:
 
+    def __init__(self) -> None:
+        self.headers = False
+
     @staticmethod
     def display_obj(obj):
         display(obj)

--- a/eda/tests/unittests/analysis/test_dataset.py
+++ b/eda/tests/unittests/analysis/test_dataset.py
@@ -1,9 +1,13 @@
 import numpy as np
 import pandas as pd
+import pytest
 
+import autogluon.eda.auto as auto
+from autogluon.common.features.types import R_INT, R_FLOAT, R_OBJECT, R_CATEGORY, R_BOOL
 from autogluon.eda import AnalysisState
 from autogluon.eda.analysis import Sampler, Namespace
 from autogluon.eda.analysis.base import BaseAnalysis
+from autogluon.eda.analysis.dataset import RawTypesAnalysis, VariableTypeAnalysis, SpecialTypesAnalysis, DatasetSummary
 
 
 class SomeAnalysis(BaseAnalysis):
@@ -64,3 +68,96 @@ def test_Sampler_frac():
     assert state.sample_size == 0.5
     assert state.args.train_data.shape == (5, 4)
     assert state.args.test_data.shape == (10, 4)
+
+
+def __get_dataset_summary_test_datasets():
+    cols = list('ABCDEFG')
+    df_train = pd.DataFrame((np.arange(100))[:, None].repeat([len(cols)], axis=1), columns=cols)
+    df_test = pd.DataFrame((np.arange(200))[:, None].repeat([len(cols)], axis=1), columns=cols)
+    str_mappings = {i: 'Lorem ipsum ' * (i + 1) for i in range(10)}
+    for df in [df_train, df_test]:
+        df['A'] = (df['A'] % 4).map({0: 'a', 1: 'b', 2: 'c', 3: 'd'})
+        df['B'] = (df['B'] % 2).map({0: False, 1: True})
+        df['C'] = df['C'] % 2
+        df['D'] = df['D'] % 3
+        df['E'] = (df['E'] % len(str_mappings.keys())).map(str_mappings)
+        df['F'] = df['F'] * 0.1
+    return df_train, df_test
+
+
+def test_DatasetSummary():
+    df_train, df_test = __get_dataset_summary_test_datasets()
+    state = auto.analyze(
+        train_data=df_train, test_data=df_test, return_state=True,
+        anlz_facets=[DatasetSummary()]
+    )
+    expected_cols = ['25%', '50%', '75%', 'count', 'dtypes', 'freq', 'max', 'mean', 'min', 'std', 'top', 'unique']
+    expected_fields = list('ABCDEFG')
+    assert sorted(state.dataset_stats.train_data.keys()) == expected_cols
+    assert sorted(pd.DataFrame(state.dataset_stats.train_data).index) == expected_fields
+    assert sorted(state.dataset_stats.test_data.keys()) == expected_cols
+    assert sorted(pd.DataFrame(state.dataset_stats.test_data).index) == expected_fields
+
+
+def test_RawTypesAnalysis():
+    df_train, df_test = __get_dataset_summary_test_datasets()
+    state = auto.analyze(
+        train_data=df_train, test_data=df_test, return_state=True,
+        anlz_facets=[RawTypesAnalysis()]
+    )
+    expected_types = {'A': 'object', 'B': 'bool', 'C': 'int', 'D': 'int', 'E': 'object', 'F': 'float', 'G': 'int'}
+    assert state.raw_type.train_data == expected_types
+    assert state.raw_type.test_data == expected_types
+
+
+def test_VariableTypeAnalysis_can_handle():
+    df_train, _ = __get_dataset_summary_test_datasets()
+    assert VariableTypeAnalysis().can_handle(state=AnalysisState(), args=AnalysisState()) is False
+    assert VariableTypeAnalysis().can_handle(state=AnalysisState({'raw_type': 'some_state'}), args=AnalysisState()) is True
+
+
+def test_VariableTypeAnalysis__map_raw_type_to_feature_type__special_cases():
+    df = pd.DataFrame({'a': np.arange(20) % 10})
+    f = VariableTypeAnalysis().map_raw_type_to_feature_type
+    assert f(col=None, raw_type='', df=df) is None
+    assert f(col='a', df=df, raw_type='', numeric_as_categorical_threshold=3) is None
+    assert f(col='a', df=df, raw_type='', numeric_as_categorical_threshold=100) == 'category'
+
+
+@pytest.mark.parametrize(
+    "test_type,expected",
+    [(R_INT, 'numeric'),
+     (R_FLOAT, 'numeric'),
+     (R_OBJECT, 'category'),
+     (R_CATEGORY, 'category'),
+     (R_BOOL, 'category')]
+)
+def test_VariableTypeAnalysis__map_raw_type_to_feature_type__regular_cases(test_type, expected):
+    df = pd.DataFrame({'a': np.arange(20) % 10})
+    f = VariableTypeAnalysis().map_raw_type_to_feature_type
+    args = dict(col='a', df=df, numeric_as_categorical_threshold=3)
+    assert f(**{**args, **dict(raw_type=test_type)}) == expected
+
+
+def test_VariableTypeAnalysis():
+    df_train, df_test = __get_dataset_summary_test_datasets()
+    state = auto.analyze(
+        train_data=df_train, test_data=df_test, return_state=True,
+        anlz_facets=[RawTypesAnalysis(), VariableTypeAnalysis()]
+    )
+
+    expected_types = {'A': 'category', 'B': 'category', 'C': 'category', 'D': 'category', 'E': 'category', 'F': 'numeric', 'G': 'numeric'}
+    assert state.variable_type.train_data == expected_types
+    assert state.variable_type.test_data == expected_types
+
+
+def test_SpecialTypesAnalysis():
+    df_train, df_test = __get_dataset_summary_test_datasets()
+    state = auto.analyze(
+        train_data=df_train, test_data=df_test, return_state=True,
+        anlz_facets=[SpecialTypesAnalysis()]
+    )
+
+    expected_types = {'E': 'text'}
+    assert state.special_types.train_data == expected_types
+    assert state.special_types.test_data == expected_types

--- a/eda/tests/unittests/auto/test_simple.py
+++ b/eda/tests/unittests/auto/test_simple.py
@@ -67,6 +67,11 @@ def test_analyze_return_state():
     assert analyze(state=state, return_state=True) == state
 
 
+def test_analyze_None_state():
+    state = None
+    assert analyze(state=state, return_state=True) == {}
+
+
 def test_analyze_state_dict_convert():
     state = {'some_previous_state': {'arg': 1}}
     assert not isinstance(state, AnalysisState)

--- a/eda/tests/unittests/test_shift.py
+++ b/eda/tests/unittests/test_shift.py
@@ -47,7 +47,7 @@ class TestShift(unittest.TestCase):
             test_data=test,
             label='class',
             classifier_kwargs={'path': 'AutogluonModels'},
-            classifier_fit_kwargs={'hyperparameters': {'XGB': {}}}
+            classifier_fit_kwargs={'hyperparameters': {'RF': {}}}
         )
         shft_ana = eda.shift.XShiftDetector(**analysis_args)
         shft_ana.fit()

--- a/eda/tests/unittests/visualization/test_dataset.py
+++ b/eda/tests/unittests/visualization/test_dataset.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.eda import AnalysisState
+from autogluon.eda.visualization import DatasetStatistics
+
+
+@pytest.mark.parametrize(
+    "state_present,expected",
+    [('dataset_stats', True),
+     ('missing_statistics', True),
+     ('raw_type', True),
+     ('special_types', True),
+     ('unknown_type', False),
+     ]
+)
+def test_DatasetStatistics(state_present, expected):
+    assert DatasetStatistics().can_handle(AnalysisState({state_present: ''})) is expected
+
+
+@pytest.mark.parametrize("field", ['dataset_stats', 'raw_type', 'variable_type', 'special_types'])
+def test__merge_analysis_facets__single_values(field):
+    expected_result = {'some_stat': 'value'}
+    state = AnalysisState({field: {'ds': expected_result}})
+    if field == 'dataset_stats':
+        assert DatasetStatistics._merge_analysis_facets('ds', state) == expected_result
+    else:
+        assert DatasetStatistics._merge_analysis_facets('ds', state) == {field: expected_result}
+
+
+def test__merge_analysis_facets__single_values__missing_statistics():
+    state = AnalysisState({'missing_statistics': {'ds': {'count': [1, 2], 'ratio': [0.1, 0.2], 'some_field': ['a', 'b']}}})
+    assert DatasetStatistics._merge_analysis_facets('ds', state) == {'missing_count': [1, 2], 'missing_ratio': [0.1, 0.2]}
+
+
+def test__merge_analysis_facets__multiple_values():
+    state = AnalysisState({
+        'dataset_stats': {'ds': {'dataset_stats': 'value'}},
+        'missing_statistics': {'ds': {'count': [1, 2], 'ratio': [0.1, 0.2], 'some_field': ['a', 'b']}},
+        'raw_type': {'ds': {'raw_type': 'value'}},
+        'variable_type': {'ds': {'variable_type': 'value'}},
+        'special_types': {'ds': {'special_types': 'value'}},
+    })
+    assert DatasetStatistics._merge_analysis_facets('ds', state) == {
+        'dataset_stats': 'value',
+        'missing_count': [1, 2],
+        'missing_ratio': [0.1, 0.2],
+        'raw_type': {'raw_type': 'value'},
+        'special_types': {'special_types': 'value'},
+        'variable_type': {'variable_type': 'value'},
+    }
+
+
+def test__fix_counts():
+    df = pd.DataFrame({
+        'a': [1.0, np.NaN],
+        'b': [1.0, np.NaN],
+        'c': [1, np.NaN],
+        'd': [1, 2],
+    })
+    expected_out = {
+        'a': {0: 1, 1: ''},
+        'b': {0: 1.0, 1: '--NA--'},
+        'c': {0: 1, 1: ''},
+        'd': {0: 1, 1: 2}
+    }
+    assert DatasetStatistics._fix_counts(df, cols=['a', 'c', 'd']).fillna('--NA--').to_dict() == expected_out


### PR DESCRIPTION
*Description of changes:*

### DatasetStatistics

Dataset-level summary tooling. The output is a composite of a few analysis types. They can be present in any combination (assuming all the dependencies are satisfied: `VariableTypeAnalysis` requires `RawTypesAnalysis` to be present)

```python
state = auto.analyze(
    train_data=df_train, label=target_col, return_state=True,
    anlz_facets=[
        eda.dataset.DatasetSummary(),
        eda.dataset.RawTypesAnalysis(),
        eda.dataset.VariableTypeAnalysis(),
        eda.dataset.SpecialTypesAnalysis(),
    ],
    viz_facets=[
        viz.dataset.DatasetStatistics()
    ]
)
```

Output example:

<img width="991" alt="image" src="https://user-images.githubusercontent.com/10080307/198730246-51024511-3fef-452b-b746-0d2be9290e60.png">

---

### DatasetTypeMismatch

Display mismatch between raw types between datasets provided. In case if mismatch found, mark the row with a warning.

```python
auto.analyze(
    train_data=df_train, test_data=df_test,
    anlz_facets=[
        eda.dataset.RawTypesAnalysis(),
    ],
    viz_facets=[
        viz.dataset.DatasetTypeMismatch()
    ]
)
```

Output example:

<img width="287" alt="image" src="https://user-images.githubusercontent.com/10080307/198730907-0405cd3e-70a8-4649-ab57-5762bb510f2b.png">

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
