### PR TITLE
add import error to timeseries sktime module

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/sktime/__init__.py
+++ b/timeseries/src/autogluon/timeseries/models/sktime/__init__.py
@@ -1,3 +1,13 @@
+import autogluon.timeseries as agts
+
+if not agts.SKTIME_INSTALLED:
+    raise ImportError(
+        "The sktime models in autogluon.timeseries depend on sktime v0.13.1 or greater (below v0.14)."
+        "Please install a suitable version of sktime in order to use these models, with "
+        "`pip install 'sktime>=0.13.1,<0.14`."
+    )
+
+
 from .abstract_sktime import AbstractSktimeModel
 from .models import ARIMASktimeModel, AutoARIMASktimeModel, AutoETSSktimeModel, TBATSSktimeModel, ThetaSktimeModel
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Small missing safeguard for timeseries sktime module

Tested in isolated envs with and without sktime.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
