### PR TITLE
prioritize the CUDA libraries from PyTorch wheel instead of the system/DLC

### DIFF
--- a/.github/workflow_scripts/test_multimodal.sh
+++ b/.github/workflow_scripts/test_multimodal.sh
@@ -11,8 +11,16 @@ function test_multimodal {
     install_local_packages "common/[tests]" "core/[all,tests]" "features/"
     install_multimodal "[tests]"
 
-    # Use wheel bundled CUDA instead of DLC CUDA 
-    export LD_LIBRARY_PATH=$(python -c "import torch; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path) if torch_cuda_path else ''; except: print('')"):$LD_LIBRARY_PATH:
+    # Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
+    PYTORCH_CUDA_PATH=$(python -c "import torch, sys; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path if torch_cuda_path else ''); except: print('')")
+    
+    if [ -n "$PYTORCH_CUDA_PATH" ]; then
+        echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
+        export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
+    else
+        echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
+        export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
+    fi
 
     cd multimodal/
     if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_tabular.sh
+++ b/.github/workflow_scripts/test_tabular.sh
@@ -25,8 +25,16 @@ else
     install_multimodal "[tests]"
 fi
 
-# Use wheel bundled CUDA instead of DLC CUDA 
-export LD_LIBRARY_PATH=$(python -c "import torch; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path) if torch_cuda_path else ''; except: print('')"):$LD_LIBRARY_PATH:
+# Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
+PYTORCH_CUDA_PATH=$(python -c "import torch, sys; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path if torch_cuda_path else ''); except: print('')")
+
+if [ -n "$PYTORCH_CUDA_PATH" ]; then
+    echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
+    export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
+else
+    echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
+    export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
+fi
 
 cd tabular/
 if [ -n "$ADDITIONAL_TEST_ARGS" ]

--- a/.github/workflow_scripts/test_timeseries.sh
+++ b/.github/workflow_scripts/test_timeseries.sh
@@ -15,8 +15,16 @@ python -m pip install --upgrade pytest-xdist
 
 export PYTHONHASHSEED=0  # for consistency in xdist tests
 
-# Use wheel bundled CUDA instead of DLC CUDA 
-export LD_LIBRARY_PATH=$(python -c "import torch; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path) if torch_cuda_path else ''; except: print('')"):$LD_LIBRARY_PATH:
+# Use wheel bundled CUDA instead of DLC CUDA with fallback to compatibility check bypass
+PYTORCH_CUDA_PATH=$(python -c "import torch, sys; torch_cuda_path=''; try: torch_cuda_path=torch._C._cuda_getLibPath(); print(torch_cuda_path if torch_cuda_path else ''); except: print('')")
+
+if [ -n "$PYTORCH_CUDA_PATH" ]; then
+    echo "Using PyTorch bundled CUDA libraries from: $PYTORCH_CUDA_PATH"
+    export LD_LIBRARY_PATH=$PYTORCH_CUDA_PATH:$LD_LIBRARY_PATH
+else
+    echo "Warning: Could not get PyTorch bundled CUDA path. Falling back to PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1"
+    export PYTORCH_SKIP_CUDNN_COMPATIBILITY_CHECK=1
+fi
 
 cd timeseries/
 if [ "$IS_PLATFORM_TEST" = 1 ]; then


### PR DESCRIPTION
prioritize the CUDA libraries from PyTorch wheel instead of the system/DLC to avoid incompatible version issues as seen at https://github.com/autogluon/autogluon/actions/runs/15449884138/job/43489311199?pr=5089#step:4:4578

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
