### PR TITLE
[timeseries] Fix random seed in TimeSeriesPredictor

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -22,8 +22,7 @@ logger = logging.getLogger(__name__)
 
 class TimeSeriesLearner(AbstractLearner):
     """TimeSeriesLearner encompasses a full time series learning problem for a
-    training run, and keeps track of datasets, features, random seeds, and the
-    trainer object.
+    training run, and keeps track of datasets, features, and the trainer object.
     """
 
     def __init__(
@@ -31,14 +30,13 @@ class TimeSeriesLearner(AbstractLearner):
         path_context: str,
         target: str = "target",
         known_covariates_names: Optional[List[str]] = None,
-        random_state: int = 0,
         trainer_type: Type[AbstractTimeSeriesTrainer] = AutoTimeSeriesTrainer,
         eval_metric: Optional[str] = None,
         prediction_length: int = 1,
         validation_splitter: AbstractTimeSeriesSplitter = LastWindowSplitter(),
         **kwargs,
     ):
-        super().__init__(path_context=path_context, random_state=random_state)
+        super().__init__(path_context=path_context)
         self.eval_metric: str = TimeSeriesEvaluator.check_get_evaluation_metric(eval_metric)
         self.trainer_type = trainer_type
         self.target = target
@@ -49,7 +47,6 @@ class TimeSeriesLearner(AbstractLearner):
             kwargs.get("quantiles", [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]),
         )
         self.validation_splitter = validation_splitter
-        logger.info(f"Learner random seed set to {random_state}")
         self.static_feature_pipeline = ContinuousAndCategoricalFeatureGenerator()
         self._train_static_feature_columns: pd.Index = None
         self._train_static_feature_dtypes: pd.Series = None

--- a/timeseries/src/autogluon/timeseries/utils/random.py
+++ b/timeseries/src/autogluon/timeseries/utils/random.py
@@ -1,0 +1,13 @@
+import pytorch_lightning as pl
+
+import autogluon.timeseries as agts
+
+
+def set_random_seed(seed: int) -> None:
+    """Set the seed for Numpy, PyTorch and MXNet random number generators."""
+    if seed is not None:
+        pl.seed_everything(seed)
+        if agts.MXNET_INSTALLED:
+            import mxnet as mx
+
+            mx.random.seed(seed)

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -187,29 +187,6 @@ def test_given_hyperparameters_when_learner_called_and_loaded_back_then_all_mode
         assert not np.any(np.isnan(predictions))
 
 
-@pytest.mark.parametrize("random_seed", [None, 1616])
-def test_given_random_seed_when_learner_called_then_random_seed_set_correctly(temp_model_path, random_seed):
-    init_kwargs = dict(path_context=temp_model_path, eval_metric="MAPE")
-    if random_seed is not None:
-        init_kwargs["random_state"] = random_seed
-
-    learner = TimeSeriesLearner(**init_kwargs)
-    learner.fit(
-        train_data=DUMMY_TS_DATAFRAME,
-        hyperparameters="local_only",
-        val_data=DUMMY_TS_DATAFRAME,
-        time_limit=2,
-    )
-    if random_seed is None:
-        random_seed = learner.random_state
-        assert random_seed is not None
-    learner.save()
-    del learner
-
-    loaded_learner = TimeSeriesLearner.load(temp_model_path)
-    assert random_seed == loaded_learner.random_state
-
-
 def test_when_static_features_in_tuning_data_are_missing_then_exception_is_raised(temp_model_path):
     train_data = get_data_frame_with_variable_lengths(
         {"B": 20, "A": 15}, static_features=get_static_features(["B", "A"], feature_names=["f1", "f2"])


### PR DESCRIPTION
*Description of changes:*
- Add optional argument `random_seed` to `TimeSeriesPredictor.fit` and `TimeSeriesPredictor.predict`. This ensures that predictions for sampling-based models are now deterministic.
- Remove the `random_state` argument to `TimeSeriesLearner`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
