### PR TITLE
Improve image-to-image matching tutorial

### DIFF
--- a/docs/tutorials/multimodal/matching/image2image_matching.md
+++ b/docs/tutorials/multimodal/matching/image2image_matching.md
@@ -20,7 +20,7 @@ The following code downloads the dataset and unzip the images and annotation fil
 
 
 ```{.python .input}
-download_dir = './ag_automm_tutorial'
+download_dir = './ag_automm_tutorial_img2img'
 zip_file = 'https://automl-mm-bench.s3.amazonaws.com/Stanford_Online_Products.zip'
 from autogluon.core.utils.loaders import load_zip
 load_zip.unzip(zip_file, unzip_dir=download_dir)

--- a/docs/tutorials/multimodal/matching/image2image_matching.md
+++ b/docs/tutorials/multimodal/matching/image2image_matching.md
@@ -34,9 +34,11 @@ test_data = pd.read_csv(f'{dataset_path}/test.csv', index_col=0)
 image_col_1 = "Image1"
 image_col_2 = "Image2"
 label_col = "Label"
+match_label = 1
 ```
+Here you need to specify the `match_label`, the label class representing that a pair semantically match. In this demo dataset, we use 1 since we assigned 1 to image pairs from the same product. You may consider your task context to specify `match_label`.
 
-We need to expand the image paths since the original paths are relative.
+Next, we expand the image paths since the original paths are relative.
 ```{.python .input}
 def path_expander(path, base_folder):
     path_l = path.split(';')
@@ -87,6 +89,7 @@ predictor = MultiModalPredictor(
         query=image_col_1, # the column name of the first image
         response=image_col_2, # the column name of the second image
         label=label_col, # the label column name
+        match_label=match_label, # the label indicating that query and response have the same semantic meanings.
         eval_metric='auc', # the evaluation metric
     )
     

--- a/docs/tutorials/multimodal/matching/image_text_matching.md
+++ b/docs/tutorials/multimodal/matching/image_text_matching.md
@@ -1,4 +1,4 @@
-# Image<-->Text Matching with AutoMM - Quick Start
+# Image<-->Text Matching with AutoMM
 :label:`image_text_matching`
 
 Vision and language are two important aspects of human intelligence to understand the real world. Image-text matching, measuring the visual-semantic

--- a/docs/tutorials/multimodal/matching/image_text_matching.md
+++ b/docs/tutorials/multimodal/matching/image_text_matching.md
@@ -27,7 +27,7 @@ The Flickr30k dataset is a popular benchmark for sentence-based picture portraya
 ```{.python .input}
 from autogluon.core.utils.loaders import load_pd
 import pandas as pd
-download_dir = './ag_automm_tutorial'
+download_dir = './ag_automm_tutorial_imgtxt'
 zip_file = 'https://automl-mm-bench.s3.amazonaws.com/flickr30k.zip'
 from autogluon.core.utils.loaders import load_zip
 load_zip.unzip(zip_file, unzip_dir=download_dir)

--- a/docs/tutorials/multimodal/matching/text2text_matching.md
+++ b/docs/tutorials/multimodal/matching/text2text_matching.md
@@ -33,7 +33,7 @@ With AutoMM, you just need to specify the query, response, and label column name
 from autogluon.multimodal import MultiModalPredictor
 
 # Initialize the model
