### PR TITLE
[timeseries] adjust Toto docstring

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/toto/model.py
+++ b/timeseries/src/autogluon/timeseries/models/toto/model.py
@@ -26,9 +26,9 @@ class TotoModel(AbstractTimeSeriesModel):
     `Hugging Face <https://huggingface.co/Datadog/Toto-Open-Base-1.0>`_ and `GitHub <https://github.com/DataDog/toto>`_.
 
     The AutoGluon implementation of Toto is on a port of the original implementation. AutoGluon supports Toto for
-    **inference only**, i.e., the model will not be trained or fine-tuned on the provided training data. Toto is optimized 
-    for easy maintenance with the rest of the AutoGluon model zoo, and does not feature some important optimizations such 
-    as xformers and flash-attention available in the original model repository. The AutoGluon implementation of Toto 
+    **inference only**, i.e., the model will not be trained or fine-tuned on the provided training data. Toto is optimized
+    for easy maintenance with the rest of the AutoGluon model zoo, and does not feature some important optimizations such
+    as xformers and flash-attention available in the original model repository. The AutoGluon implementation of Toto
     requires a CUDA-compatible GPU.
 
     References


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Related to #5387, the current docstring of Toto did not clarify that fine-tuning is not supported. This edit clarifies this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
