### PR TITLE
Fixed model save and load path with uuid for multiple runs

### DIFF
--- a/docs/tutorials/multimodal/advanced_topics/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/advanced_topics/efficient_finetuning_basic.md
@@ -85,9 +85,11 @@ In AutoMM, to enable efficient finetuning, just specify the `optimization.effici
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
+import uuid
 
+model_path = f"./tmp/{uuid.uuid4().hex}-multilingual_ia3"
 predictor = MultiModalPredictor(label="label",
-                                path="multilingual_ia3")
+                                path=model_path)
 predictor.fit(train_en_df,
               presets="multilingual",
               hyperparameters={
@@ -133,10 +135,11 @@ shutil.rmtree("multilingual_ia3")
 ```python
 from autogluon.multimodal import MultiModalPredictor
 
-train_en_df_downsample = train_en_df.sample(200, random_state=123) 
+train_en_df_downsample = train_en_df.sample(200, random_state=123)
 
+new_model_path = f"./tmp/{uuid.uuid4().hex}-multilingual_ia3_gradient_checkpoint"
 predictor = MultiModalPredictor(label="label",
-                                path="multilingual_ia3_gradient_checkpoint")
+                                path=new_model_path)
 predictor.fit(train_en_df_downsample,
               presets="multilingual",
               hyperparameters={

--- a/docs/tutorials/multimodal/advanced_topics/efficient_finetuning_basic.md
+++ b/docs/tutorials/multimodal/advanced_topics/efficient_finetuning_basic.md
@@ -128,7 +128,7 @@ To accelerate the training, we downsample the number of training sampels to be 2
 ```{.python .input}
 # Just for clean the space
 clear_cache()
-shutil.rmtree("multilingual_ia3")
+shutil.rmtree(model_path)
 ```
 
 
@@ -203,7 +203,7 @@ Score in the English Testset: {'roc_auc': 0.931263189629183}
 ```python
 # Just for clean the space
 clear_cache()
-shutil.rmtree("multilingual_ia3_gradient_checkpoint")
+shutil.rmtree(new_model_path)
 ```
 
 ## Other Examples

--- a/docs/tutorials/multimodal/image_prediction/beginner_image_cls.md
+++ b/docs/tutorials/multimodal/image_prediction/beginner_image_cls.md
@@ -29,10 +29,13 @@ Now, we fit a classifier using AutoMM as follows:
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
-predictor = MultiModalPredictor(label="label", path="./automm_imgcls")
+import uuid
+
+model_path = f"./tmp/{uuid.uuid4().hex}-automm_imgcls"
+predictor = MultiModalPredictor(label="label", path=model_path)
 predictor.fit(
     train_data=train_dataset,
-    time_limit=30, # seconds
+    time_limit=60, # seconds
 ) # you can trust the default config, e.g., we use a `swin_base_patch4_window7_224` model
 ```
 
@@ -96,7 +99,7 @@ The trained predictor is automatically saved at the end of `fit()`, and you can 
 :::
 
 ```{.python .input}
-loaded_predictor = MultiModalPredictor.load('automm_imgcls')
+loaded_predictor = MultiModalPredictor.load(model_path)
 load_proba = loaded_predictor.predict_proba({'image': [image_path]})
 print(load_proba)
 ```

--- a/docs/tutorials/multimodal/image_prediction/beginner_image_cls.md
+++ b/docs/tutorials/multimodal/image_prediction/beginner_image_cls.md
@@ -29,13 +29,10 @@ Now, we fit a classifier using AutoMM as follows:
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
-import uuid
-
-model_path = f"./tmp/{uuid.uuid4().hex}-automm_imgcls"
-predictor = MultiModalPredictor(label="label", path=model_path)
+predictor = MultiModalPredictor(label="label", path="./automm_imgcls")
 predictor.fit(
     train_data=train_dataset,
-    time_limit=60, # seconds
+    time_limit=30, # seconds
 ) # you can trust the default config, e.g., we use a `swin_base_patch4_window7_224` model
 ```
 
@@ -99,7 +96,7 @@ The trained predictor is automatically saved at the end of `fit()`, and you can 
 :::
 
 ```{.python .input}
-loaded_predictor = MultiModalPredictor.load(model_path)
+loaded_predictor = MultiModalPredictor.load('automm_imgcls')
 load_proba = loaded_predictor.predict_proba({'image': [image_path]})
 print(load_proba)
 ```

--- a/docs/tutorials/multimodal/multimodal_prediction/beginner_multimodal.md
+++ b/docs/tutorials/multimodal/multimodal_prediction/beginner_multimodal.md
@@ -142,8 +142,11 @@ It is also convenient to save a predictor and re-load it.
 :::
 
 ```{.python .input}
-predictor.save('my_saved_dir')
-loaded_predictor = MultiModalPredictor.load('my_saved_dir')
+import uuid
+
+model_path = f"./tmp/{uuid.uuid4().hex}-saved_model"
+predictor.save(model_path)
+loaded_predictor = MultiModalPredictor.load(model_path)
 scores2 = loaded_predictor.evaluate(test_data, metrics=["roc_auc"])
 scores2
 ```

--- a/docs/tutorials/multimodal/multimodal_prediction/multimodal_text_tabular.md
+++ b/docs/tutorials/multimodal/multimodal_prediction/multimodal_text_tabular.md
@@ -66,8 +66,11 @@ To save time, we subsample the data and only train for three minutes.
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
+import uuid
+
 time_limit = 3 * 60  # set to larger value in your applications
-predictor = MultiModalPredictor(label='Price', path='automm_text_book_price_prediction')
+model_path = f"./tmp/{uuid.uuid4().hex}-automm_text_book_price_prediction"
+predictor = MultiModalPredictor(label='Price', path=model_path)
 predictor.fit(train_data, time_limit=time_limit)
 ```
 

--- a/docs/tutorials/multimodal/object_detection/quick_start/quick_start_coco.md
+++ b/docs/tutorials/multimodal/object_detection/quick_start/quick_start_coco.md
@@ -62,6 +62,9 @@ It will be saved to a automatically generated directory with timestamp under `Au
 
 ```python .input
 # Init predictor
+import uuid
+
+model_path = f"./tmp/{uuid.uuid4().hex}-quick_start_tutorial_temp_save"
 predictor = MultiModalPredictor(
     hyperparameters={
         "model.mmdet_image.checkpoint_name": checkpoint_name,
@@ -69,7 +72,7 @@ predictor = MultiModalPredictor(
     },
     problem_type="object_detection",
     sample_data_path=train_path,
-    path="./quick_start_tutorial_temp_save",
+    path=model_path,
 )
 ```
 
@@ -134,7 +137,7 @@ and we can also reset the number of GPUs to use if not all the devices are avail
 
 ```python .input
 # Load and reset num_gpus
-new_predictor = MultiModalPredictor.load("./quick_start_tutorial_temp_save")
+new_predictor = MultiModalPredictor.load(model_path)
 new_predictor.set_num_gpus(1)
 ```
 

--- a/docs/tutorials/multimodal/text_prediction/ner.md
+++ b/docs/tutorials/multimodal/text_prediction/ner.md
@@ -38,8 +38,11 @@ Now, let's create a predictor for named entity recognition by seting the *proble
 
 ```{.python .input}
 from autogluon.multimodal import MultiModalPredictor
+import uuid
+
 label_col = "entity_annotations"
-predictor = MultiModalPredictor(problem_type="ner", label=label_col, path='./automm_ner')
+model_path = f"./tmp/{uuid.uuid4().hex}-automm_ner"
+predictor = MultiModalPredictor(problem_type="ner", label=label_col, path=model_path)
 predictor.fit(
     train_data=train_data,
     time_limit=300, #second
@@ -69,8 +72,9 @@ for entity in predictions[0]:
 The trained predictor is automatically saved and you can easily reload it using the path. If you are not saftisfied with the current model performance, you can continue training the loaded model with new data.
 
 ```{.python .input}
-new_predictor = MultiModalPredictor.load('automm_ner')
-new_predictor.fit(train_data, time_limit=60, save_path='automm_ner_continue_train')
+new_predictor = MultiModalPredictor.load(model_path)
+new_model_path = f"./tmp/{uuid.uuid4().hex}-automm_ner_continue_train"
+new_predictor.fit(train_data, time_limit=60, save_path=new_model_path)
 test_score = new_predictor.evaluate(test_data, metrics=['overall_f1', 'ACTOR'])
 print(test_score)
 ```


### PR DESCRIPTION
*Issue #, if available:*
Currently, model load and save with hard coded filename which is prone to error for multiple runs

*Description of changes:*

Added UUID to the model_path in case of multiple runs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
