### PR TITLE
Remove pytrec_eval and rewrite retrieval metrics

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -54,7 +54,6 @@ install_requires = [
     "openmim>0.1.5,<=0.2.1",
     "pycocotools>=2.0.4,<=2.0.4",
     "defusedxml>=0.7.1,<=0.7.1",
-    "pytrec-eval>=0.5,<=0.5",
     "albumentations>=1.1.0,<=1.2.0",
 ]
 

--- a/multimodal/src/autogluon/multimodal/utils/metric.py
+++ b/multimodal/src/autogluon/multimodal/utils/metric.py
@@ -1,9 +1,11 @@
 import logging
+import math
+import operator
 import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 import evaluate
-import pytrec_eval
+import numpy as np
 from sklearn.metrics import f1_score
 
 from autogluon.core.metrics import get_metric
@@ -167,6 +169,171 @@ def compute_score(
         return metric._sign * metric(metric_data[Y_TRUE], metric_data[Y_PRED])
 
 
+class RankingMetrics:
+    def __init__(
+        self,
+        pred: Dict[str, Dict],
+        target: Dict[str, Dict],
+        is_higher_better=True,
+    ):
+        """
+        Evaluation Metrics for information retrieval tasks such as document retrieval, image retrieval, etc.
+        Reference: https://www.cs.cornell.edu/courses/cs4300/2013fa/lectures/metrics-2-4pp.pdf
+
+        Parameters
+        ----------
+        pred:
+            the prediction of the ranking model. It has the following form.
+            pred = {
+                'q1': {
+                    'd1': 1,
+                    'd3': 0,
+                },
+                'q2': {
+                    'd2': 1,
+                    'd3': 1,
+                },
+            }
+            where q refers to queries, and d refers to documents, each query has a few relevant documents.
+            0s and 1s are model predicted scores (does not need to be binary).
+        target:
+            the ground truth query and response relevance which has the same form as pred.
+        is_higher_better:
+            if higher relevance score means higher ranking.
+            if the relevance score is cosine similarity / dot product, it should be set to True;
+            if it is Eulidean distance, it should be False.
+        """
+        self.pred = pred
+        self.target = target
+        self.is_higher_better = is_higher_better
+        # the supported metrics in this script
+        self.supported_metrics = {
+            "precision": 0,
+            "recall": 1,
+            "mrr": 2,
+            "map": 3,
+            "ndcg": 4,
+        }
+
+        assert len(pred) == len(
+            target
+        ), f"The prediction and groudtruth target should have the same number of queries, \
+        while there are {len(pred)} queries in prediction and {len(target)} in the target."
+
+        self.results = {}
+        for key in target.keys():
+            self.results.update({key: [target[key], pred[key]]})
+
+    def compute(self, metrics: Union[str, list] = None, k: Optional[int] = 10):
+        """
+        compute and return ranking scores.
+
+        Parameters
+        ----------
+        metrics:
+            user provided metrics
+        k:
+            the cutoff value for NDCG, MAP, Recall, MRR, and Precision
+
+        Returns
+        -------
+        Computed score.
+
+        """
+        if isinstance(metrics, str):
+            metrics = [metrics]
+        if not metrics:  # no metric is provided
+            metrics = self.supported_metrics.keys()
+
+        return_res = {}
+
+        eval_res = np.mean(
+            [list(self._compute_one(idx, k)) for idx in self.results.keys()],
+            axis=0,
+        )
+
+        for metric in metrics:
+            metric = metric.lower()
+            if metric in self.supported_metrics:
+                return_res.update({f"{metric}@{k}": eval_res[self.supported_metrics[metric]]})
+
+        return return_res
+
+    def _compute_one(self, idx, k):
+        """
+        compute and return the ranking scores for one query.
+        for definition of these metrics, please refer to
+        https://www.cs.cornell.edu/courses/cs4300/2013fa/lectures/metrics-2-4pp.pdf
+
+        Parameters
+        ----------
+        idx:
+            the index of the query
+        k:
+            the cutoff value for NDCG, MAP, Recall, MRR, and Precision
+
+        Returns
+        -------
+        Computed score.
+        """
+        precision, recall, mrr, mAP, ndcg = 0, 0, 0, 0, 0
+        target, pred = self.results[idx][0], self.results[idx][1]
+
+        # sort the ground truth and predictions in descending order
+        sorted_target = dict(
+            sorted(
+                target.items(),
+                key=operator.itemgetter(1),
+                reverse=self.is_higher_better,
+            )
+        )
+        sorted_pred = dict(
+            sorted(
+                pred.items(),
+                key=operator.itemgetter(1),
+                reverse=self.is_higher_better,
+            )
+        )
+        sorted_target_values = list(sorted_target.values())
+        sorted_pred_values = list(sorted_pred.values())
+
+        # number of positive relevance in target
+        # negative numbers and zero are considered as negative response
+        num_pos_target = len([val for val in sorted_target_values if val > 0])
+
+        at_k = k if num_pos_target > k else num_pos_target
+
+        first_k_items_list = list(sorted_pred.items())[0:k]
+
+        rank = 0
+        hit_rank = []  # correctly retrieved items
+        for key, value in first_k_items_list:
+            if key in sorted_target and sorted_target[key] > 0:
+                hit_rank.append(rank)
+            rank += 1
+        count = len(hit_rank)
+        # compute the precision and recall
+        precision = count / k
+        recall = count / num_pos_target
+
+        dcg = 0
+        if hit_rank:  # not empty
+            # compute the mean reciprocal rank
+            mrr = 1 / (hit_rank[0] + 1)
+            # compute the mean average precision
+            mAP = np.sum([sorted_pred_values[rank] * (i + 1) / (rank + 1) for i, rank in enumerate(hit_rank)])
+            # compute the discounted cumulative gain
+            dcg = np.sum([1 / math.log(rank + 2, 2) for rank in hit_rank])
+
+        # compute the ideal discounted cumulative gain
+        idcg = np.sum([1 / math.log(i + 2, 2) for i in range(at_k)])
+        # compute the normalized discounted cumulative gain
+        ndcg = dcg / idcg
+        mAP /= at_k
+
+        return precision, recall, mrr, mAP, ndcg
+
+
 def compute_ranking_score(
     results: Dict[str, Dict], qrel_dict: Dict[str, Dict], cutoff: Optional[List[int]] = [5, 10, 20]
 ):
@@ -185,33 +352,26 @@ def compute_ranking_score(
     """
     ndcg = {}
     _map = {}
+    mrr = {}
     recall = {}
     precision = {}
     for k in cutoff:
-        ndcg[f"NDCG@{k}"] = 0.0
-        _map[f"MAP@{k}"] = 0.0
-        recall[f"Recall@{k}"] = 0.0
-        precision[f"P@{k}"] = 0.0
+        ndcg[f"ndcg@{k}"] = 0.0
+        _map[f"map@{k}"] = 0.0
+        mrr[f"mrr@{k}"] = 0.0
+        recall[f"recall@{k}"] = 0.0
+        precision[f"precision@{k}"] = 0.0
 
-    map_string = "map_cut." + ",".join([str(k) for k in cutoff])
-    ndcg_string = "ndcg_cut." + ",".join([str(k) for k in cutoff])
-    recall_string = "recall." + ",".join([str(k) for k in cutoff])
-    precision_string = "P." + ",".join([str(k) for k in cutoff])
-
-    evaluator = pytrec_eval.RelevanceEvaluator(qrel_dict, {map_string, ndcg_string, recall_string, precision_string})
-    scores = evaluator.evaluate(results)
-
-    for query_id in scores.keys():
-        for k in cutoff:
-            ndcg[f"NDCG@{k}"] += scores[query_id]["ndcg_cut_" + str(k)]
-            _map[f"MAP@{k}"] += scores[query_id]["map_cut_" + str(k)]
-            recall[f"Recall@{k}"] += scores[query_id]["recall_" + str(k)]
-            precision[f"P@{k}"] += scores[query_id]["P_" + str(k)]
+    scores = {}
+    evaluator = RankingMetrics(pred=results, target=qrel_dict)
+    for k in cutoff:
+        scores.update(evaluator.compute(k=k))
 
     for k in cutoff:
-        ndcg[f"NDCG@{k}"] = round(ndcg[f"NDCG@{k}"] / len(scores), 5)
-        _map[f"MAP@{k}"] = round(_map[f"MAP@{k}"] / len(scores), 5)
-        recall[f"Recall@{k}"] = round(recall[f"Recall@{k}"] / len(scores), 5)
-        precision[f"P@{k}"] = round(precision[f"P@{k}"] / len(scores), 5)
+        ndcg[f"ndcg@{k}"] = round(scores[f"ndcg@{k}"], 5)
+        _map[f"map@{k}"] = round(scores[f"map@{k}"], 5)
+        recall[f"recall@{k}"] = round(scores[f"recall@{k}"], 5)
+        mrr[f"mrr@{k}"] = round(scores[f"mrr@{k}"], 5)
+        precision[f"precision@{k}"] = round(scores[f"precision@{k}"], 5)
 
     return ndcg, _map, recall, precision

--- a/multimodal/src/autogluon/multimodal/utils/metric.py
+++ b/multimodal/src/autogluon/multimodal/utils/metric.py
@@ -371,7 +371,7 @@ def compute_ranking_score(
     evaluator = RankingMetrics(pred=results, target=qrel_dict)
     for k in cutoff:
         scores.update(evaluator.compute(k=k))
- 
+
     metric_results = dict()
     for k in cutoff:
         for per_metric in metrics:


### PR DESCRIPTION
*Description of changes:*

We removed the dependency on pytrec_eval and rewrite the information retrieval metrics including: precision, recall, ndcg, map, and mrr, with given cutoff values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
