### PR TITLE
[Tabular] Fix XGBoost crashing on eval metric name in HPs

### DIFF
--- a/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
+++ b/tabular/src/autogluon/tabular/models/xgboost/xgboost_model.py
@@ -122,6 +122,8 @@ class XGBoostModel(AbstractModel):
             if eval_metric is not None:
                 params["eval_metric"] = eval_metric
                 eval_metric_name = eval_metric.__name__ if not isinstance(eval_metric, str) else eval_metric
+        else:
+            eval_metric_name = params["eval_metric"].__name__ if not isinstance(params["eval_metric"], str) else params["eval_metric"]
 
         if X_val is None:
             early_stopping_rounds = None


### PR DESCRIPTION
There seems to have been a bug that if you pass the name of an eval metric to the HPs of XGBoost, the `eval_metric_name` variable was never assigned. This PR fixes this. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
