### PR TITLE
[timeseries] Update time series API documentation

### DIFF
--- a/docs/api/autogluon.predictor.rst
+++ b/docs/api/autogluon.predictor.rst
@@ -167,6 +167,7 @@ Predictors built into AutoGluon such that a single call to `fit()` can produce h
 .. autoclass:: TimeSeriesPredictor
    :members:
    :inherited-members:
+   :exclude-members: refit_full, score
 
     .. rubric:: Methods
 

--- a/docs/tutorials/timeseries/forecasting-model-zoo.rst
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.rst
@@ -27,7 +27,7 @@ For example, the following code will train a ``TimeSeriesPredictor`` with ``Deep
    )
 
 Note that we don't include the ``Model`` suffix when specifying the model name in ``hyperparameters``
-(i.e., the class :class:`~autogluon.timeseries.models.DeepARModel` corresponds to the name ``"DeepAR"`` in the ``hyperparameters`` dictionary).
+(e.g., the class :class:`~autogluon.timeseries.models.DeepARModel` corresponds to the name ``"DeepAR"`` in the ``hyperparameters`` dictionary).
 
 
 Also note that some of the models' hyperparameters have names and default values that
@@ -109,17 +109,15 @@ Default models
 
 MXNet Models
 ------------
-Using the models listed below requires installing Apache MXNet v1.9. This can be done as follows:
+Using the models listed below requires installing Apache MXNet v1.9. This can be done as follows::
 
