### PR TITLE
[timeseries] Fix leaderboard bug if training data contains static features

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -375,7 +375,7 @@ class TimeSeriesLearner(AbstractLearner):
         return self.load_trainer().score(data=data, model=model, metric=metric)
 
     def leaderboard(self, data: Optional[TimeSeriesDataFrame] = None) -> pd.DataFrame:
-        if self.static_feature_pipeline.is_fit():
+        if data is not None and self.static_feature_pipeline.is_fit():
             fix_message = (
                 "Please make sure that data has static_features with columns and dtypes exactly matching "
                 "train_data.static_features. "


### PR DESCRIPTION
*Description of changes:*
- Fixes a bug where the `.leaderboard()` method would fail if (1) training data contained static features and (2) no data was given at prediction time.
- Add a test to prevent this bug in the future.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
