### PR TITLE
Enable time-varying covariates (dynamic features) in time series models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,4 +140,5 @@ cloud/src/autogluon/cloud/version.py
 eda/src/autogluon/eda/version.py
 
 AutogluonModels
+lightning_logs
 VERSION.minor

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -240,11 +240,11 @@ class TimeSeriesLearner(AbstractLearner):
     ) -> Optional[TimeSeriesDataFrame]:
         """Preprocess the columns of the TimeSeriesDataFrame and check if all expected columns are present.
 
-        This includes:
-        - Ensuring that `self.target` is present among the columns (if `must_include_target=True`)
-        - Ensuring that all `self.known_covariates_names` are present among the columns
-        - Ensuring that `self.target` and `self.known_covariates_names` columns have np.float64 dtype
-        - No columns other than `self.target` and `self.known_covariates_names` are present in the dataframe
+        This includes ensuring that:
+        - `self.target` is present among the columns (if `must_include_target=True`)
+        - all `self.known_covariates_names` are present among the columns
+        - `self.target` and `self.known_covariates_names` columns have np.float64 dtype
+        - no columns other than `self.target` and `self.known_covariates_names` are present in the dataframe
         """
         if data is None:
             return data

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -258,7 +258,7 @@ class TimeSeriesLearner(AbstractLearner):
                 data[self.target] = data[self.target].astype(np.float64)
             except ValueError:
                 raise ValueError(
-                    f"The target columns {self.target} must have numeric (float or int) dtype, "
+                    f"The target column {self.target} must have numeric (float or int) dtype, "
                     f"but in {data_frame_name} it has dtype {data[self.target].dtype}"
                 )
 
@@ -343,9 +343,11 @@ class TimeSeriesLearner(AbstractLearner):
     def score(
         self, data: TimeSeriesDataFrame, model: AbstractTimeSeriesModel = None, metric: Optional[str] = None
     ) -> float:
+        data = self._preprocess_target_and_covariates(data, data_frame_name="data")
         return self.load_trainer().score(data=data, model=model, metric=metric)
 
     def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None) -> pd.DataFrame:
+        data = self._preprocess_target_and_covariates(data, data_frame_name="data")
         return self.load_trainer().leaderboard(data)
 
     def get_info(self, include_model_info: bool = False, **kwargs) -> Dict[str, Any]:

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -286,7 +286,12 @@ class AbstractTimeSeriesModel(AbstractModel):
             data is given as a separate forecast item in the dictionary, keyed by the `item_id`s
             of input items.
         """
-        return self.predict(data.slice_by_timestep(None, -self.prediction_length), **kwargs)
+        past_data = data.slice_by_timestep(None, -self.prediction_length)
+        if len(data.columns) > 1:
+            known_covariates = data.slice_by_timestep(-self.prediction_length, None).drop(self.target, axis=1)
+        else:
+            known_covariates = None
+        return self.predict(data=past_data, known_covariates=known_covariates, **kwargs)
 
     def score(self, data: TimeSeriesDataFrame, metric: str = None, **kwargs) -> float:
         """Return the evaluation scores for given metric and dataset. The last

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -291,7 +291,7 @@ class AbstractTimeSeriesModel(AbstractModel):
             known_covariates = data.slice_by_timestep(-self.prediction_length, None).drop(self.target, axis=1)
         else:
             known_covariates = None
-        return self.predict(data=past_data, known_covariates=known_covariates, **kwargs)
+        return self.predict(past_data, known_covariates=known_covariates, **kwargs)
 
     def score(self, data: TimeSeriesDataFrame, metric: str = None, **kwargs) -> float:
         """Return the evaluation scores for given metric and dataset. The last

--- a/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
+++ b/timeseries/src/autogluon/timeseries/models/abstract/abstract_timeseries_model.py
@@ -226,7 +226,10 @@ class AbstractTimeSeriesModel(AbstractModel):
             raise ValueError("Invalid quantile value specified. Quantiles must be between 0 and 1 (exclusive).")
 
     def predict(
-        self, data: Union[TimeSeriesDataFrame, Dict[str, TimeSeriesDataFrame]], **kwargs
+        self,
+        data: Union[TimeSeriesDataFrame, Dict[str, TimeSeriesDataFrame]],
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
+        **kwargs,
     ) -> TimeSeriesDataFrame:
         """Given a dataset, predict the next `self.prediction_length` time steps.
         This method produces predictions for the forecast horizon *after* the individual time series.
@@ -240,6 +243,8 @@ class AbstractTimeSeriesModel(AbstractModel):
         data: Union[TimeSeriesDataFrame, Dict[str, TimeSeriesDataFrame]]
             The dataset where each time series is the "context" for predictions. For ensemble models that depend on
             the predictions of other models, this method may accept a dictionary of previous models' predictions.
+        known_covariates : Optional[TimeSeriesDataFrame]
+            A TimeSeriesDataFrame containing the values of the known covariates during the forecast horizon.
 
         Other Parameters
         ----------------

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -258,6 +258,11 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             feat_dynamic_real = time_series_df.drop(self.target, axis=1)
             if known_covariates is not None:
                 feat_dynamic_real = pd.concat([feat_dynamic_real, known_covariates], axis=0)
+                if len(feat_dynamic_real) != len(time_series_df) + self.prediction_length * time_series_df.num_items:
+                    raise ValueError(
+                        f"known_covariates must contain values for the next prediction_length = "
+                        f"{self.prediction_length} time steps in each time series."
+                    )
             if self.num_feat_dynamic_real > 0:
                 if len(feat_dynamic_real.columns) != self.num_feat_dynamic_real:
                     raise ValueError(

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -192,13 +192,13 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
 
             model_params = self._get_model_params()
             disable_static_features = model_params.get("disable_static_features", False)
-            disable_dynamic_features = model_params.get("disable_dynamic_features", False)
+            disable_known_covariates = model_params.get("disable_known_covariates", False)
             if not disable_static_features and ds.static_features is not None:
                 feat_static_cat, feat_static_real = get_categorical_and_continuous_features(ds.static_features)
                 self.num_feat_static_cat = len(feat_static_cat.columns)
                 self.num_feat_static_real = len(feat_static_real.columns)
                 self.feat_static_cat_cardinality = feat_static_cat.nunique().tolist()
-            if not disable_dynamic_features:
+            if not disable_known_covariates:
                 feat_dynamic_real = ds.drop(self.target, axis=1)
                 self.num_feat_dynamic_real = len(feat_dynamic_real.columns)
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -147,9 +147,9 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         )
         self.gts_predictor: Optional[GluonTSPredictor] = None
         self.callbacks = []
