### PR TITLE
[timeseries] Increase the number of samples used by DeepAR at prediction time

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -124,6 +124,8 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
     # datatype of floating point and integers passed internally to GluonTS
     float_dtype: Type = np.float64
     int_dtype: Type = np.int64
+    # default number of samples for prediction
+    default_num_samples: int = 1000
 
     def __init__(
         self,
@@ -365,7 +367,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         gts_data = self._to_gluonts_dataset(data, known_covariates=known_covariates)
 
         predictor_kwargs = dict(dataset=gts_data)
-        predictor_kwargs["num_samples"] = kwargs.get("num_samples", 1000)
+        predictor_kwargs["num_samples"] = kwargs.get("num_samples", self.default_num_samples)
 
         return list(self.gts_predictor.predict(**predictor_kwargs))
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -365,8 +365,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         gts_data = self._to_gluonts_dataset(data, known_covariates=known_covariates)
 
         predictor_kwargs = dict(dataset=gts_data)
-        if "num_samples" in kwargs:
-            predictor_kwargs["num_samples"] = kwargs["num_samples"]
+        predictor_kwargs["num_samples"] = kwargs.get("num_samples", 1000)
 
         return list(self.gts_predictor.predict(**predictor_kwargs))
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -92,6 +92,7 @@ class DeepARMXNetModel(AbstractGluonTSMXNetModel):
     """
 
     gluonts_estimator_class: Type[GluonTSEstimator] = DeepAREstimator
+    default_num_samples: int = 250
 
     def _get_estimator_init_args(self) -> dict:
         init_kwargs = super()._get_estimator_init_args()

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -162,6 +162,7 @@ class DeepARModel(AbstractGluonTSPyTorchModel):
     """
 
     gluonts_estimator_class: Type[GluonTSPyTorchLightningEstimator] = DeepAREstimator
+    default_num_samples: int = 250
 
     def _get_estimator_init_args(self) -> Dict[str, Any]:
         init_kwargs = super()._get_estimator_init_args()


### PR DESCRIPTION
*Issue #, if available:*

set DeepAR to 250 samples (2.2x slowdown in benchmarks)

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
