### PR TITLE
[Features] Fix mutable default argument in DatetimeFeatureGenerator

### DIFF
--- a/features/src/autogluon/features/generators/datetime.py
+++ b/features/src/autogluon/features/generators/datetime.py
@@ -21,8 +21,10 @@ class DatetimeFeatureGenerator(AbstractFeatureGenerator):
         For a full list of options see the methods inside pandas.Series.dt at https://pandas.pydata.org/docs/reference/api/pandas.Series.html
     """
 
-    def __init__(self, features: list = ["year", "month", "day", "dayofweek"], **kwargs):
+    def __init__(self, features: list = None, **kwargs):
         super().__init__(**kwargs)
+        if features is None:
+            features = ["year", "month", "day", "dayofweek"]
         self.features = features
 
     def _fit_transform(self, X: DataFrame, **kwargs) -> (DataFrame, dict):


### PR DESCRIPTION
*Description of changes:*
Replaces mutable default argument ['year', 'month', 'day', 'dayofweek'] with None in DatetimeFeatureGenerator.__init__ to avoid shared state issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
