### PR TITLE
[timeseries] Save lightning_logs to model directory when training PyTorch models & clean up after training

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -227,7 +227,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         `self._get_model_params` for better readability."""
         return self._get_model_params()
 
-    def _get_estimator(self, **kwargs) -> GluonTSEstimator:
+    def _get_estimator(self) -> GluonTSEstimator:
         """Return the GluonTS Estimator object for the model"""
         with warning_filter():
             return self.gluonts_estimator_class.from_hyperparameters(**self._get_estimator_init_args())
@@ -311,13 +311,12 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             dataset=train_data, callbacks=self._get_callbacks(time_limit=time_limit), **kwargs
         )
 
-        with TemporaryDirectory() as temp_dir:
-            estimator = self._get_estimator(root_dir=temp_dir)
-            with warning_filter(), disable_root_logger(), gluonts.core.settings.let(gluonts.env.env, use_tqdm=False):
-                self.gts_predictor = estimator.train(
-                    self._to_gluonts_dataset(train_data),
-                    validation_data=self._to_gluonts_dataset(val_data),
-                )
+        estimator = self._get_estimator()
+        with warning_filter(), disable_root_logger(), gluonts.core.settings.let(gluonts.env.env, use_tqdm=False):
+            self.gts_predictor = estimator.train(
+                self._to_gluonts_dataset(train_data),
+                validation_data=self._to_gluonts_dataset(val_data),
+            )
 
     def _get_callbacks(self, time_limit: int, *args, **kwargs) -> List[Callable]:
         """Retrieve a list of callback objects for the GluonTS trainer"""

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -1,7 +1,6 @@
 import logging
 import re
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Any, Callable, Dict, Iterator, List, Optional, Type
 
 import gluonts

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -5,7 +5,7 @@ import logging
 import warnings
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 import gluonts
 import numpy as np
@@ -58,7 +58,7 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
 
         return init_kwargs
 
-    def _get_estimator(self) -> GluonTSPyTorchLightningEstimator:
+    def _get_estimator(self, root_dir: Optional[Union[Path, str]], **kwargs) -> GluonTSPyTorchLightningEstimator:
         """Return the GluonTS Estimator object for the model"""
 
         # As GluonTSPyTorchLightningEstimator objects do not implement `from_hyperparameters` convenience
@@ -72,9 +72,12 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
         epochs = init_args.get("max_epochs", init_args.get("epochs"))
         callbacks = init_args.get("callbacks", [])
 
+        # TODO: Provide trainer_kwargs outside the function (e.g., to specify # of GPUs)?
         if epochs is not None:
             trainer_kwargs.update({"max_epochs": epochs})
         trainer_kwargs.update({"callbacks": callbacks, "enable_progress_bar": False})
+        if root_dir is not None:
+            trainer_kwargs["default_root_dir"] = root_dir
 
         return from_hyperparameters(
             self.gluonts_estimator_class,

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -6,7 +6,7 @@ import shutil
 import warnings
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import gluonts
 import numpy as np

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -2,6 +2,7 @@
 Module including wrappers for PyTorch implementations of models in GluonTS
 """
 import logging
+import shutil
 import warnings
 from datetime import timedelta
 from pathlib import Path
@@ -58,7 +59,7 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
 
         return init_kwargs
 
-    def _get_estimator(self, root_dir: Optional[Union[Path, str]], **kwargs) -> GluonTSPyTorchLightningEstimator:
+    def _get_estimator(self) -> GluonTSPyTorchLightningEstimator:
         """Return the GluonTS Estimator object for the model"""
 
         # As GluonTSPyTorchLightningEstimator objects do not implement `from_hyperparameters` convenience
@@ -76,8 +77,7 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
         if epochs is not None:
             trainer_kwargs.update({"max_epochs": epochs})
         trainer_kwargs.update({"callbacks": callbacks, "enable_progress_bar": False})
-        if root_dir is not None:
-            trainer_kwargs["default_root_dir"] = root_dir
+        trainer_kwargs["default_root_dir"] = self.path
 
         return from_hyperparameters(
             self.gluonts_estimator_class,
@@ -99,6 +99,10 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
         for pl_logger in pl_loggers:
             pl_logger.setLevel(logging.ERROR if verbosity <= 3 else logging.INFO)
         super()._fit(train_data=train_data, val_data=val_data, time_limit=time_limit, **kwargs)
+        lightning_logs_dir = Path(self.path) / "lightning_logs"
+        if lightning_logs_dir.exists() and lightning_logs_dir.is_dir():
+            logger.debug(f"Removing lightning_logs directory {lightning_logs_dir}")
+            shutil.rmtree(lightning_logs_dir)
 
     def save(self, path: str = None, **kwargs) -> str:
         # we flush callbacks instance variable if it has been set. it can keep weak references


### PR DESCRIPTION
*Description of changes:*
- We save the lightning logs `self.path / "lightning_logs"`. This folder gets deleted up after training. Now training PyTorch models doesn't produce a `lightning_logs` folder in the directory from where the script was run. 
- Perform all hyperparameter updates for all models in `_get_estimator_init_args` (some models did this inside `_get_estimator`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
