### PR TITLE
Make`OneFeatureGenerator` pass `check_is_fitted` test

### DIFF
--- a/tabular/src/autogluon/tabular/models/lr/lr_preprocessing_utils.py
+++ b/tabular/src/autogluon/tabular/models/lr/lr_preprocessing_utils.py
@@ -5,20 +5,19 @@ from autogluon.features.generators import OneHotEncoderFeatureGenerator
 
 class OheFeaturesGenerator(BaseEstimator, TransformerMixin):
     def __init__(self):
-        self._feature_names = []
-        self._encoder = None
+        pass
 
     def fit(self, X, y=None):
-        self._encoder = OneHotEncoderFeatureGenerator(max_levels=10000, verbosity=0)
-        self._encoder.fit(X)
-        self._feature_names = self._encoder.features_out
+        self.encoder_ = OneHotEncoderFeatureGenerator(max_levels=10000, verbosity=0)
+        self.encoder_.fit(X)
+        self.feature_names_ = self.encoder_.features_out
         return self
 
     def transform(self, X, y=None):
-        return self._encoder.transform_ohe(X)
+        return self.encoder_.transform_ohe(X)
 
     def get_feature_names(self):
-        return self._feature_names
+        return self.feature_names_
 
 
 class NlpDataPreprocessor(BaseEstimator, TransformerMixin):


### PR DESCRIPTION
*Description of changes:*

scikit-learn considers estimators as fitted if they have one public attribute that ends in a `_`. In the `Pipeline` estimator all individual steps have to be fitted for the pipeline as a whole to be considered fitted. In versions before scikit-learn 1.8 using `predict` on an unfitted pipeline raises a warning, but as of 1.8 it will be an error. This PR fixes `OneFeatureGenerator` so that it passes the `check_is_fitted` check.

One could also implement a custom [`__sklearn_is_fitted__`](https://scikit-learn.org/dev/auto_examples/developing_estimators/sklearn_is_fitted.html) but that seems like a more complicated solution compared to this PR which mostly makes `OneFeatureGenerator` more like the recommendations from https://scikit-learn.org/dev/developers/develop.html

I found this while running a slightly modified version of https://github.com/autogluon/tabarena/blob/main/examples/benchmarking/run_quickstart_tabarena.py

xref @ncclementi