### PR TITLE
[tabular]Fix FastAI deadlock on Windows by setting num_workers=0

### DIFF
--- a/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
+++ b/tabular/src/autogluon/tabular/models/fastainn/tabular_nn_fastai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 import os
+import platform
 import time
 import warnings
 from builtins import classmethod
@@ -318,7 +319,11 @@ class NNFastAiTabularModel(AbstractModel):
 
         best_epoch_stop = params.get("best_epoch", None)  # Use best epoch for refit_full.
         batch_size = self._get_batch_size(X)
-        dls = data.dataloaders(bs=batch_size)
+        loader_kwargs = {}
+        if platform.system() == "Windows":
+            loader_kwargs["num_workers"] = 0
+
+        dls = data.dataloaders(bs=batch_size, **loader_kwargs)
 
         # Make deterministic
         from fastai.torch_core import set_seed


### PR DESCRIPTION
Fixes a deadlock issue on Windows where NeuralNetFastAI hangs during training because the DataLoader defaults to using multiprocessing. This change forces num_workers=0 on Windows systems to prevent this behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
