### PR TITLE
[timeseries] Enable prediction with known_covariates when ignore_time_index=True

### DIFF
--- a/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
+++ b/timeseries/src/autogluon/timeseries/dataset/ts_dataframe.py
@@ -435,62 +435,68 @@ class TimeSeriesDataFrame(pd.DataFrame):
         ts_df : TimeSeriesDataFrame
             A new time series dataframe containing entries of the original time series between start and end indices.
 
-        Example
-        -------
-        .. code-block:: python
+        Examples
+        --------
+        >>> print(ts_dataframe)
+                            target
+        item_id timestamp
+        0       2019-01-01       0
+                2019-01-02       1
+                2019-01-03       2
+        1       2019-01-02       3
+                2019-01-03       4
+                2019-01-04       5
+        2       2019-01-03       6
+                2019-01-04       7
+                2019-01-05       8
 
-            >>> print(ts_dataframe)
-                                target
-            item_id timestamp
-            0       2019-01-01       0
-                    2019-01-02       1
-                    2019-01-03       2
-            1       2019-01-02       3
-                    2019-01-03       4
-                    2019-01-04       5
-            2       2019-01-03       6
-                    2019-01-04       7
-                    2019-01-05       8
+        Select the first entry of each time series
 
-            >>> df.slice_by_timestep(0, 1)  # select the first entry of each time series
-                                target
-            item_id timestamp
-            0       2019-01-01       0
-            1       2019-01-02       3
-            2       2019-01-03       6
+        >>> df.slice_by_timestep(0, 1)
+                            target
+        item_id timestamp
+        0       2019-01-01       0
+        1       2019-01-02       3
+        2       2019-01-03       6
 
-            >>> df.slice_by_timestep(-2, None)  # select the last 2 entries of each time series
-                                target
-            item_id timestamp
-            0       2019-01-02       1
-                    2019-01-03       2
-            1       2019-01-03       4
-                    2019-01-04       5
-            2       2019-01-04       7
-                    2019-01-05       8
+        Select the last 2 entries of each time series
 
-            >>> df.slice_by_timestep(None, -1)  # select all except the last entry of each time series
-                                target
-            item_id timestamp
-            0       2019-01-01       0
-                    2019-01-02       1
-            1       2019-01-02       3
-                    2019-01-03       4
-            2       2019-01-03       6
-                    2019-01-04       7
+        >>> df.slice_by_timestep(-2, None)
+                            target
+        item_id timestamp
+        0       2019-01-02       1
+                2019-01-03       2
+        1       2019-01-03       4
+                2019-01-04       5
+        2       2019-01-04       7
+                2019-01-05       8
 
