### PR TITLE
Deprecate passing quantile_levels to TimeSeriesPredictor.predict

### DIFF
--- a/docs/tutorials/timeseries/forecasting-indepth.md
+++ b/docs/tutorials/timeseries/forecasting-indepth.md
@@ -46,10 +46,6 @@ By default, the predictor outputs the quantiles `[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 
 ```python
 predictor = TimeSeriesPredictor(quantile_levels=[0.05, 0.5, 0.95])
 ```
-or generate forecasts for the quantiles of interest at prediction time
-```python
-predictor.predict(data, quantile_levels=[0.05, 0.5, 0.95])
-```
 
 ## Which forecasting models are available in AutoGluon?
 Forecasting models in AutoGluon can be divided into three broad categories: local, global, and ensemble models.

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -423,6 +423,14 @@ class TimeSeriesPredictor:
             Name of the model that you would like to use for prediction. By default, the best model during training
             (with highest validation score) will be used.
         """
+        if "quantile_levels" in kwargs:
+            warnings.warn(
+                "Passing `quantile_levels` as a keyword argument to `TimeSeriesPredictor.predict` is deprecated and "
+                "will be removed in v0.7.0. This might also lead to some models not working properly. "
+                "Please specify the desired quantile levels when creating the predictor as "
+                "`TimeSeriesPredictor(..., quantile_levels=quantile_levels)`.",
+                category=DeprecationWarning,
+            )
         data = self._check_and_prepare_data_frame(data)
         return self._learner.predict(data, model=model, **kwargs)
 


### PR DESCRIPTION
*Description of changes:*
- Add a `DeprecationWarning` if `quantile_levels` are passed at prediction time.
- Update in-depth tutorial to reflect this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
