### PR TITLE
[timeseries] Enable GPU and transform caching for GluonTS models

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -315,6 +315,7 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
             self.gts_predictor = estimator.train(
                 self._to_gluonts_dataset(train_data),
                 validation_data=self._to_gluonts_dataset(val_data),
+                cache_data=True,
             )
 
     def _get_callbacks(self, time_limit: int, *args, **kwargs) -> List[Callable]:

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -79,6 +79,10 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
         trainer_kwargs.update({"callbacks": callbacks, "enable_progress_bar": False})
         trainer_kwargs["default_root_dir"] = self.path
 
+        if torch.cuda.is_available():
+            trainer_kwargs["accelerator"] = "gpu"
+            trainer_kwargs["devices"] = 1
+
         return from_hyperparameters(
             self.gluonts_estimator_class,
             trainer_kwargs=trainer_kwargs,


### PR DESCRIPTION
*Description of changes:*
- Cache the transformation results & use GPU acceleration in PyTorch models if `torch.cuda.is_available()`. This leads to much faster training. For example, training time for DeepAR (PyTorch) on the `m4_yearly` dataset on `p3.8xlarge`:
  - CPU, `cache_data=False`: 748s
  - CPU, `cache_data=True`: 340s
  - GPU, `cache_data=True`: 60s
- This doesn't lead to problems with other models. I re-ran the benchmark with this setting, all models complete training without crashing.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
