### PR TITLE
Update log_loss to convert to float64

### DIFF
--- a/core/src/autogluon/core/metrics/__init__.py
+++ b/core/src/autogluon/core/metrics/__init__.py
@@ -530,7 +530,8 @@ def customized_log_loss(y_true, y_pred, eps=1e-15):
     assert y_true.ndim == 1
     if y_pred.ndim == 1:
         # First clip the y_pred which is also used in sklearn
-        y_pred = np.clip(y_pred, eps, 1 - eps)
+        # Convert to float64 to avoid rounding error on the clip operation with epsilon
+        y_pred = np.clip(y_pred.astype(float), eps, 1 - eps)
         return - (y_true * np.log(y_pred) + (1 - y_true) * np.log(1 - y_pred)).mean()
     else:
         assert y_pred.ndim == 2, 'Only ndim=2 is supported'


### PR DESCRIPTION
*Issue #, if available:*
#2306

*Description of changes:*
- Convert to float64 to avoid rounding error on the clip operation with epsilon
- float32 would not have enough granularity to handle the epsilon which would cause divide by zero warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
