### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/multimodal/setup.py
+++ b/multimodal/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "requests",
     "jsonschema<=4.8.0",
     "seqeval<=1.2.2",
-    "evaluate<=0.2.2",
+    "evaluate<=0.3.0",
     "accelerate>=0.9,<0.14",
     "timm<0.7.0",
     "torch>=1.9,<1.13",


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.