### PR TITLE
[Core][Tabular] Replace strict type checks with isinstance

### DIFF
--- a/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
+++ b/core/src/autogluon/core/models/ensemble/fold_fitting_strategy.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import copy
 import json

--- a/core/src/autogluon/core/utils/plots.py
+++ b/core/src/autogluon/core/utils/plots.py
@@ -1,4 +1,4 @@
-﻿"""Methods to create various plots used throughout AutoGluon.
+"""Methods to create various plots used throughout AutoGluon.
 If matplotlib or bokeh are not installed, simply will print warning message that plots cannot be shown.
 """
 

--- a/tabular/src/autogluon/tabular/models/mitra/_internal/models/tab2d.py
+++ b/tabular/src/autogluon/tabular/models/mitra/_internal/models/tab2d.py
@@ -1,4 +1,4 @@
-﻿import json
+import json
 import logging
 import os
 from typing import Optional, Union

--- a/tabular/src/autogluon/tabular/predictor/predictor.py
+++ b/tabular/src/autogluon/tabular/predictor/predictor.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import copy
 import inspect


### PR DESCRIPTION
*Description of changes:*

Using `isinstance` is more Pythonic, correctly handles inheritance, and adheres to generally accepted best practices defined in PEP 8.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
