### PR TITLE
[Core] Update typing-extensions constraint to >=4.14.0 for cattrs compatibility

### DIFF
--- a/core/src/autogluon/core/_setup_utils.py
+++ b/core/src/autogluon/core/_setup_utils.py
@@ -34,7 +34,7 @@ DEPENDENT_PACKAGES = {
     "transformers[sentencepiece]": ">=4.51.0,<4.58",  # lower bound because of a breaking change in 4.51
     "huggingface_hub[torch]": "<1.0",
     "accelerate": ">=0.34.0,<2.0",
-    "typing-extensions": ">=4.0,<5",
+    "typing-extensions": ">=4.14.0,<5",
     "joblib": ">=1.2,<1.7",  # <{N+1} upper cap
     "pyyaml": ">=5.0",  # Uncapped to maximize compatibility
 }


### PR DESCRIPTION
## Description
This PR updates the dependency lower bound for `typing-extensions` in [core/src/autogluon/core/_setup_utils.py](cci:7://file:///c:/Users/celes/autogluon/core/src/autogluon/core/_setup_utils.py:0:0-0:0) to resolve an installation conflict.
### Problem
The previous constraint `">=4.0,<5"` allowed older versions (e.g., 4.13.2) to be installed. However, `cattrs` (v25.3.0), pulled in by test dependencies, requires `typing-extensions>=4.14.0`.
### Solution
Updated the constraint to `">=4.14.0,<5"`. This ensures the installed version satisfies both AutoGluon and `cattrs` requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
