### PR TITLE
__init__.py is missing TabPFNV2Model

### DIFF
--- a/tabular/src/autogluon/tabular/models/__init__.py
+++ b/tabular/src/autogluon/tabular/models/__init__.py
@@ -25,6 +25,7 @@ from .tabdpt.tabdpt_model import TabDPTModel
 from .tabicl.tabicl_model import TabICLModel
 from .tabm.tabm_model import TabMModel
 from .tabpfnmix.tabpfnmix_model import TabPFNMixModel
+from .tabpfnv2.tabpfnv2_model import TabPFNV2Model
 from .tabpfnv2.tabpfnv2_5_model import RealTabPFNv2Model, RealTabPFNv25Model
 from .mitra.mitra_model import MitraModel
 from .tabular_nn.torch.tabular_nn_torch import TabularNeuralNetTorchModel


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*tabular/src/autogluon/tabular/models/__init__.py is missing TabPFNV2Model


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
