### PR TITLE
Add .gitattributes to enforce LF for Python files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,8 +13,8 @@
 *.hxx text eol=lf
 *.py text eol=lf
 *.sh text eol=lf
-*.md text
-*.txt text
+*.md  text eol=lf
+*.txt text eol=lf
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf


### PR DESCRIPTION
*Description of changes:*

It adds the .gitattributes file to enforce Unix-style (LF) line endings for Python and Shell scripts, ensuring consistency between Windows and Linux environments and avoiding large differences caused by CRLF conversions. It also explicitly marks binary files to prevent corruption.

Context: This setting was previously introduced in an older version, but the branch was closed and this file was never incorporated into the main version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
