### PR TITLE
Change backbone used in efficient finetuning tutorial to FLAN-T5 + Add flag for lowering peak CPU usage of large LMs.

### DIFF
--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -117,6 +117,7 @@ predictor.fit(train_en_df,
               hyperparameters={
                   "model.hf_text.checkpoint_name": "google/flan-t5-xl",
                   "model.hf_text.gradient_checkpointing": True,
+                  "model.hf_text.low_cpu_mem_usage": True,
                   "optimization.efficient_finetune": "ia3_bias",
                   "optimization.lr_decay": 0.9,
                   "optimization.learning_rate": 3e-03,

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -104,7 +104,8 @@ print('Score in the Japanese Testset:', score_in_jp)
 
 By combining [gradient checkpointing](https://pytorch.org/docs/stable/checkpoint.html) and parameter-efficient finetuning, it is feasible to finetune 
 models that have close to two billion parameters (e.g., [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl)) with a single GPU in [AWS G4 instances](https://aws.amazon.com/ec2/instance-types/g4/). 
-To turn on gradient checkpointing, all you need is to set `"model.hf_text.gradient_checkpointing"` to `True`. To accelerate the training speed of this tutorial, we will use [google/flan-t5-large](https://huggingface.co/google/flan-t5-large). You can change it to [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl) when running the code. 
+To turn on gradient checkpointing, all you need is to set `"model.hf_text.gradient_checkpointing"` to `True`.
+To accelerate the training speed of this tutorial, we will use [google/flan-t5-large](https://huggingface.co/google/flan-t5-large). You can change it to [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl) when running the code. 
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
@@ -114,13 +115,13 @@ predictor = MultiModalPredictor(label="label",
 predictor.fit(train_en_df,
               presets="multilingual",
               hyperparameters={
-                  "model.hf_text.checkpoint_name": "google/flan-t5-large",
+                  "model.hf_text.checkpoint_name": "google/flan-t5-xl",
                   "model.hf_text.gradient_checkpointing": True,
                   "optimization.efficient_finetune": "ia3_bias",
                   "optimization.lr_decay": 0.9,
                   "optimization.learning_rate": 3e-03,
                   "optimization.end_lr": 3e-03,
-                  "optimization.max_epochs": 2,
+                  "optimization.max_epochs": 1,
                   "optimization.warmup_steps": 0,
                   "env.batch_size": 32,
               })

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -103,10 +103,8 @@ print('Score in the Japanese Testset:', score_in_jp)
 ## Combine Gradient Checkpointing and Parameter-efficient Finetuning
 
 By combining [gradient checkpointing](https://pytorch.org/docs/stable/checkpoint.html) and parameter-efficient finetuning, it is feasible to finetune 
-models that have close to two billion parameters (e.g., [google/mt5-xl](https://huggingface.co/google/mt5-xl)) with a single GPU in [AWS G4 instances](https://aws.amazon.com/ec2/instance-types/g4/). 
-To turn on gradient checkpointing, all you need is to set `"model.hf_text.gradient_checkpointing"` to `True`. 
-To improve the training speed, we won't use [google/mt5-xl](https://huggingface.co/google/mt5-xl) in the following example and 
-you can try it by setting `"model.hf_text.checkpoint_name": "google/mt5-xl"`, or refer to [the example](https://gist.github.com/sxjscience/b011460574c7e41c47a42ba86d026cbc).
+models that have close to two billion parameters (e.g., [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl)) with a single GPU in [AWS G4 instances](https://aws.amazon.com/ec2/instance-types/g4/). 
+To turn on gradient checkpointing, all you need is to set `"model.hf_text.gradient_checkpointing"` to `True`.
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
@@ -116,6 +114,7 @@ predictor = MultiModalPredictor(label="label",
 predictor.fit(train_en_df,
               presets="multilingual",
               hyperparameters={
+                  "model.hf_text.checkpoint_name": "google/flan-t5-xl",
                   "model.hf_text.gradient_checkpointing": True,
                   "optimization.efficient_finetune": "ia3_bias",
                   "optimization.lr_decay": 0.9,
@@ -129,7 +128,11 @@ predictor.fit(train_en_df,
 
 
 ```{.python .input}
+score_in_en = predictor.evaluate(test_en_df)
+score_in_de = predictor.evaluate(test_de_df)
 score_in_jp = predictor.evaluate(test_jp_df)
+print('Score in the English Testset:', score_in_en)
+print('Score in the German Testset:', score_in_de)
 print('Score in the Japanese Testset:', score_in_jp)
 ```
 

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -1,4 +1,4 @@
-# Single GPU 1B-scale Model Training with AutoMM via Parameter-Efficient Finetuning
+# Single GPU Billion-scale Model Training via Parameter-Efficient Finetuning
 :label:`sec_automm_efficient_finetuning_basic`
 
 As pointed out by [a recent paper from Stanford Institute for Human-Centered Artificial Intelligence](https://arxiv.org/pdf/2108.07258.pdf), 

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -141,7 +141,7 @@ predictor.fit(train_en_df.sample(200, random_state=123),
                   "optimization.end_lr": 3e-03,
                   "optimization.max_epochs": 1,
                   "optimization.warmup_steps": 0,
-                  "env.batch_size": 16,
+                  "env.batch_size": 8,
                   "env.eval_batch_size_ratio": 1
               })
 
@@ -150,11 +150,7 @@ predictor.fit(train_en_df.sample(200, random_state=123),
 
 ```{.python .input}
 score_in_en = predictor.evaluate(test_en_df)
-score_in_de = predictor.evaluate(test_de_df)
-score_in_jp = predictor.evaluate(test_jp_df)
 print('Score in the English Testset:', score_in_en)
-print('Score in the German Testset:', score_in_de)
-print('Score in the Japanese Testset:', score_in_jp)
 ```
 
 ```{.python .input}

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -33,6 +33,17 @@ directly evaluate its performance on the German and Japanese test set.
 !unzip -q -o amazon_review_sentiment_cross_lingual.zip -d .
 ```
 
+```{.python .input}
+import os
+import shutil
+os.environ["TRANSFORMERS_CACHE"] = "cache"
+
+def clear_cache():
+    if os.path.exists("cache"):
+        shutil.rmtree("cache")
+
+clear_cache()
+```
 
 ```{.python .input}
 import pandas as pd
@@ -108,11 +119,17 @@ To turn on gradient checkpointing, all you need is to set `"model.hf_text.gradie
 To accelerate the training speed of this tutorial, we will use [google/flan-t5-large](https://huggingface.co/google/flan-t5-large). You can change it to [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl) when running the code. 
 
 ```{.python .input}
+# Just for clean the space
+clear_cache()
+shutil.rmtree("multilingual_ia3")
+```
+
+```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
 
 predictor = MultiModalPredictor(label="label",
                                 path="multilingual_ia3_gradient_checkpoint")
-predictor.fit(train_en_df,
+predictor.fit(train_en_df.sample(200, random_state=123),
               presets="multilingual",
               hyperparameters={
                   "model.hf_text.checkpoint_name": "google/flan-t5-xl",
@@ -137,6 +154,12 @@ score_in_jp = predictor.evaluate(test_jp_df)
 print('Score in the English Testset:', score_in_en)
 print('Score in the German Testset:', score_in_de)
 print('Score in the Japanese Testset:', score_in_jp)
+```
+
+```{.python .input}
+# Just for clean the space
+clear_cache()
+shutil.rmtree("multilingual_ia3_gradient_checkpoint")
 ```
 
 ## Other Examples

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -141,7 +141,8 @@ predictor.fit(train_en_df.sample(200, random_state=123),
                   "optimization.end_lr": 3e-03,
                   "optimization.max_epochs": 1,
                   "optimization.warmup_steps": 0,
-                  "env.batch_size": 32,
+                  "env.batch_size": 16,
+                  "env.eval_batch_size_ratio": 1
               })
 
 ```

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -120,7 +120,7 @@ predictor.fit(train_en_df,
                   "optimization.lr_decay": 0.9,
                   "optimization.learning_rate": 3e-03,
                   "optimization.end_lr": 3e-03,
-                  "optimization.max_epochs": 3,
+                  "optimization.max_epochs": 2,
                   "optimization.warmup_steps": 0,
                   "env.batch_size": 32,
               })

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -104,7 +104,7 @@ print('Score in the Japanese Testset:', score_in_jp)
 
 By combining [gradient checkpointing](https://pytorch.org/docs/stable/checkpoint.html) and parameter-efficient finetuning, it is feasible to finetune 
 models that have close to two billion parameters (e.g., [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl)) with a single GPU in [AWS G4 instances](https://aws.amazon.com/ec2/instance-types/g4/). 
-To turn on gradient checkpointing, all you need is to set `"model.hf_text.gradient_checkpointing"` to `True`.
+To turn on gradient checkpointing, all you need is to set `"model.hf_text.gradient_checkpointing"` to `True`. To accelerate the training speed of this tutorial, we will use [google/flan-t5-large](https://huggingface.co/google/flan-t5-large). You can change it to [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl) when running the code. 
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
@@ -114,7 +114,7 @@ predictor = MultiModalPredictor(label="label",
 predictor.fit(train_en_df,
               presets="multilingual",
               hyperparameters={
-                  "model.hf_text.checkpoint_name": "google/flan-t5-xl",
+                  "model.hf_text.checkpoint_name": "google/flan-t5-large",
                   "model.hf_text.gradient_checkpointing": True,
                   "optimization.efficient_finetune": "ia3_bias",
                   "optimization.lr_decay": 0.9,

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -125,6 +125,7 @@ predictor.fit(train_en_df,
                   "optimization.warmup_steps": 0,
                   "env.batch_size": 32,
               })
+
 ```
 
 

--- a/docs/tutorials/multimodal/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/efficient_finetuning_basic.md
@@ -1,4 +1,4 @@
-# Parameter-Efficient Finetuning in AutoMM -- Basic Usage
+# Single GPU 1B-scale Model Training with AutoMM via Parameter-Efficient Finetuning
 :label:`sec_automm_efficient_finetuning_basic`
 
 As pointed out by [a recent paper from Stanford Institute for Human-Centered Artificial Intelligence](https://arxiv.org/pdf/2108.07258.pdf), 
@@ -9,16 +9,17 @@ Following is a figure from the [Microsoft research blog](https://www.microsoft.c
 ![Scaling of foundation models](https://www.microsoft.com/en-us/research/uploads/prod/2021/10/model-size-graph.jpg)
 :width:`500px`
 
-The goal of AutoMM is to democratize the publicly available foundation models, whether they are big or not, to every developers. 
-To finetune the giant models, we adopt the recently popularized **parameter-efficient finetuning** technique. 
+The goal of AutoMM is to help anyone solve machine learning problems via open source foundation models, including these giant models. 
+To finetune these large-scale models, we adopt the recently popularized **parameter-efficient finetuning** technique. 
 The idea is to either finetune a small subset of the weights in the foundation model (e.g., [BitFit](https://aclanthology.org/2022.acl-short.1.pdf)), 
 or adding a tiny tunable structure on top of the fixed backbone (e.g., [Prompt Tuning](https://aclanthology.org/2021.emnlp-main.243.pdf),
 [LoRA](https://arxiv.org/pdf/2106.09685.pdf), [Adapter](https://arxiv.org/abs/1902.00751), [MAM Adapter](https://arxiv.org/pdf/2110.04366.pdf), [IA^3](https://arxiv.org/abs/2205.05638)). 
 These techniques can effectively reduce the peak memory usage and model training time, while maintaining the performance.
 
-In this tutorial, we introduce how to apply parameter-efficient finetuning in MultiModalPredictor.
-We will reuse the same multilingual dataset as in :ref:`sec_automm_textprediction_multilingual` and train 
-models with the `"ia3_bias"` algorithm. `"ia3_bias"` is a parameter-efficient finetuning algorithm that combines IA^3 and BitFit.
+In this tutorial, we introduce how to apply parameter-efficient finetuning in MultiModalPredictor. 
+We first introduce how to adopt the `"ia3_bias"` algorithm for parameter-efficient finetuning. Afterwards, we show how you can simply combine `"ia3_bias"` 
+and gradient checkpointing to finetune the XL-variant of Google's [FLAN-T5](https://arxiv.org/abs/2210.11416) via a single NVIDIA T4 GPU. 
+
 
 ## Prepare Dataset
 
@@ -76,7 +77,7 @@ train_en_df.head(5)
 test_jp_df.head(5)
 ```
 
-## Finetuning with IA3 + BitFit
+## Finetuning Multilingual Model with IA3 + BitFit
 
 In AutoMM, to enable efficient finetuning, just specify the `optimization.efficient_finetune` to be `"ia3_bias"`.
 
@@ -111,12 +112,12 @@ print('Score in the German Testset:', score_in_de)
 print('Score in the Japanese Testset:', score_in_jp)
 ```
 
-## Combine Gradient Checkpointing and Parameter-efficient Finetuning
+## Training FLAN-T5-XL on Single GPU
 
 By combining [gradient checkpointing](https://pytorch.org/docs/stable/checkpoint.html) and parameter-efficient finetuning, it is feasible to finetune 
-models that have close to two billion parameters (e.g., [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl)) with a single GPU in [AWS G4 instances](https://aws.amazon.com/ec2/instance-types/g4/). 
-To turn on gradient checkpointing, all you need is to set `"model.hf_text.gradient_checkpointing"` to `True`.
-To accelerate the training speed of this tutorial, we will use [google/flan-t5-large](https://huggingface.co/google/flan-t5-large). You can change it to [google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl) when running the code. 
+[google/flan-t5-xl](https://huggingface.co/google/flan-t5-xl) that has close to two billion parameterswith a single T4 GPU available in
+[AWS G4 instances](https://aws.amazon.com/ec2/instance-types/g4/). 
+To turn on gradient checkpointing, you just need to set `"model.hf_text.gradient_checkpointing"` to `True`.
 
 ```{.python .input}
 # Just for clean the space

--- a/docs/tutorials/multimodal/index.rst
+++ b/docs/tutorials/multimodal/index.rst
@@ -69,7 +69,7 @@ In the following, we prepared a few tutorials to help you learn how to use `Auto
       How to use AutoMM for entity extraction.
 
    .. card::
-      :title: Single GPU 1B-Scale Model Training with AutoMM via Parameter-Efficient Finetuning
+      :title: Single GPU Billion-scale Model Training via Parameter-Efficient Finetuning
       :link: efficient_finetuning_basic.html
 
       How to take advantage of larger foundation models with the help of parameter-efficient finetuning.

--- a/docs/tutorials/multimodal/index.rst
+++ b/docs/tutorials/multimodal/index.rst
@@ -69,11 +69,11 @@ In the following, we prepared a few tutorials to help you learn how to use `Auto
       How to use AutoMM for entity extraction.
 
    .. card::
-      :title: Parameter-Efficient Finetuning in AutoMM -- Basic Usage
+      :title: Single GPU 1B-Scale Model Training with AutoMM via Parameter-Efficient Finetuning
       :link: efficient_finetuning_basic.html
 
       How to take advantage of larger foundation models with the help of parameter-efficient finetuning.
-      In the tutorial, we will use the combination of IA^3 and BitFit to finetune a multilingual backbone.
+      In the tutorial, we will use combine IA^3, BitFit, and gradient checkpointing to finetune FLAN-T5-XL.
 
    .. card::
       :title: Customize AutoMM

--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -31,6 +31,7 @@ install_requires = [
     "jsonschema<=4.8.0",
     "seqeval<=1.2.2",
     "evaluate<=0.2.2",
+    "accelerate>=0.9,<0.14",
     "timm<0.7.0",
     "torch>=1.9,<1.13",
     "torchvision<0.14.0",

--- a/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
+++ b/multimodal/src/autogluon/multimodal/configs/model/fusion_mlp_image_text_tabular.yaml
@@ -64,6 +64,7 @@ model:
     tokenizer_name: "hf_auto"
     max_text_len: 512  # If None or <=0, then use the max length of pretrained models.
     insert_sep: True
+    low_cpu_mem_usage: False
     text_segment_num: 2
     stochastic_chunk: False
     text_aug_detect_length: 10                # We perform text augmentation only if a text has more than text_detection_length words. It is used to differentiate text columns versus tabular columns that are treated as text.
@@ -98,6 +99,7 @@ model:
     max_text_len: 512  # If None or <=0, then use the max length of pretrained models.
     text_segment_num: 2
     insert_sep: True
+    low_cpu_mem_usage: False
     stochastic_chunk: False
     text_aug_detect_length: 10                # We perform text augmentation only if a text has more than text_detection_length words. It is used to differentiate text columns versus tabular columns that are treated as text.
     text_trivial_aug_maxscale: 0.0            # augmentation magnititude randomly drawn from [0, text_trivial_aug_maxscale]

--- a/multimodal/src/autogluon/multimodal/models/huggingface_text.py
+++ b/multimodal/src/autogluon/multimodal/models/huggingface_text.py
@@ -38,6 +38,7 @@ class HFAutoModelForTextPrediction(nn.Module):
         num_classes: Optional[int] = 0,
         pooling_mode: Optional[str] = "cls",
         gradient_checkpointing: Optional[bool] = False,
+        low_cpu_mem_usage: Optional[bool] = False,
         pretrained: Optional[bool] = True,
     ):
         """
@@ -65,6 +66,8 @@ class HFAutoModelForTextPrediction(nn.Module):
             The pooling mode for the Transformer. Can be "cls", or "mean"
         gradient_checkpointing
             Whether to enable gradient checkpointing
+        low_cpu_mem_usage
+            Whether to turn on the optimization of reducing the peak CPU memory usage when loading the pretrained model.
         pretrained
             Whether using the pretrained weights. If pretrained=True, download the pretrained model.
         """

--- a/multimodal/src/autogluon/multimodal/models/t_few.py
+++ b/multimodal/src/autogluon/multimodal/models/t_few.py
@@ -53,6 +53,7 @@ class TFewModel(nn.Module):
         unlikely_loss: float = 1.0,  # Adds loss term that lowers probability of incorrect outputs
         mc_loss: float = 1.0,  # Adds multiple choice cross entropy loss
         gradient_checkpointing: Optional[bool] = False,
+        low_cpu_mem_usage: Optional[bool] = False,
         pretrained: Optional[bool] = True,
     ):
         """
@@ -71,14 +72,16 @@ class TFewModel(nn.Module):
                 - 'bigscience/T0pp'
         num_classes
             The number of classes. 1 for a regression task.
-        gradient_checkpointing
-            Whether to enable gradient checkpointing
         length_norm
              Normalizes length to adjust for length bias in target template
         unlikely_loss
             Adds loss term that lowers probability of incorrect outputs
         mc_loss
             Adds multiple choice cross entropy loss
+        gradient_checkpointing
+            Whether to enable gradient checkpointing
+        low_cpu_mem_usage
+            Whether to turn on the optimization of reducing the peak CPU memory usage when loading the pretrained model.
         pretrained
             Whether using the pretrained weights. If pretrained=True, download the pretrained model.
         """
@@ -91,7 +94,7 @@ class TFewModel(nn.Module):
         self.config = AutoConfig.from_pretrained(checkpoint_name)
 
         if pretrained:
-            self.model = AutoModelForSeq2SeqLM.from_pretrained(checkpoint_name)
+            self.model = AutoModelForSeq2SeqLM.from_pretrained(checkpoint_name, low_cpu_mem_usage=low_cpu_mem_usage)
         else:
             self.model = AutoModelForSeq2SeqLM.from_config(self.config)
 

--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -522,7 +522,11 @@ def get_model_head(model: nn.Module):
     return head
 
 
-def get_hf_config_and_model(checkpoint_name: str, pretrained: Optional[bool] = True):
+def get_hf_config_and_model(
+    checkpoint_name: str,
+    pretrained: Optional[bool] = True,
+    low_cpu_mem_usage: Optional[bool] = False
+):
     """
     Get a Huggingface config and model based on a checkpoint name.
 
@@ -532,6 +536,8 @@ def get_hf_config_and_model(checkpoint_name: str, pretrained: Optional[bool] = T
         A model checkpoint name.
     pretrained
          Whether using the pretrained weights. If pretrained=True, download the pretrained model.
+    low_cpu_mem_usage
+        Whether to turn on the optimization of reducing the peak CPU memory usage when loading the pretrained model.
 
     Returns
     -------
@@ -540,7 +546,7 @@ def get_hf_config_and_model(checkpoint_name: str, pretrained: Optional[bool] = T
     config = AutoConfig.from_pretrained(checkpoint_name)
 
     if pretrained:
-        model = AutoModel.from_pretrained(checkpoint_name)
+        model = AutoModel.from_pretrained(checkpoint_name, low_cpu_mem_usage=low_cpu_mem_usage)
     else:
         model = AutoModel.from_config(config)
 

--- a/multimodal/src/autogluon/multimodal/models/utils.py
+++ b/multimodal/src/autogluon/multimodal/models/utils.py
@@ -523,9 +523,7 @@ def get_model_head(model: nn.Module):
 
 
 def get_hf_config_and_model(
-    checkpoint_name: str,
-    pretrained: Optional[bool] = True,
-    low_cpu_mem_usage: Optional[bool] = False
+    checkpoint_name: str, pretrained: Optional[bool] = True, low_cpu_mem_usage: Optional[bool] = False
 ):
     """
     Get a Huggingface config and model based on a checkpoint name.

--- a/multimodal/src/autogluon/multimodal/utils/model.py
+++ b/multimodal/src/autogluon/multimodal/utils/model.py
@@ -178,6 +178,7 @@ def create_model(
             num_classes=num_classes,
             pooling_mode=OmegaConf.select(model_config, "pooling_mode", default="cls"),
             gradient_checkpointing=OmegaConf.select(model_config, "gradient_checkpointing"),
+            low_cpu_mem_usage=OmegaConf.select(model_config, "low_cpu_mem_usage", default=False),
             pretrained=pretrained,
         )
     elif model_name.lower().startswith(T_FEW):
@@ -189,6 +190,7 @@ def create_model(
             mc_loss=model_config.mc_loss,  # Adds multiple choice cross entropy loss
             num_classes=num_classes,
             gradient_checkpointing=OmegaConf.select(model_config, "gradient_checkpointing"),
+            low_cpu_mem_usage=OmegaConf.select(model_config, "low_cpu_mem_usage", default=False),
             pretrained=pretrained,
         )
     elif model_name.lower().startswith(NUMERICAL_MLP):

--- a/multimodal/tests/unittests/test_predictor_advanced.py
+++ b/multimodal/tests/unittests/test_predictor_advanced.py
@@ -35,7 +35,7 @@ def trainable_parameters(model) -> int:
     "backbone,efficient_finetuning,pooling_mode,precision,expected_ratio,standalone",
     [
         ("t5-small", LORA_NORM, "mean", "bf16", 0.00557, True),
-        ("t5-small", IA3, "mean", "bf16", 0.00039118, False),
+        ("google/flan-t5-small", IA3, "mean", "bf16", 0.0004201, False),
         ("microsoft/deberta-v3-small", LORA_BIAS, "mean", "16", 0.001422, True),
         ("microsoft/deberta-v3-small", IA3_BIAS, "mean", "16", 0.00044566, False),
     ],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- [x] Revise the efficient finetuning tutorial to use FLAN-T5.
   [FLAN-T5](https://arxiv.org/abs/2210.11416) was released by Google. The model has been pretrained on a wide collection of tasks, and is performing very well on downstream applications. In this PR, we are adding FLAN-T5 in the test case of efficient finetuning and also change the backbone in our efficient finetuning tutorial as FLAN-T5.

- [x] Add `low_cpu_mem_usage` flag
   Usually, loading the pytorch model will need you to 1) initialize the weight matrices, 2) load the pretrained model, and 3) overwrite the initialized matrices with the pretrained weights. Via the “low_cpu_mem_usage” flag, it will initialize the model into "meta device" that is available at pytorch 1.9. Meta tensors are just normal tensors without carrying out any memory. See the [related implementation](https://github.com/huggingface/accelerate/blob/8b16276a41857e25f8e0d0cfe45eb69c60134add/src/accelerate/big_modeling.py#L35-L36), [the huggingface blog](https://huggingface.co/blog/accelerate-large-models), and the related [lightning ai blog](https://devblog.pytorchlightning.ai/experiment-with-billion-parameter-models-faster-using-deepspeed-and-meta-tensors-2e9c255edd71).


Attached the profiling numbers for loading `"bigscience/T0pp"`:

```python
AutoModel.from_pretrained("bigscience/T0pp", low_cpu_mem_usage=True) # Time spent: 53.514538049697876
AutoModel.from_pretrained("bigscience/T0pp") # Time spent: 95.05165839195251
```

```bash
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
     4     72.2 MiB     72.2 MiB           1   @profile
     5                                         def my_func():
     6  42377.2 MiB  42305.0 MiB           1       model = AutoModel.from_pretrained("bigscience/T0pp", low_cpu_mem_usage=True)
     7    399.6 MiB -41977.7 MiB           1       del model
     8  84857.2 MiB  84457.7 MiB           1       model = AutoModel.from_pretrained("bigscience/T0pp")
     9  42880.5 MiB -41976.7 MiB           1       del model
```

In addition, upgrade the version of Transformers and add `accelerate` to the dependency, which implements loading to meta tensor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
