### PR TITLE
[v0.6] Updated dependency versions

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -16,10 +16,10 @@ PYTHON_REQUIRES = '>=3.7, <3.10'
 # Only put packages here that would otherwise appear multiple times across different module's setup.py files.
 DEPENDENT_PACKAGES = {
     # note: if python 3.7 is used, the open CVEs are present: CVE-2021-41496 | CVE-2021-34141; fixes are available in 1.22.x, but python 3.8 only
-    'numpy': '>=1.21,<1.23',
-    'pandas': '>=1.2.5,!=1.4.0,<1.5',
-    'scikit-learn': '>=1.0.0,<1.1',
-    'scipy': '>=1.5.4,<1.8.0',
+    'numpy': '>=1.21,<1.24',
+    'pandas': '>=1.2.5,!=1.4.0,<1.6',
+    'scikit-learn': '>=1.0.0,<1.2',
+    'scipy': '>=1.5.4,<1.10.0',
     'psutil': '>=5.7.3,<6',
     'gluoncv': '>=0.10.5,<0.10.6',
     'tqdm': '>=4.38.0',

--- a/core/src/autogluon/core/utils/try_import.py
+++ b/core/src/autogluon/core/utils/try_import.py
@@ -166,6 +166,11 @@ def try_import_lightgbm():
 def try_import_xgboost():
     try:
         import xgboost
+        from pkg_resources import parse_version  # pylint: disable=import-outside-toplevel
+        xgboost_version = parse_version(xgboost.__version__)
+        min_version = "1.6"
+        assert xgboost_version >= parse_version(min_version),\
+            f'Currently, we only support "xgboost>={min_version}". Installed version: "xgboost=={xgboost.__version__}".'
     except ImportError:
         raise ImportError("`import xgboost` failed. "
                           f"A quick tip is to install via `pip install autogluon.tabular[xgboost]=={__version__}`.")

--- a/core/src/autogluon/core/utils/utils.py
+++ b/core/src/autogluon/core/utils/utils.py
@@ -360,12 +360,115 @@ def get_pred_from_proba(y_pred_proba, problem_type=BINARY):
     return y_pred
 
 
+def extract_label(data: DataFrame, label: str) -> (DataFrame, Series):
+    """
+    Extract the label column from a dataset and return X, y.
+
+    Parameters
+    ----------
+    data : DataFrame
+        The data containing features and the label column.
+    label : str
+        The label column name.
+
+    Returns
+    -------
+    X, y : (DataFrame, Series)
+        X is the data with the label column dropped.
+        y is the label column as a pd.Series.
+    """
+    if label not in list(data.columns):
+        raise ValueError(f"Provided DataFrame does not contain label column: {label}")
+    y = data[label].copy()
+    X = data.drop(label, axis=1)
+    return X, y
+
+
+def generate_train_test_split_combined(data: DataFrame,
+                                       label: str,
+                                       problem_type: str,
+                                       test_size: float = 0.1,
+                                       random_state: int = 0,
+                                       min_cls_count_train: int = 1) -> (DataFrame, DataFrame):
+    """
+    Generate a train test split from a DataFrame that contains the label column.
+
+    Parameters
+    ----------
+    data : DataFrame
+        DataFrame containing the features plus the label column to split into train and test sets.
+    label : str
+        The label column name.
+        Used for stratification and to ensure all classes in multiclass classification are preserved in train data.
+    problem_type : str
+        The problem_type the label is used for. Determines if stratification is used.
+        Options: ["binary", "multiclass", "regression", "softclass", "quantile"]
+    test_size : float, default = 0.1
+        The proportion of data to use for the test set.
+        The remaining (1 - test_size) of data will be used for the training set.
+    random_state : int, default = 0
+        Random seed to use during the split.
+    min_cls_count_train : int, default = 1
+        The minimum number of instances of each class that must occur in the training set (for classification).
+        If not satisfied by the original split, instances of unsatisfied classes are
+        taken from test and put into train until satisfied.
+        Raises an exception if impossible to satisfy.
+
+    Returns
+    -------
+    train_data, test_data : (DataFrame, DataFrame)
+        The train_data and test_data after performing the split. Includes the label column.
+    """
+    X, y = extract_label(data=data, label=label)
+    train_data, test_data, y_train, y_test = generate_train_test_split(
+        X=X,
+        y=y,
+        problem_type=problem_type,
+        test_size=test_size,
+        random_state=random_state,
+        min_cls_count_train=min_cls_count_train)
+    train_data[label] = y_train
+    test_data[label] = y_test
+    return train_data, test_data
+
+
 def generate_train_test_split(X: DataFrame,
                               y: Series,
                               problem_type: str,
                               test_size: float = 0.1,
-                              random_state=0,
-                              min_cls_count_train=1) -> (DataFrame, DataFrame, Series, Series):
+                              random_state: int = 0,
+                              min_cls_count_train: int = 1) -> (DataFrame, DataFrame, Series, Series):
+    """
+    Generate a train test split from input X, y.
+    If you have a combined X, y DataFrame, refer to `generate_train_test_split_combined` instead.
+
+    Parameters
+    ----------
+    X : DataFrame
+        pd.DataFrame containing the features minus the label column to split into train and test sets.
+    y : Series
+        pd.Series containing the label with matching indices to X.
+        Used for stratification and to ensure all classes in multiclass classification are preserved in train data.
+    problem_type : str
+        The problem_type the label is used for. Determines if stratification is used.
+        Options: ["binary", "multiclass", "regression", "softclass", "quantile"]
+    test_size : float, default = 0.1
+        The proportion of data to use for the test set.
+        The remaining (1 - test_size) of data will be used for the training set.
+    random_state : int, default = 0
+        Random seed to use during the split.
+    min_cls_count_train : int, default = 1
+        The minimum number of instances of each class that must occur in the training set (for classification).
+        If not satisfied by the original split, instances of unsatisfied classes are
+        taken from test and put into train until satisfied.
+        Raises an exception if impossible to satisfy.
+
+    Returns
+    -------
+    X_train, X_test, y_train, y_test : (DataFrame, DataFrame, Series, Series)
+        The train_data and test_data after performing the split, separated into X and y.
+
+    """
     if (test_size <= 0.0) or (test_size >= 1.0):
         raise ValueError("fraction of data to hold-out must be specified between 0 and 1")
 