-        self.use_feat_static_cat = False
-        self.use_feat_static_real = False
-        self.use_feat_dynamic_real = False
+        self.num_feat_static_cat = 0
+        self.num_feat_static_real = 0
+        self.num_feat_dynamic_real = 0
         self.feat_static_cat_cardinality: List[int] = []
 
     def save(self, path: str = None, **kwargs) -> str:
@@ -232,9 +232,9 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
     def _to_gluonts_dataset(self, time_series_df: Optional[TimeSeriesDataFrame]) -> Optional[GluonTSDataset]:
         if time_series_df is not None:
             feat_static_cat, feat_static_real = get_categorical_and_continuous_features(time_series_df.static_features)
-            if not self.use_feat_static_cat:
+            if self.num_feat_static_cat == 0:
                 feat_static_cat = None
-            if not self.use_feat_static_real:
+            if self.num_feat_static_real == 0:
                 feat_static_real = None
             feat_dynamic_real = time_series_df.drop(self.target, axis=1) if self.use_feat_dynamic_real else None
             return SimpleGluonTSDataset(

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -12,6 +12,7 @@ from autogluon.timeseries.models.gluonts.abstract_gluonts import AbstractGluonTS
 
 with warning_filter():
     from gluonts.model.estimator import Estimator as GluonTSEstimator
+    from gluonts.dataset.field_names import FieldName
     from gluonts.mx.context import get_mxnet_context
     from gluonts.mx.model.deepar import DeepAREstimator
     from gluonts.mx.model.simple_feedforward import SimpleFeedForwardEstimator
@@ -337,6 +338,14 @@ class TemporalFusionTransformerMXNetModel(AbstractGluonTSMXNetModel):
 
     gluonts_estimator_class: Type[GluonTSEstimator] = TemporalFusionTransformerEstimator
     supported_quantiles: set = set([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9])
+
+    def _get_estimator_init_args(self) -> dict:
+        init_kwargs = super()._get_estimator_init_args()
+        if self.num_feat_static_real > 0:
+            init_kwargs["static_feature_dims"] = {FieldName.FEAT_STATIC_REAL: self.num_feat_static_real}
+        if self.num_feat_dynamic_real > 0:
+            init_kwargs["dynamic_feature_dims"] = {FieldName.FEAT_DYNAMIC_REAL: self.num_feat_dynamic_real}
+        return init_kwargs
 
     def _get_estimator(self) -> GluonTSEstimator:
         """Return the GluonTS Estimator object for the model"""

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -94,10 +94,10 @@ class DeepARMXNetModel(AbstractGluonTSMXNetModel):
 
     def _get_model_params(self) -> dict:
         args = super()._get_model_params()
-        args.setdefault("use_feat_static_cat", self.use_feat_static_cat)
-        args.setdefault("use_feat_static_real", self.use_feat_static_real)
+        args.setdefault("use_feat_static_cat", self.num_feat_static_cat > 0)
+        args.setdefault("use_feat_static_real", self.num_feat_static_real > 0)
         args.setdefault("cardinality", self.feat_static_cat_cardinality)
-        args.setdefault("use_feat_dynamic_real", self.use_feat_dynamic_real)
+        args.setdefault("use_feat_dynamic_real", self.num_feat_dynamic_real > 0)
         return args
 
 
@@ -187,10 +187,10 @@ class MQCNNMXNetModel(AbstractGluonTSSeq2SeqModel):
 
     def _get_model_params(self) -> dict:
         args = super()._get_model_params()
-        args.setdefault("use_feat_static_cat", self.use_feat_static_cat)
-        args.setdefault("use_feat_static_real", self.use_feat_static_real)
+        args.setdefault("use_feat_static_cat", self.num_feat_static_cat > 0)
+        args.setdefault("use_feat_static_real", self.num_feat_static_real > 0)
         args.setdefault("cardinality", self.feat_static_cat_cardinality)
-        args.setdefault("use_feat_dynamic_real", self.use_feat_dynamic_real)
+        args.setdefault("use_feat_dynamic_real", self.num_feat_dynamic_real > 0)
         return args
 
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -37,7 +37,7 @@ class AbstractGluonTSMXNetModel(AbstractGluonTSModel):
 
 
 class DeepARMXNetModel(AbstractGluonTSMXNetModel):
-    """DeepAR model from GluonTS.
+    """DeepAR model from GluonTS based on the MXNet backend.
 
     The model consists of an RNN encoder (LSTM or GRU) and a decoder that outputs the
     distribution of the next target value. Close to the model described in [Salinas2020]_.
@@ -46,7 +46,7 @@ class DeepARMXNetModel(AbstractGluonTSMXNetModel):
         "DeepAR: Probabilistic forecasting with autoregressive recurrent networks."
         International Journal of Forecasting. 2020.
 
-    Based on `gluonts.model.deepar.DeepAREstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.model.deepar.html>`_.
+    Based on `gluonts.mx.model.deepar.DeepAREstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.deepar.html>`_.
     See GluonTS documentation for additional hyperparameters.
 
 
@@ -92,13 +92,15 @@ class DeepARMXNetModel(AbstractGluonTSMXNetModel):
 
     gluonts_estimator_class: Type[GluonTSEstimator] = DeepAREstimator
 
-    def _get_model_params(self) -> dict:
-        args = super()._get_model_params()
-        args.setdefault("use_feat_static_cat", self.num_feat_static_cat > 0)
-        args.setdefault("use_feat_static_real", self.num_feat_static_real > 0)
-        args.setdefault("cardinality", self.feat_static_cat_cardinality)
-        args.setdefault("use_feat_dynamic_real", self.num_feat_dynamic_real > 0)
-        return args
+    def _get_estimator_init_args(self) -> dict:
+        init_kwargs = super()._get_estimator_init_args()
+        # Our API hides these model kwargs from the user. They can only be controlled through disable_static_features
+        # and disable_dynamic_features
+        init_kwargs["use_feat_static_cat"] = self.num_feat_static_cat > 0
+        init_kwargs["use_feat_static_real"] = self.num_feat_static_real > 0
+        init_kwargs["cardinality"] = self.feat_static_cat_cardinality
+        init_kwargs["use_feat_dynamic_real"] = self.num_feat_dynamic_real > 0
+        return init_kwargs
 
 
 class AbstractGluonTSSeq2SeqModel(AbstractGluonTSMXNetModel):
@@ -126,7 +128,7 @@ class MQCNNMXNetModel(AbstractGluonTSSeq2SeqModel):
         "A multi-horizon quantile recurrent forecaster."
         arXiv preprint arXiv:1711.11053 (2017)
 
-    Based on `gluonts.model.seq2seq.MQCNNEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.model.seq2seq.html#gluonts.model.seq2seq.MQCNNEstimator>`_.
+    Based on `gluonts.mx.model.seq2seq.MQCNNEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.seq2seq.html#gluonts.mx.model.seq2seq.MQCNNEstimator>`_.
     See GluonTS documentation for additional hyperparameters.
 
 
@@ -185,13 +187,13 @@ class MQCNNMXNetModel(AbstractGluonTSSeq2SeqModel):
 
     gluonts_estimator_class: Type[GluonTSEstimator] = MQCNNEstimator
 
-    def _get_model_params(self) -> dict:
-        args = super()._get_model_params()
-        args.setdefault("use_feat_static_cat", self.num_feat_static_cat > 0)
-        args.setdefault("use_feat_static_real", self.num_feat_static_real > 0)
-        args.setdefault("cardinality", self.feat_static_cat_cardinality)
-        args.setdefault("use_feat_dynamic_real", self.num_feat_dynamic_real > 0)
-        return args
+    def _get_estimator_init_args(self) -> dict:
+        init_kwargs = super()._get_estimator_init_args()
+        init_kwargs["use_feat_static_cat"] = self.num_feat_static_cat > 0
+        init_kwargs["use_feat_static_real"] = self.num_feat_static_real > 0
+        init_kwargs["cardinality"] = self.feat_static_cat_cardinality
+        init_kwargs["use_feat_dynamic_real"] = self.num_feat_dynamic_real > 0
+        return init_kwargs
 
 
 class MQRNNMXNetModel(AbstractGluonTSSeq2SeqModel):
@@ -204,7 +206,7 @@ class MQRNNMXNetModel(AbstractGluonTSSeq2SeqModel):
         "A multi-horizon quantile recurrent forecaster."
         arXiv preprint arXiv:1711.11053 (2017)
 
-    Based on `gluonts.model.seq2seq.MQRNNEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.model.seq2seq.html#gluonts.model.seq2seq.MQRNNEstimator>`_.
+    Based on `gluonts.mx.model.seq2seq.MQRNNEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.seq2seq.html#gluonts.mx.model.seq2seq.MQRNNEstimator>`_.
     See GluonTS documentation for additional hyperparameters.
 
 
@@ -241,12 +243,12 @@ class MQRNNMXNetModel(AbstractGluonTSSeq2SeqModel):
 
 
 class SimpleFeedForwardMXNetModel(AbstractGluonTSMXNetModel):
-    """SimpleFeedForward model from GluonTS.
+    """SimpleFeedForward model from GluonTS based on the MXNet backend.
 
     The model consists of a multilayer perceptron (MLP) that predicts the distribution
     of the next target value.
 
-    Based on `gluonts.model.simple_feedforward.SimpleFeedForwardEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.model.simple_feedforward.html?highlight=simplefeedforward>`_.
+    Based on `gluonts.mx.model.simple_feedforward.SimpleFeedForwardEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.simple_feedforward.html>`_.
     See GluonTS documentation for additional hyperparameters.
 
     Note that AutoGluon uses hyperparameters ``hidden_dim`` and ``num_layers`` instead of ``num_hidden_dimensions``
@@ -309,7 +311,7 @@ class TemporalFusionTransformerMXNetModel(AbstractGluonTSMXNetModel):
         "Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting."
         International Journal of Forecasting. 2021.
 
-    Based on `gluonts.model.tft.TemporalFusionTransformerEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.model.tft.html>`_.
+    Based on `gluonts.mx.model.tft.TemporalFusionTransformerEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.tft.html>`_.
     See GluonTS documentation for additional hyperparameters.
 
     Other Parameters
@@ -370,7 +372,7 @@ class TransformerMXNetModel(AbstractGluonTSMXNetModel):
     .. [Vaswani2017] Vaswani, Ashish, et al. "Attention is all you need."
         Advances in neural information processing systems. 2017.
 
-    Based on `gluonts.model.transformer.TransformerEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.model.transformer.html>`_.
+    Based on `gluonts.mx.model.transformer.TransformerEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.transformer.html>`_.
     See GluonTS documentation for additional hyperparameters.
 
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -59,9 +59,9 @@ class DeepARMXNetModel(AbstractGluonTSMXNetModel):
     disable_static_features : bool, default = False
         If True, static features won't be used by the model even if they are present in the dataset.
         If False, static features will be used by the model if they are present in the dataset.
-    disable_dynamic_features : bool, default = False
-        If True, dynamic features won't be used by the model even if they are present in the dataset.
-        If False, dynamic features will be used by the model if they are present in the dataset.
+    disable_known_covariates : bool, default = False
+        If True, known covariates won't be used by the model even if they are present in the dataset.
+        If False, known covariates will be used by the model if they are present in the dataset.
     num_layers : int, default = 2
         Number of RNN layers
     num_cells : int, default = 40
@@ -96,7 +96,7 @@ class DeepARMXNetModel(AbstractGluonTSMXNetModel):
     def _get_estimator_init_args(self) -> dict:
         init_kwargs = super()._get_estimator_init_args()
         # Our API hides these model kwargs from the user. They can only be controlled through disable_static_features
-        # and disable_dynamic_features
+        # and disable_known_covariates
         init_kwargs["use_feat_static_cat"] = self.num_feat_static_cat > 0
         init_kwargs["use_feat_static_real"] = self.num_feat_static_real > 0
         init_kwargs["cardinality"] = self.feat_static_cat_cardinality
@@ -141,9 +141,9 @@ class MQCNNMXNetModel(AbstractGluonTSSeq2SeqModel):
     disable_static_features : bool, default = False
         If True, static features won't be used by the model even if they are present in the dataset.
         If False, static features will be used by the model if they are present in the dataset.
-    disable_dynamic_features : bool, default = False
-        If True, dynamic features won't be used by the model even if they are present in the dataset.
-        If False, dynamic features will be used by the model if they are present in the dataset.
+    disable_known_covariates : bool, default = False
+        If True, known covariates won't be used by the model even if they are present in the dataset.
+        If False, known covariates will be used by the model if they are present in the dataset.
     embedding_dimension : int, optional
         Dimension of the embeddings for categorical features. (default: [min(50, (cat+1)//2) for cat in cardinality])
     add_time_feature : bool, default = True

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -134,9 +134,9 @@ class DeepARModel(AbstractGluonTSPyTorchModel):
     disable_static_features : bool, default = False
         If True, static features won't be used by the model even if they are present in the dataset.
         If False, static features will be used by the model if they are present in the dataset.
-    disable_dynamic_features : bool, default = False
-        If True, dynamic features won't be used by the model even if they are present in the dataset.
-        If False, dynamic features will be used by the model if they are present in the dataset.
+    disable_known_covariates : bool, default = False
+        If True, known covariates won't be used by the model even if they are present in the dataset.
+        If False, known covariates will be used by the model if they are present in the dataset.
     num_layers : int, default = 2
         Number of RNN layers
     hidden_size : int, default = 40
@@ -161,6 +161,7 @@ class DeepARModel(AbstractGluonTSPyTorchModel):
     """
 
     gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = DeepAREstimator
+    float_dtype: Type = np.float32
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -42,6 +42,7 @@ pl_loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDic
 
 class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
     gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator]
+    float_dtype: Type = np.float32
 
     def _get_hpo_backend(self):
         return CUSTOM_BACKEND
@@ -161,7 +162,6 @@ class DeepARModel(AbstractGluonTSPyTorchModel):
     """
 
     gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = DeepAREstimator
-    float_dtype: Type = np.float32
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()
@@ -206,7 +206,6 @@ class SimpleFeedForwardModel(AbstractGluonTSPyTorchModel):
     """
 
     gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = SimpleFeedForwardEstimator
-    float_dtype: Type = np.float32
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()

--- a/timeseries/src/autogluon/timeseries/models/local/models.py
+++ b/timeseries/src/autogluon/timeseries/models/local/models.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from scipy.stats import norm
 
-from autogluon.timeseries.utils.forecast import get_forecast_horizon_timestamps
+from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_single_time_series
 
 from .abstract_local_model import AbstractLocalModel
 
@@ -12,7 +12,7 @@ from .abstract_local_model import AbstractLocalModel
 def seasonal_naive_forecast(
     time_series: pd.Series, freq: str, prediction_length: int, quantile_levels: List[float], seasonal_period: int
 ):
-    forecast_timestamps = get_forecast_horizon_timestamps(
+    forecast_timestamps = get_forecast_horizon_index_single_time_series(
         past_timestamps=time_series.index, freq=freq, prediction_length=prediction_length
     )
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -417,6 +417,7 @@ class TimeSeriesPredictor:
     def predict(
         self,
         data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
         model: Optional[str] = None,
         **kwargs,
     ) -> TimeSeriesDataFrame:
@@ -442,7 +443,8 @@ class TimeSeriesPredictor:
                 category=DeprecationWarning,
             )
         data = self._check_and_prepare_data_frame(data)
-        return self._learner.predict(data, model=model, **kwargs)
+        known_covariates = self._check_and_prepare_data_frame(known_covariates)
+        return self._learner.predict(data, known_covariates=known_covariates, model=model, **kwargs)
 
     def evaluate(self, data: TimeSeriesDataFrame, **kwargs):
         """Evaluate the performance for given dataset, computing the score determined by ``self.eval_metric``

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -486,9 +486,14 @@ class TimeSeriesPredictor:
         Parameters
         ----------
         data : TimeSeriesDataFrame
-            The data to evaluate the best model on. The last ``prediction_length`` time steps of the
-            data set, for each item, will be held out for prediction and forecast accuracy will be calculated
-            on these time steps.
+            The data to evaluate the best model on. The last ``prediction_length`` time steps of the data set, for each
+            item, will be held out for prediction and forecast accuracy will be calculated on these time steps.
+
+            If ``known_covariates_names`` were specified when creating the predictor, ``data`` must include the columns
+            listed in ``known_covariates_names`` with the covariates values aligned with the target time series.
+
+            If ``train_data`` used to train the predictor contained static features, then ``data`` must also contain
+            static features that have the same columns and dtypes.
 
         Other Parameters
         ----------------
@@ -577,6 +582,13 @@ class TimeSeriesPredictor:
         data : TimeSeriesDataFrame, optional
             dataset used for additional evaluation. If not provided, the validation set used during training will be
             used.
+
+            If ``known_covariates_names`` were specified when creating the predictor, ``data`` must include the columns
+            listed in ``known_covariates_names`` with the covariates values aligned with the target time series.
+
+            If ``train_data`` used to train the predictor contained static features, then ``data`` must also contain
+            static features that have the same columns and dtypes.
+
         silent : bool, default = False
             If False, the leaderboard DataFrame will be printed.
 

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -462,8 +462,6 @@ class TimeSeriesPredictor:
             - The ``item_id`` index must include all item ids present in ``data``
             - The ``timestamp`` index must include the values for ``prediction_length`` many time steps into the future from the end of each time series in ``data``
 
-            Example::
-            TODO
         model : str, optional
             Name of the model that you would like to use for prediction. By default, the best model during training
             (with highest validation score) will be used.
@@ -471,13 +469,14 @@ class TimeSeriesPredictor:
         if "quantile_levels" in kwargs:
             warnings.warn(
                 "Passing `quantile_levels` as a keyword argument to `TimeSeriesPredictor.predict` is deprecated and "
-                "will be removed in v0.7.0. This might also lead to some models not working properly. "
+                "will be removed in v0.7. This might also lead to some models not working properly. "
                 "Please specify the desired quantile levels when creating the predictor as "
                 "`TimeSeriesPredictor(..., quantile_levels=quantile_levels)`.",
                 category=DeprecationWarning,
             )
+        # TODO: What happens to `known_covariates` if `ignore_index=True`?
+        # TODO: Add example
         data = self._check_and_prepare_data_frame(data)
-        # TODO: What happens if `ignore_index=True`?
         return self._learner.predict(data, known_covariates=known_covariates, model=model, **kwargs)
 
     def evaluate(self, data: TimeSeriesDataFrame, **kwargs):

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -812,13 +812,14 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
     def predict(
         self,
         data: TimeSeriesDataFrame,
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
         model: Optional[Union[str, AbstractTimeSeriesModel]] = None,
         **kwargs,
     ) -> Union[TimeSeriesDataFrame, None]:
         model_was_selected_automatically = model is None
         model = self._get_model_for_prediction(model)
         try:
-            return self._predict_model(data, model, **kwargs)
+            return self._predict_model(data, model, known_covariates=known_covariates, **kwargs)
         except Exception as err:
             logger.error(f"\tWarning: Model {model.name} failed during prediction with exception: {err}")
             other_models = [m for m in self.get_model_names() if m != model.name]
@@ -859,12 +860,13 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
         self,
         data: TimeSeriesDataFrame,
         model: Union[str, AbstractTimeSeriesModel],
+        known_covariates: Optional[TimeSeriesDataFrame] = None,
         **kwargs,
     ) -> TimeSeriesDataFrame:
         if isinstance(model, str):
             model = self.load_model(model)
         data = self.get_inputs_to_model(model=model, X=data)
-        return model.predict(data, **kwargs)
+        return model.predict(data, known_covariates=known_covariates, **kwargs)
 
     # TODO: experimental
     def refit_single_full(self, train_data=None, val_data=None, models=None):

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -34,16 +34,11 @@ class ContinuousAndCategoricalFeatureGenerator(PipelineFeatureGenerator):
         )
 
 
-def get_categorical_and_continuous_features(
-    dataframe: Optional[pd.DataFrame],
-) -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
+def get_categorical_and_continuous_features(dataframe: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Split categorical and continuous columns of a dataframe into two separate dataframes.
 
-    If the dataframe doesn't contain columns of the given type, None is returned.
+    Columns that have neither categorical nor numerical dtypes are ignored.
     """
-    if dataframe is None:
-        return None, None
-
     categorical_column_names = []
     continuous_column_names = []
 
@@ -53,20 +48,11 @@ def get_categorical_and_continuous_features(
         elif is_numeric_dtype(column_values):
             continuous_column_names.append(column_name)
 
-    if len(categorical_column_names) > 0:
-        categorical_features = dataframe[categorical_column_names]
-    else:
-        categorical_features = None
-
-    if len(continuous_column_names) > 0:
-        continuous_features = dataframe[continuous_column_names]
-    else:
-        continuous_features = None
-
-    return categorical_features, continuous_features
+    return dataframe[categorical_column_names], dataframe[continuous_column_names]
 
 
 def convert_numerical_features_to_float(dataframe: pd.DataFrame, float_dtype=np.float64):
+    """In-place convert the dtype of all numerical (float or int) columns to the given float dtype."""
     for col_name in dataframe.columns:
         if pd.api.types.is_numeric_dtype(dataframe[col_name]):
             dataframe[col_name] = dataframe[col_name].astype(float_dtype)

--- a/timeseries/src/autogluon/timeseries/utils/forecast.py
+++ b/timeseries/src/autogluon/timeseries/utils/forecast.py
@@ -1,8 +1,30 @@
 import pandas as pd
 
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TIMESTAMP, TimeSeriesDataFrame
 
-def get_forecast_horizon_timestamps(
+
+def get_forecast_horizon_index_single_time_series(
     past_timestamps: pd.DatetimeIndex, freq: str, prediction_length: int
 ) -> pd.DatetimeIndex:
+    """Get timestamps for the next prediction_length many time steps of the time series with given frequency."""
     start_ts = past_timestamps.max() + 1 * pd.tseries.frequencies.to_offset(freq)
     return pd.date_range(start=start_ts, periods=prediction_length, freq=freq)
+
+
+def get_forecast_horizon_index_ts_dataframe(
+    ts_dataframe: TimeSeriesDataFrame, prediction_length: int
+) -> pd.MultiIndex:
+    """For each item in the dataframe, get timestamps for the next prediction_length many time steps into the future.
+
+    Returns a pandas.MultiIndex, where
+    - level 0 ("item_id") contains the same item_ids as the input ts_dataframe.
+    - level 1 ("timestamp") contains the next prediction_length time steps starting from the end of each time series.
+    """
+
+    def get_series_with_timestamps_per_item(group: pd.DataFrame) -> pd.Series:
+        timestamps = group.index.get_level_values(TIMESTAMP)
+        return get_forecast_horizon_index_single_time_series(
+            past_timestamps=timestamps, freq=ts_dataframe.freq, prediction_length=prediction_length
+        ).to_series()
+
+    return ts_dataframe.groupby(ITEMID, sort=False).apply(get_series_with_timestamps_per_item).index

--- a/timeseries/tests/unittests/common.py
+++ b/timeseries/tests/unittests/common.py
@@ -56,7 +56,9 @@ DUMMY_TS_DATAFRAME = get_data_frame_with_item_index(["10", "A", "2", "1"])
 
 
 def get_data_frame_with_variable_lengths(
-    item_id_to_length: Dict[str, int], static_features: Optional[pd.DataFrame] = None
+    item_id_to_length: Dict[str, int],
+    static_features: Optional[pd.DataFrame] = None,
+    known_covariates_names: Optional[List[str]] = None,
 ):
     tuples = []
     for item_id, length in item_id_to_length.items():
@@ -72,6 +74,9 @@ def get_data_frame_with_variable_lengths(
     )
     df.freq  # compute _cached_freq
     df.static_features = static_features
+    if known_covariates_names is not None:
+        for name in known_covariates_names:
+            df[name] = np.random.normal(size=len(df))
     return df
 
 
@@ -92,8 +97,12 @@ def get_static_features(item_ids: List[Union[str, int]], feature_names: List[str
     return df
 
 
-DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC = get_data_frame_with_variable_lengths(
+DATAFRAME_WITH_STATIC = get_data_frame_with_variable_lengths(
     ITEM_ID_TO_LENGTH, static_features=get_static_features(ITEM_ID_TO_LENGTH.keys(), ["feat1", "feat2", "feat3"])
+)
+
+DATAFRAME_WITH_COVARIATES = get_data_frame_with_variable_lengths(
+    ITEM_ID_TO_LENGTH, known_covariates_names=["cov1", "cov2", "cov3"]
 )
 
 

--- a/timeseries/tests/unittests/models/gluonts/mx/test_mx.py
+++ b/timeseries/tests/unittests/models/gluonts/mx/test_mx.py
@@ -21,7 +21,7 @@ from autogluon.timeseries.models.gluonts.mx.models import GenericGluonTSMXNetMod
 from autogluon.timeseries.models.presets import get_default_hps
 from autogluon.timeseries.utils.features import ContinuousAndCategoricalFeatureGenerator
 
-from ....common import DUMMY_TS_DATAFRAME, DATAFRAME_WITH_STATIC
+from ....common import DATAFRAME_WITH_STATIC, DUMMY_TS_DATAFRAME
 
 TESTABLE_MX_MODELS = [
     DeepARMXNetModel,

--- a/timeseries/tests/unittests/models/gluonts/mx/test_mx.py
+++ b/timeseries/tests/unittests/models/gluonts/mx/test_mx.py
@@ -21,7 +21,7 @@ from autogluon.timeseries.models.gluonts.mx.models import GenericGluonTSMXNetMod
 from autogluon.timeseries.models.presets import get_default_hps
 from autogluon.timeseries.utils.features import ContinuousAndCategoricalFeatureGenerator
 
-from ....common import DUMMY_TS_DATAFRAME, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC
+from ....common import DUMMY_TS_DATAFRAME, DATAFRAME_WITH_STATIC
 
 TESTABLE_MX_MODELS = [
     DeepARMXNetModel,
@@ -36,6 +36,11 @@ TESTABLE_MX_MODELS = [
 TESTABLE_MX_MODELS_WITH_STATIC_FEATURES = [
     DeepARMXNetModel,
     MQCNNMXNetModel,
+]
+TESTABLE_MX_MODELS_WITH_KNOWN_COVARIATES = [
+    DeepARMXNetModel,
+    MQCNNMXNetModel,
+    TemporalFusionTransformerMXNetModel,
 ]
 
 
@@ -89,7 +94,7 @@ def test_when_mxnet_installed_then_default_presets_include_mxnet_models(preset_k
 @pytest.fixture(scope="module")
 def df_with_static():
     feature_pipeline = ContinuousAndCategoricalFeatureGenerator()
-    df = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC.copy(deep=False)
+    df = DATAFRAME_WITH_STATIC.copy(deep=False)
     df.static_features = feature_pipeline.fit_transform(df.static_features)
     return df
 

--- a/timeseries/tests/unittests/models/gluonts/test_gluonts.py
+++ b/timeseries/tests/unittests/models/gluonts/test_gluonts.py
@@ -8,17 +8,25 @@ from autogluon.timeseries.models.gluonts import DeepARModel, SimpleFeedForwardMo
 from autogluon.timeseries.models.gluonts.torch.models import AbstractGluonTSPyTorchModel
 from autogluon.timeseries.utils.features import ContinuousAndCategoricalFeatureGenerator
 
-from ...common import DUMMY_TS_DATAFRAME, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC
+from ...common import DUMMY_TS_DATAFRAME, DATAFRAME_WITH_STATIC, DATAFRAME_WITH_COVARIATES
 
 if agts.MXNET_INSTALLED:
-    from .mx.test_mx import TESTABLE_MX_MODELS, TESTABLE_MX_MODELS_WITH_STATIC_FEATURES
+    from .mx.test_mx import (
+        TESTABLE_MX_MODELS,
+        TESTABLE_MX_MODELS_WITH_STATIC_FEATURES,
+        TESTABLE_MX_MODELS_WITH_KNOWN_COVARIATES,
+    )
 else:
     TESTABLE_MX_MODELS = []
     TESTABLE_MX_MODELS_WITH_STATIC_FEATURES = []
+    TESTABLE_MX_MODELS_WITH_KNOWN_COVARIATES = []
 
 MODELS_WITH_STATIC_FEATURES = [DeepARModel] + TESTABLE_MX_MODELS_WITH_STATIC_FEATURES
+MODELS_WITH_KNOWN_COVARIATES = [DeepARModel] + TESTABLE_MX_MODELS_WITH_KNOWN_COVARIATES
 TESTABLE_PYTORCH_MODELS = [DeepARModel, SimpleFeedForwardModel]
 TESTABLE_MODELS = TESTABLE_MX_MODELS + TESTABLE_PYTORCH_MODELS
+
+DUMMY_HYPERPARAMETERS = {"epochs": 1, "num_batches_per_epoch": 1}
 
 
 @pytest.mark.parametrize("model_class", TESTABLE_MODELS)
@@ -61,9 +69,7 @@ def test_when_models_saved_then_gluonts_predictors_can_be_loaded(model_class, te
         path=temp_model_path,
         freq="H",
         quantile_levels=[0.1, 0.9],
-        hyperparameters={
-            "epochs": 1,
-        },
+        hyperparameters=DUMMY_HYPERPARAMETERS,
     )
     model.fit(
         train_data=DUMMY_TS_DATAFRAME,
@@ -82,14 +88,14 @@ def test_when_models_saved_then_gluonts_predictors_can_be_loaded(model_class, te
 @pytest.fixture(scope="module")
 def df_with_static():
     feature_pipeline = ContinuousAndCategoricalFeatureGenerator()
-    df = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC.copy(deep=False)
+    df = DATAFRAME_WITH_STATIC.copy(deep=False)
     df.static_features = feature_pipeline.fit_transform(df.static_features)
     return df
 
 
 @pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
 def test_when_static_features_present_then_they_are_passed_to_dataset(model_class, df_with_static):
-    model = model_class()
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS)
     with mock.patch(
         "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
     ) as patch_dataset:
@@ -105,17 +111,17 @@ def test_when_static_features_present_then_they_are_passed_to_dataset(model_clas
 
 @pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
 def test_when_static_features_present_then_model_attributes_set_correctly(model_class, df_with_static):
-    model = model_class(hyperparameters={"epochs": 1, "num_batches_per_epoch": 1})
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS)
     model.fit(train_data=df_with_static)
-    assert model.use_feat_static_cat
-    assert model.use_feat_static_real
-    assert len(model.feat_static_cat_cardinality) == 1
+    assert model.num_feat_static_cat > 0
+    assert model.num_feat_static_real > 0
+    assert len(model.feat_static_cat_cardinality) == model.num_feat_static_cat
     assert 1 <= model.feat_static_cat_cardinality[0] <= 4
 
 
 @pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
 def test_when_disable_static_features_set_to_true_then_static_features_are_not_used(model_class, df_with_static):
-    model = model_class(hyperparameters={"disable_static_features": True})
+    model = model_class(hyperparameters={**DUMMY_HYPERPARAMETERS, "disable_static_features": True})
     with mock.patch(
         "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
     ) as patch_dataset:
@@ -127,3 +133,38 @@ def test_when_disable_static_features_set_to_true_then_static_features_are_not_u
             feat_static_real = call_kwargs["feat_static_real"]
             assert feat_static_cat is None
             assert feat_static_real is None
+
+
+@pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
+def test_when_known_covariates_present_then_they_are_passed_to_dataset(model_class, df_with_static):
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS)
+    with mock.patch(
+        "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
+    ) as patch_dataset:
+        try:
+            model.fit(train_data=DATAFRAME_WITH_COVARIATES)
+        except TypeError:
+            call_kwargs = patch_dataset.call_args[1]
+            feat_dynamic_real = call_kwargs["feat_dynamic_real"]
+            assert (feat_dynamic_real.dtypes == "float").all()
+
+
+@pytest.mark.parametrize("model_class", MODELS_WITH_KNOWN_COVARIATES)
+def test_when_known_covariates_present_then_model_attributes_set_correctly(model_class, df_with_static):
+    model = model_class(hyperparameters=DUMMY_HYPERPARAMETERS)
+    model.fit(train_data=DATAFRAME_WITH_COVARIATES)
+    assert model.num_feat_dynamic_real > 0
+
+
+@pytest.mark.parametrize("model_class", MODELS_WITH_STATIC_FEATURES)
+def test_when_disable_known_covariates_set_to_true_then_known_covariates_are_not_used(model_class, df_with_static):
+    model = model_class(hyperparameters={**DUMMY_HYPERPARAMETERS, "disable_known_covariates": True})
+    with mock.patch(
+        "autogluon.timeseries.models.gluonts.abstract_gluonts.SimpleGluonTSDataset.__init__"
+    ) as patch_dataset:
+        try:
+            model.fit(train_data=DATAFRAME_WITH_COVARIATES)
+        except TypeError:
+            call_kwargs = patch_dataset.call_args[1]
+            feat_dynamic_real = call_kwargs["feat_dynamic_real"]
+            assert feat_dynamic_real is None

--- a/timeseries/tests/unittests/models/gluonts/test_gluonts.py
+++ b/timeseries/tests/unittests/models/gluonts/test_gluonts.py
@@ -8,13 +8,13 @@ from autogluon.timeseries.models.gluonts import DeepARModel, SimpleFeedForwardMo
 from autogluon.timeseries.models.gluonts.torch.models import AbstractGluonTSPyTorchModel
 from autogluon.timeseries.utils.features import ContinuousAndCategoricalFeatureGenerator
 
-from ...common import DUMMY_TS_DATAFRAME, DATAFRAME_WITH_STATIC, DATAFRAME_WITH_COVARIATES
+from ...common import DATAFRAME_WITH_COVARIATES, DATAFRAME_WITH_STATIC, DUMMY_TS_DATAFRAME
 
 if agts.MXNET_INSTALLED:
     from .mx.test_mx import (
         TESTABLE_MX_MODELS,
-        TESTABLE_MX_MODELS_WITH_STATIC_FEATURES,
         TESTABLE_MX_MODELS_WITH_KNOWN_COVARIATES,
+        TESTABLE_MX_MODELS_WITH_STATIC_FEATURES,
     )
 else:
     TESTABLE_MX_MODELS = []

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -6,16 +6,17 @@ from collections import defaultdict
 from unittest import mock
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import autogluon.core as ag
 from autogluon.timeseries.dataset import TimeSeriesDataFrame
 from autogluon.timeseries.learner import TimeSeriesLearner
 from autogluon.timeseries.models import DeepARModel, ETSModel
+from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_single_time_series
 
 from .common import (
     DUMMY_TS_DATAFRAME,
-    DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC,
     get_data_frame_with_variable_lengths,
     get_static_features,
 )
@@ -286,3 +287,103 @@ def test_when_train_data_has_static_feat_but_pred_data_has_no_static_feat_then_e
     learner.fit(train_data=train_data, hyperparameters={"ETS": {"maxiter": 1}})
     with pytest.raises(ValueError, match="Provided data has no static_features"):
         learner.predict(pred_data)
+
+
+ITEM_ID_TO_LENGTH = {"B": 15, "A": 23, "C": 17}
+HYPERPARAMETERS_DUMMY = {"Naive": {}}
+
+
+def test_given_expected_known_covariates_missing_from_train_data_when_learner_fits_then_exception_is_raised(
+    temp_model_path,
+):
+    learner = TimeSeriesLearner(path_context=temp_model_path, known_covariates_names=["Y", "Z", "X"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Z"])
+    with pytest.raises(ValueError, match="\\['Y'\\] provided as known_covariates_names are missing from train_data"):
+        learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
+
+
+def test_given_extra_covariates_are_present_in_dataframe_when_learner_fits_then_they_are_ignored(temp_model_path):
+    learner = TimeSeriesLearner(path_context=temp_model_path, known_covariates_names=["Y", "X"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Y", "Z"])
+    with mock.patch("autogluon.timeseries.trainer.auto_trainer.AutoTimeSeriesTrainer.fit") as mock_fit:
+        learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
+        passed_train = mock_fit.call_args[1]["train_data"]
+        assert len(passed_train.columns.symmetric_difference(["Y", "X", "target"])) == 0
+
+
+def test_given_known_covariates_have_non_numeric_dtypes_when_learner_fits_then_exception_is_raised(temp_model_path):
+    learner = TimeSeriesLearner(path_context=temp_model_path, known_covariates_names=["Y", "Z", "X"])
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Z", "Y"])
+    train_data["Y"] = np.random.choice(["foo", "bar", "baz"], size=len(train_data)).astype("O")
+    with pytest.raises(ValueError, match="must all have numeric \(float or int\) dtypes"):
+        learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
+
+
+def test_given_expected_known_covariates_missing_from_data_when_learner_predicts_then_exception_is_raised(
+    temp_model_path,
+):
+    prediction_length = 5
+    learner = TimeSeriesLearner(
+        path_context=temp_model_path, known_covariates_names=["X", "Y"], prediction_length=prediction_length
+    )
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
+
+    pred_data = train_data.slice_by_timestep(None, -prediction_length)
+    known_covariates = train_data.slice_by_timestep(-prediction_length, None).drop("target", axis=1)
+    known_covariates.drop("X", axis=1, inplace=True)
+    with pytest.raises(
+        ValueError, match="\\['X'\\] provided as known_covariates_names are missing from known_covariates."
+    ):
+        learner.predict(data=pred_data, known_covariates=known_covariates)
+
+
+def test_given_extra_covariates_are_present_in_dataframe_when_learner_predicts_then_they_are_ignored(temp_model_path):
+    prediction_length = 5
+    learner = TimeSeriesLearner(
+        path_context=temp_model_path, known_covariates_names=["Y", "X"], prediction_length=prediction_length
+    )
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
+
+    data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Z", "Y", "X"])
+    pred_data = data.slice_by_timestep(None, -prediction_length)
+    known_covariates = data.slice_by_timestep(-prediction_length, None).drop("target", axis=1)
+    with mock.patch("autogluon.timeseries.trainer.auto_trainer.AutoTimeSeriesTrainer.predict") as mock_predict:
+        learner.predict(data=pred_data, known_covariates=known_covariates)
+        passed_data = mock_predict.call_args[1]["data"]
+        passed_known_covariates = mock_predict.call_args[1]["known_covariates"]
+        assert len(passed_data.columns.symmetric_difference(["Y", "X", "target"])) == 0
+        assert len(passed_known_covariates.columns.symmetric_difference(["Y", "X"])) == 0
+
+
+@pytest.mark.parametrize("prediction_length", [5, 2])
+def test_given_extra_items_and_timestamps_are_present_in_dataframe_when_learner_predicts_then_correct_subset_is_selected(
+    temp_model_path,
+    prediction_length,
+):
+    learner = TimeSeriesLearner(
+        path_context=temp_model_path, known_covariates_names=["Y", "X"], prediction_length=prediction_length
+    )
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
+
+    data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    pred_data = data.slice_by_timestep(None, -prediction_length)
+
+    # known_covariates includes additional item_ids and additional timestamps
+    extended_item_id_to_length = {"D": 25, "E": 37, "F": 14}
+    for item_id, length in ITEM_ID_TO_LENGTH.items():
+        extended_item_id_to_length[item_id] = length + 7
+    extended_data = get_data_frame_with_variable_lengths(extended_item_id_to_length, known_covariates_names=["Y", "X"])
+    known_covariates = extended_data.drop("target", axis=1)
+
+    with mock.patch("autogluon.timeseries.trainer.auto_trainer.AutoTimeSeriesTrainer.predict") as mock_predict:
+        learner.predict(data=pred_data, known_covariates=known_covariates)
+        passed_known_covariates = mock_predict.call_args[1]["known_covariates"]
+        assert len(passed_known_covariates.item_ids.symmetric_difference(pred_data.item_ids)) == 0
+        for item_id in pred_data.item_ids:
+            expected_forecast_timestamps = get_forecast_horizon_index_single_time_series(
+                pred_data.loc[item_id].index, freq=pred_data.freq, prediction_length=prediction_length
+            )
+            assert (passed_known_covariates.loc[item_id].index == expected_forecast_timestamps).all()

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -17,7 +17,6 @@ from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_singl
 
 from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_variable_lengths, get_static_features
 
-
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1, "num_batches_per_epoch": 1}},
     {"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}, "Naive": {}},

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -15,11 +15,7 @@ from autogluon.timeseries.learner import TimeSeriesLearner
 from autogluon.timeseries.models import DeepARModel, ETSModel
 from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_single_time_series
 
-from .common import (
-    DUMMY_TS_DATAFRAME,
-    get_data_frame_with_variable_lengths,
-    get_static_features,
-)
+from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_variable_lengths, get_static_features
 
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1}},

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -17,9 +17,10 @@ from autogluon.timeseries.utils.forecast import get_forecast_horizon_index_singl
 
 from .common import DUMMY_TS_DATAFRAME, get_data_frame_with_variable_lengths, get_static_features
 
+
 TEST_HYPERPARAMETER_SETTINGS = [
-    {"SimpleFeedForward": {"epochs": 1}},
-    {"DeepAR": {"epochs": 1}, "ETS": {}},
+    {"SimpleFeedForward": {"epochs": 1, "num_batches_per_epoch": 1}},
+    {"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}, "Naive": {}},
 ]
 TEST_HYPERPARAMETER_SETTINGS_EXPECTED_LB_LENGTHS = [1, 2]
 

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -13,7 +13,7 @@ from autogluon.timeseries.models import DeepARModel, SimpleFeedForwardModel
 from autogluon.timeseries.predictor import TimeSeriesPredictor
 from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter
 
-from .common import DUMMY_TS_DATAFRAME
+from .common import DUMMY_TS_DATAFRAME, DATAFRAME_WITH_COVARIATES
 
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1}},
@@ -495,3 +495,11 @@ def test_given_mixed_searchspace_and_hyperparameter_tune_kwargs_when_predictor_f
             "num_trials": 2,
         },
     )
+
+
+@pytest.mark.parametrize("target_columns", ["target", "CUSTOM_TARGET"])
+def test_when_target_included_in_known_covariates_then_exception_is_raised(temp_model_path, target_column):
+    with pytest.raises(ValueError, match="cannot be one of the known covariates"):
+        predictor = TimeSeriesPredictor(
+            path_context=temp_model_path, target=target_column, known_covariates_names=["Y", target_column, "X"]
+        )

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -13,7 +13,7 @@ from autogluon.timeseries.models import DeepARModel, SimpleFeedForwardModel
 from autogluon.timeseries.predictor import TimeSeriesPredictor
 from autogluon.timeseries.splitter import LastWindowSplitter, MultiWindowSplitter
 
-from .common import DUMMY_TS_DATAFRAME, DATAFRAME_WITH_COVARIATES
+from .common import DATAFRAME_WITH_COVARIATES, DUMMY_TS_DATAFRAME
 
 TEST_HYPERPARAMETER_SETTINGS = [
     {"SimpleFeedForward": {"epochs": 1}},

--- a/timeseries/tests/unittests/test_predictor.py
+++ b/timeseries/tests/unittests/test_predictor.py
@@ -497,7 +497,7 @@ def test_given_mixed_searchspace_and_hyperparameter_tune_kwargs_when_predictor_f
     )
 
 
-@pytest.mark.parametrize("target_columns", ["target", "CUSTOM_TARGET"])
+@pytest.mark.parametrize("target_column", ["target", "CUSTOM_TARGET"])
 def test_when_target_included_in_known_covariates_then_exception_is_raised(temp_model_path, target_column):
     with pytest.raises(ValueError, match="cannot be one of the known covariates"):
         predictor = TimeSeriesPredictor(

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -6,7 +6,7 @@ from autogluon.timeseries.splitter import MultiWindowSplitter, append_suffix_to_
 
 from .common import (
     DUMMY_VARIABLE_LENGTH_TS_DATAFRAME,
-    DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC,
+    DATAFRAME_WITH_STATIC,
     get_data_frame_with_variable_lengths,
 )
 
@@ -73,7 +73,7 @@ def test_when_splitter_adds_suffix_to_index_then_data_is_not_copied():
 
 
 def test_when_static_features_are_present_then_splitter_correctly_splits_them():
-    original_df = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC.copy()
+    original_df = DATAFRAME_WITH_STATIC.copy()
     splitter = MultiWindowSplitter()
     prediction_length = 7
     train_data, val_data = splitter.split(ts_dataframe=original_df, prediction_length=prediction_length)

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -5,10 +5,10 @@ import pytest
 from autogluon.timeseries.splitter import MultiWindowSplitter, append_suffix_to_item_id
 
 from .common import (
+    DATAFRAME_WITH_COVARIATES,
     DATAFRAME_WITH_STATIC,
     DUMMY_VARIABLE_LENGTH_TS_DATAFRAME,
     get_data_frame_with_variable_lengths,
-    DATAFRAME_WITH_COVARIATES,
 )
 
 

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -4,11 +4,7 @@ import pytest
 
 from autogluon.timeseries.splitter import MultiWindowSplitter, append_suffix_to_item_id
 
-from .common import (
-    DUMMY_VARIABLE_LENGTH_TS_DATAFRAME,
-    DATAFRAME_WITH_STATIC,
-    get_data_frame_with_variable_lengths,
-)
+from .common import DATAFRAME_WITH_STATIC, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, get_data_frame_with_variable_lengths
 
 
 def get_original_item_id_and_slice(tuning_item_id: str):


### PR DESCRIPTION
*Description of changes:*
- Add `known_covariates_names` argument to `TimeSeriesPredictor` that contains the names of the columns in `TimeSeriesDataFrame` that are known at prediction time
- Add logic for checking & preprocessing the known covariates inside `TimeSeriesLearner`
- Add `known_covariates` argument to `TimeSeriesPredictor.predict` and `AbstractTimeSeriesModel.predict`. This argument contains the values of the known covariates during the forecast horizon
- Use the known covariates during training & prediction in `DeepARModel`, `DeepARMXNetModel`, `MQCNNMXNetModel` and `TemporalFusionTransformerMXNetModel`.

*To do:*
- [x] Add tests for Learner
- [x] Add tests for GluonTS models after rebasing on top of #2279 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
