### PR TITLE
Remove build_all from platform tests

### DIFF
--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -232,4 +232,3 @@ jobs:
           source .github/workflow_scripts/env_setup.sh
           setup_build_env
           install_all
-          build_all


### PR DESCRIPTION
*Issue #, if available:* 
Platform tests are failing on windows due to introduction of wheel building on the platform

*Description of changes:*

Our wheels are not platform specific, so there is no need to test build on each as long as the wheel can be used there


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
