### PR TITLE
linting fix for ruff==0.15.0

### DIFF
--- a/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
+++ b/multimodal/src/autogluon/multimodal/data/preprocess_dataframe.py
@@ -615,9 +615,9 @@ class MultiModalFeaturePreprocessor(TransformerMixin, BaseEstimator):
                 processed_data = col_value.apply(lambda ele: ele if isinstance(ele, list) else [ele]).tolist()
             elif col_type == IMAGE_BASE64_STR:
                 processed_data = col_value.apply(
-                    lambda ele: [base64.b64decode(e) for e in ele]
-                    if isinstance(ele, list)
-                    else [base64.b64decode(ele)]
+                    lambda ele: (
+                        [base64.b64decode(e) for e in ele] if isinstance(ele, list) else [base64.b64decode(ele)]
+                    )
                 ).tolist()
             elif col_type == f"{IMAGE}_{IDENTIFIER}":
                 processed_data = col_value


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The logic for ruff's linting changed slightly with the 0.15.0 ruff release, causing our lint check to fail. This PR fixes the lint check for ruff 0.15.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
