### PR TITLE
Fix crash when tuning_data label dtype is invalid

### DIFF
--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -172,6 +172,7 @@ class DefaultLearner(AbstractTabularLearner):
             logger.warning(f"Warning: Ignoring {len(missinglabel_inds)} (out of {len(X)}) training examples for which the label value in column '{self.label}' is missing")
             X = X.drop(missinglabel_inds, axis=0)
 
+        holdout_frac_og = holdout_frac
         if X_val is not None and self.label in X_val.columns:
             holdout_frac = 1
 
@@ -202,10 +203,14 @@ class DefaultLearner(AbstractTabularLearner):
         if X_val is not None and self.label in X_val.columns:
             X_val = self.cleaner.transform(X_val)
             if len(X_val) == 0:
-                logger.warning('All X_val data contained low frequency classes, ignoring X_val and generating from subset of X')
+                logger.warning('############################################################################################################\n'
+                               'WARNING: All X_val data contained low frequency classes, ignoring X_val and generating from subset of X\n'
+                               '\tYour input validation data or training data labels might be corrupted, please manually inspect them for correctness!\n'
+                               '############################################################################################################')
                 X_val = None
                 y_val = None
                 w_val = None
+                holdout_frac = holdout_frac_og
             else:
                 X_val, y_val = self.extract_label(X_val)
                 y_val = self.label_cleaner.transform(y_val)

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -201,12 +201,21 @@ class DefaultLearner(AbstractTabularLearner):
             logger.log(20, f'Train Data Class Count: {self.label_cleaner.num_classes}')
 
         if X_val is not None and self.label in X_val.columns:
+            X_val_og = X_val
             X_val = self.cleaner.transform(X_val)
             if len(X_val) == 0:
                 logger.warning('############################################################################################################\n'
                                'WARNING: All X_val data contained low frequency classes, ignoring X_val and generating from subset of X\n'
-                               '\tYour input validation data or training data labels might be corrupted, please manually inspect them for correctness!\n'
-                               '############################################################################################################')
+                               '\tYour input validation data or training data labels might be corrupted, please manually inspect them for correctness!')
+                if self.problem_type in [BINARY, MULTICLASS]:
+                    train_classes = sorted(list(y_uncleaned.unique()))
+                    val_classes = sorted(list(X_val_og[self.label].unique()))
+                    logger.warning(f'\tTraining Classes: {train_classes}')
+                    logger.warning(f'\tTuning   Classes: {val_classes}')
+                    missing_classes = [c for c in val_classes if c not in train_classes]
+                    logger.warning(f'\tClasses missing from Training Data: {missing_classes}')
+                logger.warning('############################################################################################################')
+
                 X_val = None
                 y_val = None
                 w_val = None

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -201,7 +201,7 @@ class DefaultLearner(AbstractTabularLearner):
             logger.log(20, f'Train Data Class Count: {self.label_cleaner.num_classes}')
 
         if X_val is not None and self.label in X_val.columns:
-            X_val_og = X_val
+            y_val_og = X_val[self.label]
             X_val = self.cleaner.transform(X_val)
             if len(X_val) == 0:
                 logger.warning('############################################################################################################\n'
@@ -209,9 +209,11 @@ class DefaultLearner(AbstractTabularLearner):
                                '\tYour input validation data or training data labels might be corrupted, please manually inspect them for correctness!')
                 if self.problem_type in [BINARY, MULTICLASS]:
                     train_classes = sorted(list(y_uncleaned.unique()))
-                    val_classes = sorted(list(X_val_og[self.label].unique()))
+                    val_classes = sorted(list(y_val_og.unique()))
                     logger.warning(f'\tTraining Classes: {train_classes}')
                     logger.warning(f'\tTuning   Classes: {val_classes}')
+                    logger.warning(f'\tTraining Class Dtype: {y_uncleaned.dtype}')
+                    logger.warning(f'\tTuning   Class Dtype: {y_val_og.dtype}')
                     missing_classes = [c for c in val_classes if c not in train_classes]
                     logger.warning(f'\tClasses missing from Training Data: {missing_classes}')
                 logger.warning('############################################################################################################')

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -3226,6 +3226,17 @@ class TabularPredictor:
             tuning_features = np.array(tuning_features)
             if np.any(train_features != tuning_features):
                 raise ValueError("Column names must match between training and tuning data")
+
+            if self.label in tuning_data:
+                train_label_type = train_data[self.label].dtype
+                tuning_label_type = tuning_data[self.label].dtype
+
+                if train_label_type != tuning_label_type:
+                    logger.warning(f'WARNING: train_data and tuning_data have mismatched label column dtypes! '
+                                   f'train_label_type={train_label_type}, tuning_data_type={tuning_label_type}.\n'
+                                   f'\tYou should ensure the dtypes match to avoid bugs or instability.\n'
+                                   f'\tAutoGluon will attempt to convert the dtypes to align.')
+
         if unlabeled_data is not None:
             if not isinstance(unlabeled_data, pd.DataFrame):
                 raise AssertionError(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed bug caused by tuning_data having a different dtype in the label column than train_data, which caused a crash due to holdout_frac being incorrectly specified. Now we correctly discard the tuning_data and split the train_data.
- Improved warning message when this scenario occurs so it is easier to understand.

Example updated output in this scenario:

```
No path specified. Models will be saved in: "AutogluonModels/ag-20221108_223519/"
WARNING: train_data and tuning_data have mismatched label column dtypes! train_label_type=object, tuning_data_type=int64.
	You should ensure the dtypes match to avoid bugs or instability.
	AutoGluon will attempt to convert the dtypes to align.
Beginning AutoGluon training ...
AutoGluon will save models to "AutogluonModels/ag-20221108_223519/"
AutoGluon Version:  0.5.3b20221101
Python Version:     3.8.10
Operating System:   Darwin
Platform Machine:   x86_64
Platform Version:   Darwin Kernel Version 21.6.0: Thu Sep 29 20:12:57 PDT 2022; root:xnu-8020.240.7~1/RELEASE_X86_64
Train Data Rows:    605
Train Data Columns: 4
Tuning Data Rows:    145
Tuning Data Columns: 4
Label Column: class
Preprocessing data ...
Warning: Some classes in the training set have fewer than 10 examples. AutoGluon will only keep 3 out of 4 classes for training and will not try to predict the rare classes. To keep more classes, increase the number of datapoints from these rare classes in the training data or reduce label_count_threshold.
Fraction of data from classes with at least 10 examples that will be kept for training models: 0.9950413223140496
Train Data Class Count: 3
############################################################################################################
WARNING: All X_val data contained low frequency classes, ignoring X_val and generating from subset of X
	Your input validation data or training data labels might be corrupted, please manually inspect them for correctness!
	Training Classes: ['0', '1', '2', 'N']
	Tuning   Classes: [0, 1, 2]
	Training Class Dtype: object
	Tuning   Class Dtype: int64
	Classes missing from Training Data: [0, 1, 2]
############################################################################################################
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
