### PR TITLE
[common] Fix get_bool_true_val failing on category dtype

### DIFF
--- a/common/src/autogluon/common/features/infer_types.py
+++ b/common/src/autogluon/common/features/infer_types.py
@@ -173,7 +173,7 @@ def get_bool_true_val(uniques):
     # and therefore we use the unsorted values.
     try:
         # Sort the values to avoid relying on row-order when determining which value is mapped to `True`.
-        uniques.sort()
+        uniques = np.sort(uniques)
     except (ValueError, TypeError):
         pass
     replace_val = uniques[1]

--- a/common/tests/unittests/test_infer_types.py
+++ b/common/tests/unittests/test_infer_types.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.common.features.infer_types import get_bool_true_val
+
+
+@pytest.mark.parametrize(
+    "uniques,expected",
+    [
+        (np.array([0, 1]), 1),
+        (np.array([1, 0]), 1),  # reversed order, still sorted
+        (np.array(["no", "yes"]), "yes"),
+        (pd.Index([0, 1]), 1),
+    ],
+)
+def test_when_sortable_uniques_then_returns_sorted_second_value(uniques, expected):
+    assert get_bool_true_val(uniques) == expected
+
+
+def test_when_numpy_array_with_nan_then_nan_not_chosen_as_true():
+    uniques = np.array([1.0, np.nan])
+    assert get_bool_true_val(uniques) == 1.0
+
+
+@pytest.mark.parametrize(
+    "series",
+    [
+        pd.Series([1, 0, 1, 0], dtype="category"),
+        pd.Series(["yes", "no", "yes", "no"], dtype="category"),
+    ],
+)
+def test_when_pandas_categorical_then_no_attribute_error(series):
+    """Regression test: Categorical objects don't have .sort() method."""
+    uniques = series.unique()
+    result = get_bool_true_val(uniques)
+    assert result in list(series.unique())


### PR DESCRIPTION
*Issue #, if available:* 

Fix bug introduced in #5561 that led to the failure of `test_timeseries`. When the `except` block was narrowed to `(ValueError, TypeError)` [here](https://github.com/autogluon/autogluon/pull/5561/changes#diff-876fe843782a50648c0f2ab39e52d83c001f7f9a0ef19557495778f397407964R183), this ignored the case when the underlying series had dtype `"category"`, leading to `AttributeError`.

*Description of changes:*
- Replace `uniques.sort()` with `np.sort(uniques)` to correctly handle the category dtype
- Add unit tests for `infer_types` to catch such bugs in the future


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
