### PR TITLE
[timeseries] make core and tabular dependencies explicit

### DIFF
--- a/timeseries/setup.py
+++ b/timeseries/setup.py
@@ -34,9 +34,9 @@ install_requires = [
     "pytorch-lightning>=1.7.4,<1.8.0",
     "networkx",
     "tqdm",
-    f"autogluon.core=={version}",
+    f"autogluon.core[raytune]=={version}",
     f"autogluon.common=={version}",
-    f"autogluon.tabular=={version}",
+    f"autogluon.tabular[catboost,lightgbm,xgboost]=={version}",
 ]
 
 extras_require = {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Optional dependencies were missing from core and tabular dependency listings in time series. This can lead to errors (currently caught, but leads to failing models) in edge cases: if the user does not `pip install autogluon` or `full_install` but instead tries to do a bare install of time series. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
