### PR TITLE
[timeseries] extend EnsembleComposer to multilayer stacking

### DIFF
--- a/timeseries/src/autogluon/timeseries/learner.py
+++ b/timeseries/src/autogluon/timeseries/learner.py
@@ -59,7 +59,7 @@ class TimeSeriesLearner(AbstractLearner):
         val_data: TimeSeriesDataFrame | None = None,
         hyperparameter_tune_kwargs: str | dict | None = None,
         time_limit: float | None = None,
-        num_val_windows: int | None = None,
+        num_val_windows: int = 1,
         val_step_size: int | None = None,
         refit_every_n_windows: int | None = 1,
         random_seed: int | None = None,

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1678,7 +1678,7 @@ class TimeSeriesPredictor:
         trainer = self._trainer
         train_data = trainer.load_train_data()
         val_data = trainer.load_val_data()
-        base_model_names = trainer.get_model_names(level=0)
+        base_model_names = trainer.get_model_names(layer=0)
         pred_proba_dict_val: dict[str, list[TimeSeriesDataFrame]] = {
             model_name: trainer._get_model_oof_predictions(model_name)
             for model_name in base_model_names

--- a/timeseries/src/autogluon/timeseries/trainer/ensemble_composer.py
+++ b/timeseries/src/autogluon/timeseries/trainer/ensemble_composer.py
@@ -2,7 +2,8 @@ import logging
 import os
 import time
 import traceback
-from typing import Iterator
+from pathlib import Path
+from typing import Any, Iterator
 
 import networkx as nx
 import numpy as np
@@ -10,7 +11,12 @@ from typing_extensions import Self
 
 from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.metrics import TimeSeriesScorer
-from autogluon.timeseries.models.ensemble import AbstractTimeSeriesEnsembleModel, get_ensemble_class
+from autogluon.timeseries.models.ensemble import (
+    AbstractTimeSeriesEnsembleModel,
+    PerformanceWeightedEnsemble,
+    get_ensemble_class,
+)
+from autogluon.timeseries.utils.timer import SplitTimer
 from autogluon.timeseries.utils.warning_filters import warning_filter
 
 from .utils import log_scores_and_times
@@ -19,17 +25,59 @@ logger = logging.getLogger("autogluon.timeseries.trainer")
 
 
 class EnsembleComposer:
-    """Helper class for TimeSeriesTrainer to build multi-layer stack ensembles."""
+    """Helper class for TimeSeriesTrainer to build multi-layer stack ensembles.
+
+    This class depends on the trainer to provide the necessary initialization parameters, training
+    and validation data, as well as having fit the base (non-ensemble) models and persisted their
+    out-of-fold predictions which will be used for ensemble training.
+
+    Parameters
+    ----------
+    path
+        Path of the calling TimeSeriesTrainer. EnsembleComposer finds the model objects and their
+        out-of-fold prediction artifacts with respect to this path. EnsembleComposer only saves
+        ensemble models and their out-of-fold predictions to this folder (i.e., does not pickle
+        itself).
+    prediction_length
+        Number of time steps to forecast.
+    eval_metric
+        Metric used to evaluate ensemble performance.
+    target
+        Name of the target column in the time series data.
+    num_windows_per_layer
+        Number of windows used for training each ensemble layer. Length must match the number of layers
+        in ensemble_hyperparameters. Example: (3, 2) means first layer uses 3 windows, second layer uses
+        2 windows.
+
+        Base models must have OOF predictions saved for all sum(num_windows_per_layer) windows, prior
+        to this class being called.
+    ensemble_hyperparameters
+        Ensemble configuration. A list of dicts, one per layer. If an ensemble model should be fitted
+        with multiple hyperparameter configurations, a list of dicts may be provided as the value.
+        Each layer's dict maps ensemble names to either a single hyperparameter dict or a list of
+        hyperparameter dicts.
+
+        Examples:
+        - ``[{"GreedyEnsemble": {}}, {"GreedyEnsemble": {}}]`` for 2 layers of greedy ensembles.
+        - ``[{"GreedyEnsemble": [{"ensemble_size": 10}, {"ensemble_size": 20}]}]`` for a single layer of
+          two greedy ensembles, with differing ensemble sizes.
+    quantile_levels
+        Quantile levels for probabilistic forecasting.
+    model_graph
+        Directed graph containing base models and their metadata (val_score, fit_time, etc.). Only
+        base models (nodes without predecessors) are used for ensemble training.
+    """
 
     def __init__(
         self,
-        path,
+        path: str,
         prediction_length: int,
         eval_metric: TimeSeriesScorer,
         target: str,
+        num_windows_per_layer: tuple[int, ...],
+        ensemble_hyperparameters: list[dict[str, dict | list[dict]]],
         quantile_levels: list[float],
         model_graph: nx.DiGraph,
-        ensemble_hyperparameters: dict,
     ):
         self.eval_metric = eval_metric
         self.path = path
@@ -37,6 +85,15 @@ class EnsembleComposer:
         self.target = target
         self.quantile_levels = quantile_levels
 
+        self.num_windows_per_layer = num_windows_per_layer
+        self.num_layers = len(num_windows_per_layer)
+
+        if len(ensemble_hyperparameters) != self.num_layers:
+            raise ValueError(
+                "Number of ensemble_hyperparameters must match the number of layers. "
+                f"Received {len(ensemble_hyperparameters)} ensemble_hyperparameters, "
+                f"but {self.num_layers} layers."
+            )
         self.ensemble_hyperparameters = ensemble_hyperparameters
 
         self.banned_model_names = list(model_graph.nodes)
@@ -44,8 +101,9 @@ class EnsembleComposer:
 
     @staticmethod
     def _get_base_model_graph(source_graph: nx.DiGraph) -> nx.DiGraph:
-        """Return a model graph by copying only base models (nodes without predecessors)
-        This ensures we start fresh for ensemble building.
+        """Return a model graph by copying only base models (nodes without predecessors).
+
+        This ensures we start fresh for training ensembles.
         """
         rootset = EnsembleComposer._get_rootset(source_graph)
 
@@ -59,34 +117,53 @@ class EnsembleComposer:
     def _get_rootset(graph: nx.DiGraph) -> list[str]:
         return [n for n in graph.nodes if not list(graph.predecessors(n))]
 
-    def iter_ensembles(self) -> Iterator[tuple[int, AbstractTimeSeriesEnsembleModel, list[str]]]:
-        """Iterate over trained ensemble models, layer by layer.
+    def _load_model(self, model_name: str) -> Any:
+        """Load a model from the graph by name."""
+        attrs = self.model_graph.nodes[model_name]
+        model_path = os.path.join(self.path, *attrs["path"])
+        return attrs["type"].load(path=model_path)
+
+    def _iter_models(self, layer: int) -> Iterator[tuple[str, Any]]:
+        """Iterate over models in a specific layer of the model graph.
+
+        Parameters
+        ----------
+        layer
+            Layer index (0 for base models, 1+ for ensemble layers)
 
         Yields
         ------
-        layer_ix
+        model_name
+            Name of the model
+        model
+            Loaded model instance
+        """
+        rootset = self._get_rootset(self.model_graph)
+        layer_iter = nx.traversal.bfs_layers(self.model_graph, rootset)
+        for layer_idx, layer_keys in enumerate(layer_iter):
+            if layer_idx != layer:
+                continue
+
+            for model_name in layer_keys:
+                model = self._load_model(model_name)
+                yield model_name, model
+
+    def iter_ensembles(self) -> Iterator[tuple[int, AbstractTimeSeriesEnsembleModel, list[str]]]:
+        """Iterate over trained ensemble models, layer by layer. Used by the Trainer to copy the
+        fitted models in EnsembleComposer's ``model_graph``.
+
+        Yields
+        ------
+        layer_idx
             The layer index of the ensemble.
         model
             The ensemble model object
         base_model_names
             The names of the base models that are part of the ensemble.
         """
-        rootset = self._get_rootset(self.model_graph)
-
-        for layer_ix, layer in enumerate(nx.traversal.bfs_layers(self.model_graph, rootset)):
-            if layer_ix == 0:  # we don't need base models
-                continue
-
-            for model_name in layer:
-                attrs = self.model_graph.nodes[model_name]
-                model_path = os.path.join(self.path, *attrs["path"])
-                model = attrs["type"].load(path=model_path)
-
-                yield (
-                    layer_ix,
-                    model,
-                    list(self.model_graph.predecessors(model_name)),
-                )
+        for layer_idx in range(1, self.num_layers + 1):
+            for model_name, model in self._iter_models(layer=layer_idx):
+                yield (layer_idx, model, list(self.model_graph.predecessors(model_name)))
 
     def fit(
         self,
@@ -94,72 +171,197 @@ class EnsembleComposer:
         predictions_per_window: dict[str, list[TimeSeriesDataFrame]],
         time_limit: float | None = None,
     ) -> Self:
-        base_model_scores = {k: self.model_graph.nodes[k]["val_score"] for k in self.model_graph.nodes}
-        model_names = list(base_model_scores.keys())
-
-        if not self._can_fit_ensemble(time_limit, len(model_names)):
+        base_model_names = [name for name, _ in self._iter_models(layer=0)]
+        if not self._can_fit_ensemble(time_limit, len(base_model_names)):
             return self
 
-        logger.info(f"Fitting {len(self.ensemble_hyperparameters)} ensemble(s).")
+        num_ensembles = sum(
+            len(list(self.iter_layer_models_and_hps(layer))) for layer in range(1, self.num_layers + 1)
+        )
+        logger.info(f"Fitting {num_ensembles} ensemble(s), in {self.num_layers} layers.")
 
-        for ensemble_name, ensemble_hp_dict in self.ensemble_hyperparameters.items():
-            try:
-                time_start = time.monotonic()
-                ensemble_class = get_ensemble_class(ensemble_name)
-                ensemble = ensemble_class(
-                    eval_metric=self.eval_metric,
-                    target=self.target,
-                    prediction_length=self.prediction_length,
-                    path=self.path,
-                    freq=data_per_window[0].freq,
-                    quantile_levels=self.quantile_levels,
-                    hyperparameters=ensemble_hp_dict,
+        assert len(data_per_window) == sum(self.num_windows_per_layer)
+
+        def get_inputs_for_layer(layer_idx, model_names):
+            """Retrieve predictions from previous layer models for current layer training."""
+            if layer_idx == 1:
+                # we need base models, so we use predictions_per_window provided by the trainer,
+                # which contains base model predictions for all windows where ensembles will be
+                # trained.
+                num_windows = self.num_windows_per_layer[0]
+                inputs = {name: predictions_per_window[name][:num_windows] for name in model_names}
+            else:
+                # if layer_idx > 1, we will be relying on predictions of previously trained ensembles
+                window_start = -sum(self.num_windows_per_layer[layer_idx - 1 :])
+                window_slice = slice(
+                    window_start,
+                    window_start + self.num_windows_per_layer[layer_idx - 1] if layer_idx < self.num_layers else None,
                 )
-                # update name to prevent name collisions
-                ensemble.name = self._get_ensemble_model_name(ensemble.name)
 
-                with warning_filter():
-                    ensemble.fit(
-                        predictions_per_window=predictions_per_window,
-                        data_per_window=data_per_window,
-                        model_scores=base_model_scores,
-                        time_limit=time_limit,
+                inputs = {}
+                for model_name in model_names:
+                    oof_predictions = self._get_model_oof_predictions(model_name)
+                    inputs[model_name] = oof_predictions[window_slice]
+
+            return inputs
+
+        def get_ground_truth_for_layer(layer_idx):
+            window_start = sum(self.num_windows_per_layer[: layer_idx - 1])
+            window_end = window_start + self.num_windows_per_layer[layer_idx - 1]
+            return data_per_window[window_start:window_end]
+
+        main_loop_timer = SplitTimer(time_limit, rounds=num_ensembles).start()
+
+        # main loop over layers of ensembles
+        for layer_idx in range(1, self.num_layers + 1):
+            layer_input_model_names = [name for name, _ in self._iter_models(layer=layer_idx - 1)]
+            layer_input_model_scores = {
+                name: self.model_graph.nodes[name]["val_score"] for name in layer_input_model_names
+            }
+
+            layer_predictions_per_window = get_inputs_for_layer(layer_idx, model_names=layer_input_model_names)
+            layer_data_per_window = get_ground_truth_for_layer(layer_idx)
+
+            for ensemble_name, ensemble_hp_dict in self.iter_layer_models_and_hps(layer_idx):
+                try:
+                    # train the ensemble model
+                    time_start = time.monotonic()
+
+                    ensemble = self._fit_single_ensemble(
+                        model_name=ensemble_name,
+                        hyperparameters=ensemble_hp_dict,
+                        predictions_per_window=layer_predictions_per_window,
+                        data_per_window=layer_data_per_window,
+                        base_model_scores=layer_input_model_scores,
+                        layer_idx=layer_idx,
+                        time_limit=main_loop_timer.round_time_remaining(),
                     )
-                ensemble.fit_time = time.monotonic() - time_start
+                    ensemble.fit_time = time.monotonic() - time_start
 
-                ensemble_predictions_per_window = []
-                score_per_window = []
-                for window_idx, data in enumerate(data_per_window):
-                    predictions = ensemble.predict(
-                        {n: predictions_per_window[n][window_idx] for n in ensemble.model_names}
+                    # for all windows of all layers starting from this layer, predict and save predictions
+                    predictions = []
+                    predict_time = 0
+                    for pred_layer_idx in range(layer_idx, self.num_layers + 1):
+                        predict_time_start = time.monotonic()
+
+                        pred_base_predictions = get_inputs_for_layer(pred_layer_idx, ensemble.model_names)
+                        for window_idx in range(self.num_windows_per_layer[pred_layer_idx - 1]):
+                            prediction = ensemble.predict(
+                                {n: pred_base_predictions[n][window_idx] for n in ensemble.model_names}
+                            )
+                            predictions.append(prediction)
+
+                        predict_time = time.monotonic() - predict_time_start
+
+                    # prediction time is last layer's time + base models
+                    ensemble.predict_time = predict_time + self._calculate_base_models_predict_time(
+                        ensemble.model_names
                     )
-                    ensemble_predictions_per_window.append(predictions)
-                    score_per_window.append(self.eval_metric.score(data, predictions, self.target))
-                ensemble.cache_oof_predictions(ensemble_predictions_per_window)
-                ensemble.val_score = float(np.mean(score_per_window, dtype=np.float64))
+                    ensemble.cache_oof_predictions(predictions)
 
-                # TODO: add ensemble's own time to predict_time
-                ensemble.predict_time = self._calculate_base_models_predict_time(ensemble.model_names)
+                    # compute validation score using the last layer's validation windows
+                    last_layer_oof_predictions = ensemble.get_oof_predictions()[-self.num_windows_per_layer[-1] :]
+                    last_layer_ground_truth = get_ground_truth_for_layer(self.num_layers)
+                    score_per_fold = [
+                        self.eval_metric(data, prediction, target=self.target)
+                        for prediction, data in zip(last_layer_oof_predictions, last_layer_ground_truth)
+                    ]
+                    ensemble.val_score = float(np.mean(score_per_fold, dtype=np.float64))
 
-                log_scores_and_times(
-                    ensemble.val_score,
-                    ensemble.fit_time,
-                    ensemble.predict_time,
-                    eval_metric_name=self.eval_metric.name_with_sign,
-                )
+                    # log performance and save
+                    log_scores_and_times(
+                        ensemble.val_score,
+                        ensemble.fit_time,
+                        ensemble.predict_time,
+                        eval_metric_name=self.eval_metric.name_with_sign,
+                    )
 
-                self._add_model(ensemble, base_models=ensemble.model_names)
+                    # save ensemble
+                    self._add_model(ensemble, base_models=ensemble.model_names)
+                    ensemble.save()
 
-                # Save the ensemble model to disk
-                ensemble.save()
-            except Exception as err:  # noqa
-                logger.error(
-                    f"\tWarning: Exception caused {ensemble_name} to fail during training... Skipping this model."
-                )
-                logger.error(f"\t{err}")
-                logger.debug(traceback.format_exc())
+                    # check time and advance round
+                    if main_loop_timer.timed_out():
+                        logger.warning(
+                            "Time limit exceeded during ensemble training, will stop training new ensembles."
+                        )
+                        return self
+
+                except Exception as err:  # noqa
+                    logger.error(
+                        f"\tWarning: Exception caused {ensemble_name} to fail during training... Skipping this model."
+                    )
+                    logger.error(f"\t{err}")
+                    logger.debug(traceback.format_exc())
+
+                finally:
+                    main_loop_timer.next_round()
 
         return self
+
+    def iter_layer_models_and_hps(self, layer_idx: int):
+        layer_hps = self.ensemble_hyperparameters[layer_idx - 1]
+
+        for model_name, hps in layer_hps.items():
+            if isinstance(hps, list):
+                # If a list is provided, create one ensemble per hyperparameter dict
+                for hp in hps:
+                    yield model_name, hp
+            else:
+                yield model_name, hps
+
+    def _fit_single_ensemble(
+        self,
+        model_name: str,
+        hyperparameters: dict,
+        predictions_per_window: dict[str, list[TimeSeriesDataFrame]],
+        data_per_window: list[TimeSeriesDataFrame],
+        base_model_scores: dict[str, float],
+        layer_idx: int,
+        time_limit: float | None = None,
+    ) -> AbstractTimeSeriesEnsembleModel:
+        ensemble_class = get_ensemble_class(model_name)
+
+        # TODO: remove this after PerformanceWeightedEnsemble is removed. This is a temporary fix
+        # to make sure PerformanceWeightedEnsemble is not fit on the validation scores of future
+        # out-of-fold splits.
+        if layer_idx < self.num_layers and ensemble_class is PerformanceWeightedEnsemble:
+            raise RuntimeError(
+                "PerformanceWeightedEnsemble is not supported for multilayer stack ensembles, except "
+                "when it's used in the last layer of the ensemble."
+            )
+
+        ensemble: AbstractTimeSeriesEnsembleModel = ensemble_class(
+            eval_metric=self.eval_metric,
+            target=self.target,
+            prediction_length=self.prediction_length,
+            path=self.path,
+            freq=data_per_window[0].freq,
+            quantile_levels=self.quantile_levels,
+            hyperparameters=hyperparameters,
+        )
+
+        # update name to prevent name collisions
+        old_name = ensemble.name
+        ensemble.name = self._get_ensemble_model_name(ensemble.name, layer_idx)
+        if ensemble.name != old_name:
+            path_obj = Path(ensemble.path)
+            ensemble.path = str(path_obj.parent / ensemble.name)
+
+        with warning_filter():
+            ensemble.fit(
+                predictions_per_window=predictions_per_window,
+                data_per_window=data_per_window,
+                model_scores=base_model_scores,
+                time_limit=time_limit,
+            )
+
+        return ensemble
+
+    def _get_model_oof_predictions(self, model_name: str) -> list[TimeSeriesDataFrame]:
+        model_attrs = self.model_graph.nodes[model_name]
+        model_path = os.path.join(self.path, *model_attrs["path"])
+        return model_attrs["type"].load_oof_predictions(path=model_path)
 
     def _add_model(self, model, base_models: list[str]):
         self.model_graph.add_node(
@@ -172,6 +374,7 @@ class EnsembleComposer:
         )
         for base_model in base_models:
             self.model_graph.add_edge(base_model, model.name)
+        self.banned_model_names.append(model.name)
 
     def _can_fit_ensemble(
         self,
@@ -195,13 +398,15 @@ class EnsembleComposer:
 
         return True
 
-    def _get_ensemble_model_name(self, name: str) -> str:
+    def _get_ensemble_model_name(self, name: str, layer_idx: int) -> str:
         """Revise name for an ensemble model, ensuring we don't have name collisions"""
         base_name = name
+        layer_suffix = f"_L{layer_idx + 1}" if self.num_layers > 1 else ""
+        name = f"{base_name}" + layer_suffix
         increment = 1
         while name in self.banned_model_names:
             increment += 1
-            name = f"{base_name}_{increment}"
+            name = f"{base_name}_{increment}" + layer_suffix
         return name
 
     def _calculate_base_models_predict_time(self, model_names: list[str]) -> float:
@@ -209,13 +414,16 @@ class EnsembleComposer:
         return sum(self.model_graph.nodes[name]["predict_time"] for name in model_names)
 
 
-def validate_ensemble_hyperparameters(hyperparameters) -> dict:
-    """Validate ensemble hyperparameters dict."""
-    if not isinstance(hyperparameters, dict):
-        raise ValueError(f"ensemble_hyperparameters must be dict, got {type(hyperparameters)}")
+def validate_ensemble_hyperparameters(hyperparameters: list[dict[str, dict | list[dict]]]) -> None:
+    if not isinstance(hyperparameters, list):
+        raise ValueError(f"ensemble_hyperparameters must be list, got {type(hyperparameters)}")
 
-    # Validate all ensemble names are known
-    for ensemble_name, ensemble_hyperparameters in hyperparameters.items():
-        get_ensemble_class(ensemble_name)  # Will raise if unknown
-        assert isinstance(ensemble_hyperparameters, dict)
-    return hyperparameters
+    for layer_idx, layer_hp in enumerate(hyperparameters):
+        if not isinstance(layer_hp, dict):
+            raise ValueError(f"Layer {layer_idx} hyperparameters must be dict, got {type(layer_hp)}")
+        for ensemble_name, ensemble_hp in layer_hp.items():
+            get_ensemble_class(ensemble_name)  # Will raise if unknown
+            hp_is_dict = isinstance(ensemble_hp, dict)
+            hp_is_valid_list = isinstance(ensemble_hp, list) and all(isinstance(d, dict) for d in ensemble_hp)
+            if not (hp_is_dict or hp_is_valid_list):
+                raise ValueError(f"Hyperparameters for {ensemble_name} must be dict or list, got {type(ensemble_hp)}")

--- a/timeseries/tests/unittests/trainer/test_ensemble_composer.py
+++ b/timeseries/tests/unittests/trainer/test_ensemble_composer.py
@@ -1,75 +1,527 @@
+import random
+from pathlib import Path
+from unittest import mock
+
+import networkx as nx
+import numpy as np
+import pandas as pd
 import pytest
 
+from autogluon.timeseries import TimeSeriesDataFrame
 from autogluon.timeseries.trainer import TimeSeriesTrainer
 from autogluon.timeseries.trainer.ensemble_composer import EnsembleComposer, validate_ensemble_hyperparameters
 
-from ..common import DUMMY_TS_DATAFRAME
+from ..common import DUMMY_TS_DATAFRAME, get_data_frame_with_item_index, get_prediction_for_df
 
 
-@pytest.fixture(scope="module")
-def trainer(tmp_path_factory):
-    path = str(tmp_path_factory.mktemp("agts_ensemble_composer_dummy_trainer"))
-    trainer = TimeSeriesTrainer(path=path, prediction_length=3)
+@pytest.fixture()
+def patch_models():
+    rng = random.Random(42)
+
+    def mock_predict(self, data, **kwargs):
+        return get_prediction_for_df(data, prediction_length=self.prediction_length)
+
+    def mock_greedy_fit(self, predictions_per_window, *args, **kwargs):
+        model_names = list(predictions_per_window.keys())
+        weights = [rng.uniform(0, 1) for _ in range(len(model_names))]
+        self.model_to_weight = {model_name: weights[i] / sum(weights) for i, model_name in enumerate(model_names)}
+        return self
+
+    with (
+        mock.patch("autogluon.timeseries.models.local.naive.NaiveModel.predict", mock_predict),
+        mock.patch("autogluon.timeseries.models.local.naive.SeasonalNaiveModel.predict", mock_predict),
+        mock.patch("autogluon.timeseries.models.ensemble.weighted.greedy.GreedyEnsemble.fit", mock_greedy_fit),
+        # nvutil cudaInit and cudaShutdown is triggered for each run of the trainer. we disable this here
+        mock.patch("autogluon.common.utils.resource_utils.ResourceManager.get_gpu_count", return_value=0),
+    ):
+        yield
+
+
+class TestSingleLayerEnsemble:
+    @pytest.fixture()
+    def trainer(self, tmp_path_factory, patch_models):
+        path = str(tmp_path_factory.mktemp("agts_ensemble_composer_dummy_trainer"))
+        trainer = TimeSeriesTrainer(path=path, prediction_length=3)
+        trainer.fit(
+            train_data=DUMMY_TS_DATAFRAME,
+            hyperparameters={"Naive": {}, "SeasonalNaive": {}},
+        )
+        yield trainer
+
+    @pytest.mark.parametrize(
+        "ensemble_hyperparameters,expected_count",
+        [
+            ([{"GreedyEnsemble": {"ensemble_size": 2}}], 1),
+            ([{"GreedyEnsemble": {"ensemble_size": 2}, "PerformanceWeightedEnsemble": {}}], 2),
+            ([{"PerformanceWeightedEnsemble": {"weight_scheme": "sq"}}], 1),
+            ([{"SimpleAverageEnsemble": {}}], 1),
+            ([{"GreedyEnsemble": [{"ensemble_size": 2}, {"ensemble_size": 3}]}], 2),
+            (
+                [
+                    {
+                        "GreedyEnsemble": {"ensemble_size": 2},
+                        "SimpleAverageEnsemble": {},
+                        "PerformanceWeightedEnsemble": {},
+                    }
+                ],
+                3,
+            ),
+        ],
+    )
+    def test_when_ensemble_composer_created_then_can_train_single_layer_ensembles(
+        self, trainer, ensemble_hyperparameters, expected_count
+    ):
+        """Test that the ensemble composer can create single-layer ensembles correctly."""
+        ensemble_composer = EnsembleComposer(
+            path=trainer.path,
+            prediction_length=trainer.prediction_length,
+            eval_metric=trainer.eval_metric,
+            ensemble_hyperparameters=ensemble_hyperparameters,
+            num_windows_per_layer=(1,),
+            target=trainer.target,
+            quantile_levels=trainer.quantile_levels,
+            model_graph=trainer.model_graph,
+        )
+        data_per_window = trainer._get_validation_windows(DUMMY_TS_DATAFRAME, None)
+        model_names = trainer.get_model_names(layer=0)
+        predictions_per_window = trainer._get_base_model_predictions(model_names)
+        ensemble_composer.fit(data_per_window=data_per_window, predictions_per_window=predictions_per_window)
+
+        ensembles = list(ensemble_composer.iter_ensembles())
+        assert len(ensembles) == expected_count
+
+        for layer_idx, _, base_models in ensembles:
+            assert layer_idx == 1
+            assert len(base_models) >= 1
+
+    def test_when_single_layer_then_ensemble_names_have_no_suffix(self, trainer):
+        """Test that single-layer ensembles don't get a layer suffix."""
+        ensemble_composer = EnsembleComposer(
+            path=trainer.path,
+            prediction_length=trainer.prediction_length,
+            eval_metric=trainer.eval_metric,
+            ensemble_hyperparameters=[{"GreedyEnsemble": {}, "SimpleAverageEnsemble": {}}],
+            num_windows_per_layer=(1,),
+            target=trainer.target,
+            quantile_levels=trainer.quantile_levels,
+            model_graph=trainer.model_graph,
+        )
+        data_per_window = trainer._get_validation_windows(DUMMY_TS_DATAFRAME, None)
+        model_names = trainer.get_model_names(layer=0)
+        predictions_per_window = trainer._get_base_model_predictions(model_names)
+        ensemble_composer.fit(data_per_window=data_per_window, predictions_per_window=predictions_per_window)
+
+        ensembles = list(ensemble_composer.iter_ensembles())
+
+        for layer_idx, ensemble, _ in ensembles:
+            assert not ensemble.name.endswith("_L2"), (
+                f"Single-layer ensemble {ensemble.name} should not have layer suffix"
+            )
+
+
+class TestTwoLayerStacking:
+    @pytest.fixture(
+        params=[
+            # ensemble_hyperparameters, expected_count_per_layer
+            ([{"GreedyEnsemble": {"ensemble_size": 2}}, {"SimpleAverageEnsemble": {}}], [1, 1]),
+            (
+                [{"GreedyEnsemble": [{"ensemble_size": 2}, {"ensemble_size": 3}]}, {"SimpleAverageEnsemble": {}}],
+                [2, 1],
+            ),
+            (
+                [
+                    {"GreedyEnsemble": [{"ensemble_size": 2}, {"ensemble_size": 3}]},
+                    {"SimpleAverageEnsemble": {}, "PerformanceWeightedEnsemble": {}},
+                ],
+                [2, 2],
+            ),
+        ],
+    )
+    def fitted_composer_and_expected_count(self, tmp_path_factory, request, patch_models):
+        path = str(tmp_path_factory.mktemp("agts_l2_trainer"))
+        trainer = TimeSeriesTrainer(path=path, prediction_length=3, num_val_windows=5)
+        trainer.fit(
+            train_data=DUMMY_TS_DATAFRAME,
+            hyperparameters={"Naive": {}, "SeasonalNaive": {}},
+        )
+
+        ensemble_hyperparameters, expected_count_per_layer = request.param
+
+        data_per_window = trainer._get_validation_windows(DUMMY_TS_DATAFRAME, None)
+        model_names = trainer.get_model_names(layer=0)
+        predictions_per_window = trainer._get_base_model_predictions(model_names)
+
+        ensemble_composer = EnsembleComposer(
+            path=trainer.path,
+            prediction_length=trainer.prediction_length,
+            eval_metric=trainer.eval_metric,
+            ensemble_hyperparameters=ensemble_hyperparameters,
+            num_windows_per_layer=(3, 2),
+            target=trainer.target,
+            quantile_levels=trainer.quantile_levels,
+            model_graph=trainer.model_graph,
+        ).fit(data_per_window=data_per_window, predictions_per_window=predictions_per_window)
+
+        return ensemble_composer, expected_count_per_layer
+
+    def test_when_two_layers_then_correct_number_of_ensembles_created(self, fitted_composer_and_expected_count):
+        ensemble_composer, expected_count_per_layer = fitted_composer_and_expected_count
+        ensembles = list(ensemble_composer.iter_ensembles())
+        assert len(ensembles) == sum(expected_count_per_layer)
+
+    def test_when_two_layers_then_layer_indices_correct(self, fitted_composer_and_expected_count):
+        ensemble_composer, expected_count_per_layer = fitted_composer_and_expected_count
+
+        ensembles = list(ensemble_composer.iter_ensembles())
+        layer_indices = [layer_idx for layer_idx, _, _ in ensembles]
+        assert layer_indices == [j for j, count in enumerate(expected_count_per_layer, start=1) for _ in range(count)]
+
+    def test_when_two_layers_then_every_layer_has_correct_oof_predictions(self, fitted_composer_and_expected_count):
+        ensemble_composer, _ = fitted_composer_and_expected_count
+
+        ensembles = list(ensemble_composer.iter_ensembles())
+        expected_oof_counts = {1: 5, 2: 2}
+
+        for layer_idx, ensemble, _ in ensembles:
+            oof_predictions = ensemble.load_oof_predictions(ensemble.path)
+            assert len(oof_predictions) == expected_oof_counts[layer_idx]
+
+    def test_when_two_layers_then_l3_uses_l2_as_base(self, fitted_composer_and_expected_count):
+        ensemble_composer, _ = fitted_composer_and_expected_count
+        ensembles = list(ensemble_composer.iter_ensembles())
+
+        l2_models = [ens.name for layer_idx, ens, _ in ensembles if layer_idx == 1]
+        l3_base_models = [base_models for layer_idx, _, base_models in ensembles if layer_idx == 2]
+
+        for base_models in l3_base_models:
+            assert set(base_models).issubset(set(l2_models))
+
+    def test_when_two_layers_then_graph_structure_correct(self, fitted_composer_and_expected_count):
+        ensemble_composer, expected_count_per_layer = fitted_composer_and_expected_count
+
+        graph = ensemble_composer.model_graph
+        rootset = [n for n in graph.nodes if not list(graph.predecessors(n))]
+        layers = list(nx.traversal.bfs_layers(graph, rootset))
+
+        assert len(layers) == 3  # Base models (layer 0), L2 (layer 1), L3 (layer 2)
+        assert len(layers[0]) == 2  # 2 base models
+        assert len(layers[1]) == expected_count_per_layer[0]
+        assert len(layers[2]) == expected_count_per_layer[1]
+
+    def test_when_two_layers_then_ensemble_names_have_layer_suffix(self, fitted_composer_and_expected_count):
+        ensemble_composer, _ = fitted_composer_and_expected_count
+        ensembles = list(ensemble_composer.iter_ensembles())
+
+        for layer_idx, ensemble, _ in ensembles:
+            expected_suffix = f"_L{layer_idx + 1}"
+            assert ensemble.name.endswith(expected_suffix)
+
+
+class TestThreeLayerStacking:
+    @pytest.fixture()
+    def fitted_composer(self, tmp_path_factory, patch_models):
+        path = str(tmp_path_factory.mktemp("agts_l3_trainer"))
+        trainer = TimeSeriesTrainer(path=path, prediction_length=3, num_val_windows=5)
+        trainer.fit(
+            train_data=DUMMY_TS_DATAFRAME,
+            hyperparameters={"Naive": {}, "SeasonalNaive": {}},
+        )
+
+        ensemble_hyperparameters = [
+            {"GreedyEnsemble": {}, "SimpleAverageEnsemble": {}},
+            {"GreedyEnsemble": {}, "SimpleAverageEnsemble": {}},
+            {"GreedyEnsemble": {}},
+        ]
+
+        data_per_window = trainer._get_validation_windows(DUMMY_TS_DATAFRAME, None)
+        model_names = trainer.get_model_names(layer=0)
+        predictions_per_window = trainer._get_base_model_predictions(model_names)
+
+        ensemble_composer = EnsembleComposer(
+            path=trainer.path,
+            prediction_length=trainer.prediction_length,
+            eval_metric=trainer.eval_metric,
+            ensemble_hyperparameters=ensemble_hyperparameters,  # type: ignore
+            num_windows_per_layer=(2, 2, 1),
+            target=trainer.target,
+            quantile_levels=trainer.quantile_levels,
+            model_graph=trainer.model_graph,
+        ).fit(data_per_window=data_per_window, predictions_per_window=predictions_per_window)
+
+        return ensemble_composer
+
+    def test_when_three_layers_then_correct_number_of_ensembles_created(self, fitted_composer):
+        ensembles = list(fitted_composer.iter_ensembles())
+        assert len(ensembles) == 5
+
+    def test_when_three_layers_then_layer_indices_correct(self, fitted_composer):
+        ensembles = list(fitted_composer.iter_ensembles())
+        layer_indices = [layer_idx for layer_idx, _, _ in ensembles]
+        assert layer_indices == [1, 1, 2, 2, 3]
+
+    def test_when_three_layers_then_oof_predictions_correct(self, fitted_composer):
+        ensembles = list(fitted_composer.iter_ensembles())
+        expected_oof_counts = {1: 5, 2: 3, 3: 1}
+
+        for layer_idx, ensemble, _ in ensembles:
+            oof_predictions = ensemble.load_oof_predictions(ensemble.path)
+            assert len(oof_predictions) == expected_oof_counts[layer_idx]
+
+    def test_when_three_layers_then_ensemble_names_have_layer_suffix(self, fitted_composer):
+        ensembles = list(fitted_composer.iter_ensembles())
+
+        for layer_idx, ensemble, _ in ensembles:
+            expected_suffix = f"_L{layer_idx + 1}"
+            assert ensemble.name.endswith(expected_suffix)
+
+
+class TestMultilayerStackingValidationScoreComputation:
+    @pytest.mark.parametrize(
+        "ensemble_hyperparameters, num_windows_per_layer",
+        [
+            ([{"GreedyEnsemble": {"ensemble_size": 2}}, {"SimpleAverageEnsemble": {}}], (3, 2)),
+            ([{"GreedyEnsemble": {"ensemble_size": 2}}, {"SimpleAverageEnsemble": {}}], (4, 1)),
+            ([{"GreedyEnsemble": {"ensemble_size": 2}, "SimpleAverageEnsemble": {}}], (5,)),
+        ],
+    )
+    def test_when_fit_called_then_all_ensembles_are_scored_on_last_layers_data(
+        self, tmp_path_factory, patch_models, ensemble_hyperparameters, num_windows_per_layer
+    ):
+        path = str(tmp_path_factory.mktemp("agts_scoring_test"))
+        trainer = TimeSeriesTrainer(path=path, prediction_length=3, num_val_windows=5)
+        trainer.fit(
+            train_data=DUMMY_TS_DATAFRAME,
+            hyperparameters={"Naive": {}, "SeasonalNaive": {}},
+        )
+
+        data_per_window = trainer._get_validation_windows(DUMMY_TS_DATAFRAME, None)
+        model_names = trainer.get_model_names(layer=0)
+        predictions_per_window = trainer._get_base_model_predictions(model_names)
+
+        ensemble_composer = EnsembleComposer(
+            path=trainer.path,
+            prediction_length=trainer.prediction_length,
+            eval_metric=trainer.eval_metric,
+            ensemble_hyperparameters=ensemble_hyperparameters,
+            num_windows_per_layer=num_windows_per_layer,
+            target=trainer.target,
+            quantile_levels=trainer.quantile_levels,
+            model_graph=trainer.model_graph,
+        )
+
+        last_layer_ground_truth = data_per_window[-num_windows_per_layer[-1] :]
+
+        ensemble_composer.fit(
+            data_per_window=data_per_window,
+            predictions_per_window=predictions_per_window,
+        )
+
+        # Verify all ensembles were trained and scored
+        ensembles = list(ensemble_composer.iter_ensembles())
+        assert len(ensembles) > 0
+
+        # For each ensemble, verify its val_score was computed using last layer data
+        # by checking that recomputing with last layer data gives the same score
+        for layer_idx, ensemble, _ in ensembles:
+            last_layer_oof = ensemble.get_oof_predictions()[-len(last_layer_ground_truth) :]
+
+            # Recompute score using last layer ground truth
+            recomputed_scores = [
+                trainer.eval_metric(data, pred, target=trainer.target)
+                for pred, data in zip(last_layer_oof, last_layer_ground_truth)
+            ]
+            recomputed_val_score = float(np.mean(recomputed_scores))
+
+            # Should match the ensemble's val_score
+            assert ensemble.val_score is not None
+            assert abs(ensemble.val_score - recomputed_val_score) < 1e-6, (
+                f"Ensemble {ensemble.name} at layer {layer_idx} was not scored on last layer data. "
+                f"Expected val_score={recomputed_val_score}, got={ensemble.val_score}"
+            )
+
+
+class TestWindowSlicing:
+    def get_trainer_and_composer(
+        self,
+        path: Path,
+        train_data: TimeSeriesDataFrame,
+        ensemble_hyperparameters: list[dict],
+        num_windows_per_layer: tuple[int, ...],
+        prediction_length: int,
+        num_val_windows: int,
+    ):
+        trainer = TimeSeriesTrainer(
+            path=str(path / "agts_window_slicing"),
+            prediction_length=prediction_length,
+            num_val_windows=num_val_windows,
+        )
+        trainer.fit(
+            train_data=train_data,
+            hyperparameters={"Naive": {}, "SeasonalNaive": {}},
+        )
+
+        ensemble_composer = EnsembleComposer(
+            path=trainer.path,
+            prediction_length=trainer.prediction_length,
+            eval_metric=trainer.eval_metric,
+            ensemble_hyperparameters=ensemble_hyperparameters,
+            num_windows_per_layer=num_windows_per_layer,
+            target=trainer.target,
+            quantile_levels=trainer.quantile_levels,
+            model_graph=trainer.model_graph,
+        )
+
+        return trainer, ensemble_composer
+
+    @pytest.mark.parametrize(
+        "ensemble_hyperparameters, num_windows_per_layer, expected_num_windows, expected_first_window_offset",
+        [
+            (
+                # ensemble_hyperparameters
+                [{"GreedyEnsemble": {}}, {"GreedyEnsemble": {}}],
+                # num_windows_per_layer provided to ensemble composer
+                (3, 2),
+                # expected_num_windows: number of windows we expect to be in the prediction_per_window and
+                # data_per_window parameters in the call to _fit_single_ensemble
+                (3, 2),
+                # first_window_offset: number of prediction_length windows we expect the first window of this
+                # call to _fit_single_ensemble to be offset from the start of the trainer's validation windows
+                (0, 3),
+            ),
+            (
+                [{"GreedyEnsemble": {}}, {"GreedyEnsemble": {}}, {"GreedyEnsemble": {}}],
+                (2, 2, 1),
+                (2, 2, 1),
+                (0, 2, 4),
+            ),
+            (
+                [{"GreedyEnsemble": [{"ensemble_size": 2}, {"ensemble_size": 3}]}, {"GreedyEnsemble": {}}],
+                (4, 1),
+                (4, 4, 1),
+                (0, 0, 4),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("prediction_length", [1, 5])
+    def test_when_ensemble_composer_called_then_window_indices_correct(
+        self,
+        tmp_path,
+        patch_models,
+        ensemble_hyperparameters,
+        num_windows_per_layer,
+        expected_num_windows,
+        expected_first_window_offset,
+        prediction_length,
+    ):
+        num_val_windows = 5
+        train_df = get_data_frame_with_item_index(["10", "A", "2", "1"], data_length=50)
+        trainer, ensemble_composer = self.get_trainer_and_composer(
+            path=tmp_path,
+            train_data=train_df,
+            ensemble_hyperparameters=ensemble_hyperparameters,
+            num_windows_per_layer=num_windows_per_layer,
+            prediction_length=prediction_length,
+            num_val_windows=num_val_windows,
+        )
+        validation_window_start = train_df.loc[train_df.item_ids[0]].index[-(prediction_length * num_val_windows)]
+
+        data_per_window = trainer._get_validation_windows(train_df, None)
+        model_names = trainer.get_model_names(layer=0)
+        predictions_per_window = trainer._get_base_model_predictions(model_names)
+
+        # mock the _fit_single_ensemble method with a method that captures the predictions per window and
+        # data_per_window provided and adds them to captured_windows at every call. the method should be
+        # called once per each ensemble specified in ensemble_hyperparameters
+        captured_windows = []
+        original_fit = ensemble_composer._fit_single_ensemble
+
+        def capture_windows(*args, **kwargs):
+            ppw = kwargs.get("predictions_per_window", {})
+            labels = kwargs.get("data_per_window", {})
+            captured_windows.append((ppw, labels))
+            return original_fit(*args, **kwargs)
+
+        with mock.patch.object(ensemble_composer, "_fit_single_ensemble", side_effect=capture_windows):
+            ensemble_composer.fit(data_per_window=data_per_window, predictions_per_window=predictions_per_window)
+
+            # assert the number of calls to _fit_single_ensemble is correct
+            assert len(captured_windows) == len(expected_num_windows)
+
+            for call_idx, (ppw, labels) in enumerate(captured_windows):
+                assert len(labels) == expected_num_windows[call_idx]
+                assert all(len(windows) == expected_num_windows[call_idx] for _, windows in ppw.items())
+                for window_idx in range(len(labels)):
+                    # for each window, assert that the data_per_window and predictions_per_window specify the same
+                    # item and time indices
+                    label = labels[window_idx].slice_by_timestep(-trainer.prediction_length, None)
+                    inputs = [w[window_idx] for _, w in ppw.items()]
+
+                    for input_ in inputs:
+                        assert input_.index.tolist() == label.index.tolist()
+
+                    # also assert, for each window, the start times of the windows are as expected
+                    expected_offset = (expected_first_window_offset[call_idx] + window_idx) * trainer.prediction_length
+                    expected_start = validation_window_start + pd.Timedelta(
+                        expected_offset,
+                        train_df.freq,  # type: ignore
+                    )
+                    actual_start = min(ts for _, ts in label.index)
+                    assert actual_start == expected_start
+
+
+def test_when_time_limit_exceeded_then_training_stops_early(tmp_path_factory, patch_models):
+    """Test that ensemble training stops gracefully when time limit is exceeded."""
+    path = str(tmp_path_factory.mktemp("agts_ensemble_time_limit_test"))
+    trainer = TimeSeriesTrainer(path=path, prediction_length=3, num_val_windows=5)
     trainer.fit(
         train_data=DUMMY_TS_DATAFRAME,
         hyperparameters={"Naive": {}, "SeasonalNaive": {}},
     )
-    yield trainer
 
-
-@pytest.mark.parametrize(
-    "ensemble_hyperparameters",
-    [
-        {"GreedyEnsemble": {"ensemble_size": 5}},
-        {"GreedyEnsemble": {}, "PerformanceWeightedEnsemble": {}},
-        {"PerformanceWeightedEnsemble": {"weight_scheme": "sq"}},
-        {"SimpleAverageEnsemble": {}},
-        {},
-    ],
-)
-def test_when_ensemble_composer_created_then_can_train_ensembles(tmp_path, trainer, ensemble_hyperparameters):
-    """Test that the ensemble composer can create ensembles correctly."""
     ensemble_composer = EnsembleComposer(
         path=trainer.path,
         prediction_length=trainer.prediction_length,
         eval_metric=trainer.eval_metric,
+        ensemble_hyperparameters=[
+            {"GreedyEnsemble": {}, "SimpleAverageEnsemble": {}},
+            {"GreedyEnsemble": {}},
+        ],
+        num_windows_per_layer=(3, 2),
         target=trainer.target,
         quantile_levels=trainer.quantile_levels,
         model_graph=trainer.model_graph,
-        ensemble_hyperparameters=ensemble_hyperparameters,
     )
+
     data_per_window = trainer._get_validation_windows(DUMMY_TS_DATAFRAME, None)
-    model_names = trainer.get_model_names(level=0)
+    model_names = trainer.get_model_names(layer=0)
     predictions_per_window = trainer._get_base_model_predictions(model_names)
-    ensemble_composer.fit(data_per_window=data_per_window, predictions_per_window=predictions_per_window)
 
+    # Set very short time limit to trigger timeout
+    ensemble_composer.fit(
+        data_per_window=data_per_window,
+        predictions_per_window=predictions_per_window,
+        time_limit=0.001,
+    )
+
+    # Should have trained fewer ensembles than requested due to timeout
     ensembles = list(ensemble_composer.iter_ensembles())
-    assert len(ensembles) == len(ensemble_hyperparameters)
-
-    for layer_ix, _, base_models in ensembles:
-        assert layer_ix == 1
-        assert len(base_models) >= 1
+    assert len(ensembles) < 3, "Expected timeout to stop training before all ensembles completed"
 
 
 class TestValidateEnsembleHyperparameters:
-    def test_given_valid_hyperparameters_when_validate_called_then_hyperparameters_returned(self):
-        """Test validation of valid ensemble hyperparameters dict."""
-        hyperparams = {"GreedyEnsemble": {}, "PerformanceWeightedEnsemble": {"some_param": "value"}}
-        result = validate_ensemble_hyperparameters(hyperparams)
-        assert result == hyperparams
+    def test_given_valid_hyperparameters_when_validate_called_then_does_not_raise(self):
+        hyperparams = [{"GreedyEnsemble": {}, "PerformanceWeightedEnsemble": {"some_param": "value"}}]
+        try:
+            validate_ensemble_hyperparameters(hyperparams)
+        except ValueError:
+            pytest.fail("Unexpected ValueError raised")
 
     def test_given_invalid_ensemble_name_when_validate_called_then_error_raised(self):
-        """Test validation fails for unknown ensemble names."""
-        hyperparams = {"InvalidEnsemble": {}}
+        hyperparams = [{"InvalidEnsemble": {}}]
         with pytest.raises(ValueError, match="Unknown ensemble type: InvalidEnsemble"):
-            validate_ensemble_hyperparameters(hyperparams)
+            validate_ensemble_hyperparameters(hyperparams)  # type: ignore
 
-    def test_given_non_dict_input_when_validate_called_then_error_raised(self):
-        """Test validation fails for non-dict input."""
-        with pytest.raises(ValueError, match="ensemble_hyperparameters must be dict"):
-            validate_ensemble_hyperparameters("invalid")
-
-    def test_given_empty_dict_when_validate_called_then_empty_dict_returned(self):
-        """Test validation of empty dict."""
-        result = validate_ensemble_hyperparameters({})
-        assert result == {}
+    @pytest.mark.parametrize("hyperparameters", ["invalid", {"invalid": {}}, {"GreedyEnsemble": {}}])
+    def test_given_non_dict_input_when_validate_called_then_error_raised(self, hyperparameters):
+        with pytest.raises(ValueError, match="ensemble_hyperparameters must be list"):
+            validate_ensemble_hyperparameters(hyperparameters)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Extends EnsembleComposer to handle multilayer stacking. 

TODOS:
- [x] discussion on naming format for ensemble models, and implementation. currently, names are set as they would be set if every ensemble model was layer 1.
- [x] implement time limit with SplitTimer. discussion: the plan is to divide split time equally among all ensembles. If time limit is exceeded, we have fit the models that are in lower layers. 
- [x] ensure that double calls to `.save()` per ensemble model do not cause issues with serde.
- [x] revise and update docstrings
- [x] compute `val_score`s on the fly during training, on the correct window.
- [x] rename all references to `level` to `layer`
- [x] raise if performance weighted ensemble is fit before the last layer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
