### PR TITLE
Fix broken link in TabICLModel docstring

### DIFF
--- a/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
+++ b/tabular/src/autogluon/tabular/models/tabicl/tabicl_model.py
@@ -1,5 +1,5 @@
 """
-Code Adapted from TabArena: https://github.com/autogluon/tabrepo/blob/main/tabrepo/benchmark/models/ag/tabicl/tabicl_model.py
+Code Adapted from TabArena: https://github.com/autogluon/tabarena/blob/main/tabarena/tabarena/benchmark/models/ag/tabicl/tabicl_model.py
 """
 
 from __future__ import annotations


### PR DESCRIPTION
*Description of changes:*
The previous link pointed to TabRepo, which has been superseded by TabArena.
The reference was updated to point to the current, actively maintained
repository.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
