### PR TITLE
[CI][Cloud] Ping python version of cloud CI and fix cloud setup

### DIFF
--- a/.github/workflows/cloud_continuous_integration.yml
+++ b/.github/workflows/cloud_continuous_integration.yml
@@ -53,6 +53,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
       - name: Test General Cloud
         uses: ./.github/actions/test-cloud
         with:
@@ -69,6 +72,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
       - name: Test Tabular Cloud
         uses: ./.github/actions/test-cloud
         with:
@@ -85,6 +91,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
       - name: Test Tabular Cloud
         uses: ./.github/actions/test-cloud
         with:
@@ -101,6 +110,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
       - name: Test Image Cloud
         uses: ./.github/actions/test-cloud
         with:
@@ -117,6 +129,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
       - name: Test Multimodal Cloud
         uses: ./.github/actions/test-cloud
         with:

--- a/cloud/setup.py
+++ b/cloud/setup.py
@@ -18,7 +18,7 @@ version = ag.update_version(version, use_file_if_exists=False, create_file=True)
 submodule = 'cloud'
 install_requires = [
     # version ranges added in ag.get_dependency_version_ranges()
-    'autogluon.common<0.7'
+    'autogluon.common<0.7',
     'boto3',
     'numpy',
     'opencv-python>=4.6,<4.7',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* https://github.com/awslabs/autogluon/actions/runs/3492726758/jobs/5846811139
  * Not sure why the CI for the [PR](https://github.com/awslabs/autogluon/pull/2408) went through... But missing a colon there. Also ping the version of python in the ci.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
