### PR TITLE
Add inference time penalty to model pruning

### DIFF
--- a/tabular/src/autogluon/tabular/learner/default_learner.py
+++ b/tabular/src/autogluon/tabular/learner/default_learner.py
@@ -52,6 +52,7 @@ class DefaultLearner(AbstractTabularLearner):
         time_limit: float | None = None,
         infer_limit: float | None = None,
         infer_limit_batch_size: int | None = None,
+        infer_time_penalty_factor: float | None = None,
         verbosity: int = 2,
         raise_on_model_failure: bool = False,
         **trainer_fit_kwargs,
@@ -134,6 +135,7 @@ class DefaultLearner(AbstractTabularLearner):
             random_state=self.random_state,
             verbosity=verbosity,
             raise_on_model_failure=raise_on_model_failure,
+            infer_time_penalty_factor=infer_time_penalty_factor,
         )
 
         self.trainer_path = trainer.path


### PR DESCRIPTION
When enforcing [infer_limit](cci:1://file:///c:/Users/celes/autogluon/tabular/src/autogluon/tabular/learner/default_learner.py:179:4-215:26), the current pruning logic greedily removes models with the lowest validation score. This is suboptimal because it ignores the "cost" (inference time) of keeping a model. A slightly better model that is 100x slower might be kept over a slightly worse model that is instant, leading to a scenario where we are forced to remove *both* later on to satisfy the time constraint.

This PR introduces a penalty-based tie-breaker (`score - 1e-4 * time`). This ensures that when two models have comparable accuracy, the pruning logic prefers to remove the computationally expensive one first, preserving faster models that contribute to ensemble diversity within the inference budget. This directly addresses the TODO in the code: `# TODO: Incorporate score vs inference speed tradeoff in a smarter way`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
