### PR TITLE
[Tabular] Add short-term feature_importance safeguard for LightGBMPrep pipelines

### DIFF
--- a/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
+++ b/tabular/src/autogluon/tabular/trainer/abstract_trainer.py
@@ -63,6 +63,7 @@ from autogluon.core.utils.exceptions import (
 from autogluon.core.utils.feature_selection import FeatureSelector
 from autogluon.core.utils.loaders import load_pkl
 from autogluon.core.utils.savers import save_pkl
+from autogluon.tabular.models.tabprep.prep_lgb_model import PrepLGBModel
 
 logger = logging.getLogger(__name__)
 
@@ -3772,9 +3773,103 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
     # TODO: Enable raw=True for bagged models when X=None
     #  This is non-trivial to implement for multi-layer stacking ensembles on the OOF data.
     # TODO: Consider limiting X to 10k rows here instead of inside the model call
-    def get_feature_importance(self, model=None, X=None, y=None, raw=True, **kwargs) -> pd.DataFrame:
+    # TODO: Long-term solution tracked in issue #5641.
+    @staticmethod
+    def _model_has_non_empty_prep_params(model: AbstractModel) -> bool:
+        """
+        Check whether a model has active prep parameters enabled.
+
+        Parameters
+        ----------
+        model : AbstractModel
+            The model to inspect.
+
+        Returns
+        -------
+        bool
+            True if the model has non-empty `prep_params`, otherwise False.
+        """
+        ag_param_sources = [
+            getattr(model, "params_aux", {}),
+            getattr(model, "_user_params_aux", {}),
+        ]
+
+        hyperparameters = model.get_params().get("hyperparameters", {})
+        if isinstance(hyperparameters, dict):
+            ag_param_sources.append(hyperparameters.get("ag_args_fit", {}))
+
+        return any(params.get("prep_params") for params in ag_param_sources if isinstance(params, dict))
+
+    def _assert_feature_importance_lightgbm_prep_safe(
+        self,
+        model: str | AbstractModel | None,
+        silent: bool = False,
+    ) -> str:
+        """
+        Validate that feature importance can safely run for the requested model.
+
+        Parameters
+        ----------
+        model : str | AbstractModel | None
+            The model whose feature importance is being requested.
+            If None, the trainer's best model is used.
+        silent : bool, default = False
+            If True, suppresses the warning message before raising.
+
+        Returns
+        -------
+        str
+            The normalized model name if the request is allowed.
+
+        Raises
+        ------
+        NotImplementedError
+            Raised when the model's prediction pipeline depends on `LightGBMPrep`
+            with active `prep_params`.
+        """
         if model is None:
             model = self.model_best
+        if not isinstance(model, str):
+            model = model.name
+
+        prep_models = []
+        type_inner_dict = self.get_models_attribute_dict(
+            attribute="type_inner",
+            models=self.get_minimum_model_set(model),
+        )
+        for model_name, model_type_inner in type_inner_dict.items():
+            if not issubclass(model_type_inner, PrepLGBModel):
+                continue
+
+            model_loaded = self.load_model(model_name=model_name)
+            if isinstance(model_loaded, BaggedEnsembleModel):
+                model_loaded = model_loaded._get_model_base()
+
+            if self._model_has_non_empty_prep_params(model_loaded):
+                prep_models.append(model_name)
+
+        if prep_models:
+            prep_models_str = ", ".join(prep_models)
+            message = (
+                "Temporary safeguard: feature importance is currently disabled when the prediction pipeline depends on "
+                f"LightGBMPrep with active `prep_params` (requested model='{model}', prep_models=[{prep_models_str}]). "
+                "This path may take a very long time and can trigger large memory allocations before failing with a "
+                "raw MemoryError, so AutoGluon will stop early instead. If you want to avoid these models, refit with "
+                "`excluded_model_types=['LGBMPrep']`, remove `GBM_PREP` from the requested hyperparameters, or choose "
+                "a different model that does not depend on LightGBMPrep for feature importance. "
+                "See issue #5641 for background."
+            )
+            if not silent:
+                logger.warning(message)
+            raise NotImplementedError(message)
+
+        return model
+
+    def get_feature_importance(self, model=None, X=None, y=None, raw=True, **kwargs) -> pd.DataFrame:
+        model = self._assert_feature_importance_lightgbm_prep_safe(
+            model=model,
+            silent=kwargs.get("silent", False),
+        )
         model: AbstractModel = self.load_model(model)
         if X is None and model.val_score is None:
             raise AssertionError(
@@ -3839,8 +3934,7 @@ class AbstractTabularTrainer(AbstractTrainer[AbstractModel]):
     def _get_feature_importance_raw(self, X, y, model, eval_metric=None, **kwargs) -> pd.DataFrame:
         if eval_metric is None:
             eval_metric = self.eval_metric
-        if model is None:
-            model = self._get_best()
+        model = self._assert_feature_importance_lightgbm_prep_safe(model=model, silent=kwargs.get("silent", False))
         if eval_metric.needs_pred:
             predict_func = self.predict
         else:

--- a/tabular/tests/unittests/models/test_lightgbm_prep.py
+++ b/tabular/tests/unittests/models/test_lightgbm_prep.py
@@ -1,20 +1,92 @@
+import pytest
+
+from autogluon.tabular import TabularPredictor
 from autogluon.tabular.models.tabprep.prep_lgb_model import PrepLGBModel
 from autogluon.tabular.testing import FitHelper
+from autogluon.tabular.trainer import abstract_trainer as abstract_trainer_module
+
+
+PREP_HYPERPARAMETERS = {
+    "ag.prep_params": [
+        [
+            ["ArithmeticFeatureGenerator", {}],
+            [
+                ["CategoricalInteractionFeatureGenerator", {"passthrough": True}],
+                ["OOFTargetEncodingFeatureGenerator", {}],
+            ],
+        ],
+    ],
+    "ag.prep_params.passthrough_types": {"invalid_raw_types": ["category", "object"]},
+}
 
 
 def test_lightgbm():
     model_cls = PrepLGBModel
-    model_hyperparameters = {
-        "ag.prep_params": [
-            [
-                ["ArithmeticFeatureGenerator", {}],
-                [
-                    ["CategoricalInteractionFeatureGenerator", {"passthrough": True}],
-                    ["OOFTargetEncodingFeatureGenerator", {}],
-                ],
-            ],
-        ],
-        "ag.prep_params.passthrough_types": {"invalid_raw_types": ["category", "object"]},
-    }
+    model_hyperparameters = PREP_HYPERPARAMETERS.copy()
     """Additionally tests that all metrics work"""
     FitHelper.verify_model(model_cls=model_cls, model_hyperparameters=model_hyperparameters, extra_metrics=True)
+
+
+def test_feature_importance_temporarily_blocked_when_pipeline_uses_lightgbm_prep(
+    tmp_path,
+    monkeypatch,
+):
+    train_data, test_data, dataset_info = FitHelper.load_dataset("toy_binary_10")
+
+    predictor = TabularPredictor(
+        label=dataset_info["label"],
+        problem_type=dataset_info["problem_type"],
+        path=str(tmp_path / "AutogluonOutput"),
+    ).fit(
+        train_data,
+        hyperparameters={
+            "GBM_PREP": [{**PREP_HYPERPARAMETERS, "num_boost_round": 10}],
+            "GBM": [{"num_boost_round": 10}],
+        },
+        num_bag_folds=2,
+        num_stack_levels=1,
+        fit_weighted_ensemble=True,
+        ag_args_ensemble={"fold_fitting_strategy": "sequential_local"},
+    )
+
+    warning_messages = []
+    monkeypatch.setattr(
+        abstract_trainer_module.logger,
+        "warning",
+        lambda message: warning_messages.append(message),
+    )
+
+    stacked_model = next(
+        model_name for model_name in predictor.model_names() if predictor._trainer.get_model_level(model_name) > 1
+    )
+    with pytest.raises(NotImplementedError, match="Temporary safeguard"):
+        predictor.feature_importance(data=test_data, model=stacked_model, num_shuffle_sets=1)
+    assert len(warning_messages) == 1
+    assert "excluded_model_types=['LGBMPrep']" in warning_messages[0]
+    assert "remove `GBM_PREP` from the requested hyperparameters" in warning_messages[0]
+
+    prep_model = next(model_name for model_name in predictor.model_names() if model_name.startswith("LightGBMPrep"))
+    warning_messages.clear()
+    with pytest.raises(NotImplementedError, match=prep_model):
+        predictor.feature_importance(data=test_data, model=prep_model, num_shuffle_sets=1)
+    assert len(warning_messages) == 1
+    assert prep_model in warning_messages[0]
+
+
+def test_feature_importance_allowed_when_lightgbm_prep_has_no_prep_params(tmp_path):
+    train_data, test_data, dataset_info = FitHelper.load_dataset("toy_binary_10")
+
+    predictor = TabularPredictor(
+        label=dataset_info["label"],
+        problem_type=dataset_info["problem_type"],
+        path=str(tmp_path / "AutogluonOutput"),
+    ).fit(
+        train_data,
+        hyperparameters={"GBM_PREP": [{"ag.prep_params": [], "num_boost_round": 10}]},
+        fit_weighted_ensemble=False,
+    )
+
+    prep_model = next(model_name for model_name in predictor.model_names() if model_name.startswith("LightGBMPrep"))
+    fi_df = predictor.feature_importance(data=test_data, model=prep_model, num_shuffle_sets=1, subsample_size=10)
+
+    assert "importance" in fi_df.columns


### PR DESCRIPTION
*Issue*  
Addresses #5641.

*Description of changes:*  
This PR adds a short-term safeguard for `predictor.feature_importance()` when the requested model depends on `LightGBMPrep` in the prediction pipeline with active `prep_params`.

Instead of proceeding into a likely raw `MemoryError`, AutoGluon now emits a warning and raises a clearer explicit error with suggested workarounds.

This is intentionally a narrow short-term mitigation rather than a full solution for feature importance support on these pipelines.

*Validation:*
- `conda run -n ag-supported-311 python -m pytest tabular/tests/unittests/models/test_lightgbm_prep.py -q -k feature_importance` -> `2 passed, 1 deselected`
- `conda run -n ag-supported-311 python -m pytest tabular/tests/unittests/models/test_lightgbm_prep.py -q` -> `3 passed`
