### PR TITLE
Fix permissions for platform_tests action

### DIFF
--- a/.github/workflows/platform_tests-command.yml
+++ b/.github/workflows/platform_tests-command.yml
@@ -20,11 +20,6 @@ on:
         description: 'Get info of forked repository and branch'
         required: false
 
-permissions:
-  contents: read
-  pull-requests: write
-  actions: read
-
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Undo the error introduced in #5351 that excessively narrowed down the permissions for the platform tests action


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
