### PR TITLE
[timeseries] Fix use of dataframe.iteritems in timeseries

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -96,7 +96,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
 
         self._fit_and_cache_predictions(data, quantile_levels=quantile_levels)
         item_id_to_prediction = {}
-        for item_id, ts_hash in hash_ts_dataframe_items(data).iteritems():
+        for item_id, ts_hash in hash_ts_dataframe_items(data).items():
             item_id_to_prediction[item_id] = self._cached_predictions[ts_hash]
         predictions_df = pd.concat(item_id_to_prediction)
         predictions_df.index.rename([ITEMID, TIMESTAMP], inplace=True)
@@ -105,7 +105,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
     def _fit_and_cache_predictions(self, data: TimeSeriesDataFrame, quantile_levels: List[float]):
         data_hash = hash_ts_dataframe_items(data)
         items_to_fit = [
-            item_id for item_id, ts_hash in data_hash.iteritems() if ts_hash not in self._cached_predictions
+            item_id for item_id, ts_hash in data_hash.items() if ts_hash not in self._cached_predictions
         ]
         if len(items_to_fit) > 0:
             logger.debug(f"{self.name} received {len(items_to_fit)} new items to predict, generating predictions")

--- a/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
+++ b/timeseries/src/autogluon/timeseries/models/local/abstract_local_model.py
@@ -104,9 +104,7 @@ class AbstractLocalModel(AbstractTimeSeriesModel):
 
     def _fit_and_cache_predictions(self, data: TimeSeriesDataFrame, quantile_levels: List[float]):
         data_hash = hash_ts_dataframe_items(data)
-        items_to_fit = [
-            item_id for item_id, ts_hash in data_hash.items() if ts_hash not in self._cached_predictions
-        ]
+        items_to_fit = [item_id for item_id, ts_hash in data_hash.items() if ts_hash not in self._cached_predictions]
         if len(items_to_fit) > 0:
             logger.debug(f"{self.name} received {len(items_to_fit)} new items to predict, generating predictions")
             time_series_to_fit = [data.loc[item_id][self.target] for item_id in items_to_fit]

--- a/timeseries/src/autogluon/timeseries/utils/features.py
+++ b/timeseries/src/autogluon/timeseries/utils/features.py
@@ -42,7 +42,7 @@ def get_categorical_and_continuous_features(dataframe: pd.DataFrame) -> Tuple[pd
     categorical_column_names = []
     continuous_column_names = []
 
-    for column_name, column_values in dataframe.iteritems():
+    for column_name, column_values in dataframe.items():
         if is_categorical_dtype(column_values):
             categorical_column_names.append(column_name)
         elif is_numeric_dtype(column_values):

--- a/timeseries/tests/unittests/test_splitter.py
+++ b/timeseries/tests/unittests/test_splitter.py
@@ -29,7 +29,7 @@ def test_when_multi_window_splitter_splits_then_train_items_have_correct_length(
     train_data, _ = splitter.split(ts_dataframe=ts_dataframe, prediction_length=prediction_length)
     original_lengths = ts_dataframe.num_timesteps_per_item()
 
-    for item_id, length in original_lengths.iteritems():
+    for item_id, length in original_lengths.items():
         num_windows_from_this_item = min(num_windows, max((length - 1) // prediction_length - 1, 0))
         expected_length = length - num_windows_from_this_item * prediction_length
         assert expected_length == len(train_data.loc[item_id])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

replace usages of pandas `DataFrame.iteritems()` with `items()`, which is an [alias](https://github.com/pandas-dev/pandas/blob/91111fd99898d9dcaa6bf6bedb662db4108da6e6/pandas/core/frame.py#L1355) that replaces `iteritems`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
