### PR TITLE
Fix AutoMM Tabular altering outer context

### DIFF
--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -1,9 +1,11 @@
 """Wrapper of the MultiModalPredictor."""
-from typing import Dict, Optional
+
+import copy
 import logging
 import os
-import pandas as pd
+from typing import Dict, Optional
 
+import pandas as pd
 
 from autogluon.common.features.types import R_OBJECT, R_INT, R_FLOAT, R_CATEGORY, \
     S_TEXT_NGRAM, S_TEXT_AS_CATEGORY, S_TEXT_SPECIAL, S_IMAGE_PATH
@@ -127,8 +129,11 @@ class MultiModalPredictorModel(AbstractModel):
             logger.log(15, "sample_weight not yet supported for MultiModalPredictorModel, "
                            "this model will ignore them in training.")
 
+        # Need to deep copy to avoid altering outer context
+        X_train = copy.deepcopy(X_train)
         X_train.insert(len(X_train.columns), self._label_column_name, y)
         if X_val is not None:
+            X_val = copy.deepcopy(X_val)
             X_val.insert(len(X_val.columns), self._label_column_name, y_val)
 
         verbosity_text = max(0, verbosity - 1)

--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -1,6 +1,5 @@
 """Wrapper of the MultiModalPredictor."""
 
-import copy
 import logging
 import os
 from typing import Dict, Optional
@@ -130,10 +129,10 @@ class MultiModalPredictorModel(AbstractModel):
                            "this model will ignore them in training.")
 
         # Need to deep copy to avoid altering outer context
-        X_train = copy.deepcopy(X_train)
+        X_train = X_train.copy()
         X_train.insert(len(X_train.columns), self._label_column_name, y)
         if X_val is not None:
-            X_val = copy.deepcopy(X_val)
+            X_val = X_val.copy()
             X_val.insert(len(X_val.columns), self._label_column_name, y_val)
 
         verbosity_text = max(0, verbosity - 1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed a major bug causing the outer context to be altered when Tabular AutoMM model concatenates the label to the features. This caused future models to either crash or have the label in their training and validation data features.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
