### PR TITLE
Add missing import sys in setup.py

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -35,12 +35,12 @@ extras_require = {
         'lightgbm>=3.3,<3.4',
     ],
     'catboost': [
-        'catboost>=1.0,<1.2',
+        'catboost>=1.0,<1.1',
     ],
     # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4
     #  It is possibly only present on MacOS, haven't tested linux.
     'xgboost': [
-        'xgboost>=1.4,<1.8',
+        'xgboost>=1.4,<1.5',
     ],
     'fastai': [
         'torch>=1.0,<1.13',

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -12,6 +12,8 @@ ag = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(ag)
 ###########################
 
+import sys
+
 version = ag.load_version_file()
 version = ag.update_version(version)
 
@@ -33,12 +35,12 @@ extras_require = {
         'lightgbm>=3.3,<3.4',
     ],
     'catboost': [
-        'catboost>=1.0,<1.1',
+        'catboost>=1.0,<1.2',
     ],
     # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4
     #  It is possibly only present on MacOS, haven't tested linux.
     'xgboost': [
-        'xgboost>=1.4,<1.5',
+        'xgboost>=1.4,<1.8',
     ],
     'fastai': [
         'torch>=1.0,<1.13',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- sys import missing from setup.py, causing pre-release to fail (https://pypi.org/project/autogluon/#history). Also will crash any local install attempts.

Original bug from #2225 that added `if sys.platform == 'darwin'` logic.

Log showing error in pre-release build:

https://github.com/awslabs/autogluon/actions/runs/3392499510/jobs/5638772315#step:5:1061

```
Traceback (most recent call last):
  File "setup.py", line 61, in <module>
    ] if sys.platform == 'darwin' else [
NameError: name 'sys' is not defined
Error: Process completed with exit code 1.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
