### PR TITLE
[timeseries] Fix several minor bugs in TimeSeriesLearner related to static_features handling

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -224,7 +224,7 @@ class TimeSeriesLearner(AbstractLearner):
         ]
         if len(different_dtype_columns) > 0:
             raise ValueError(
-                f"Columns {different_dtype_columns.to_list()} in tuning_data.static_features have dtypes that don't "
+                f"Columns {different_dtype_columns.to_list()} in {other_name}.static_features have dtypes that don't "
                 "match train_data.static_features. " + fix_message
             )
 
@@ -324,6 +324,7 @@ class TimeSeriesLearner(AbstractLearner):
                 "Please make sure that data has static_features with columns and dtypes exactly matching "
                 "train_data.static_features. "
             )
+            data = data.copy(deep=False)
             self._check_static_feature_compatibility(data.static_features, fix_message=fix_message, other_name="data")
             data.static_features = self.static_feature_pipeline.transform(data.static_features)
             data.static_features = convert_numerical_features_to_float(data.static_features)
@@ -340,10 +341,28 @@ class TimeSeriesLearner(AbstractLearner):
     def score(
         self, data: TimeSeriesDataFrame, model: AbstractTimeSeriesModel = None, metric: Optional[str] = None
     ) -> float:
+        if self.static_feature_pipeline.is_fit():
+            fix_message = (
+                "Please make sure that data has static_features with columns and dtypes exactly matching "
+                "train_data.static_features. "
+            )
+            data = data.copy(deep=False)
+            self._check_static_feature_compatibility(data.static_features, fix_message=fix_message, other_name="data")
+            data.static_features = self.static_feature_pipeline.transform(data.static_features)
+            data.static_features = convert_numerical_features_to_float(data.static_features)
         data = self._preprocess_target_and_covariates(data, data_frame_name="data")
         return self.load_trainer().score(data=data, model=model, metric=metric)
 
     def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None) -> pd.DataFrame:
+        if self.static_feature_pipeline.is_fit():
+            fix_message = (
+                "Please make sure that data has static_features with columns and dtypes exactly matching "
+                "train_data.static_features. "
+            )
+            data = data.copy(deep=False)
+            self._check_static_feature_compatibility(data.static_features, fix_message=fix_message, other_name="data")
+            data.static_features = self.static_feature_pipeline.transform(data.static_features)
+            data.static_features = convert_numerical_features_to_float(data.static_features)
         data = self._preprocess_target_and_covariates(data, data_frame_name="data")
         return self.load_trainer().leaderboard(data)
 

--- a/timeseries/src/autogluon/timeseries/utils/forecast.py
+++ b/timeseries/src/autogluon/timeseries/utils/forecast.py
@@ -8,7 +8,7 @@ def get_forecast_horizon_index_single_time_series(
 ) -> pd.DatetimeIndex:
     """Get timestamps for the next prediction_length many time steps of the time series with given frequency."""
     start_ts = past_timestamps.max() + 1 * pd.tseries.frequencies.to_offset(freq)
-    return pd.date_range(start=start_ts, periods=prediction_length, freq=freq)
+    return pd.date_range(start=start_ts, periods=prediction_length, freq=freq, name=TIMESTAMP)
 
 
 def get_forecast_horizon_index_ts_dataframe(
@@ -25,6 +25,6 @@ def get_forecast_horizon_index_ts_dataframe(
         timestamps = group.index.get_level_values(TIMESTAMP)
         return get_forecast_horizon_index_single_time_series(
             past_timestamps=timestamps, freq=ts_dataframe.freq, prediction_length=prediction_length
-        ).to_series()
+        ).to_frame()
 
     return ts_dataframe.groupby(ITEMID, sort=False).apply(get_series_with_timestamps_per_item).index


### PR DESCRIPTION
*Description of changes:*
- Make sure the `static_feature_pipeline` is applied also during `leaderboard` and `score` calls
- Fix a small bug in `get_forecast_horizon_index_ts_dataframe` when `item_id` is a string (not int)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
