### PR TITLE
Support pd.SparseArray in simulation_utils.py

### DIFF
--- a/common/src/autogluon/common/utils/simulation_utils.py
+++ b/common/src/autogluon/common/utils/simulation_utils.py
@@ -79,6 +79,8 @@ def convert_simulation_artifacts_to_tabular_predictions_dict(
 
                 if ground_truth_idx is not None:
                     ground_truth_np = zeroshot_metadata[ground_truth_key]
+                    if isinstance(ground_truth_np, pd.arrays.SparseArray):
+                        ground_truth_np = ground_truth_np.to_dense()
                     assert isinstance(ground_truth_np, np.ndarray)
                     assert isinstance(ground_truth_idx, np.ndarray)
                     # memory opt variant in np.ndarray format, convert to pandas


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Support pd.SparseArray in simulation_utils.py
- Needed for certain datasets that use sparse y values rather than dense y values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
