### PR TITLE
[Tabular] Pass label cleaner to model for semantic encodings

### DIFF
--- a/core/src/autogluon/core/models/abstract/abstract_model.py
+++ b/core/src/autogluon/core/models/abstract/abstract_model.py
@@ -249,6 +249,7 @@ class AbstractModel(ModelBase, Tunable):
 
         # whether to calibrate predictions via conformal methods
         self.conformalize: bool | None = None
+        self.label_cleaner: LabelCleaner | None = None
 
         if eval_metric is not None:
             self.eval_metric: Scorer | None = metrics.get_metric(eval_metric, self.problem_type, "eval_metric")  # Note: we require higher values = better performance
@@ -720,7 +721,7 @@ class AbstractModel(ModelBase, Tunable):
         label_cleaner = LabelCleaner.construct(problem_type=problem_type, y=y)
         return label_cleaner.num_classes
 
-    def _initialize(self, X=None, y=None, feature_metadata=None, num_classes=None, **kwargs):
+    def _initialize(self, X=None, y=None, feature_metadata=None, num_classes=None, label_cleaner=None, **kwargs):
         if num_classes is not None:
             self.num_classes = num_classes
         if y is not None:
@@ -728,6 +729,7 @@ class AbstractModel(ModelBase, Tunable):
                 self.problem_type = self._infer_problem_type(y=y)
             if self.num_classes is None:
                 self.num_classes = self._infer_num_classes(y=y, problem_type=self.problem_type)
+        self.label_cleaner = label_cleaner
 
         self._init_params_aux()
 

--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -143,6 +143,7 @@ class DefaultLearner(AbstractTabularLearner):
             infer_limit=infer_limit,
             infer_limit_batch_size=infer_limit_batch_size,
             groups=groups,
+            label_cleaner=copy.deepcopy(self.label_cleaner),
             **trainer_fit_kwargs,
         )
         self.save_trainer(trainer=trainer)

--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -27,7 +27,7 @@ from autogluon.core.calibrate.conformity_score import compute_conformity_score
 from autogluon.core.calibrate.temperature_scaling import apply_temperature_scaling, tune_temperature_scaling
 from autogluon.core.callbacks import AbstractCallback
 from autogluon.core.constants import BINARY, MULTICLASS, QUANTILE, REFIT_FULL_NAME, REGRESSION, SOFTCLASS
-from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary
+from autogluon.core.data.label_cleaner import LabelCleanerMulticlassToBinary, LabelCleaner
 from autogluon.core.metrics import Scorer, compute_metric, get_metric
 from autogluon.core.models import (
     AbstractModel,
@@ -2493,6 +2493,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         errors_ignore: list | None = None,
         errors_raise: list | None = None,
         is_ray_worker: bool = False,
+        label_cleaner: None | LabelCleaner = None,
         **kwargs,
     ) -> list[str]:
         """
@@ -2527,7 +2528,8 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
             return []
 
         model_fit_kwargs = self._get_model_fit_kwargs(
-            X=X, X_val=X_val, time_limit=time_limit, k_fold=k_fold, fit_kwargs=fit_kwargs, ens_sample_weight=kwargs.get("ens_sample_weight", None)
+            X=X, X_val=X_val, time_limit=time_limit, k_fold=k_fold, fit_kwargs=fit_kwargs,
+            ens_sample_weight=kwargs.get("ens_sample_weight", None), label_cleaner=label_cleaner,
         )
         exception = None
         if hyperparameter_tune_kwargs:
@@ -4294,7 +4296,8 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         return distilled_model_names
 
     def _get_model_fit_kwargs(
-        self, X: pd.DataFrame, X_val: pd.DataFrame, time_limit: float, k_fold: int, fit_kwargs: dict, ens_sample_weight: list | None = None
+        self, X: pd.DataFrame, X_val: pd.DataFrame, time_limit: float, k_fold: int,
+        fit_kwargs: dict, ens_sample_weight: list | None = None, label_cleaner: None | LabelCleaner = None
     ) -> dict:
         # Returns kwargs to be passed to AbstractModel's fit function
         if fit_kwargs is None:
@@ -4315,6 +4318,9 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
         if self._groups is not None and "groups" not in model_fit_kwargs:
             if k_fold == self.k_fold:  # don't do this on refit full
                 model_fit_kwargs["groups"] = self._groups
+
+        if label_cleaner is not None:
+            model_fit_kwargs["label_cleaner"] = label_cleaner
 
         # FIXME: Sample weight `extract_column` is a hack, have to compute feature_metadata here because sample weight column could be in X upstream, extract sample weight column upstream instead.
         if "feature_metadata" not in model_fit_kwargs:

--- a/tabular/src/autogluon/tabular/trainer/auto_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/auto_trainer.py
@@ -59,6 +59,7 @@ class AutoTrainer(AbstractTabularTrainer):
         use_bag_holdout=False,
         groups=None,
         callbacks: list[callable] = None,
+        label_cleaner=None,
         **kwargs,
     ):
         for key in kwargs:
@@ -131,6 +132,9 @@ class AutoTrainer(AbstractTabularTrainer):
                     log_str += f"\t'{k}': {hyperparameters[k][:3]},\n"
         log_str += "}"
         logger.log(20, log_str)
+
+        if label_cleaner is not None:
+            core_kwargs["label_cleaner"] = label_cleaner
 
         self._train_multi_and_ensemble(
             X=X,


### PR DESCRIPTION
Add support for passing the label cleaner to the model, such that models and preprocessing can invert the label encoding and ensure the semantics of the label. 

*Description of changes:*
* add label cleaner as a `self.label_cleaner` variable in AbstractModel and pass it to the `_fit` call. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