@@ -406,8 +509,8 @@ def generate_train_test_split(X: DataFrame,
         y_test = pd.DataFrame(y_test, index=X_test.index)
 
     if rare_indices:
-        X_train = X_train.append(X.loc[rare_indices])
-        y_train = y_train.append(y.loc[rare_indices])
+        X_train = pd.concat([X_train, X.loc[rare_indices]])
+        y_train = pd.concat([y_train, y.loc[rare_indices]])
 
     if problem_type in [BINARY, MULTICLASS]:
         class_counts_dict_orig = y.value_counts().to_dict()

--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -35,12 +35,13 @@ extras_require = {
         'lightgbm>=3.3,<3.4',
     ],
     'catboost': [
-        'catboost>=1.0,<1.1',
+        'catboost>=1.0,<1.2',
     ],
     # FIXME: Debug why xgboost 1.6 has 4x+ slower inference on multiclass datasets compared to 1.4
     #  It is possibly only present on MacOS, haven't tested linux.
+    # XGBoost made API breaking changes in 1.6 with custom metric and callback support, so we don't support older versions.
     'xgboost': [
-        'xgboost>=1.4,<1.5',
+        'xgboost>=1.6,<1.8',
     ],
     'fastai': [
         'torch>=1.0,<1.13',

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -167,7 +167,7 @@ class DefaultLearner(AbstractTabularLearner):
         X = copy.deepcopy(X)
 
         # Remove all examples with missing labels from this dataset:
-        missinglabel_inds = [index for index, x in X[self.label].isna().iteritems() if x]
+        missinglabel_inds = list(X[X[self.label].isna()].index)
         if len(missinglabel_inds) > 0:
             logger.warning(f"Warning: Ignoring {len(missinglabel_inds)} (out of {len(X)}) training examples for which the label value in column '{self.label}' is missing")
             X = X.drop(missinglabel_inds, axis=0)

--- a/tabular/src/autogluon/tabular/models/xgboost/callbacks.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/callbacks.py
@@ -19,11 +19,13 @@ class EarlyStoppingCustom(EarlyStopping):
        If int, The possible number of rounds without the trend occurrence.
        If tuple, contains early stopping class as first element and class init kwargs as second element.
     """
-    def __init__(self, rounds, time_limit=None, start_time=None, verbose=False, **kwargs):
+    def __init__(self, rounds, time_limit=None, start_time=None, verbose=False, min_delta=2e-6, **kwargs):
         if rounds is None:
             # Disable early stopping via rounds
             rounds = 999999
-        super().__init__(rounds=999999, **kwargs)
+        # Add a tiny min_delta so training doesn't go on for extremely long if only tiny improvements are being made
+        #  (can occur when validation error is almost 0, such as val log_loss <0.00005)
+        super().__init__(rounds=999999, min_delta=min_delta, **kwargs)
         if isinstance(rounds, int):
             self.es = SimpleES(patience=rounds)
         else:

--- a/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/parameters.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/hyperparameters/parameters.py
@@ -23,7 +23,7 @@ def get_base_params():
         'n_estimators': DEFAULT_NUM_BOOST_ROUND,
         'learning_rate': 0.1,
         'n_jobs': -1,
-        'proc.max_category_levels' : MAX_CATEGORY_LEVELS,
+        'proc.max_category_levels': MAX_CATEGORY_LEVELS,
     }
     return base_params
 
@@ -33,7 +33,6 @@ def get_param_binary_baseline():
     baseline_params = {
         'objective': 'binary:logistic',
         'booster': 'gbtree',
-        'use_label_encoder': False,
     }
     params.update(baseline_params)
     return params
@@ -42,10 +41,9 @@ def get_param_binary_baseline():
 def get_param_multiclass_baseline(num_classes):
     params = get_base_params()
     baseline_params = {
-        'objective': 'multi:softmax',
+        'objective': 'multi:softprob',
         'booster': 'gbtree',
         'num_class': num_classes,
-        'use_label_encoder': False,
     }
     params.update(baseline_params)
     return params

--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -50,7 +50,7 @@ class XGBoostModel(AbstractModel):
     def get_eval_metric(self):
         eval_metric = xgboost_utils.convert_ag_metric_to_xgbm(ag_metric_name=self.stopping_metric.name, problem_type=self.problem_type)
         if eval_metric is None:
-            eval_metric = xgboost_utils.func_generator(metric=self.stopping_metric, is_higher_better=True, needs_pred_proba=not self.stopping_metric.needs_pred, problem_type=self.problem_type)
+            eval_metric = xgboost_utils.func_generator(metric=self.stopping_metric, problem_type=self.problem_type)
         return eval_metric
 
     def _preprocess(self, X, is_train=False, max_category_levels=None, **kwargs):
@@ -100,7 +100,10 @@ class XGBoostModel(AbstractModel):
         num_rows_train = X.shape[0]
 
         eval_set = []
-        eval_metric = self.get_eval_metric()
+        if 'eval_metric' not in params:
+            eval_metric = self.get_eval_metric()
+            if eval_metric is not None:
+                params['eval_metric'] = eval_metric
 
         if X_val is None:
             early_stopping_rounds = None
@@ -122,24 +125,21 @@ class XGBoostModel(AbstractModel):
         try_import_xgboost()
         from .callbacks import EarlyStoppingCustom
         from xgboost.callback import EvaluationMonitor
-        callbacks = []
-        if eval_set is not None:
+        if eval_set is not None and 'callbacks' not in params:
+            callbacks = []
             if log_period is not None:
                 callbacks.append(EvaluationMonitor(period=log_period))
             callbacks.append(EarlyStoppingCustom(early_stopping_rounds, start_time=start_time, time_limit=time_limit, verbose=verbose))
+            params['callbacks'] = callbacks
 
         from xgboost import XGBClassifier, XGBRegressor
         model_type = XGBClassifier if self.problem_type in PROBLEM_TYPES_CLASSIFICATION else XGBRegressor
-        if 'eval_metric' not in params and params.get('objective') == 'binary:logistic':
-            # avoid unnecessary warning from XGBoost v1.3.0
-            params['eval_metric'] = 'logloss'
         self.model = model_type(**params)
         self.model.fit(
             X=X,
             y=y,
             eval_set=eval_set,
             verbose=False,
-            callbacks=callbacks,
             sample_weight=sample_weight
         )
 
@@ -148,6 +148,8 @@ class XGBoostModel(AbstractModel):
         # bst.set_param({"predictor": "gpu_predictor"})
 
         self.params_trained['n_estimators'] = bst.best_ntree_limit
+        # Don't save the callback or eval_metric objects
+        self.model.set_params(callbacks=None, eval_metric=None)
 
     def _predict_proba(self, X, num_cpus=-1, **kwargs):
         X = self.preprocess(X, **kwargs)


### PR DESCRIPTION
*Description of changes:*
Updated dependency versions.

TODO: 

- [x] Tested autogluon.tabular locally on Ubuntu Python 3.8 and MacOS Python 3.8
- [x] Checked that min versions of dependencies remain compatible with Python 3.7
- [x] Get approval from autogluon.multimodal lead (scikit-learn, scipy, numpy, pandas)
- [x] Get approval from autogluon.timeseries lead (scikit-learn, scipy, numpy, pandas)
- [x] Benchmark on AutoMLBenchmark : Results look good, no major change, no stability issues.
- [x] Checked XGBoost upgrade is stable
- [x] Checked CatBoost upgrade is stable

Old:

```
'numpy': '>=1.21,<1.23',
'pandas': '>=1.2.5,!=1.4.0,<1.5',
'scikit-learn': '>=1.0.0,<1.1',
'scipy': '>=1.5.4,<1.8.0',
'catboost>=1.0,<1.1',
'xgboost>=1.4,<1.5',
```

New:

```
'numpy': '>=1.21,<1.24',
'pandas': '>=1.2.5,!=1.4.0,<1.6',
'scikit-learn': '>=1.0.0,<1.2',
'scipy': '>=1.5.4,<1.10.0',
'catboost>=1.0,<1.2',
'xgboost>=1.6,<1.8',
```

Beyond the version updates, I have added logic to address deprecation warnings, including:
- Removed the usage of Pandas `.append` which is deprecated, now using `.concat`.
- Removed usage of Pandas `.iteritems` which is deprecated.
- Refactored XGBoost custom metric logic to adhere to the API change in XGBoost 1.6+. I have tested this locally with a variety of metrics and problem types.
- Removed `use_label_encoder` parameter setting in XGBoost, it is now deprecated. No functional change.

Additional changes:
- Fixed bug introduced in #2234 that caused XGBoost to ignore the user-specified eval metric. Now it properly uses the eval metric as before by specifying it in `params`.
- Added version range check when importing XGBoost to ensure user isn't using an old version of XGBoost. This is because callbacks are incompatible with the older versions and will cause the model to never early stop, making the result very poor. Now we error if XGBoost isn't installed with expected version range.
- Changed objective for multiclass XGBoost to `objective': 'multi:softprob'` to satisfy custom metric API requirements. This has no functional change in model training or inference.
- Added documentation to `generate_train_test_split`
- Added new function `generate_train_test_split_combined` that will simplify tutorials where we need to split a dataset into train and test from ~6 LoC to 1 LoC. Currently unused within the core AutoGluon logic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
