### PR TITLE
Refactor TabularNeuralNetTorch to use state_dict for persistence

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
+++ b/tabular/src/autogluon/tabular/models/tabular_nn/torch/tabular_nn_torch.py
@@ -464,7 +464,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
                         is_best = True
                     best_val_metric = val_metric
                     io_buffer = io.BytesIO()
-                    torch.save(self.model, io_buffer)  # nosec B614
+                    torch.save(self.model.state_dict(), io_buffer)
                     best_epoch = epoch
                     best_val_update = total_updates
                 early_stop = early_stopping_method.update(cur_round=epoch-1, is_best=is_best)
@@ -517,7 +517,7 @@ class TabularNeuralNetTorchModel(AbstractNeuralNetworkModel):
             logger.log(15, f"Best model found on Epoch {best_epoch} (Update {best_val_update}). Val {self.stopping_metric.name}: {best_val_metric}")
             if io_buffer is not None:
                 io_buffer.seek(0)
-                self.model = torch.load(io_buffer, weights_only=False)  # nosec B614
+                self.model.load_state_dict(torch.load(io_buffer, weights_only=True))
         else:
             logger.log(15, f"Best model found on Epoch {best_epoch} (Update {best_val_update}).")
         self.params_trained["batch_size"] = batch_size


### PR DESCRIPTION
**Summary**
Refactors TabularNeuralNetTorch to use `state_dict` for saving and loading models instead of pickling the entire model object. This aligns with PyTorch best practices and improves security.

**Changes**
Changed `torch.save(self.model, io_buffer)` to `torch.save(self.model.state_dict(), io_buffer)`.
Changed loading logic to use `self.model.load_state_dict(torch.load(..., weights_only=True))`.
Removed `# nosec B614` comments as weights_only=True addresses the security concerns associated with pickle.

**Motivation**
**Best Practices:** Saving the `state_dict` is the recommended approach in PyTorch as it is more robust to code changes (e.g., directory structure or class definitions).
**Security:** Using `weights_only=True` during load mitigates the risk of arbitrary code execution during unpickling, which allows us to remove the **bandit** security exclusions (`# nosec`).

## References
- [PyTorch: Saving & Loading Models (Recommended Approach)](https://pytorch.org/tutorials/beginner/saving_loading_models.html#save-load-state-dict-recommended)
- [PyTorch: Serialization Security Best Practices](https://pytorch.org/docs/stable/notes/serialization.html#security)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
