### PR TITLE
[Core] Refactor greedy ensemble selection to use np.isclose for floating point comparisons

### DIFF
--- a/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
+++ b/core/src/autogluon/core/models/greedy_ensemble/ensemble_selection.py
@@ -164,7 +164,7 @@ class EnsembleSelection(AbstractWeightedEnsemble):
                                 y_true=labels, y_pred_proba=fant_ensemble_prediction, metric=secondary_metric
                             )
                         all_best_tiebreak = np.argwhere(
-                            np.isclose(scores_tiebreak, np.nanmin(scores_tiebreak), atol=0)
+                            np.isclose(scores_tiebreak, np.nanmin(scores_tiebreak), atol=0, rtol=1e-12)
                         ).flatten()
                         all_best = [index_map[index] for index in all_best_tiebreak]
 


### PR DESCRIPTION
*Description of changes:*

Refactors the strike degree selection to use np.isclose in floating-point comparison instead of direct comparison (==). This improves the robustness of the algorithm when working with close floating-point scores.

Currently, the direct comparison method of floating-point values ​​can lead to inconsistent results in tie scenarios or when values ​​are very close, due to the nature of floating-point numbers in Python. Using np.isclose solves this by ensuring more stable numerical comparisons.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
