### PR TITLE
Refactor TabularNeuralNetTorch: Fix bugs, optimize memory, and improve performance

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -664,7 +664,8 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             new_data = self._process_test_data(new_data)
         if not isinstance(new_data, TabularTorchDataset):
             raise ValueError("new_data must be of type TabularTorchDataset if process=False")
-        val_dataloader = new_data.build_loader(self.max_batch_size, self.num_dataloading_workers, is_test=True)
+        # Ensure single-process loading for inference to guarantee order
+        val_dataloader = new_data.build_loader(self.max_batch_size, 0, is_test=True)
         preds_dataset = []
         for data_batch in val_dataloader:
             preds_batch = self.model.predict(data_batch)

--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_torch_dataset.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_torch_dataset.py
@@ -154,6 +154,12 @@ class TabularTorchDataset(torch.utils.data.IterableDataset):
         if self.shuffle:
             np.random.shuffle(idxarray)
         indices = range(0, self.num_examples, self.batch_size)
+
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is not None:
+            # Split data across workers
+            indices = indices[worker_info.id :: worker_info.num_workers]
+
         for idx_start in indices:
             # Drop last batch
             if self.drop_last and (idx_start + self.batch_size) > self.num_examples:


### PR DESCRIPTION
**Description:** This PR refactors TabularNeuralNetTorch  to fix critical logic bugs, optimize memory usage, and enable parallel data loading on non-MacOS systems.

**Critical Fixes**
Early Stopping: Fixed off-by-one error where epoch-1 was passed instead of epoch, causing misalignment between logging and internal logic.
Time Estimation: Corrected time-per-epoch calculation (removed incorrect divisor epoch + 1), which was underestimating training time by up to 50% in early epochs.
Stability: Fixed a ValueError crash in _predict_tabular_data when predicting on empty datasets. Ensures returned empty array has correct shape (0, num_outputs) to maintain downstream compatibility.

**Optimizations**
Memory & Speed: Changed internal checkpointing to save model.state_dict() instead of pickling the entire model object. This reduces memory pressure and serialization overhead during validation.
Data Loading: Enabled parallel data loading (num_dataloading_workers > 0) for Windows and Linux systems. It remains disabled on MacOS due to platform-specific issues.

**Code Quality**
Replaced non-functional Warning(...) instantiation with logger.log(15, ...) for consistent and effective logging.
Fixed typo in error message ("must of of" -> "must be of").
Fixed typo in docstrings.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
