### PR TITLE
[Tabular] Fix flash attention check for TabDPT

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
+++ b/tabular/src/autogluon/tabular/models/tabdpt/tabdpt_model.py
@@ -117,6 +117,9 @@ class TabDPTModel(AbstractTorchModel):
         if not torch.cuda.is_available():
             return False
 
+        if not torch.backends.cuda.is_flash_attention_available():
+            return False
+        
         device = torch.device("cuda:0")
         capability = torch.cuda.get_device_capability(device)
 


### PR DESCRIPTION
This is a quick improvement to the way flash attention availability is checked in TabDPT. 

On Windows, even if CUDA is available and you have the right version, flash attention is still not available (it's not part of the official PyTorch wheel for Windows). 

Without the following check, AutoGluon falsely concludes that flash attention can be used. This will lead to an error and will prevent users from using TabDPT, even though other versions of scaled dot product attention can be used in sdpa_kernel. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
