### PR TITLE
Speed up roc_auc_scorer by 25%

### DIFF
--- a/core/src/autogluon/core/metrics/classification_metrics.py
+++ b/core/src/autogluon/core/metrics/classification_metrics.py
@@ -413,7 +413,9 @@ def customized_binary_roc_auc_score(y_true: Union[np.array, pd.Series], y_score:
     tps = np.cumsum(y_true)[threshold_idxs]
     fps = 1 + threshold_idxs - tps
 
-    if len(tps) > 2:
+    if tps.size > 100000:
+        # optimize indices only when there is enough size to justify
+        # this has no impact on the final score
         optimal_idxs = np.where(
             np.r_[True, np.logical_or(np.diff(fps, 2), np.diff(tps, 2)), True]
         )[0]

--- a/core/src/autogluon/core/metrics/classification_metrics.py
+++ b/core/src/autogluon/core/metrics/classification_metrics.py
@@ -370,6 +370,14 @@ def quadratic_kappa(y_true, y_pred):
     return cohen_kappa_score(y_true, y_pred, labels=labels, weights='quadratic')
 
 
+# Refer to https://github.com/scikit-learn/scikit-learn/blame/f3f51f9b611bf873bd5836748647221480071a87/sklearn/metrics/_ranking.py#L985-L1000
+#  for the original logic and full explanation of what this does. This number has no impact on the score calculated, and is purely for speed.
+#  This value was chosen as having a lower value simply slows down the majority of function calls more than it speeds them up.
+#  It was observed that function calls were sped up by 25% by increasing this from 2 to 100000.
+#  Values greater than this were not tested but would be marginal difference as large samples get less speed up.
+_OPTIMIZE_INDICES_THRESHOLD = 100000
+
+
 def customized_binary_roc_auc_score(y_true: Union[np.array, pd.Series], y_score: Union[np.array, pd.Series], **kwargs) -> float:
     """
     Functionally identical to sklearn.metrics.roc_auc_score for binary classification.
@@ -413,7 +421,7 @@ def customized_binary_roc_auc_score(y_true: Union[np.array, pd.Series], y_score:
     tps = np.cumsum(y_true)[threshold_idxs]
     fps = 1 + threshold_idxs - tps
 
-    if tps.size > 100000:
+    if tps.size > _OPTIMIZE_INDICES_THRESHOLD:
         # optimize indices only when there is enough size to justify
         # this has no impact on the final score
         optimal_idxs = np.where(


### PR DESCRIPTION
*Issue #, if available:*
#2318

*Description of changes:*
Follow-up to #2318, speed up by an additional 25% by only performing the index optimization logic if the number of rows is >100K.

Benchmark:

```python3
import numpy as np
import sklearn
from autogluon.core.metrics import roc_auc, make_scorer
import time

roc_auc_sklearn = make_scorer('roc_auc',
                      sklearn.metrics.roc_auc_score,
                      greater_is_better=True,
                      needs_threshold=True)

for sample_size in [
    10,
    100,
    1000,
    10000,
    100000,
]:
    y_true = np.random.randint(low=0, high=2, size=sample_size)
    y_score = np.random.random_sample(sample_size)

    print(f'### sample_size={sample_size} ###')
    ts = time.time()
    for i in range(1000):
        expected_score = roc_auc_sklearn(y_true, y_score)
    te = time.time()
    print(f'Sklearn: {round(te-ts, 2)}ms')

    ts = time.time()
    for i in range(1000):
        actual_score = roc_auc(y_true, y_score)
    te = time.time()
    print(f'Fast: {round(te-ts, 2)}ms')
    print(f'')
    assert np.isclose(expected_score, actual_score)

```

Out: (ML = mainline, PR = this PR version)

```
### sample_size=10 ###
Sklearn: 0.8ms
Fast (ML): 0.14ms
Fast (PR): 0.12ms
### sample_size=100 ###
Sklearn: 0.73ms
Fast (ML): 0.15ms
Fast (PR): 0.12ms
### sample_size=1000 ###
Sklearn: 0.91ms
Fast (ML): 0.26ms
Fast (PR): 0.21ms
### sample_size=10000 ###
Sklearn: 2.93ms
Fast (ML): 1.36ms
Fast (PR): 1.16ms
### sample_size=100000 ###
Sklearn: 28.33ms
Fast (ML): 15.74ms
Fast (PR): 14.36ms
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
