### PR TITLE
Disable parallel bagging with AutoMM

### DIFF
--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -72,6 +72,14 @@ class MultiModalPredictorModel(AbstractModel):
         default_ag_args.update(extra_ag_args)
         return default_ag_args
 
+    # FIXME: Enable parallel bagging once AutoMM supports being run within Ray without hanging
+    @classmethod
+    def _get_default_ag_args_ensemble(cls, **kwargs) -> dict:
+        default_ag_args_ensemble = super()._get_default_ag_args_ensemble(**kwargs)
+        extra_ag_args_ensemble = {'fold_fitting_strategy': 'sequential_local'}
+        default_ag_args_ensemble.update(extra_ag_args_ensemble)
+        return default_ag_args_ensemble
+
     def _set_default_params(self):
         super()._set_default_params()
         try_import_autogluon_text()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Disable parallel bagging with AutoMM
- It appears that parallel bagging with AutoMM hangs the process. Reverting to using sequential bagging which does work correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