-```shell
-python -m pip install mxnet~=1.9
-```
+   python -m pip install mxnet~=1.9
 
 If you want to use a GPU, install the version of MXNet that matches your CUDA version. See the
 MXNet [documentation](https://mxnet.apache.org/versions/1.9.1/get_started?) for more info.
 
 If a GPU is available and MXNet version with CUDA is installed, all the MXNet models will be trained using the GPU.
-Otherwise, the models will train on CPU.
+Otherwise, the models will be trained on CPU.
 
 
 .. automodule:: autogluon.timeseries.models.gluonts.mx
@@ -167,14 +165,14 @@ Otherwise, the models will train on CPU.
 
 
 :hidden:`DeepARMXNetModel`
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: DeepARMXNetModel
    :members: init
 
 
 :hidden:`SimpleFeedForwardMXNetModel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: SimpleFeedForwardMXNetModel
    :members: init

--- a/docs/tutorials/timeseries/forecasting-model-zoo.rst
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.rst
@@ -12,7 +12,7 @@ Forecasting Time Series - Model Zoo
 
 
 This page contains the list of time series forecasting models available in AutoGluon.
-The available hyperparameters for each model are listed under **Other parameters**.
+The available hyperparameters for each model are listed under **Other Parameters**.
 
 This list is useful if you want to override the default hyperparameters (:ref:`sec_forecasting_indepth_manual_config`)
 or define custom hyperparameter search spaces (:ref:`sec_forecasting_indepth_hpo`), as described in the In-depth Tutorial.
@@ -185,7 +185,7 @@ Models not included in this table currently do not support any additional featur
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :align: left
+   :align: center
    :widths: 40 20 20 20
 
    * - Model

--- a/docs/tutorials/timeseries/forecasting-model-zoo.rst
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.rst
@@ -11,18 +11,30 @@ Forecasting Time Series - Model Zoo
    For a stable public API, refer to TimeSeriesPredictor.
 
 
-
-Models
-------
-
 This page contains the list of time series forecasting models available in AutoGluon.
 The available hyperparameters for each model are listed under **Other parameters**.
 
 This list is useful if you want to override the default hyperparameters (:ref:`sec_forecasting_indepth_manual_config`)
 or define custom hyperparameter search spaces (:ref:`sec_forecasting_indepth_hpo`), as described in the In-depth Tutorial.
+For example, the following code will train a ``TimeSeriesPredictor`` with ``DeepAR`` and ``ETS`` models with default hyperparameters (and a weighted ensemble on top of them)::
 
-Please note that some of the models' hyperparameters have names and default values that
+   predictor = TimeSeriesPredictor().fit(
+      train_data,
+      hyperparameters={
+         "DeepAR": {},
+         "ETS": {},
+      },
+   )
+
+Note that we don't include the ``Model`` suffix when specifying the model name in ``hyperparameters``
+(i.e., the class :class:`~autogluon.timeseries.models.DeepARModel` corresponds to the name ``"DeepAR"`` in the ``hyperparameters`` dictionary).
+
+
+Also note that some of the models' hyperparameters have names and default values that
 are different from the original libraries.
+
+Default models
+--------------
 
 .. automodule:: autogluon.timeseries.models
 .. currentmodule:: autogluon.timeseries.models
@@ -30,16 +42,27 @@ are different from the original libraries.
 .. autosummary::
    :nosignatures:
 
+   NaiveModel
+   SeasonalNaiveModel
    ARIMAModel
    ETSModel
    ThetaModel
+   AutoGluonTabularModel
    DeepARModel
    SimpleFeedForwardModel
-   MQCNNModel
-   MQRNNModel
-   TransformerModel
-   TemporalFusionTransformerModel
-   SktimeTBATSModel
+
+
+:hidden:`NaiveModel`
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: NaiveModel
+   :members: init
+
+:hidden:`SeasonalNaiveModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: SeasonalNaiveModel
+   :members: init
 
 
 :hidden:`ARIMAModel`
@@ -57,9 +80,15 @@ are different from the original libraries.
 
 
 :hidden:`ThetaModel`
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: ThetaModel
+   :members: init
+
+:hidden:`AutoGluonTabularModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: AutoGluonTabularModel
    :members: init
 
 
@@ -77,36 +106,75 @@ are different from the original libraries.
    :members: init
 
 
-:hidden:`MQCNNModel`
-~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: MQCNNModel
+MXNet Models
+------------
+Using the models listed below requires installing Apache MXNet v1.9. This can be done as follows:
+
+```shell
+python -m pip install mxnet~=1.9
+```
+
+If you want to use a GPU, install the version of MXNet that matches your CUDA version. See the
+MXNet [documentation](https://mxnet.apache.org/versions/1.9.1/get_started?) for more info.
+
+If a GPU is available and MXNet version with CUDA is installed, all the MXNet models will be trained using the GPU.
+Otherwise, the models will train on CPU.
+
+
+.. automodule:: autogluon.timeseries.models.gluonts.mx
+.. currentmodule:: autogluon.timeseries.models.gluonts.mx
+
+
+.. autosummary::
+   :nosignatures:
+
+   TemporalFusionTransformerMXNetModel
+   TransformerMXNetModel
+   MQCNNMXNetModel
+   MQRNNMXNetModel
+   DeepARMXNetModel
+   SimpleFeedForwardMXNetModel
+
+
+:hidden:`TemporalFusionTransformerMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: TemporalFusionTransformerMXNetModel
    :members: init
 
 
-:hidden:`MQRNNModel`
-~~~~~~~~~~~~~~~~~~~~
+:hidden:`TransformerMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: MQRNNModel
+.. autoclass:: TransformerMXNetModel
    :members: init
 
 
-:hidden:`TransformerModel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+:hidden:`MQCNNMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: TransformerModel
+.. autoclass:: MQCNNMXNetModel
    :members: init
 
 
-:hidden:`TemporalFusionTransformerModel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:hidden:`MQRNNMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: TemporalFusionTransformerModel
+.. autoclass:: MQRNNMXNetModel
    :members: init
 
 
-:hidden:`SktimeTBATSModel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: SktimeTBATSModel
+:hidden:`DeepARMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: DeepARMXNetModel
+   :members: init
+
+
+:hidden:`SimpleFeedForwardMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: SimpleFeedForwardMXNetModel
    :members: init

--- a/docs/tutorials/timeseries/forecasting-model-zoo.rst
+++ b/docs/tutorials/timeseries/forecasting-model-zoo.rst
@@ -114,7 +114,7 @@ Using the models listed below requires installing Apache MXNet v1.9. This can be
    python -m pip install mxnet~=1.9
 
 If you want to use a GPU, install the version of MXNet that matches your CUDA version. See the
-MXNet [documentation](https://mxnet.apache.org/versions/1.9.1/get_started?) for more info.
+MXNet `documentation <https://mxnet.apache.org/versions/1.9.1/get_started?>`_ for more info.
 
 If a GPU is available and MXNet version with CUDA is installed, all the MXNet models will be trained using the GPU.
 Otherwise, the models will be trained on CPU.
@@ -127,25 +127,17 @@ Otherwise, the models will be trained on CPU.
 .. autosummary::
    :nosignatures:
 
-   TemporalFusionTransformerMXNetModel
-   TransformerMXNetModel
+   DeepARMXNetModel
    MQCNNMXNetModel
    MQRNNMXNetModel
-   DeepARMXNetModel
    SimpleFeedForwardMXNetModel
+   TemporalFusionTransformerMXNetModel
+   TransformerMXNetModel
 
+:hidden:`DeepARMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:hidden:`TemporalFusionTransformerMXNetModel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: TemporalFusionTransformerMXNetModel
-   :members: init
-
-
-:hidden:`TransformerMXNetModel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: TransformerMXNetModel
+.. autoclass:: DeepARMXNetModel
    :members: init
 
 
@@ -163,16 +155,60 @@ Otherwise, the models will be trained on CPU.
    :members: init
 
 
-
-:hidden:`DeepARMXNetModel`
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. autoclass:: DeepARMXNetModel
-   :members: init
-
-
 :hidden:`SimpleFeedForwardMXNetModel`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: SimpleFeedForwardMXNetModel
    :members: init
+
+
+:hidden:`TemporalFusionTransformerMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: TemporalFusionTransformerMXNetModel
+   :members: init
+
+
+:hidden:`TransformerMXNetModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: TransformerMXNetModel
+   :members: init
+
+
+
+Additional features
+-------------------
+Overview of the additional features and covariates supported by different models.
+Models not included in this table currently do not support any additional features.
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :align: left
+   :widths: 40 20 20 20
+
+   * - Model
+     - Static features (continuous)
+     - Static features (categorical)
+     - Known covariates (continuous)
+   * - :class:`~autogluon.timeseries.models.AutoGluonTabularModel`
+     - ✓
+     - ✓
+     -
+   * - :class:`~autogluon.timeseries.models.DeepARModel`
+     - ✓
+     - ✓
+     - ✓
+   * - :class:`~autogluon.timeseries.models.gluonts.mx.DeepARMXNetModel`
+     - ✓
+     - ✓
+     - ✓
+   * - :class:`~autogluon.timeseries.models.gluonts.mx.MQCNNMXNetModel`
+     - ✓
+     - ✓
+     - ✓
+   * - :class:`~autogluon.timeseries.models.gluonts.mx.TemporalFusionTransformerMXNetModel`
+     - ✓
+     -
+     - ✓

--- a/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
+++ b/timeseries/src/autogluon/timeseries/models/autogluon_tabular/tabular_model.py
@@ -20,12 +20,17 @@ logger = logging.getLogger(__name__)
 
 
 class AutoGluonTabularModel(AbstractTimeSeriesModel):
-    """Uses TabularPredictor to forecast future time series values one step at a time.
+    """Predict future time series values using autogluon.tabular.TabularPredictor.
 
     The forecasting is converted to a tabular problem using the following features:
 
     - lag features (observed time series values) based on ``freq`` of the data
     - time features (e.g., day of the week) based on the timestamp of the measurement
+    - static features of each item (if available)
+
+    Quantiles are obtained by assuming that the residuals follow zero-mean normal distribution, scale of which is
+    estimated from the empirical distribution of the residuals.
+
 
     Other Parameters
     ----------------

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -411,6 +411,7 @@ class TransformerMXNetModel(AbstractGluonTSMXNetModel):
         Learning rate used during training
     """
 
+    # TODO: Enable static and dynamic features
     gluonts_estimator_class: Type[GluonTSEstimator] = TransformerEstimator
 
 

--- a/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/mx/models.py
@@ -43,12 +43,16 @@ class DeepARMXNetModel(AbstractGluonTSMXNetModel):
     The model consists of an RNN encoder (LSTM or GRU) and a decoder that outputs the
     distribution of the next target value. Close to the model described in [Salinas2020]_.
 
-    .. [Salinas2020] Salinas, David, et al.
-        "DeepAR: Probabilistic forecasting with autoregressive recurrent networks."
-        International Journal of Forecasting. 2020.
 
     Based on `gluonts.mx.model.deepar.DeepAREstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.deepar.html>`_.
     See GluonTS documentation for additional hyperparameters.
+
+
+    References
+    ----------
+    .. [Salinas2020] Salinas, David, et al.
+        "DeepAR: Probabilistic forecasting with autoregressive recurrent networks."
+        International Journal of Forecasting. 2020.
 
 
     Other Parameters
@@ -125,12 +129,15 @@ class MQCNNMXNetModel(AbstractGluonTSSeq2SeqModel):
     The model consists of a CNN encoder and a decoder that directly predicts the
     quantiles of the future target values' distribution. As described in [Wen2017]_.
 
+    Based on `gluonts.mx.model.seq2seq.MQCNNEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.seq2seq.html#gluonts.mx.model.seq2seq.MQCNNEstimator>`_.
+    See GluonTS documentation for additional hyperparameters.
+
+
+    References
+    ----------
     .. [Wen2017] Wen, Ruofeng, et al.
         "A multi-horizon quantile recurrent forecaster."
         arXiv preprint arXiv:1711.11053 (2017)
-
-    Based on `gluonts.mx.model.seq2seq.MQCNNEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.seq2seq.html#gluonts.mx.model.seq2seq.MQCNNEstimator>`_.
-    See GluonTS documentation for additional hyperparameters.
 
 
     Other Parameters
@@ -203,12 +210,15 @@ class MQRNNMXNetModel(AbstractGluonTSSeq2SeqModel):
     The model consists of an RNN encoder and a decoder that directly predicts the
     quantiles of the future target values' distribution. As described in [Wen2017]_.
 
+    Based on `gluonts.mx.model.seq2seq.MQRNNEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.seq2seq.html#gluonts.mx.model.seq2seq.MQRNNEstimator>`_.
+    See GluonTS documentation for additional hyperparameters.
+
+
+    References
+    ----------
     .. [Wen2017] Wen, Ruofeng, et al.
         "A multi-horizon quantile recurrent forecaster."
         arXiv preprint arXiv:1711.11053 (2017)
-
-    Based on `gluonts.mx.model.seq2seq.MQRNNEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.seq2seq.html#gluonts.mx.model.seq2seq.MQRNNEstimator>`_.
-    See GluonTS documentation for additional hyperparameters.
 
 
     Other Parameters
@@ -305,12 +315,16 @@ class TemporalFusionTransformerMXNetModel(AbstractGluonTSMXNetModel):
     The model combines an LSTM encoder, a transformer decoder, and directly predicts
     the quantiles of future target values. As described in [Lim2021]_.
 
+    Based on `gluonts.mx.model.tft.TemporalFusionTransformerEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.tft.html>`_.
+    See GluonTS documentation for additional hyperparameters.
+
+
+    References
+    ----------
     .. [Lim2021] Lim, Bryan, et al.
         "Temporal Fusion Transformers for Interpretable Multi-horizon Time Series Forecasting."
         International Journal of Forecasting. 2021.
 
-    Based on `gluonts.mx.model.tft.TemporalFusionTransformerEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.tft.html>`_.
-    See GluonTS documentation for additional hyperparameters.
 
     Other Parameters
     ----------------
@@ -371,11 +385,14 @@ class TransformerMXNetModel(AbstractGluonTSMXNetModel):
     distribution of the next target value. The transformer architecture is close to the
     one described in [Vaswani2017]_.
 
-    .. [Vaswani2017] Vaswani, Ashish, et al. "Attention is all you need."
-        Advances in neural information processing systems. 2017.
-
     Based on `gluonts.mx.model.transformer.TransformerEstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.mx.model.transformer.html>`_.
     See GluonTS documentation for additional hyperparameters.
+
+
+    References
+    ----------
+    .. [Vaswani2017] Vaswani, Ashish, et al. "Attention is all you need."
+        Advances in neural information processing systems. 2017.
 
 
     Other Parameters

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -127,7 +127,7 @@ class AbstractGluonTSPyTorchModel(AbstractGluonTSModel):
 class DeepARModel(AbstractGluonTSPyTorchModel):
     """DeepAR model from GluonTS based on the PyTorch backend.
 
-    The model consists of an RNN encoder (LSTM or GRU) and a decoder that outputs the
+    The model consists of an LSTM encoder and a decoder that outputs the
     distribution of the next target value. Close to the model described in [Salinas2020]_.
 
     .. [Salinas2020] Salinas, David, et al.

--- a/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/torch/models.py
@@ -130,11 +130,14 @@ class DeepARModel(AbstractGluonTSPyTorchModel):
     The model consists of an LSTM encoder and a decoder that outputs the
     distribution of the next target value. Close to the model described in [Salinas2020]_.
 
+    Based on `gluonts.torch.model.deepar.DeepAREstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.torch.model.deepar.html>`_.
+
+
+    References
+    ----------
     .. [Salinas2020] Salinas, David, et al.
         "DeepAR: Probabilistic forecasting with autoregressive recurrent networks."
         International Journal of Forecasting. 2020.
-
-    Based on `gluonts.torch.model.deepar.DeepAREstimator <https://ts.gluon.ai/stable/api/gluonts/gluonts.torch.model.deepar.html>`_.
 
 
     Other Parameters

--- a/timeseries/src/autogluon/timeseries/models/local/naive.py
+++ b/timeseries/src/autogluon/timeseries/models/local/naive.py
@@ -46,7 +46,6 @@ class NaiveModel(AbstractLocalModel):
 
     Quantiles are obtained by assuming that the residuals follow zero-mean normal distribution, scale of which is
     estimated from the empirical distribution of the residuals.
-
     As described in https://otexts.com/fpp3/prediction-intervals.html
 
     """
@@ -76,7 +75,6 @@ class SeasonalNaiveModel(AbstractLocalModel):
 
     Quantiles are obtained by assuming that the residuals follow zero-mean normal distribution, scale of which is
     estimated from the empirical distribution of the residuals.
-
     As described in https://otexts.com/fpp3/prediction-intervals.html
 
 

--- a/timeseries/src/autogluon/timeseries/models/local/statsmodels.py
+++ b/timeseries/src/autogluon/timeseries/models/local/statsmodels.py
@@ -266,6 +266,13 @@ class ThetaModel(AbstractLocalModel):
     as multi-CPU training and reducing the disk usage when saving models.
 
 
+    References
+    ----------
+    Assimakopoulos, Vassilis, and Konstantinos Nikolopoulos.
+    "The theta model: a decomposition approach to forecasting."
+    International journal of forecasting 16.4 (2000): 521-530.
+
+
     Other Parameters
     ----------------
     deseasonalize : bool, default = True

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -73,7 +73,7 @@ class TimeSeriesPredictor:
 
         If ``known_covariates_names`` are provided, then:
 
-        - :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit` will expect that ``train_data`` contains the columns listed in ``known_covariates_names``.
+        - :meth:`~autogluon.timeseries.TimeSeriesPredictor.fit`, :meth:`~autogluon.timeseries.TimeSeriesPredictor.evaluate`, and :meth:`~autogluon.timeseries.TimeSeriesPredictor.leaderboard` will expect a data frame with columns listed in ``known_covariates_names`` (in addition to the ``target`` column).
         - :meth:`~autogluon.timeseries.TimeSeriesPredictor.predict` will expect an additional keyword argument ``known_covariates`` containing the future values of the known covariates in ``TimeSeriesDataFrame`` format.
 
     quantile_levels : List[float], optional
@@ -116,9 +116,6 @@ class TimeSeriesPredictor:
     quantiles : List[float]
         Alias for :attr:`quantile_levels`.
     """
-
-    # TODO: Update description of presets after the presets are finalized
-    # TODO: Update docstring for predict
 
     predictor_file_name = "predictor.pkl"
 
@@ -498,14 +495,14 @@ class TimeSeriesPredictor:
                 2020-03-02      44          1    2.9
                 2020-03-03      72          1    2.9
         >>> predictor = TimeSeriesPredictor(prediction_length=2, known_covariates_names=["promotion", "price"]).fit(data)
-        >>> print(known_covariates)
+        >>> print(future_known_covariates)
                             promotion  price
         item_id timestamp
         A       2020-01-08          1   12.9
                 2020-01-09          1   12.9
         B       2020-03-04          0    5.0
                 2020-03-05          0    7.0
-        >>> predictor.predict(data, known_covariates=known_covariates)
+        >>> predictor.predict(data, known_covariates=future_known_covariates)
                             target
         item_id timestamp
         A       2020-01-08      30


### PR DESCRIPTION
*Description of changes:*
- Update docstrings for TimeSeriesPredictor, several model docstrings, and update the Model Zoo to the reflect the current state of the code base.

[Rendered `Model Zoo` documentation webpage](https://github.com/awslabs/autogluon/files/9979136/forecasting_model_zoo.pdf)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

