### PR TITLE
Remove unused variable val_improve_epoch in TabularNeuralNetTorchModel

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -371,7 +371,6 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
         best_epoch = 0
         best_val_metric = -np.inf  # higher = better
         best_val_update = 0
-        val_improve_epoch = 0  # most recent epoch where validation-score strictly improved
         start_fit_time = time.time()
         if time_limit is not None:
             time_limit = time_limit - (start_fit_time - start_time)


### PR DESCRIPTION
## Description
Remove unused variable `val_improve_epoch` in `TabularNeuralNetTorchModel._train_net()` method.
## Details
The variable `val_improve_epoch` is initialized at line 374 but is never referenced or updated anywhere in the codebase. While the comment suggests it was intended to track "most recent epoch where validation-score strictly improved", this functionality appears to be already covered by the existing `best_epoch` and `best_val_update` variables.
## Changes
- Removed line 374: `val_improve_epoch = 0  # most recent epoch where validation-score strictly improved`
## Type of change
- [x] Code cleanup (removing unused code)