### PR TITLE
Minor fix to infer_speed calc

### DIFF
--- a/core/src/autogluon/core/utils/infer_utils.py
+++ b/core/src/autogluon/core/utils/infer_utils.py
@@ -64,7 +64,7 @@ def get_model_true_infer_speed_per_row_batch(
 
     leaderboards = []
     for i in range(repeats):
-        leaderboard = predictor.leaderboard(data_batch, silent=True)
+        leaderboard = predictor.leaderboard(data_batch, skip_score=True, silent=True)
         leaderboard = leaderboard[leaderboard['can_infer']][['model', 'pred_time_test', 'pred_time_test_marginal']]
         leaderboard = leaderboard.set_index('model')
         leaderboards.append(leaderboard)

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1478,7 +1478,7 @@ class TabularPredictor:
         return self._learner.evaluate_predictions(y_true=y_true, y_pred=y_pred, sample_weight=sample_weight, silent=silent,
                                                   auxiliary_metrics=auxiliary_metrics, detailed_report=detailed_report)
 
-    def leaderboard(self, data=None, extra_info=False, extra_metrics=None, only_pareto_frontier=False, silent=False):
+    def leaderboard(self, data=None, extra_info=False, extra_metrics=None, only_pareto_frontier=False, skip_score=False, silent=False):
         """
         Output summary of information about models produced during `fit()` as a :class:`pd.DataFrame`.
         Includes information on test and validation scores for all models, model training times, inference times, and stack levels.
@@ -1590,6 +1590,10 @@ class TabularPredictor:
             At minimum this will include the model with the highest score and the model with the lowest inference time.
             This is useful when deciding which model to use during inference if inference time is a consideration.
             Models filtered out by this process would never be optimal choices for a user that only cares about model inference time and score.
+        skip_score : bool, default = False
+            [Advanced, primarily for developers]
+            If `True`, will skip computing `score_test` if `data` is specified. `score_test` will be set to NaN for all models.
+            `pred_time_test` and related columns will still be computed.
         silent : bool, default = False
             Should leaderboard DataFrame be printed?
 
@@ -1600,7 +1604,7 @@ class TabularPredictor:
         self._assert_is_fit('leaderboard')
         data = self.__get_dataset(data) if data is not None else data
         return self._learner.leaderboard(X=data, extra_info=extra_info, extra_metrics=extra_metrics,
-                                         only_pareto_frontier=only_pareto_frontier, silent=silent)
+                                         only_pareto_frontier=only_pareto_frontier, skip_score=skip_score, silent=silent)
 
     def fit_summary(self, verbosity=3, show_plot=False):
         """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixes crash when calculating infer_speed in `get_model_true_infer_speed_per_row_batch` when eval_metric isn't able to be calculated for a single row and batch_size=1. Now we avoid calculating the score on the batch (it isn't required to calculate inference speed).
- This has no impact on user functionality, it is purely a fix for benchmarking analytics to calculate genuine inference speed.

Error that has been fixed:

```
Traceback (most recent call last):
  File "/Users/neerick/workspace/virtual/autogluon38/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3433, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-7ea70903d95e>", line 3, in <module>
    runfile('/Users/neerick/workspace/code/autogluon-scratch/scripts/run_adult4.py', wdir='/Users/neerick/workspace/code/autogluon-scratch/scripts')
  File "/Users/neerick/Library/Application Support/JetBrains/Toolbox/apps/PyCharm-P/ch-1/223.7255.83/PyCharm 2022.3 EAP.app/Contents/plugins/python/helpers/pydev/_pydev_bundle/pydev_umd.py", line 198, in runfile
    pydev_imports.execfile(filename, global_vars, local_vars)  # execute the script
  File "/Users/neerick/Library/Application Support/JetBrains/Toolbox/apps/PyCharm-P/ch-1/223.7255.83/PyCharm 2022.3 EAP.app/Contents/plugins/python/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/Users/neerick/workspace/code/autogluon-scratch/scripts/run_adult4.py", line 49, in <module>
    infer_df, time_per_row_transform = get_model_true_infer_speed_per_row_batch(data=test_data, predictor=predictor, batch_size=batch_size, repeats=repeats)
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/utils/infer_utils.py", line 67, in get_model_true_infer_speed_per_row_batch
    leaderboard = predictor.leaderboard(data_batch, silent=True)
  File "/Users/neerick/workspace/code/autogluon/tabular/src/autogluon/tabular/predictor/predictor.py", line 1606, in leaderboard
    return self._learner.leaderboard(X=data, extra_info=extra_info, extra_metrics=extra_metrics,
  File "/Users/neerick/workspace/code/autogluon/tabular/src/autogluon/tabular/learner/abstract_learner.py", line 627, in leaderboard
    leaderboard = self.score_debug(X=X, y=y, extra_info=extra_info, extra_metrics=extra_metrics, skip_score=skip_score, silent=True)
  File "/Users/neerick/workspace/code/autogluon/tabular/src/autogluon/tabular/learner/abstract_learner.py", line 333, in score_debug
    scores[model_name] = self._score_with_pred_proba(
  File "/Users/neerick/workspace/code/autogluon/tabular/src/autogluon/tabular/learner/abstract_learner.py", line 447, in _score_with_pred_proba
    return compute_weighted_metric(y_tmp, y_pred, metric, weights=sample_weight, weight_evaluation=weight_evaluation, quantile_levels=self.quantile_levels)
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/utils/utils.py", line 572, in compute_weighted_metric
    return metric(y, y_pred, **kwargs)
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/metrics/__init__.py", line 94, in __call__
    return self._score(y_true=y_true, y_pred=y_pred, **k)
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/metrics/__init__.py", line 124, in _score
    return self._sign * self._score_func(y_true, y_pred, **kwargs)
  File "/Users/neerick/workspace/code/autogluon/core/src/autogluon/core/metrics/classification_metrics.py", line 438, in customized_binary_roc_auc_score
    raise ValueError("Only one class present in y_true. ROC AUC score is not defined in that case.")
ValueError: Only one class present in y_true. ROC AUC score is not defined in that case.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
