### PR TITLE
Modified save path and FTT default parameter

### DIFF
--- a/tabular/src/autogluon/tabular/models/automm/automm_model.py
+++ b/tabular/src/autogluon/tabular/models/automm/automm_model.py
@@ -147,9 +147,11 @@ class MultiModalPredictorModel(AbstractModel):
         verbosity_text = max(0, verbosity - 1)
         root_logger = logging.getLogger('autogluon')
         root_log_level = root_logger.level
+        # in self.save(), the model is saved to automm_nn_path
+        automm_nn_path = os.path.join(path, self._NN_MODEL_NAME)
         self.model = MultiModalPredictor(label=self._label_column_name,
                                      problem_type=self.problem_type,
-                                     path=self.path,
+                                     path=automm_nn_path,
                                      eval_metric=self.eval_metric,
                                      verbosity=verbosity_text)
         params = self._get_model_params()

--- a/tabular/src/autogluon/tabular/models/automm/ft_transformer.py
+++ b/tabular/src/autogluon/tabular/models/automm/ft_transformer.py
@@ -47,6 +47,8 @@ class FTTransformerModel(MultiModalPredictorModel):
             "model.names": ["categorical_transformer", "numerical_transformer", "fusion_transformer"],
             "model.numerical_transformer.embedding_arch": ["linear"],
             "env.batch_size": 128,
+            "env.num_workers": 0,
+            "env.num_workers_evaluation": 0,
             "optimization.max_epochs": 2000,  # Specify a large value to train until convergence
             "optimization.weight_decay": 1.0e-5,
             "optimization.lr_choice": None,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1, Set default ```env.num_workers=0``` to avoid the "too many open files error".
2, Fixed a bug with automm model save path. Checkpoints are saved as ```FTTransformer/automm_model/``` when called with ```TabularPredictor()```.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
