### PR TITLE
[timeseries] Fix SeasonalNaive producing NaN forecasts if leading NaNs are present

### DIFF
--- a/timeseries/tests/unittests/models/test_local.py
+++ b/timeseries/tests/unittests/models/test_local.py
@@ -410,3 +410,15 @@ def test_when_local_models_fit_then_quantiles_are_present_and_ranked(model_class
 
     assert set(model.quantile_levels) == set(float(q) for q in quantile_columns)
     assert np.diff(predictions[quantile_columns].values, axis=1).min() >= 0
+
+
+def test_when_leading_nans_are_present_then_seasonal_naive_can_forecast(temp_model_path):
+    data = get_data_frame_with_item_index(item_list=["A"], data_length=30, freq="D")
+    data.iloc[:-3] = float("nan")
+    model = SeasonalNaiveModel(
+        path=temp_model_path, prediction_length=7, hyperparameters={**DEFAULT_HYPERPARAMETERS, "seasonal_period": 7}
+    )
+    model.fit(train_data=data)
+    predictions = model.predict(data)
+
+    assert not pd.isna(predictions).any(axis=None)


### PR DESCRIPTION
*Description of changes:*
- Currently, `SeasonalNaive` fails to produce forecasts if the first `y[:-(seasonal_period+2)]` observations contain NaN values, which leads to the predictor failing since the fallback model does not work. This PR fixes this issue by falling back to avg fill in this case.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
