### PR TITLE
[timeseries] Chronos-2: Add fine_tune_context_length

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
+++ b/timeseries/src/autogluon/timeseries/models/chronos/chronos2.py
@@ -46,8 +46,8 @@ class Chronos2Model(AbstractTimeSeriesModel):
         predictions across time series in a batch, by default True
         Note: Enabling this mode makes the results sensitive to the ``batch_size`` used.
     context_length : int or None, default = None
-        The context length to use in the model. If None, the model will use its default context length
-        of 8192. Shorter context lengths will decrease model accuracy, but result in faster inference.
+        The context length to use for inference. If None, the model will use its default context length
+        of 8192. Shorter context lengths may reduce accuracy, but result in faster inference.
     fine_tune : bool, default = False
         If True, the pretrained model will be fine-tuned.
     fine_tune_mode : str, default = "lora"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adds `fine_tune_context_length` defaulting to 2048
- Fixes issue with `context_length` not being respected during inference

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
