### PR TITLE
Fix CodeQL GitHub action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   CodeQL-Build:
@@ -22,7 +23,7 @@ jobs:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
-      
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- #5351 has incorrectly restricted the scope of the `codeql.yaml` action, which led to this action failing since then:
<img width="823" height="694" alt="image" src="https://github.com/user-attachments/assets/d246e284-f306-4b52-8442-215349340eb2" />

This PR fixes this issue (following https://github.com/github/codeql-action?tab=readme-ov-file#workflow-permissions)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
