### PR TITLE
[timeseries] Skip Toto and Wavenet tests on CPU

### DIFF
--- a/timeseries/tests/smoketests/test_all_models.py
+++ b/timeseries/tests/smoketests/test_all_models.py
@@ -3,6 +3,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 from packaging.version import Version
 
 from autogluon.timeseries import TimeSeriesPredictor
@@ -88,12 +89,15 @@ ALL_MODELS = {
     "SimpleFeedForward": DUMMY_MODEL_HPARAMS,
     "TemporalFusionTransformer": DUMMY_MODEL_HPARAMS,
     "TiDE": DUMMY_MODEL_HPARAMS,
-    "Toto": {"num_samples": 5},
-    "WaveNet": DUMMY_MODEL_HPARAMS,
     "Zero": DUMMY_MODEL_HPARAMS,
     # Override default hyperparameters for faster training
     "AutoARIMA": {"max_p": 2, "use_fallback_model": False},
 }
+
+if torch.cuda.is_available():
+    # Optional models that are too slow to run on a CPU
+    ALL_MODELS["Toto"] = {"num_samples": 5}
+    ALL_MODELS["WaveNet"] = DUMMY_MODEL_HPARAMS
 
 
 def assert_leaderboard_contains_all_models(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Currently platform tests are failing since they use CPU instances, where Toto cannot be run (no GPU available). Wavenet is also rather slow, so we can speed things up by only running it on GPU machines.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