-            >>> df.slice_by_timestep(None, None)  # copy the entire dataframe
-                                target
-            item_id timestamp
-            0       2019-01-01       0
-                    2019-01-02       1
-                    2019-01-03       2
-            1       2019-01-02       3
-                    2019-01-03       4
-                    2019-01-04       5
-            2       2019-01-03       6
-                    2019-01-04       7
-                    2019-01-05       8
+        Select all except the last entry of each time series
+
+        >>> df.slice_by_timestep(None, -1)
+                            target
+        item_id timestamp
+        0       2019-01-01       0
+                2019-01-02       1
+        1       2019-01-02       3
+                2019-01-03       4
+        2       2019-01-03       6
+                2019-01-04       7
+
+        Copy the entire dataframe
+
+        >>> df.slice_by_timestep(None, None)
+                            target
+        item_id timestamp
+        0       2019-01-01       0
+                2019-01-02       1
+                2019-01-03       2
+        1       2019-01-02       3
+                2019-01-03       4
+                2019-01-04       5
+        2       2019-01-03       6
+                2019-01-04       7
+                2019-01-05       8
 
         """
 

--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from autogluon.core.learner import AbstractLearner
-from autogluon.timeseries.dataset.ts_dataframe import TimeSeriesDataFrame, ITEMID
+from autogluon.timeseries.dataset.ts_dataframe import ITEMID, TimeSeriesDataFrame
 from autogluon.timeseries.evaluator import TimeSeriesEvaluator
 from autogluon.timeseries.models.abstract import AbstractTimeSeriesModel
 from autogluon.timeseries.splitter import AbstractTimeSeriesSplitter, LastWindowSplitter

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import time
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
@@ -179,13 +180,15 @@ class AutoGluonTabularModel(AbstractTimeSeriesModel):
         time_elapsed = time.time() - start_time
         autogluon_logger = logging.getLogger("autogluon")
         logging_level = autogluon_logger.level
-        self.tabular_predictor.fit(
-            train_data=train_df,
-            tuning_data=val_df,
-            time_limit=time_limit - time_elapsed if time_limit else None,
-            hyperparameters=tabular_hyperparameters,
-            verbosity=verbosity - 2,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.tabular_predictor.fit(
+                train_data=train_df,
+                tuning_data=val_df,
+                time_limit=time_limit - time_elapsed if time_limit else None,
+                hyperparameters=tabular_hyperparameters,
+                verbosity=verbosity - 2,
+            )
         residuals = (self.tabular_predictor.predict(train_df) - train_df[self.target]).values
         self.residuals_std = np.sqrt(np.mean(np.square(residuals)))
         # Logger level is changed inside .fit(), restore to the initial value

--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -270,7 +270,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
                 if len(feat_dynamic_real.columns) != self.num_feat_dynamic_real:
                     raise ValueError(
                         f"Data must contain {self.num_feat_dynamic_real} columns with known covariates, "
-                        f"(only received {len(feat_dynamic_real.columns)} columns with known covariates)."
+                        f"(received {len(feat_dynamic_real.columns)} columns with known covariates)."
                     )
             else:
                 feat_dynamic_real = None

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -186,6 +186,7 @@ class TimeSeriesPredictor:
                 prediction_length=self.prediction_length,
                 quantile_levels=self.quantile_levels,
                 validation_splitter=splitter,
+                ignore_time_index=ignore_time_index,
             )
         )
         self._learner: AbstractLearner = learner_type(**learner_kwargs)

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -610,11 +610,10 @@ class TimeSeriesPredictor:
 
         * ``model``: The name of the model.
         * ``score_test``: The test score of the model on ``data``, if provided. Computed according to ``eval_metric``.
-        * ``score_val``: The validation score of the model using the internal validation data. Computed according
-            to ``eval_metric``.
+        * ``score_val``: The validation score of the model using the internal validation data. Computed according to ``eval_metric``.
 
-            **NOTE:** Metrics scores are always shown in higher is better form.
-            This means that metrics such as MASE or MAPE will have their signs `flipped`, and values will be negative.
+            **NOTE:** Metrics scores are always shown in 'higher is better' format.
+            This means that metrics such as MASE or MAPE will be multiplied by -1, so their values will be negative.
             This is necessary to avoid the user needing to know the metric to understand if higher is better when
             looking at leaderboard.
 

--- a/timeseries/src/autogluon/timeseries/splitter.py
+++ b/timeseries/src/autogluon/timeseries/splitter.py
@@ -94,52 +94,52 @@ class MultiWindowSplitter(AbstractTimeSeriesSplitter):
     num_windows: int, default = 3
         Number of windows to generate from each time series in the dataset.
 
-    Example
-    -------
-    .. code-block:: python
+    Examples
+    --------
+    >>> print(ts_dataframe)
+                        target
+    item_id timestamp
+    0       1970-01-01       1
+            1970-01-02       2
+            1970-01-03       3
+            1970-01-04       4
+            1970-01-05       5
+            1970-01-06       6
+            1970-01-07       7
+            1970-01-08       8
+            1970-01-09       9
+            1970-01-10      10
 
-        >>> print(ts_dataframe)
+    >>> splitter = SlidingWindowSplitter(num_windows=2)
+    >>> train_data, val_data = splitter.split(ts_dataframe, prediction_length=3)
+    >>> print(train_data)
                             target
-        item_id timestamp
-        0       1970-01-01       1
-                1970-01-02       2
-                1970-01-03       3
-                1970-01-04       4
-                1970-01-05       5
-                1970-01-06       6
-                1970-01-07       7
-                1970-01-08       8
-                1970-01-09       9
-                1970-01-10      10
-        >>> splitter = SlidingWindowSplitter(num_windows=2)
-        >>> train_data, val_data = splitter.split(ts_dataframe, prediction_length=3)
-        >>> print(train_data)
+    item_id timestamp
+    0       1970-01-01       1
+            1970-01-02       2
+            1970-01-03       3
+            1970-01-04       4
+
+    >>> print(val_data)
                                 target
-        item_id timestamp
-        0       1970-01-01       1
-                1970-01-02       2
-                1970-01-03       3
-                1970-01-04       4
-        >>> print(val_data)
-                                    target
-        item_id       timestamp
-        0_[None:None] 1970-01-01       1
-                      1970-01-02       2
-                      1970-01-03       3
-                      1970-01-04       4
-                      1970-01-05       5
-                      1970-01-06       6
-                      1970-01-07       7
-                      1970-01-08       8
-                      1970-01-09       9
-                      1970-01-10      10
-        0_[None:-3]   1970-01-01       1
-                      1970-01-02       2
-                      1970-01-03       3
-                      1970-01-04       4
-                      1970-01-05       5
-                      1970-01-06       6
-                      1970-01-07       7
+    item_id         timestamp
+    0_[None:None]   1970-01-01       1
+                    1970-01-02       2
+                    1970-01-03       3
+                    1970-01-04       4
+                    1970-01-05       5
+                    1970-01-06       6
+                    1970-01-07       7
+                    1970-01-08       8
+                    1970-01-09       9
+                    1970-01-10      10
+    0_[None:-3]     1970-01-01       1
+                    1970-01-02       2
+                    1970-01-03       3
+                    1970-01-04       4
+                    1970-01-05       5
+                    1970-01-06       6
+                    1970-01-07       7
     """
 
     def __init__(self, num_windows: int = 3):

