### PR TITLE
[timeseries] Fix broken link to custom models tutorial in the advanced page

### DIFF
--- a/docs/tutorials/timeseries/advanced/index.md
+++ b/docs/tutorials/timeseries/advanced/index.md
@@ -6,7 +6,7 @@ This section contains advanced tutorials related to AutoGluon's time series fore
   :gutter: 3
 
 :::{grid-item-card} Custom Models
-  :link: advanced/forecasting-custom-model.html
+  :link: forecasting-custom-model.html
 
   How to add a custom time series forecasting model to AutoGluon.
 :::


### PR DESCRIPTION
When on the advanced page of the time series tutorials (https://auto.gluon.ai/stable/tutorials/timeseries/advanced/index.html), the link in the card to the custom models page is advanced/forecasting-custom-model.html.

This duplicates advanced/ and points to https://auto.gluon.ai/stable/tutorials/timeseries/advanced/advanced/forecasting-custom-model.html. This does not work and leads to an AccessDenied error.

I removed advanced/ from the link in the card in the index.md so now it should point to the right thing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.