### PR TITLE
[timeseries] Make WeightedEnsemble robust to base model failures

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -119,7 +119,7 @@ class TimeSeriesEnsembleWrapper(AbstractTimeSeriesModel):
         if len(failed_models) > 0:
             logger.warning(
                 f"Following models failed during prediction: {failed_models}. "
-                f"{self.name} will ignore these models and re-normalize the weights to sum up to 1 when predicting."
+                f"{self.name} will set the weight of these models to zero and re-normalize the weights when predicting."
             )
 
         return self.weighted_ensemble.predict([data[k] for k in self.model_names])

--- a/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
+++ b/timeseries/src/autogluon/timeseries/models/ensemble/greedy_ensemble.py
@@ -115,5 +115,11 @@ class TimeSeriesEnsembleWrapper(AbstractTimeSeriesModel):
                 "Set of models given for prediction in the weighted ensemble differ from those "
                 "provided during initialization."
             )
+        failed_models = [model_name for (model_name, model_preds) in data.items() if model_preds is None]
+        if len(failed_models) > 0:
+            logger.warning(
+                f"Following models failed during prediction: {failed_models}. "
+                f"{self.name} will ignore these models and re-normalize the weights to sum up to 1 when predicting."
+            )
 
         return self.weighted_ensemble.predict([data[k] for k in self.model_names])

--- a/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/abstract_trainer.py
@@ -850,11 +850,7 @@ class AbstractTimeSeriesTrainer(SimpleAbstractTrainer):
                     model_preds[base_model] = base_model_loaded.predict_for_scoring(
                         data, quantile_levels=self.quantile_levels
                     )
-                except Exception as err:
-                    logger.error(
-                        f"Warning: Model {base_model} failed during prediction and will be ignored by "
-                        f"WeightedEnsemble. Error message: {err}"
-                    )
+                except Exception:
                     model_preds[base_model] = None
             forecasts = model.predict(model_preds)
 

--- a/timeseries/tests/unittests/test_trainer.py
+++ b/timeseries/tests/unittests/test_trainer.py
@@ -435,9 +435,7 @@ def test_given_base_model_fails_when_trainer_predicts_then_weighted_ensemble_can
 
 
 @pytest.mark.parametrize("failing_model", ["NaiveModel", "SeasonalNaiveModel"])
-def test_given_base_model_fails_when_trainer_predicts_then_weighted_ensemble_can_score(
-    temp_model_path, failing_model
-):
+def test_given_base_model_fails_when_trainer_scores_then_weighted_ensemble_can_score(temp_model_path, failing_model):
     trainer = AutoTimeSeriesTrainer(path=temp_model_path, enable_ensemble=False)
     trainer.fit(train_data=DUMMY_TS_DATAFRAME, hyperparameters={"Naive": {}, "SeasonalNaive": {}})
     ensemble = TimeSeriesEnsembleWrapper(weights={"Naive": 0.5, "SeasonalNaive": 0.5}, name="WeightedEnsemble")


### PR DESCRIPTION
*Description of changes:*
- Currently, if one of the base models for the ensemble fails, the ensemble can `predict` but cannot `score`. This PR fixes this problem and adds tests covering such cases.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