-matcher = MultiModalPredictor(
+predictor = MultiModalPredictor(
         problem_type="text_similarity",
         query="premise", # the column name of the first sentence
         response="hypothesis", # the column name of the second sentence
@@ -42,7 +42,7 @@ matcher = MultiModalPredictor(
     )
 
 # Fit the model
-matcher.fit(
+predictor.fit(
     train_data=snli_train,
     time_limit=180,
 )
@@ -52,7 +52,7 @@ matcher.fit(
 You can evaluate the macther on the test dataset to see how it performs with the roc_auc score:
 
 ```{.python .input}
-score = matcher.evaluate(snli_test)
+score = predictor.evaluate(snli_test)
 print("evaluation score: ", score)
 ```
 
@@ -62,23 +62,23 @@ We create a new sentence pair with similar meaning (expected to be predicted as 
 pred_data = pd.DataFrame.from_dict({"premise":["The teacher gave his speech to an empty room."], 
                                     "hypothesis":["There was almost nobody when the professor was talking."]})
 
-predictions = matcher.predict(pred_data)
+predictions = predictor.predict(pred_data)
 print('Predicted entities:', predictions[0])
 ```
 
 ## Predict Matching Probabilities
 We can also compute the matching probabilities of sentence pairs.
 ```{.python .input}
-probabilities = matcher.predict_proba(pred_data)
+probabilities = predictor.predict_proba(pred_data)
 print(probabilities)
 ```
 
 ## Extract Embeddings
 Moreover, we support extracting embeddings separately for two sentence groups.
 ```{.python .input}
-embeddings_1 = matcher.extract_embedding({"premise":["The teacher gave his speech to an empty room."]})
+embeddings_1 = predictor.extract_embedding({"premise":["The teacher gave his speech to an empty room."]})
 print(embeddings_1.shape)
-embeddings_2 = matcher.extract_embedding({"hypothesis":["There was almost nobody when the professor was talking."]})
+embeddings_2 = predictor.extract_embedding({"hypothesis":["There was almost nobody when the professor was talking."]})
 print(embeddings_2.shape)
 ```
 

--- a/docs/tutorials/multimodal/matching/text2text_matching.md
+++ b/docs/tutorials/multimodal/matching/text2text_matching.md
@@ -27,7 +27,7 @@ snli_train.head()
 
 Ideally, we want to obtain a model that can return high/low scores for positive/negative text pairs. Traditional text similarity methods only work on a lexical level without taking the semantic aspect into account, for example, using term frequency or tf-idf vectors. With AutoMM, we can easily train a model that captures the semantic relationship between sentences. Bascially, it uses [BERT](https://arxiv.org/abs/1810.04805) to project each sentence into a high-dimensional vector and treat the matching problem as a classification problem following the design in [sentence transformers](https://www.sbert.net/). 
 
-With AutoMM, you just need to specify the query, response, and label column names and fit the model on the training dataset without worrying the implementation details.
+With AutoMM, you just need to specify the query, response, and label column names and fit the model on the training dataset without worrying the implementation details. Note that the labels should be binary, and we need to specify the `match_label`, which means two sentences have the same semantic meaning. In practice, your tasks may have different labels, e.g., duplicate or not duplicate. You may need to define the `match_label` by considering your specific task contexts.
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
@@ -38,6 +38,7 @@ predictor = MultiModalPredictor(
         query="premise", # the column name of the first sentence
         response="hypothesis", # the column name of the second sentence
         label="label", # the label column name
+        match_label=1, # the label indicating that query and response have the same semantic meanings.
         eval_metric='auc', # the evaluation metric
     )
 

--- a/multimodal/src/autogluon/multimodal/predictor.py
+++ b/multimodal/src/autogluon/multimodal/predictor.py
@@ -281,9 +281,8 @@ class MultiModalPredictor:
         match_label
             The label class that indicates the <query, response> pair is counted as "match".
             This is used when the problem_type is one of the matching problem types, and when the labels are binary.
-            For example, the label column can contain ["match", "not match"]. And match_label can be "match".
-            It is similar as the "pos_label" in F1-score: https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
-            Internally, we will set match_label to self.class_labels[1] by default.
+            For example, the label column can contain ["duplicate", "not duplicate"]. And match_label can be "duplicate".
+            If match_label is not provided, every sample is assumed to have a unique label.
         pipeline
             Pipeline has been deprecated and merged in problem_type.
         presets


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Make image-to-image tutorial online runnable.
2. Fix the match_label docstring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
