### PR TITLE
[BUG] Optimize FastAI hyperparameter throws exception: unsupported operand type(s) for *: 'NoneType' and 'float'

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -1075,7 +1075,10 @@ class AbstractModel:
         model_cls = self.__class__
         init_params = self.get_params()
         # We set soft time limit to avoid trials being terminated directly by ray tune
-        trial_soft_time_limit = max(hpo_executor.time_limit * 0.9, hpo_executor.time_limit - 5)  # 5 seconds max for buffer
+        if hpo_executor.time_limit is None:
+            trial_soft_time_limit = None
+        else:
+            trial_soft_time_limit = max(hpo_executor.time_limit * 0.9, hpo_executor.time_limit - 5)  # 5 seconds max for buffer
 
         fit_kwargs = dict()
         fit_kwargs['feature_metadata'] = self.feature_metadata


### PR DESCRIPTION
*Issue #, if available:*
#2202 

*Description of changes:*
Added `None` case handling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