--- a/timeseries/src/autogluon/timeseries/utils/forecast.py
+++ b/timeseries/src/autogluon/timeseries/utils/forecast.py
@@ -21,7 +21,7 @@ def get_forecast_horizon_index_ts_dataframe(
     - level 1 ("timestamp") contains the next prediction_length time steps starting from the end of each time series.
     """
 
-    def get_series_with_timestamps_per_item(group: pd.DataFrame) -> pd.Series:
+    def get_series_with_timestamps_per_item(group: pd.DataFrame) -> pd.DataFrame:
         timestamps = group.index.get_level_values(TIMESTAMP)
         return get_forecast_horizon_index_single_time_series(
             past_timestamps=timestamps, freq=ts_dataframe.freq, prediction_length=prediction_length

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -370,6 +370,7 @@ def test_given_ignore_index_is_true_and_covariates_too_short_when_learner_predic
         path_context=temp_model_path,
         known_covariates_names=["Y", "X"],
         prediction_length=prediction_length,
+        ignore_time_index=True,
     )
     train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
@@ -377,7 +378,7 @@ def test_given_ignore_index_is_true_and_covariates_too_short_when_learner_predic
         {k: 4 for k in ITEM_ID_TO_LENGTH.keys()}, known_covariates_names=["X", "Y"]
     )
     with pytest.raises(ValueError, match=f"should include the values for prediction_length={prediction_length}"):
-        learner.predict(train_data, known_covariates=short_known_covariates, ignore_index=True)
+        learner.predict(train_data, known_covariates=short_known_covariates)
 
 
 def test_when_ignore_index_is_true_and_known_covariates_available_then_learner_can_predict(temp_model_path):
@@ -386,9 +387,10 @@ def test_when_ignore_index_is_true_and_known_covariates_available_then_learner_c
         path_context=temp_model_path,
         known_covariates_names=["Y", "X"],
         prediction_length=prediction_length,
+        ignore_time_index=True,
     )
     train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
     learner.fit(train_data=train_data, hyperparameters={"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}})
     known_covariates = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Y"])
-    preds = learner.predict(train_data, known_covariates=known_covariates, ignore_index=True)
+    preds = learner.predict(train_data, known_covariates=known_covariates)
     assert preds.item_ids.equals(train_data.item_ids)

--- a/timeseries/tests/unittests/test_learner.py
+++ b/timeseries/tests/unittests/test_learner.py
@@ -360,3 +360,35 @@ def test_given_extra_items_and_timestamps_are_present_in_dataframe_when_learner_
                 pred_data.loc[item_id].index, freq=pred_data.freq, prediction_length=prediction_length
             )
             assert (passed_known_covariates.loc[item_id].index == expected_forecast_timestamps).all()
+
+
+def test_given_ignore_index_is_true_and_covariates_too_short_when_learner_predicts_then_exception_is_raised(
+    temp_model_path,
+):
+    prediction_length = 5
+    learner = TimeSeriesLearner(
+        path_context=temp_model_path,
+        known_covariates_names=["Y", "X"],
+        prediction_length=prediction_length,
+    )
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    learner.fit(train_data=train_data, hyperparameters=HYPERPARAMETERS_DUMMY)
+    short_known_covariates = get_data_frame_with_variable_lengths(
+        {k: 4 for k in ITEM_ID_TO_LENGTH.keys()}, known_covariates_names=["X", "Y"]
+    )
+    with pytest.raises(ValueError, match=f"should include the values for prediction_length={prediction_length}"):
+        learner.predict(train_data, known_covariates=short_known_covariates, ignore_index=True)
+
+
+def test_when_ignore_index_is_true_and_known_covariates_available_then_learner_can_predict(temp_model_path):
+    prediction_length = 5
+    learner = TimeSeriesLearner(
+        path_context=temp_model_path,
+        known_covariates_names=["Y", "X"],
+        prediction_length=prediction_length,
+    )
+    train_data = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["Y", "X"])
+    learner.fit(train_data=train_data, hyperparameters={"DeepAR": {"epochs": 1, "num_batches_per_epoch": 1}})
+    known_covariates = get_data_frame_with_variable_lengths(ITEM_ID_TO_LENGTH, known_covariates_names=["X", "Y"])
+    preds = learner.predict(train_data, known_covariates=known_covariates, ignore_index=True)
+    assert preds.item_ids.equals(train_data.item_ids)


### PR DESCRIPTION
*Description of changes:*
- Correctly handle the case when `ignore_time_index=True` and `known_covariates` are used by the predictor.
- Several minor updates to the `TimeSeriesPredictor` docstrings.
- Fix warnings emitted by the `TabularPredictor` inside `AutoGluonTabularModel`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
