### PR TITLE
Use static features in AutoGluonTabularModel forecasting model

### DIFF
--- a/timeseries/tests/unittests/models/test_autogluon_tabular.py
+++ b/timeseries/tests/unittests/models/test_autogluon_tabular.py
@@ -4,7 +4,7 @@ import pytest
 
 from autogluon.timeseries.models.autogluon_tabular import AutoGluonTabularModel
 
-from ..common import DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC
+from ..common import DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, DATAFRAME_WITH_STATIC
 
 TESTABLE_MODELS = [
     AutoGluonTabularModel,
@@ -44,7 +44,7 @@ def test_when_predict_is_called_then_get_features_dataframe_receives_correct_inp
 
 
 def test_when_static_features_present_then_shape_is_correct(temp_model_path):
-    data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC.copy()
+    data = DATAFRAME_WITH_STATIC.copy()
     model = AutoGluonTabularModel(path=temp_model_path)
     # Initialize model._lag_indices and model._time_features from freq
     model.fit(train_data=data, time_limit=2)
@@ -55,7 +55,7 @@ def test_when_static_features_present_then_shape_is_correct(temp_model_path):
 
 
 def test_when_static_features_present_then_prediction_works(temp_model_path):
-    data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC.copy()
+    data = DATAFRAME_WITH_STATIC.copy()
     model = AutoGluonTabularModel(path=temp_model_path)
     model.fit(train_data=data, time_limit=2)
     model.predict(data)

--- a/timeseries/tests/unittests/models/test_autogluon_tabular.py
+++ b/timeseries/tests/unittests/models/test_autogluon_tabular.py
@@ -4,7 +4,7 @@ import pytest
 
 from autogluon.timeseries.models.autogluon_tabular import AutoGluonTabularModel
 
-from ..common import DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, DATAFRAME_WITH_STATIC
+from ..common import DATAFRAME_WITH_STATIC, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME
 
 TESTABLE_MODELS = [
     AutoGluonTabularModel,

--- a/timeseries/tests/unittests/models/test_autogluon_tabular.py
+++ b/timeseries/tests/unittests/models/test_autogluon_tabular.py
@@ -4,7 +4,7 @@ import pytest
 
 from autogluon.timeseries.models.autogluon_tabular import AutoGluonTabularModel
 
-from ..common import DUMMY_VARIABLE_LENGTH_TS_DATAFRAME
+from ..common import DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC
 
 TESTABLE_MODELS = [
     AutoGluonTabularModel,
@@ -12,24 +12,24 @@ TESTABLE_MODELS = [
 
 
 @pytest.mark.parametrize(
-    "df, last_k_values, expected_length",
+    "data, last_k_values, expected_length",
     [
         (DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, None, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.shape[0]),
         (DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, 1, DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.num_items),
         (DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, 3, 3 * DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.num_items),
     ],
 )
-def test_when_feature_df_is_constructed_then_shape_is_correct(df, last_k_values, expected_length):
-    model = AutoGluonTabularModel()
+def test_when_feature_df_is_constructed_then_shape_is_correct(data, last_k_values, expected_length, temp_model_path):
+    model = AutoGluonTabularModel(path=temp_model_path)
     # Initialize model._lag_indices and model._time_features from freq
-    model.fit(train_data=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, time_limit=2)
-    df = model._get_features_dataframe(DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, last_k_values=last_k_values)
+    model.fit(train_data=data, time_limit=2)
+    df = model._get_features_dataframe(data, last_k_values=last_k_values)
     expected_num_features = len(model._lag_indices) + len(model._time_features) + 1
     assert df.shape == (expected_length, expected_num_features)
 
 
-def test_when_predict_is_called_then_get_features_dataframe_receives_correct_input_with_dummy():
-    model = AutoGluonTabularModel(prediction_length=1)
+def test_when_predict_is_called_then_get_features_dataframe_receives_correct_input_with_dummy(temp_model_path):
+    model = AutoGluonTabularModel(path=temp_model_path, prediction_length=1)
     model.fit(train_data=DUMMY_VARIABLE_LENGTH_TS_DATAFRAME, time_limit=2)
     with mock.patch.object(model, "_get_features_dataframe") as patch_method:
         try:
@@ -41,3 +41,21 @@ def test_when_predict_is_called_then_get_features_dataframe_receives_correct_inp
                     original_timestamps = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME.loc[item_id].index
                     new_timestamps = df_with_dummy.loc[item_id].index
                     assert len(new_timestamps.difference(original_timestamps)) == 1
+
+
+def test_when_static_features_present_then_shape_is_correct(temp_model_path):
+    data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC.copy()
+    model = AutoGluonTabularModel(path=temp_model_path)
+    # Initialize model._lag_indices and model._time_features from freq
+    model.fit(train_data=data, time_limit=2)
+    df = model._get_features_dataframe(data)
+    expected_num_features = len(model._lag_indices) + len(model._time_features) + 1 + len(data.static_features.columns)
+    assert len(df.columns) == expected_num_features
+    assert all(col in df.columns for col in data.static_features.columns)
+
+
+def test_when_static_features_present_then_prediction_works(temp_model_path):
+    data = DUMMY_VARIABLE_LENGTH_TS_DATAFRAME_WITH_STATIC.copy()
+    model = AutoGluonTabularModel(path=temp_model_path)
+    model.fit(train_data=data, time_limit=2)
+    model.predict(data)


### PR DESCRIPTION
*Description of changes:*
- Static features are added to the features dataframe, if available in TimeSeriesDataFrame
- Clean up typos in the tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
